### PR TITLE
Circuit cleanup

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -196,7 +196,8 @@ def assign_cell (c: Cell F) (v: Variable F) := as_circuit (
   fun _ => (Operation.Assign (c, v), ())
 )
 
--- extract information from circuits by running them
+-- formal concepts of soundness and completeness of a circuit
+
 @[simp]
 def constraints_hold_from_list [Field F] (env: (ℕ → F)) : List (Operation F) → Prop
   | [] => True
@@ -242,68 +243,9 @@ def constraints_hold_from_list_default [Field F] : List (Operation F) → Prop
 @[simp]
 def constraints_hold_default (circuit: Circuit F α) (ctx : Context F := Context.empty) : Prop :=
   constraints_hold_from_list_default (circuit ctx).1.2
-end Circuit
 
-namespace PreOperation
--- in the following, we prove equivalence between flattened and nested constraints
+variable {α β: TypePair} [ProvableType F α] [ProvableType F β]
 
-def to_flat_operations [Field F] (ops: List (Operation F)) : List (PreOperation F) :=
-  match ops with
-  | [] => []
-  | op :: ops => match op with
-    | Operation.Witness compute => PreOperation.Witness compute :: to_flat_operations ops
-    | Operation.Assert e => PreOperation.Assert e :: to_flat_operations ops
-    | Operation.Lookup l => PreOperation.Lookup l :: to_flat_operations ops
-    | Operation.Assign (c, v) => PreOperation.Assign (c, v) :: to_flat_operations ops
-    | Operation.SubCircuit circuit => circuit.ops ++ to_flat_operations ops
-
--- TODO super painful, mainly because `cases` doesn't allow rich patterns -- how does this work again?
-theorem can_flatten_first : ∀ (env: ℕ → F) (ops: List (Operation F)),
-  PreOperation.constraints_hold env (to_flat_operations ops)
-  → Circuit.constraints_hold_from_list env ops
-:= by
-  intro env ops
-  induction ops with
-  | nil => intro h; exact h
-  | cons op ops ih =>
-    cases ops with
-    | nil =>
-      simp at ih
-      cases op with
-      | SubCircuit c =>
-        sorry
-      | _ => simp [PreOperation.constraints_hold]
-    | cons op' ops' =>
-      let ops := op' :: ops'
-      cases op with
-      | SubCircuit c => sorry
-      | Assert e => sorry
-      | Witness c =>
-        have h_ops : to_flat_operations (Operation.Witness c :: op' :: ops') = PreOperation.Witness c :: to_flat_operations (op' :: ops') := rfl
-        rw [h_ops]
-        intro h_pre
-        have h1 : PreOperation.constraints_hold env (to_flat_operations (op' :: ops')) := by
-          rw [PreOperation.constraints_hold] at h_pre
-          · exact h_pre
-          · sorry
-          · simp
-          · simp
-        have ih1 := ih h1
-        simp [ih1]
-      | Lookup l => sorry
-      | Assign a => sorry
-
-theorem can_flatten : ∀ (ops: List (Operation F)),
-  Circuit.constraints_hold_from_list_default ops →
-  PreOperation.constraints_hold_default (to_flat_operations ops)
-:= by
- sorry
-end PreOperation
-
-namespace Circuit
-variable {α β γ: TypePair} [ProvableType F α] [ProvableType F β] [ProvableType F γ]
-
--- goal: define circuit such that we can provably use it as subcircuit
 structure FormalCircuit (F: Type) (β α: TypePair)
   [Field F] [ProvableType F α] [ProvableType F β]
 where
@@ -341,102 +283,4 @@ def subcircuit_soundness (circuit: FormalCircuit F β α) (b_var : β.var) (a_va
 def subcircuit_completeness (circuit: FormalCircuit F β α) (b_var : β.var) :=
   let b := Provable.eval F b_var
   circuit.assumptions b
-
-def formal_circuit_to_subcircuit (ctx: Context F)
-  (circuit: FormalCircuit F β α) (b_var : β.var) : α.var × SubCircuit F :=
-  let res := circuit.main b_var ctx
-  -- TODO: weirdly, when we destructure we can't deduce origin of the results anymore
-  -- let ((_, ops), a_var) := res
-  let ops := res.1.2
-  let a_var := res.2
-
-  have s: SubCircuit F := by
-    let flat_ops := PreOperation.to_flat_operations ops
-    let soundness := subcircuit_soundness circuit b_var a_var
-    let completeness := subcircuit_completeness circuit b_var
-    use flat_ops, soundness, completeness
-
-    -- `imply_soundness`
-    -- we are given an environment where the constraints hold, and can assume the assumptions are true
-    intro env h_holds
-    show soundness env
-
-    let b : β.value := Provable.eval_env env b_var
-    let a : α.value := Provable.eval_env env a_var
-    rintro (as : circuit.assumptions b)
-    show circuit.spec b a
-
-    -- by soundness of the circuit, the spec is satisfied if only the constraints hold
-    suffices h: constraints_hold_from_list env ops by
-      exact circuit.soundness ctx env b b_var rfl as h
-
-    -- so we just need to go from flattened constraints to constraints
-    guard_hyp h_holds : PreOperation.constraints_hold env (PreOperation.to_flat_operations ops)
-    exact PreOperation.can_flatten_first env ops h_holds
-
-    -- `implied_by_completeness`
-    -- we are given that the assumptions are true
-    intro h_completeness
-    let b := Provable.eval F b_var
-    have as : circuit.assumptions b := h_completeness
-
-    -- by completeness of the circuit, this means we can make the constraints hold
-    have h_holds : constraints_hold_from_list_default ops := circuit.completeness ctx b b_var rfl as
-
-    -- so we just need to go from constraints to flattened constraints
-    exact PreOperation.can_flatten ops h_holds
-
-  ⟨ a_var, s ⟩
-
--- run a sub-circuit
-@[simp]
-def subcircuit (circuit: FormalCircuit F β α) (b: β.var) := as_circuit (F:=F) (
-  fun ctx =>
-    let ⟨ a, subcircuit ⟩ := formal_circuit_to_subcircuit ctx circuit b
-    (Operation.SubCircuit subcircuit, a)
-)
-end Circuit
-
-namespace Provable
-variable {α β: TypePair} [ProvableType F α] [ProvableType F β]
-
-@[simp]
-def witness {F: Type} [Field F] [ProvableType F α] (compute : Unit → α.value) :=
-  let n := ProvableType.size F α
-  let values : Vector F n := ProvableType.to_values (compute ())
-  let varsM : Vector (Circuit F (Expression F)) n := values.map (fun v => Circuit.witness (fun () => v))
-  do
-    let vars ← varsM.mapM
-    return ProvableType.from_vars vars
-
-@[simp]
-def assert_equal {F: Type} [Field F] [ProvableType F α] (a a': α.var) : Circuit F Unit :=
-  let n := ProvableType.size F α
-  let vars: Vector (Expression F) n := ProvableType.to_vars a
-  let vars': Vector (Expression F) n := ProvableType.to_vars a'
-  let eqs := (vars.zip vars').map (fun ⟨ x, x' ⟩ => Circuit.assert_zero (x - x'))
-  do let _ ← eqs.mapM
-end Provable
-
--- inputs, already connected to a cell, that you can assign the next row's value of
--- TODO figure out if this is the best way to connect to a trace
-namespace Circuit
-def to_var [Field F] (x: Expression F) : Circuit F (Variable F) :=
-  match x with
-  | Expression.var v => pure v
-  | x => do
-    let x' ← witness_var (fun _ => x.eval)
-    assert_zero (x - (Expression.var x'))
-    return x'
-
-structure InputCell (F : Type) where
-  cell: { cell: Cell F // cell.row = RowIndex.Current }
-  var: Variable F
-
-def InputCell.set_next [Field F] (c: InputCell F) (v: Expression F) := do
-  let v' ← to_var v
-  assign_cell { c.cell.val with row := RowIndex.Next } v'
-
-instance : Coe (InputCell F) (Variable F) where
-  coe x := x.var
 end Circuit

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -131,7 +131,7 @@ def toString [Repr F] : (op : Operation F) → String
   | Assert e => "(Assert " ++ reprStr e ++ " == 0)"
   | Lookup l => reprStr l
   | Assign (c, v) => "(Assign " ++ reprStr c ++ ", " ++ reprStr v ++ ")"
-  | SubCircuit { ops, .. } => "(Circuit " ++ reprStr ops ++ ")"
+  | SubCircuit { ops, .. } => "(SubCircuit " ++ reprStr ops ++ ")"
 
 instance [Repr F] : ToString (Operation F) where
   toString := toString

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -59,6 +59,9 @@ def toString [Repr F] : (op : PreOperation F) → String
   | Lookup l => reprStr l
   | Assign (c, v) => "(Assign " ++ reprStr c ++ ", " ++ reprStr v ++ ")"
 
+instance [Repr F] : Repr (PreOperation F) where
+  reprPrec op _ := toString op
+
 def constraints_hold (env: ℕ → F) : List (PreOperation F) → Prop
   | [] => True
   | op :: [] => match op with
@@ -67,7 +70,7 @@ def constraints_hold (env: ℕ → F) : List (PreOperation F) → Prop
       table.contains (entry.map (fun e => e.eval_env env))
     | _ => True
   | op :: ops => match op with
-    | PreOperation.Assert e => ((e.eval_env env) = 0) ∧ constraints_hold env ops
+    | Assert e => ((e.eval_env env) = 0) ∧ constraints_hold env ops
     | Lookup { table, entry, index := _ } =>
       table.contains (entry.map (fun e => e.eval_env env)) ∧ constraints_hold env ops
     | _ => constraints_hold env ops
@@ -80,7 +83,7 @@ def constraints_hold_default : List (PreOperation F) → Prop
       table.contains (entry.map (fun e => e.eval))
     | _ => True
   | op :: ops => match op with
-    | PreOperation.Assert e => (e.eval = 0) ∧ constraints_hold_default ops
+    | Assert e => (e.eval = 0) ∧ constraints_hold_default ops
     | Lookup { table, entry, index := _ } =>
       table.contains (entry.map (fun e => e.eval)) ∧ constraints_hold_default ops
     | _ => constraints_hold_default ops
@@ -129,7 +132,7 @@ def toString [Repr F] : (op : Operation F) → String
   | Assert e => "(Assert " ++ reprStr e ++ " == 0)"
   | Lookup l => reprStr l
   | Assign (c, v) => "(Assign " ++ reprStr c ++ ", " ++ reprStr v ++ ")"
-  | Circuit { ops, .. } => "(Circuit " ++ reprStr (ops.map PreOperation.toString) ++ ")"
+  | Circuit { ops, .. } => "(Circuit " ++ reprStr ops ++ ")"
 
 instance [Repr F] : ToString (Operation F) where
   toString := toString

--- a/Clean/Circuit/Expression.lean
+++ b/Clean/Circuit/Expression.lean
@@ -18,6 +18,8 @@ inductive Expression (F : Type) where
   | add : Expression F -> Expression F -> Expression F
   | mul : Expression F -> Expression F -> Expression F
 
+export Expression (var const)
+
 namespace Expression
 variable [Field F]
 

--- a/Clean/Circuit/Extensions.lean
+++ b/Clean/Circuit/Extensions.lean
@@ -27,10 +27,10 @@ end Provable
 namespace Circuit
 def to_var [Field F] (x: Expression F) : Circuit F (Variable F) :=
   match x with
-  | Expression.var v => pure v
+  | var v => pure v
   | x => do
     let x' ← witness_var (fun _ => x.eval)
-    assert_zero (x - (Expression.var x'))
+    assert_zero (x - (var x'))
     return x'
 
 -- inputs, already connected to a cell, that you can assign the next row's value of

--- a/Clean/Circuit/Extensions.lean
+++ b/Clean/Circuit/Extensions.lean
@@ -1,0 +1,48 @@
+/- This file contains possible additions to the Circuit DSL that aren't currently used -/
+import Clean.Circuit.Basic
+
+variable {F :Type} [Field F]
+
+namespace Provable
+variable {α β: TypePair} [ProvableType F α] [ProvableType F β]
+
+@[simp]
+def witness {F: Type} [Field F] [ProvableType F α] (compute : Unit → α.value) :=
+  let n := ProvableType.size F α
+  let values : Vector F n := ProvableType.to_values (compute ())
+  let varsM : Vector (Circuit F (Expression F)) n := values.map (fun v => Circuit.witness (fun () => v))
+  do
+    let vars ← varsM.mapM
+    return ProvableType.from_vars vars
+
+@[simp]
+def assert_equal {F: Type} [Field F] [ProvableType F α] (a a': α.var) : Circuit F Unit :=
+  let n := ProvableType.size F α
+  let vars: Vector (Expression F) n := ProvableType.to_vars a
+  let vars': Vector (Expression F) n := ProvableType.to_vars a'
+  let eqs := (vars.zip vars').map (fun ⟨ x, x' ⟩ => Circuit.assert_zero (x - x'))
+  do let _ ← eqs.mapM
+end Provable
+
+namespace Circuit
+def to_var [Field F] (x: Expression F) : Circuit F (Variable F) :=
+  match x with
+  | Expression.var v => pure v
+  | x => do
+    let x' ← witness_var (fun _ => x.eval)
+    assert_zero (x - (Expression.var x'))
+    return x'
+
+-- inputs, already connected to a cell, that you can assign the next row's value of
+-- TODO figure out if this is the best way to connect to a trace
+structure InputCell (F : Type) where
+  cell: { cell: Cell F // cell.row = RowIndex.Current }
+  var: Variable F
+
+def InputCell.set_next [Field F] (c: InputCell F) (v: Expression F) := do
+  let v' ← to_var v
+  assign_cell { c.cell.val with row := RowIndex.Next } v'
+
+instance : Coe (InputCell F) (Variable F) where
+  coe x := x.var
+end Circuit

--- a/Clean/Circuit/SubCircuit.lean
+++ b/Clean/Circuit/SubCircuit.lean
@@ -1,0 +1,117 @@
+import Clean.Circuit.Basic
+
+variable {F: Type} [Field F]
+
+namespace PreOperation
+-- in the following, we prove equivalence between flattened and nested constraints
+
+def to_flat_operations [Field F] (ops: List (Operation F)) : List (PreOperation F) :=
+  match ops with
+  | [] => []
+  | op :: ops => match op with
+    | Operation.Witness compute => PreOperation.Witness compute :: to_flat_operations ops
+    | Operation.Assert e => PreOperation.Assert e :: to_flat_operations ops
+    | Operation.Lookup l => PreOperation.Lookup l :: to_flat_operations ops
+    | Operation.Assign (c, v) => PreOperation.Assign (c, v) :: to_flat_operations ops
+    | Operation.SubCircuit circuit => circuit.ops ++ to_flat_operations ops
+
+-- TODO super painful, mainly because `cases` doesn't allow rich patterns -- how does this work again?
+theorem can_flatten_first : ∀ (env: ℕ → F) (ops: List (Operation F)),
+  PreOperation.constraints_hold env (to_flat_operations ops)
+  → Circuit.constraints_hold_from_list env ops
+:= by
+  intro env ops
+  induction ops with
+  | nil => intro h; exact h
+  | cons op ops ih =>
+    cases ops with
+    | nil =>
+      simp at ih
+      cases op with
+      | SubCircuit c =>
+        sorry
+      | _ => simp [PreOperation.constraints_hold]
+    | cons op' ops' =>
+      let ops := op' :: ops'
+      cases op with
+      | SubCircuit c => sorry
+      | Assert e => sorry
+      | Witness c =>
+        have h_ops : to_flat_operations (Operation.Witness c :: op' :: ops') = PreOperation.Witness c :: to_flat_operations (op' :: ops') := rfl
+        rw [h_ops]
+        intro h_pre
+        have h1 : PreOperation.constraints_hold env (to_flat_operations (op' :: ops')) := by
+          rw [PreOperation.constraints_hold] at h_pre
+          · exact h_pre
+          · sorry
+          · simp
+          · simp
+        have ih1 := ih h1
+        simp [ih1]
+      | Lookup l => sorry
+      | Assign a => sorry
+
+theorem can_flatten : ∀ (ops: List (Operation F)),
+  Circuit.constraints_hold_from_list_default ops →
+  PreOperation.constraints_hold_default (to_flat_operations ops)
+:= by
+ sorry
+end PreOperation
+
+variable {α β: TypePair} [ProvableType F α] [ProvableType F β]
+
+namespace Circuit
+def formal_circuit_to_subcircuit (ctx: Context F)
+  (circuit: FormalCircuit F β α) (b_var : β.var) : α.var × SubCircuit F :=
+  let res := circuit.main b_var ctx
+  -- TODO: weirdly, when we destructure we can't deduce origin of the results anymore
+  -- let ((_, ops), a_var) := res
+  let ops := res.1.2
+  let a_var := res.2
+
+  have s: SubCircuit F := by
+    let flat_ops := PreOperation.to_flat_operations ops
+    let soundness := subcircuit_soundness circuit b_var a_var
+    let completeness := subcircuit_completeness circuit b_var
+    use flat_ops, soundness, completeness
+
+    -- `imply_soundness`
+    -- we are given an environment where the constraints hold, and can assume the assumptions are true
+    intro env h_holds
+    show soundness env
+
+    let b : β.value := Provable.eval_env env b_var
+    let a : α.value := Provable.eval_env env a_var
+    rintro (as : circuit.assumptions b)
+    show circuit.spec b a
+
+    -- by soundness of the circuit, the spec is satisfied if only the constraints hold
+    suffices h: constraints_hold_from_list env ops by
+      exact circuit.soundness ctx env b b_var rfl as h
+
+    -- so we just need to go from flattened constraints to constraints
+    guard_hyp h_holds : PreOperation.constraints_hold env (PreOperation.to_flat_operations ops)
+    exact PreOperation.can_flatten_first env ops h_holds
+
+    -- `implied_by_completeness`
+    -- we are given that the assumptions are true
+    intro h_completeness
+    let b := Provable.eval F b_var
+    have as : circuit.assumptions b := h_completeness
+
+    -- by completeness of the circuit, this means we can make the constraints hold
+    have h_holds : constraints_hold_from_list_default ops := circuit.completeness ctx b b_var rfl as
+
+    -- so we just need to go from constraints to flattened constraints
+    exact PreOperation.can_flatten ops h_holds
+
+  ⟨ a_var, s ⟩
+end Circuit
+
+-- run a sub-circuit
+@[simp]
+def subcircuit (circuit: Circuit.FormalCircuit F β α) (b: β.var) := Circuit.as_circuit (F:=F) (
+  fun ctx =>
+    let ⟨ a, subcircuit ⟩ := Circuit.formal_circuit_to_subcircuit ctx circuit b
+    (Operation.SubCircuit subcircuit, a)
+)

--- a/Clean/Circuit/SubCircuit.lean
+++ b/Clean/Circuit/SubCircuit.lean
@@ -110,7 +110,7 @@ end Circuit
 
 -- run a sub-circuit
 @[simp]
-def subcircuit (circuit: Circuit.FormalCircuit F β α) (b: β.var) := Circuit.as_circuit (F:=F) (
+def subcircuit (circuit: FormalCircuit F β α) (b: β.var) := Circuit.as_circuit (F:=F) (
   fun ctx =>
     let ⟨ a, subcircuit ⟩ := Circuit.formal_circuit_to_subcircuit ctx circuit b
     (Operation.SubCircuit subcircuit, a)

--- a/Clean/Examples/Gadgets.lean
+++ b/Clean/Examples/Gadgets.lean
@@ -9,9 +9,6 @@ import Clean.GadgetsNew.Add8.Addition8
 
 section
 
-open Circuit
-open Expression (const)
-
 #eval!
   let p := 1009
   let p_prime := Fact.mk prime_1009

--- a/Clean/Examples/Gadgets.lean
+++ b/Clean/Examples/Gadgets.lean
@@ -17,10 +17,10 @@ open Expression (const)
   let p_prime := Fact.mk prime_1009
   let p_non_zero := Fact.mk (by norm_num : p ≠ 0)
   let p_large_enough := Fact.mk (by norm_num : p > 512)
-  let main := do
+  let main : Circuit _ (Provable.field _).var := do
     let x ← witness (fun _ => 10)
     let y ← witness (fun _ => 20)
-    Add8.add8 (p:=p) { x, y }
+    let z ← Add8.add8 (p:=p) { x, y }
+    Add8.add8 (p:=p) { x, y := z }
   main.operations
-
 end

--- a/Clean/Examples/Gadgets.lean
+++ b/Clean/Examples/Gadgets.lean
@@ -14,7 +14,7 @@ section
   let p_prime := Fact.mk prime_1009
   let p_non_zero := Fact.mk (by norm_num : p ≠ 0)
   let p_large_enough := Fact.mk (by norm_num : p > 512)
-  let main : Circuit _ (Provable.field _).var := do
+  let main := do
     let x ← witness (fun _ => 10)
     let y ← witness (fun _ => 20)
     let z ← Add8.add8 (p:=p) { x, y }

--- a/Clean/Examples/Gadgets.lean
+++ b/Clean/Examples/Gadgets.lean
@@ -20,7 +20,7 @@ open Expression (const)
   let main := do
     let x ← witness (fun _ => 10)
     let y ← witness (fun _ => 20)
-    Add8.add8 (p:=p) (⟨x, y⟩)
+    Add8.add8 (p:=p) { x, y }
   main.operations
 
 end

--- a/Clean/GadgetsNew/Add8/Addition8.lean
+++ b/Clean/GadgetsNew/Add8/Addition8.lean
@@ -15,7 +15,6 @@ variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
 open Provable (field field2 fields)
-open ByteLookup
 
 structure InputStruct (F : Type) where
   x: F

--- a/Clean/GadgetsNew/Add8/Addition8.lean
+++ b/Clean/GadgetsNew/Add8/Addition8.lean
@@ -16,7 +16,6 @@ variable [p_large_enough: Fact (p > 512)]
 
 open Provable (field field2 fields)
 open ByteLookup
-open Expression
 
 structure InputStruct (F : Type) where
   x: F

--- a/Clean/GadgetsNew/Add8/Addition8.lean
+++ b/Clean/GadgetsNew/Add8/Addition8.lean
@@ -14,7 +14,6 @@ namespace Add8
 variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
-open Circuit
 open Provable (field field2 fields)
 open ByteLookup
 open Expression

--- a/Clean/GadgetsNew/Add8/Addition8Full.lean
+++ b/Clean/GadgetsNew/Add8/Addition8Full.lean
@@ -15,7 +15,6 @@ namespace Add8Full
 variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
-open Circuit
 open Provable (field field2 fields)
 open ByteLookup
 open Expression

--- a/Clean/GadgetsNew/Add8/Addition8Full.lean
+++ b/Clean/GadgetsNew/Add8/Addition8Full.lean
@@ -5,6 +5,7 @@ import Clean.Utils.Vector
 import Clean.Circuit.Expression
 import Clean.Circuit.Provable
 import Clean.Circuit.Basic
+import Clean.Circuit.SubCircuit
 import Clean.Utils.Field
 import Clean.GadgetsNew.ByteLookup
 import Clean.GadgetsNew.Boolean

--- a/Clean/GadgetsNew/Add8/Addition8Full.lean
+++ b/Clean/GadgetsNew/Add8/Addition8Full.lean
@@ -17,7 +17,6 @@ variable [p_large_enough: Fact (p > 512)]
 
 open Provable (field field2 fields)
 open ByteLookup
-open Expression
 
 structure InputStruct (F : Type) where
   x: F

--- a/Clean/GadgetsNew/Add8/Addition8Full.lean
+++ b/Clean/GadgetsNew/Add8/Addition8Full.lean
@@ -16,7 +16,6 @@ variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
 open Provable (field field2 fields)
-open ByteLookup
 
 structure InputStruct (F : Type) where
   x: F

--- a/Clean/GadgetsNew/Add8/Addition8FullCarry.lean
+++ b/Clean/GadgetsNew/Add8/Addition8FullCarry.lean
@@ -61,7 +61,7 @@ instance : ProvableType (F p) (Outputs p) where
     let ⟨ [z, carry_out], _ ⟩ := v
     ⟨ z, carry_out ⟩
 
-def add8_full_carry (input : (Inputs p).var) : Stateful (F p) (Outputs p).var := do
+def add8_full_carry (input : (Inputs p).var) : Circuit (F p) (Outputs p).var := do
   let ⟨x, y, carry_in⟩ := input
 
   -- witness the result

--- a/Clean/GadgetsNew/Add8/Addition8FullCarry.lean
+++ b/Clean/GadgetsNew/Add8/Addition8FullCarry.lean
@@ -15,7 +15,6 @@ variable {p : ℕ} [p_neq_zero: Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
 open Provable (field field2 fields)
-open ByteLookup
 
 structure InputStruct (F : Type) where
   x: F

--- a/Clean/GadgetsNew/Add8/Addition8FullCarry.lean
+++ b/Clean/GadgetsNew/Add8/Addition8FullCarry.lean
@@ -16,7 +16,6 @@ variable [p_large_enough: Fact (p > 512)]
 
 open Provable (field field2 fields)
 open ByteLookup
-open Expression
 
 structure InputStruct (F : Type) where
   x: F
@@ -71,12 +70,9 @@ def add8_full_carry (input : (Inputs p).var) : Circuit (F p) (Outputs p).var := 
   let carry_out ← witness (fun () => FieldUtils.floordiv (x + y + carry_in) 256)
   assert_bool carry_out
 
-  assert_zero (x + y + carry_in - z - carry_out * (const ↑(256 : ℕ)))
+  assert_zero (x + y + carry_in - z - carry_out * (const 256))
 
-  return {
-    z := z,
-    carry_out := carry_out
-  }
+  return { z, carry_out }
 
 def assumptions (input : (Inputs p).value) :=
   let ⟨x, y, carry_in⟩ := input

--- a/Clean/GadgetsNew/Add8/Addition8FullCarry.lean
+++ b/Clean/GadgetsNew/Add8/Addition8FullCarry.lean
@@ -14,7 +14,6 @@ namespace Add8FullCarry
 variable {p : ℕ} [p_neq_zero: Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
-open Circuit
 open Provable (field field2 fields)
 open ByteLookup
 open Expression

--- a/Clean/GadgetsNew/Addition32Full.lean
+++ b/Clean/GadgetsNew/Addition32Full.lean
@@ -17,7 +17,6 @@ variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
 open Provable (field field2 fields)
-open ByteLookup
 
 structure InputStruct (F : Type) where
   x: U32 F

--- a/Clean/GadgetsNew/Addition32Full.lean
+++ b/Clean/GadgetsNew/Addition32Full.lean
@@ -5,6 +5,7 @@ import Clean.Utils.Vector
 import Clean.Circuit.Expression
 import Clean.Circuit.Provable
 import Clean.Circuit.Basic
+import Clean.Circuit.SubCircuit
 import Clean.Utils.Field
 import Clean.GadgetsNew.ByteLookup
 import Clean.GadgetsNew.Boolean

--- a/Clean/GadgetsNew/Addition32Full.lean
+++ b/Clean/GadgetsNew/Addition32Full.lean
@@ -62,7 +62,7 @@ instance : ProvableType (F p) (Outputs p) where
     let ⟨ [z0, z1, z2, z3, carry_out], _ ⟩ := v
     ⟨ ⟨ z0, z1, z2, z3 ⟩, carry_out ⟩
 
-def add32_full (input : (Inputs p).var) : Stateful (F p) (Outputs p).var := do
+def add32_full (input : (Inputs p).var) : Circuit (F p) (Outputs p).var := do
   let ⟨x, y, carry_in⟩ := input
 
   let {

--- a/Clean/GadgetsNew/Addition32Full.lean
+++ b/Clean/GadgetsNew/Addition32Full.lean
@@ -16,7 +16,6 @@ namespace Addition32Full
 variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
-open Circuit
 open Provable (field field2 fields)
 open ByteLookup
 open Expression

--- a/Clean/GadgetsNew/Addition32Full.lean
+++ b/Clean/GadgetsNew/Addition32Full.lean
@@ -18,7 +18,6 @@ variable [p_large_enough: Fact (p > 512)]
 
 open Provable (field field2 fields)
 open ByteLookup
-open Expression
 
 structure InputStruct (F : Type) where
   x: U32 F

--- a/Clean/GadgetsNew/Boolean.lean
+++ b/Clean/GadgetsNew/Boolean.lean
@@ -50,7 +50,7 @@ by
     simp [h]
 
 theorem equiv : ∀ x: F p,
-  constraints_hold (assert_bool (const x)) ↔ spec x
+  constraints_hold_default (assert_bool (const x)) ↔ spec x
 := by
   -- simplify
   dsimp

--- a/Clean/GadgetsNew/Boolean.lean
+++ b/Clean/GadgetsNew/Boolean.lean
@@ -10,7 +10,6 @@ import Clean.Utils.Field
 section
 variable {p : ℕ} [Fact p.Prime]
 
-open Circuit
 open Expression
 
 def assert_bool (x: Expression (F p)) := do
@@ -50,7 +49,7 @@ by
     simp [h]
 
 theorem equiv : ∀ x: F p,
-  constraints_hold_default (assert_bool (const x)) ↔ spec x
+  Circuit.constraints_hold_default (assert_bool (const x)) ↔ spec x
 := by
   -- simplify
   dsimp

--- a/Clean/GadgetsNew/Boolean.lean
+++ b/Clean/GadgetsNew/Boolean.lean
@@ -10,8 +10,6 @@ import Clean.Utils.Field
 section
 variable {p : ℕ} [Fact p.Prime]
 
-open Expression
-
 def assert_bool (x: Expression (F p)) := do
   assert_zero (x * (x - 1))
 

--- a/Clean/GadgetsNew/ByteLookup.lean
+++ b/Clean/GadgetsNew/ByteLookup.lean
@@ -7,10 +7,6 @@ import Clean.Circuit.Provable
 import Clean.Circuit.Basic
 import Clean.Utils.Field
 
-
-
-namespace ByteLookup
-
 variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 

--- a/Clean/GadgetsNew/ByteLookup.lean
+++ b/Clean/GadgetsNew/ByteLookup.lean
@@ -14,8 +14,6 @@ namespace ByteLookup
 variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
-open Circuit
-
 def from_byte (x: Fin 256) : F p :=
   FieldUtils.nat_to_field x.val (by linarith [x.is_lt, p_large_enough.elim])
 

--- a/Clean/Types/Byte.lean
+++ b/Clean/Types/Byte.lean
@@ -21,7 +21,7 @@ def var (b: Byte (F p)) := Expression.var b.1
 
 def witness (compute : Unit → F p) := do
   let x ← witness_var compute
-  ByteLookup.byte_lookup x
+  byte_lookup x
   return Byte.mk x
 
 instance : Coe (Byte (F p)) (Expression (F p)) where

--- a/Clean/Types/Byte.lean
+++ b/Clean/Types/Byte.lean
@@ -13,8 +13,6 @@ section
 variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
-open Circuit
-
 inductive Byte (F: Type) where
   | private mk : (Variable F) → Byte F
 

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -13,8 +13,6 @@ section
 variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
-open Circuit
-
 /--
   A 32-bit unsigned integer is represented using four limbs of 8 bits each.
 -/

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -8,7 +8,6 @@ import Clean.Circuit.Basic
 import Clean.Utils.Field
 import Clean.GadgetsNew.ByteLookup
 
-
 section
 variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
@@ -34,10 +33,10 @@ def witness (compute : Unit → U32 (F p)) := do
   let x2 ←  witness_var (fun _ => val.x2)
   let x3 ←  witness_var (fun _ => val.x3)
 
-  ByteLookup.byte_lookup x0
-  ByteLookup.byte_lookup x1
-  ByteLookup.byte_lookup x2
-  ByteLookup.byte_lookup x3
+  byte_lookup x0
+  byte_lookup x1
+  byte_lookup x2
+  byte_lookup x3
 
   return U32.mk x0 x1 x2 x3
 


### PR DESCRIPTION
this cleans up `Circuit.Basic`, splits out two additional files whose content isn't "basic", improves some names, and adds some exports so we don't have to open various modules all the time
