### PR TITLE
End to end subcircuit soundness

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -197,7 +197,7 @@ def assign_cell (c: Cell F) (v: Variable F) := as_circuit (
 -- formal concepts of soundness and completeness of a circuit
 
 @[simp]
-def constraints_hold_from_list [Field F] (env: (ℕ → F)) : List (Operation F) → Prop
+def constraints_hold_from_list (env: (ℕ → F)) : List (Operation F) → Prop
   | [] => True
   | op :: [] => match op with
     | Operation.Assert e => (e.eval_env env) = 0
@@ -205,12 +205,12 @@ def constraints_hold_from_list [Field F] (env: (ℕ → F)) : List (Operation F)
       table.contains (entry.map (fun e => e.eval_env env))
     | Operation.SubCircuit { soundness, .. } => soundness env
     | _ => True
-  | op :: ops => match op with
-    | Operation.Assert e => ((e.eval_env env) = 0) ∧ constraints_hold_from_list env ops
+  | op :: op' :: ops => match op with
+    | Operation.Assert e => ((e.eval_env env) = 0) ∧ constraints_hold_from_list env (op' :: ops)
     | Operation.Lookup { table, entry, index := _ } =>
-      table.contains (entry.map (fun e => e.eval_env env)) ∧ constraints_hold_from_list env ops
-    | Operation.SubCircuit { soundness, .. } => soundness env ∧ constraints_hold_from_list env ops
-    | _ => constraints_hold_from_list env ops
+      table.contains (entry.map (fun e => e.eval_env env)) ∧ constraints_hold_from_list env (op' :: ops)
+    | Operation.SubCircuit { soundness, .. } => soundness env ∧ constraints_hold_from_list env (op' :: ops)
+    | _ => constraints_hold_from_list env (op' :: ops)
 
 @[reducible, simp]
 def constraints_hold [Field F] (env: (ℕ → F)) (circuit: Circuit F α) (ctx : Context F := .empty) : Prop :=

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -213,7 +213,7 @@ def constraints_hold_from_list (env: (ℕ → F)) : List (Operation F) → Prop
     | _ => constraints_hold_from_list env ops
 
 @[reducible, simp]
-def constraints_hold [Field F] (env: (ℕ → F)) (circuit: Circuit F α) (ctx : Context F := .empty) : Prop :=
+def constraints_hold (env: (ℕ → F)) (circuit: Circuit F α) (ctx : Context F := .empty) : Prop :=
   constraints_hold_from_list env (circuit ctx).1.2
 
 /--
@@ -223,7 +223,7 @@ witness generator, checking all constraints would not fail.
 For subcircuits, since we proved completeness, this only means we need to satisfy the assumptions!
 -/
 @[simp]
-def constraints_hold_from_list_default [Field F] : List (Operation F) → Prop
+def constraints_hold_from_list_default : List (Operation F) → Prop
   | [] => True
   | op :: [] => match op with
     | Operation.Assert e => e.eval = 0

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -205,12 +205,12 @@ def constraints_hold_from_list (env: (ℕ → F)) : List (Operation F) → Prop
       table.contains (entry.map (fun e => e.eval_env env))
     | Operation.SubCircuit { soundness, .. } => soundness env
     | _ => True
-  | op :: op' :: ops => match op with
-    | Operation.Assert e => ((e.eval_env env) = 0) ∧ constraints_hold_from_list env (op' :: ops)
+  | op :: ops => match op with
+    | Operation.Assert e => ((e.eval_env env) = 0) ∧ constraints_hold_from_list env ops
     | Operation.Lookup { table, entry, index := _ } =>
-      table.contains (entry.map (fun e => e.eval_env env)) ∧ constraints_hold_from_list env (op' :: ops)
-    | Operation.SubCircuit { soundness, .. } => soundness env ∧ constraints_hold_from_list env (op' :: ops)
-    | _ => constraints_hold_from_list env (op' :: ops)
+      table.contains (entry.map (fun e => e.eval_env env)) ∧ constraints_hold_from_list env ops
+    | Operation.SubCircuit { soundness, .. } => soundness env ∧ constraints_hold_from_list env ops
+    | _ => constraints_hold_from_list env ops
 
 @[reducible, simp]
 def constraints_hold [Field F] (env: (ℕ → F)) (circuit: Circuit F α) (ctx : Context F := .empty) : Prop :=

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -1,7 +1,3 @@
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Data.ZMod.Basic
-import Clean.Utils.Primes
-import Clean.Utils.Vector
 import Clean.Circuit.Expression
 import Clean.Circuit.Provable
 

--- a/Clean/Circuit/Expression.lean
+++ b/Clean/Circuit/Expression.lean
@@ -1,7 +1,4 @@
 import Mathlib.Algebra.Field.Basic
-import Mathlib.Data.ZMod.Basic
-import Clean.Utils.Primes
-import Clean.Utils.Vector
 
 variable {F: Type}
 

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -1,6 +1,4 @@
-import Mathlib.Algebra.Field.Basic
 import Mathlib.Data.ZMod.Basic
-import Clean.Utils.Primes
 import Clean.Utils.Vector
 import Clean.Circuit.Expression
 

--- a/Clean/Circuit/SubCircuit.lean
+++ b/Clean/Circuit/SubCircuit.lean
@@ -221,7 +221,7 @@ def formal_assertion_to_subcircuit (ctx: Context F)
 
     -- so we just need to go from flattened constraints to constraints
     guard_hyp h_holds : PreOperation.constraints_hold env (PreOperation.to_flat_operations ops)
-    exact PreOperation.can_flatten_first env ops h_holds
+    exact PreOperation.can_replace_subcircuits h_holds
 
     -- `implied_by_completeness`
     -- we are given that the assumptions and the spec are true
@@ -233,7 +233,7 @@ def formal_assertion_to_subcircuit (ctx: Context F)
     have h_holds : constraints_hold_from_list_default ops := circuit.completeness ctx b b_var rfl as.left as.right
 
     -- so we just need to go from constraints to flattened constraints
-    exact PreOperation.can_flatten ops h_holds
+    exact PreOperation.can_replace_subcircuits_default h_holds
 
   s
 end Circuit

--- a/Clean/Circuit/SubCircuit.lean
+++ b/Clean/Circuit/SubCircuit.lean
@@ -8,7 +8,7 @@ def to_flat_operations [Field F] (ops: List (Operation F)) : List (PreOperation 
   match ops with
   | [] => []
   | op :: ops => match op with
-    | Operation.Witness compute => Witness compute :: to_flat_operations ops
+    | Operation.Witness c => Witness c :: to_flat_operations ops
     | Operation.Assert e => Assert e :: to_flat_operations ops
     | Operation.Lookup l => Lookup l :: to_flat_operations ops
     | Operation.Assign c => Assign c :: to_flat_operations ops
@@ -51,7 +51,7 @@ Main soundness theorem which proves that flattened constraints imply nested cons
 It thereby justifies relying on the nested version `Circuit.constraints_hold_from_list`,
 where constraints of subcircuits are replaced with higher-level statements
 that imply (or are implied by) those constraints.
- -/
+-/
 theorem can_replace_subcircuits : ∀ {ops: List (Operation F)}, ∀ {env : ℕ → F},
   constraints_hold env (to_flat_operations ops) → constraints_hold_from_list env ops
 := by
@@ -108,6 +108,17 @@ lemma constraints_hold_default_append : ∀ {a b: List (PreOperation F)},
       have h_rest := ih.mpr ⟨ h_ops, h_b ⟩
       exact constraints_hold_default_cons.mpr ⟨ h_op, h_rest ⟩
 
+/--
+Main completeness theorem which proves that nested constraints imply flattened constraints
+using the default witness generator.
+
+This justifies only proving the nested version `Circuit.constraints_hold_from_list_default`,
+where constraints of subcircuits are replaced with higher-level statements
+that imply (or are implied by) those constraints.
+
+Note: Ideally, `can_replace_subcircuits` would prove both directions, and this would be just a special
+case. See https://github.com/Verified-zkEVM/clean/issues/42
+-/
 theorem can_replace_subcircuits_default : ∀ {ops: List (Operation F)},
   constraints_hold_from_list_default ops → constraints_hold_default (to_flat_operations ops)
 := by

--- a/Clean/Examples/Gadgets.lean
+++ b/Clean/Examples/Gadgets.lean
@@ -3,7 +3,7 @@ import Clean.GadgetsNew.Add8.Addition8
 
 section
 
-#eval!
+#eval
   let p := 1009
   let p_prime := Fact.mk prime_1009
   let p_non_zero := Fact.mk (by norm_num : p ≠ 0)

--- a/Clean/Examples/Gadgets.lean
+++ b/Clean/Examples/Gadgets.lean
@@ -1,10 +1,4 @@
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Data.ZMod.Basic
 import Clean.Utils.Primes
-import Clean.Utils.Vector
-import Clean.Circuit.Expression
-import Clean.Circuit.Provable
-import Clean.Circuit.Basic
 import Clean.GadgetsNew.Add8.Addition8
 
 section

--- a/Clean/GadgetsNew/Add8/Addition8.lean
+++ b/Clean/GadgetsNew/Add8/Addition8.lean
@@ -1,13 +1,3 @@
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Data.ZMod.Basic
-import Clean.Utils.Primes
-import Clean.Utils.Vector
-import Clean.Circuit.Expression
-import Clean.Circuit.Provable
-import Clean.Circuit.Basic
-import Clean.Utils.Field
-import Clean.GadgetsNew.ByteLookup
-import Clean.GadgetsNew.Boolean
 import Clean.GadgetsNew.Add8.Addition8Full
 
 namespace Add8

--- a/Clean/GadgetsNew/Add8/Addition8Full.lean
+++ b/Clean/GadgetsNew/Add8/Addition8Full.lean
@@ -1,14 +1,3 @@
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Data.ZMod.Basic
-import Clean.Utils.Primes
-import Clean.Utils.Vector
-import Clean.Circuit.Expression
-import Clean.Circuit.Provable
-import Clean.Circuit.Basic
-import Clean.Circuit.SubCircuit
-import Clean.Utils.Field
-import Clean.GadgetsNew.ByteLookup
-import Clean.GadgetsNew.Boolean
 import Clean.GadgetsNew.Add8.Addition8FullCarry
 
 namespace Add8Full

--- a/Clean/GadgetsNew/Add8/Addition8FullCarry.lean
+++ b/Clean/GadgetsNew/Add8/Addition8FullCarry.lean
@@ -1,12 +1,4 @@
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Data.ZMod.Basic
-import Clean.Utils.Primes
-import Clean.Utils.Vector
-import Clean.Circuit.Expression
-import Clean.Circuit.Provable
-import Clean.Circuit.Basic
 import Clean.Circuit.SubCircuit
-import Clean.Utils.Field
 import Clean.GadgetsNew.ByteLookup
 import Clean.GadgetsNew.Boolean
 import Clean.GadgetsNew.Add8.Theorems

--- a/Clean/GadgetsNew/Add8/Theorems.lean
+++ b/Clean/GadgetsNew/Add8/Theorems.lean
@@ -1,10 +1,3 @@
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Data.ZMod.Basic
-import Clean.Utils.Primes
-import Clean.Utils.Vector
-import Clean.Circuit.Expression
-import Clean.Circuit.Provable
-import Clean.Circuit.Basic
 import Clean.Utils.Field
 
 namespace Add8Theorems

--- a/Clean/GadgetsNew/Addition32Full.lean
+++ b/Clean/GadgetsNew/Addition32Full.lean
@@ -1,14 +1,3 @@
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Data.ZMod.Basic
-import Clean.Utils.Primes
-import Clean.Utils.Vector
-import Clean.Circuit.Expression
-import Clean.Circuit.Provable
-import Clean.Circuit.Basic
-import Clean.Circuit.SubCircuit
-import Clean.Utils.Field
-import Clean.GadgetsNew.ByteLookup
-import Clean.GadgetsNew.Boolean
 import Clean.GadgetsNew.Add8.Addition8FullCarry
 import Clean.Types.U32
 

--- a/Clean/GadgetsNew/Boolean.lean
+++ b/Clean/GadgetsNew/Boolean.lean
@@ -1,9 +1,3 @@
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Data.ZMod.Basic
-import Clean.Utils.Primes
-import Clean.Utils.Vector
-import Clean.Circuit.Expression
-import Clean.Circuit.Provable
 import Clean.Circuit.Basic
 import Clean.Utils.Field
 

--- a/Clean/GadgetsNew/ByteLookup.lean
+++ b/Clean/GadgetsNew/ByteLookup.lean
@@ -26,8 +26,7 @@ def ByteTable.completeness (x: F p) : x.val < 256 → ByteTable.contains (vec [x
   dsimp [Table.contains, ByteTable]
   use x.val
   simp [from_byte]
-  dsimp [vec]
-  rw [←Vector.vec_eq]
+  ext1
   have h' : (x.val) % 256 = x.val := by
     rw [Nat.mod_eq_iff_lt]; assumption; norm_num
   simp [h']

--- a/Clean/GadgetsNew/ByteLookup.lean
+++ b/Clean/GadgetsNew/ByteLookup.lean
@@ -1,9 +1,3 @@
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Data.ZMod.Basic
-import Clean.Utils.Primes
-import Clean.Utils.Vector
-import Clean.Circuit.Expression
-import Clean.Circuit.Provable
 import Clean.Circuit.Basic
 import Clean.Utils.Field
 

--- a/Clean/Types/Byte.lean
+++ b/Clean/Types/Byte.lean
@@ -1,13 +1,4 @@
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Data.ZMod.Basic
-import Clean.Utils.Primes
-import Clean.Utils.Vector
-import Clean.Circuit.Expression
-import Clean.Circuit.Provable
-import Clean.Circuit.Basic
-import Clean.Utils.Field
 import Clean.GadgetsNew.ByteLookup
-
 
 section
 variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -1,11 +1,3 @@
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Data.ZMod.Basic
-import Clean.Utils.Primes
-import Clean.Utils.Vector
-import Clean.Circuit.Expression
-import Clean.Circuit.Provable
-import Clean.Circuit.Basic
-import Clean.Utils.Field
 import Clean.GadgetsNew.ByteLookup
 
 section

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -1,4 +1,6 @@
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Tactic.Basic
+import Mathlib.Data.ZMod.Basic
 
 variable {α β : Type} {n : ℕ}
 
@@ -19,28 +21,28 @@ namespace Vector
     simp [Subtype.mk_eq_mk] at h
     simp [h]
 
-  theorem length_matches (v: Vector α n) : v.1.length = n := v.2
-
   @[simp]
   def map (f: α → β) : Vector α n → Vector β n
     | ⟨ l, h ⟩ => ⟨ l.map f, by rw [List.length_map, h] ⟩
 
-  @[simp]
-  def zip : Vector α n → Vector β n → Vector (α × β) n
+  def zip {n} : Vector α n → Vector β n → Vector (α × β) n
     | ⟨ [], ha ⟩, ⟨ [], _ ⟩  => ⟨ [], ha ⟩
-    | ⟨ a::as, ha ⟩, ⟨ b::bs, hb ⟩ => ⟨ (a, b) :: List.zip as bs, by sorry ⟩
+    | ⟨ a::as, (ha : as.length + 1 = n) ⟩,
+      ⟨ b::bs, (hb : bs.length + 1 = n) ⟩ =>
+      let ⟨ z, hz ⟩ := zip ⟨ as, rfl ⟩ ⟨ bs, by apply Nat.add_one_inj.mp; rw [ha, hb] ⟩
+      ⟨ (a, b) :: z, by show z.length + 1 = n; rw [hz, ha] ⟩
 
   @[simp]
   def get (v: Vector α n) (i: Fin n) : α :=
-    let i' : Fin v.1.length := Fin.cast (length_matches v).symm i
+    let i' : Fin v.1.length := Fin.cast v.prop.symm i
     v.val.get i'
 
   -- map over monad
   def mapM {M : Type → Type} {n} [Monad M] (v : Vector (M α) n) : M (Vector α n) :=
     match (v : Vector (M α) n) with
     | ⟨ [], h ⟩ => pure ⟨ [], h ⟩
-    | ⟨ a :: as, h ⟩ => do
+    | ⟨ a :: as, (h : as.length + 1 = n) ⟩ => do
       let hd ← a
       let tl ← mapM ⟨ as, rfl ⟩
-      pure ⟨ hd :: tl.val, by rwa [List.length_cons, length_matches]⟩
+      pure ⟨ hd :: tl.val, by rwa [List.length_cons, tl.prop]⟩
 end Vector


### PR DESCRIPTION
closes #37 

* Finishes the theorems that justify replacing subcircuit constraints with their soundness / completeness statements
* Finishes proofs for `Vector`
* => there are no remaining `sorry` proofs in the core lib!
* Prune imports across the project