### PR TITLE
Formalize assertion-like subcircuits

### DIFF
--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -55,6 +55,16 @@ def const (F: Type) [ProvableType F α] (x: α.value) : α.var :=
   ProvableType.from_vars (values.map (fun v => Expression.const v))
 
 @[reducible]
+def unit : TypePair := ⟨ Unit, Unit ⟩
+
+instance : ProvableType F unit where
+  size := 0
+  to_vars _ := vec []
+  from_vars _ := ()
+  to_values _ := vec []
+  from_values _ := ()
+
+@[reducible]
 def field (F : Type) : TypePair := ⟨ Expression F, F ⟩
 
 @[simp]

--- a/Clean/Circuit/SubCircuit.lean
+++ b/Clean/Circuit/SubCircuit.lean
@@ -159,7 +159,7 @@ def subcircuit (circuit: FormalCircuit F β α) (b: β.var) := Circuit.as_circui
 )
 
 @[simp]
-def subassertion (circuit: FormalAssertion F β) (b: β.var) := Circuit.as_circuit (F:=F) (
+def assertion (circuit: FormalAssertion F β) (b: β.var) := Circuit.as_circuit (F:=F) (
   fun ctx =>
     let subcircuit := Circuit.formal_assertion_to_subcircuit ctx circuit b
     (Operation.SubCircuit subcircuit, ())

--- a/Clean/GadgetsNew/Add8/Theorems.lean
+++ b/Clean/GadgetsNew/Add8/Theorems.lean
@@ -205,10 +205,8 @@ theorem completeness_bool [p_neq_zero : Fact (p ≠ 0)] (x y carry_in: F p) :
     y.val < 256 ->
     carry_in.val < 2 ->
     let carry_out := FieldUtils.floordiv (x + y + carry_in) 256
-    carry_out * (carry_out + -1 * 1) = 0 := by
+    carry_out = 0 ∨ carry_out = 1 := by
   intro as_x as_y carry_in_bound
-  simp
-  rw [add_eq_zero_iff_eq_neg, neg_neg]
   dsimp [FieldUtils.floordiv]
 
   -- we show that the carry_out is either 0 or 1 by explicitly

--- a/Clean/GadgetsNew/Boolean.lean
+++ b/Clean/GadgetsNew/Boolean.lean
@@ -29,7 +29,7 @@ instance : Coe (Boolean (F p)) (Expression (F p)) where
 
 def spec (x: F p) := x = 0 ∨ x = 1
 
-theorem dsimp_equiv : ∀ x: F p,
+theorem equiv : ∀ x: F p,
   x * (x + -1 * 1) = 0 ↔ x = 0 ∨ x = 1 :=
 by
   intro x
@@ -46,13 +46,24 @@ by
     show x + -1 = 0
     simp [h]
 
-theorem equiv : ∀ x: F p,
-  Circuit.constraints_hold_default (assert_bool (const x)) ↔ spec x
-:= by
-  -- simplify
-  dsimp
-  show ∀ (x : F p), x * (x + -1 * 1) = 0 ↔ spec x
+open Provable (field)
 
-  -- proof
-  exact dsimp_equiv
+def circuit : FormalAssertion (F p) (field (F p)) where
+  main := assert_bool
+  assumptions _ := True
+  spec := spec
+
+  soundness := by
+    intro ctx env x x_var hx _ h_holds
+    change x_var.eval_env env = x at hx
+    dsimp at h_holds
+    rw [hx] at h_holds
+    apply (equiv x).mp h_holds
+
+  completeness := by
+    intro ctx x x_var hx _ spec
+    change x_var.eval = x at hx
+    dsimp
+    rw [hx]
+    apply (equiv x).mpr spec
 end Boolean

--- a/Clean/GadgetsNew/Boolean.lean
+++ b/Clean/GadgetsNew/Boolean.lean
@@ -48,6 +48,9 @@ by
 
 open Provable (field)
 
+/--
+Asserts that x = 0 ∨ x = 1 by adding the constraint x * (x - 1) = 0
+-/
 def circuit : FormalAssertion (F p) (field (F p)) where
   main := assert_bool
   assumptions _ := True


### PR DESCRIPTION
I wanted to embed the `assert_bool` circuit in our framework but realized it's not a `FormalCircuit`: by design, `assert_bool` is not complete on all inputs - it will of course fail on non-boolean inputs!

This lead me to formulate an alternative called `FormalAssertion` to capture circuits like this. The low-level representation is the same -- `Operation.SubCircuit` - but the structure of hypotheses is slightly different.

To test this addition I also made `assert_bool` a subcircuit inside `add8`. This is done in the last commit and is not strictly necessary -- because assert_bool is so simple there's not much gained from abstracting it. But I think it doesn't hurt either