### PR TITLE
Add support for defining constraints over traces: definition and soundness direction

### DIFF
--- a/Clean.lean
+++ b/Clean.lean
@@ -5,3 +5,4 @@
 -- new version
 import Clean.Examples.Gadgets
 import Clean.GadgetsNew.Addition32Full
+import Clean.Table.Basic

--- a/Clean.lean
+++ b/Clean.lean
@@ -5,4 +5,5 @@
 -- new version
 import Clean.Examples.Gadgets
 import Clean.GadgetsNew.Addition32Full
-import Clean.Table.Basic
+import Clean.TablesNew.Addition8
+import Clean.TablesNew.Fibonacci8

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -23,13 +23,8 @@ structure Lookup (F : Type) where
 instance [Repr F] : Repr (Lookup F) where
   reprPrec l _ := "(Lookup " ++ l.table.name ++ " " ++ repr l.entry ++ ")"
 
-inductive RowIndex
-  | Current
-  | Next
-deriving Repr
-
 structure Cell (F : Type) where
-  row: RowIndex
+  rowOffset: ℕ
   column: ℕ -- index of the column
 deriving Repr
 

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -23,25 +23,18 @@ structure Lookup (F : Type) where
 instance [Repr F] : Repr (Lookup F) where
   reprPrec l _ := "(Lookup " ++ l.table.name ++ " " ++ repr l.entry ++ ")"
 
-structure Cell (F : Type) where
-  rowOffset: ℕ
-  column: ℕ -- index of the column
-deriving Repr
-
 variable {α : Type} [Field F]
 
 inductive PreOperation (F : Type) where
   | Witness : (compute : Unit → F) → PreOperation F
   | Assert : Expression F → PreOperation F
   | Lookup : Lookup F → PreOperation F
-  | Assign : Cell F × Variable F → PreOperation F
 
 namespace PreOperation
 def toString [Repr F] : PreOperation F → String
   | Witness _v => "Witness"
   | Assert e => "(Assert " ++ reprStr e ++ " == 0)"
   | Lookup l => reprStr l
-  | Assign (c, v) => "(Assign " ++ reprStr c ++ ", " ++ reprStr v ++ ")"
 
 instance [Repr F] : Repr (PreOperation F) where
   reprPrec op _ := toString op
@@ -100,7 +93,6 @@ inductive Operation (F : Type) [Field F] where
   | Witness : (compute : Unit → F) → Operation F
   | Assert : Expression F → Operation F
   | Lookup : Lookup F → Operation F
-  | Assign : Cell F × Variable F → Operation F
   | SubCircuit : SubCircuit F → Operation F
 
 structure Context (F : Type) where
@@ -122,7 +114,6 @@ instance [Repr F] : ToString (Operation F) where
     | Witness _v => "Witness"
     | Assert e => "(Assert " ++ reprStr e ++ " == 0)"
     | Lookup l => reprStr l
-    | Assign (c, v) => "(Assign " ++ reprStr c ++ ", " ++ reprStr v ++ ")"
     | SubCircuit { ops, .. } => "(SubCircuit " ++ reprStr ops ++ ")"
 end Operation
 
@@ -181,12 +172,6 @@ def assert_zero (e: Expression F) := as_circuit (
 @[simp]
 def lookup (l: Lookup F) := as_circuit (
   fun _ => (Operation.Lookup l, ())
-)
-
--- assign a variable to a cell
-@[simp]
-def assign_cell (c: Cell F) (v: Variable F) := as_circuit (
-  fun _ => (Operation.Assign (c, v), ())
 )
 
 -- formal concepts of soundness and completeness of a circuit
@@ -278,4 +263,4 @@ def subcircuit_completeness (circuit: FormalCircuit F β α) (b_var : β.var) :=
   circuit.assumptions b
 end Circuit
 
-export Circuit (witness_var witness assert_zero lookup assign_cell FormalCircuit)
+export Circuit (witness_var witness assert_zero lookup FormalCircuit)

--- a/Clean/Circuit/Extensions.lean
+++ b/Clean/Circuit/Extensions.lean
@@ -33,16 +33,5 @@ def to_var [Field F] (x: Expression F) : Circuit F (Variable F) :=
     assert_zero (x - (var x'))
     return x'
 
--- inputs, already connected to a cell, that you can assign the next row's value of
--- TODO figure out if this is the best way to connect to a trace
-structure InputCell (F : Type) where
-  cell: { cell: Cell F // cell.row = RowIndex.Current }
-  var: Variable F
 
-def InputCell.set_next [Field F] (c: InputCell F) (v: Expression F) := do
-  let v' ← to_var v
-  assign_cell { c.cell.val with row := RowIndex.Next } v'
-
-instance : Coe (InputCell F) (Variable F) where
-  coe x := x.var
 end Circuit

--- a/Clean/Circuit/SubCircuit.lean
+++ b/Clean/Circuit/SubCircuit.lean
@@ -12,7 +12,6 @@ def to_flat_operations [Field F] (ops: List (Operation F)) : List (PreOperation 
     | Operation.Witness compute => PreOperation.Witness compute :: to_flat_operations ops
     | Operation.Assert e => PreOperation.Assert e :: to_flat_operations ops
     | Operation.Lookup l => PreOperation.Lookup l :: to_flat_operations ops
-    | Operation.Assign (c, v) => PreOperation.Assign (c, v) :: to_flat_operations ops
     | Operation.SubCircuit circuit => circuit.ops ++ to_flat_operations ops
 
 -- TODO super painful, mainly because `cases` doesn't allow rich patterns -- how does this work again?
@@ -49,7 +48,6 @@ theorem can_flatten_first : ∀ (env: ℕ → F) (ops: List (Operation F)),
         have ih1 := ih h1
         simp [ih1]
       | Lookup l => sorry
-      | Assign a => sorry
 
 theorem can_flatten : ∀ (ops: List (Operation F)),
   Circuit.constraints_hold_from_list_default ops →

--- a/Clean/GadgetsNew/Equality.lean
+++ b/Clean/GadgetsNew/Equality.lean
@@ -1,0 +1,79 @@
+import Mathlib.Algebra.Field.Basic
+import Mathlib.Data.ZMod.Basic
+import Clean.Utils.Primes
+import Clean.Utils.Vector
+import Clean.Circuit.Expression
+import Clean.Circuit.Provable
+import Clean.Circuit.Basic
+import Clean.Utils.Field
+
+section
+variable {p : ℕ} [Fact p.Prime]
+
+
+namespace Equality
+structure InputStruct (F : Type) where
+  x: F
+  y: F
+
+def Inputs (p : ℕ) : TypePair := ⟨
+  InputStruct (Expression (F p)),
+  InputStruct (F p)
+⟩
+
+instance : ProvableType (F p) (Inputs p) where
+  size := 2
+  to_vars s := vec [s.x, s.y]
+  from_vars v :=
+    let ⟨ [x, y], _ ⟩ := v
+    ⟨ x, y ⟩
+  to_values s := vec [s.x, s.y]
+  from_values v :=
+    let ⟨ [x, y], _ ⟩ := v
+    ⟨ x, y ⟩
+
+
+def assert_eq (input : (Inputs p).var) := do
+  let ⟨x, y⟩ := input
+  assert_zero (x - y)
+
+def spec (input: (Inputs p).value) :=
+  let ⟨x, y⟩ := input
+  x = y
+
+
+def circuit : FormalAssertion (F p) (Inputs p) where
+  main := assert_eq
+  assumptions _ := True
+  spec := spec
+
+  soundness := by
+    intro ctx env input vars h_inputs _ h_holds
+    let ⟨x, y⟩ := input
+    let ⟨x_var, y_var⟩ := vars
+
+    dsimp at h_holds
+    have hx : x_var.eval_env env = x := by injection h_inputs
+    have hy : y_var.eval_env env = y := by injection h_inputs
+    rw [hx, hy] at h_holds
+
+    dsimp [spec]
+    ring_nf at h_holds
+    rw [sub_eq_zero] at h_holds
+    assumption
+
+  completeness := by
+    -- introductions
+    rintro ctx inputs inputs_var h_inputs _
+    let ⟨x, y⟩ := inputs
+    let ⟨x_var, y_var⟩ := inputs_var
+
+    -- characterize inputs
+    have hx : x_var.eval = x := by injection h_inputs
+    have hy : y_var.eval = y := by injection h_inputs
+
+    simp [spec]
+    intro spec
+    rw [hx, hy, spec]
+    ring
+end Equality

--- a/Clean/GadgetsNew/Equality.lean
+++ b/Clean/GadgetsNew/Equality.lean
@@ -44,7 +44,7 @@ def spec (input: (Inputs p).value) :=
 
 def circuit : FormalAssertion (F p) (Inputs p) where
   main := assert_eq
-  assumptions _ := True
+  assumptions _ := true
   spec := spec
 
   soundness := by

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -61,6 +61,11 @@ lemma len_ge_succ_of_ge {M : ℕ+} {N : ℕ} {F : Type} (trace : Trace M F) (row
   | <+> => by simp [Trace.len] at *; simp [h]
   | (rest +> row) => by simp [Trace.len] at *; linarith
 
+/--
+  This induction principle states that if a trace length is at leas two, then to prove a property
+  about the whole trace, we can provide just a proof for the first two rows, and then a proof
+  for the inductive step.
+-/
 def everyRowTwoRowsInduction' {M : ℕ+} {F : Type} {P : (t : Trace M F) → t.len ≥ 2 → Sort*}
     (base : ∀ first second (h : (<+> +> first +> second).len ≥ 2), P (<+> +> first +> second) h)
     (more : ∀ curr next : Row M F,
@@ -78,6 +83,7 @@ def everyRowTwoRowsInduction' {M : ℕ+} {F : Type} {P : (t : Trace M F) → t.l
       let ih' := (everyRowTwoRowsInduction' base more (rest))
       let ih'' := (everyRowTwoRowsInduction' base more (rest +> curr))
       (Nat.lt_or_ge 2 rest.len).by_cases
+        -- TODO: this definition should be similar to Nat.letRec
         (by sorry)
         (by sorry)
 

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -9,7 +9,7 @@ import Clean.Utils.Field
 
 import Clean.GadgetsNew.Add8.Addition8
 
-
+-- TODO: this should be something so that we can give names to the columns
 def Row (M : ℕ+) (F : Type) := Fin M -> F
 
 /--
@@ -56,6 +56,7 @@ def getLe {M :ℕ+} {F : Type}:
 
 end Trace
 
+
 /--
   A trace of length M is a trace with exactly M rows.
 -/
@@ -66,10 +67,6 @@ namespace TraceOfLength
 def get {N: ℕ+} {M : ℕ} {F : Type} : (env : TraceOfLength N M F) -> (i : Fin M) -> (j : Fin N) -> F
   | ⟨env, h⟩, i, j => env.getLe (by rw [←h] at i; exact i) j
 
-end TraceOfLength
-
-
-section Table
 /--
   Apply a proposition to every row in the trace
 -/
@@ -102,6 +99,8 @@ def forAllRowsOfTraceWithIndex {N: ℕ+} {M : ℕ} {F : Type} (trace : TraceOfLe
     | <+>, _ => true
     | rest +> row, prop => (prop row rest.len) ∧ inner rest prop
 
+end TraceOfLength
+
 /--
   A cell offset is an offset in a table that points to a specific cell in a row.
   It is used to define a relative position in the trace.
@@ -120,28 +119,158 @@ deriving Repr
 @[reducible]
 def CellAssignment (M W: ℕ+) := ℕ -> CellOffset M W
 
-inductive TableConstraint
-    (F : Type) [Field F]
-    (M : ℕ+) where
+/--
+  Atomic operations for constructing a table constraint, which is a constraint applied to a window
+  of rows in a table.
+-/
+inductive TableConstraintOperation (F : Type) [Field F] (M W : ℕ+) where
+  /--
+    Add some witnessed variable to the context
+  -/
+  | Witness : CellOffset M W -> (compute : Unit → F) -> TableConstraintOperation F M W
+
+  /--
+    Allocate a subcircuit in the trace
+  -/
+  | Allocate: SubCircuit F -> TableConstraintOperation F M W
+
+  /--
+    Assign a variable to a cell in the trace
+  -/
+  | Assign : Variable F -> CellOffset M W -> TableConstraintOperation F M W
+
+/--
+  Context of the TableConstraint that keeps track of the current state, this includes the underlying
+  context of the gadgets, and the current assignment of the variables to the cells in the trace.
+-/
+structure TableContext (F : Type) (M W : ℕ+) where
+  subContext: Context F
+  assignment : CellAssignment M W
+
+@[simp]
+def TableContext.empty {F : Type} {M W : ℕ+} : TableContext F M W := ⟨
+  Context.empty,
+  -- TODO: is there a better way?
+  fun _ => ⟨0, 0⟩
+⟩
+
+namespace TableConstraintOperation
+
+@[simp]
+def update_context {F : Type} {M W : ℕ+} [Field F] (ctx: TableContext F M W) : TableConstraintOperation F M W → TableContext F M W
+  | Witness offset _ => {
+      subContext := ⟨ ctx.subContext.offset + 1 ⟩,
+      assignment := fun x => if x = ctx.subContext.offset then offset else ctx.assignment x
+    }
+  | Allocate { ops, .. } => {
+      subContext := ⟨ ctx.subContext.offset + PreOperation.witness_length ops ⟩,
+      assignment := ctx.assignment
+    }
+  | Assign v offset => {
+      subContext := ctx.subContext,
+      assignment := fun x => if x = v.index then offset else ctx.assignment x
+    }
+
+instance {F : Type} {M W : ℕ+} [Field F] [Repr F] : ToString (TableConstraintOperation F M W) where
+  toString
+    | Witness offset _ => "(Witness " ++ reprStr offset ++ ")"
+    | Allocate {ops, ..} => "(Allocate " ++ reprStr ops ++ ")"
+    | Assign v offset => "(Assign " ++ reprStr v ++ " " ++ reprStr offset ++ ")"
+
+end TableConstraintOperation
+
+
+@[simp]
+def TableConstraint (F : Type) [Field F] (M W : ℕ+) (α : Type) :=
+  TableContext F M W → (TableContext F M W × List (TableConstraintOperation F M W)) × α
+
+namespace TableConstraint
+instance (F : Type) [Field F] (M W : ℕ+): Monad (TableConstraint F M W) where
+  pure a ctx := ((ctx, []), a)
+  bind f g ctx :=
+    let ((ctx', ops), a) := f ctx
+    let ((ctx'', ops'), b) := g a ctx'
+    ((ctx'', ops ++ ops'), b)
+
+
+def as_table_operation {α: Type} {F : Type} {M W : ℕ+} [Field F]
+  (f : TableContext F M W -> TableConstraintOperation F M W × α) : TableConstraint F M W α :=
+  fun ctx =>
+  let (op, a) := f ctx
+  let ctx' := TableConstraintOperation.update_context ctx op
+  ((ctx', [op]), a)
+
+def operations {α : Type} {F : Type} {M W : ℕ+} [Field F] (table : TableConstraint F M W α) : List (TableConstraintOperation F M W) :=
+  let ((_, ops), _) := table TableContext.empty
+  ops
+
+def output {α : Type} {F : Type} {M W : ℕ+} [Field F] (table : TableConstraint F M W α) : α :=
+  let ((_, _), a) := table TableContext.empty
+  a
+
+@[simp]
+def witness_cell {F : Type} {M W : ℕ+} [Field F] (off : CellOffset M W) (compute : Unit → F): TableConstraint F M W (Variable F) :=
+  as_table_operation fun ctx =>
+  (TableConstraintOperation.Witness off compute, ⟨ ctx.subContext.offset, compute ⟩)
+
+@[simp]
+def subcircuit
+    {F : Type} {M W : ℕ+} [Field F]
+    {α β : TypePair} [ProvableType F β] [ProvableType F α]
+    (circuit: FormalCircuit F β α) (b: β.var) : TableConstraint F M W α.var :=
+  as_table_operation fun ctx =>
+  let ⟨ a, subcircuit ⟩ := Circuit.formal_circuit_to_subcircuit ctx.subContext circuit b
+  (TableConstraintOperation.Allocate subcircuit, a)
+
+def assign {F : Type} {M W : ℕ+} [Field F] (v: Variable F) (off : CellOffset M W) : TableConstraint F M W Unit :=
+  as_table_operation fun _ =>
+  (TableConstraintOperation.Assign v off, ())
+
+end TableConstraint
+
+section Example
+#eval!
+  let p := 1009
+  let p_prime := Fact.mk prime_1009
+  let p_non_zero := Fact.mk (by norm_num : p ≠ 0)
+  let p_large_enough := Fact.mk (by norm_num : p > 512)
+  let ex : TableConstraint (F p) 3 1 _ := do
+    let x <- TableConstraint.witness_cell ⟨0, 0⟩ (fun _ => (10 : F p))
+    let y <- TableConstraint.witness_cell ⟨0, 1⟩ (fun _ => (20 : F p))
+    let add8Inputs : (Add8.Inputs p).var := ⟨x, y⟩
+    let z : Expression (F p) <- TableConstraint.subcircuit Add8.circuit add8Inputs
+    let z_var : Variable (F p) := match z with
+      | var v => v
+      | _ => Variable.mk 42 (fun _ => 42)
+    TableConstraint.assign z_var ⟨0, 2⟩
+    return z
+  ex.operations
+
+
+end Example
+
+
+
+inductive TableOperation (F : Type) [Field F] (M : ℕ+) where
   /--
     A `Boundary` constraint is a constraint that is applied only to a specific row
   -/
   | Boundary (β α : TypePair) [ProvableType F α] [ProvableType F β]:
-      FormalCircuit F β α -> CellAssignment M 1 -> (row : ℕ) -> TableConstraint F M
+      FormalCircuit F β α -> CellAssignment M 1 -> (row : ℕ) -> TableOperation F M
 
   /--
     An `EveryRow` constraint is a constraint that is applied to every row.
     It can only reference cells on the same row
   -/
   | EveryRow {β α : TypePair} [ProvableType F α] [ProvableType F β]:
-      FormalCircuit F β α -> CellAssignment M 1 -> TableConstraint F M
+      FormalCircuit F β α -> CellAssignment M 1 -> TableOperation F M
 
   /--
     An `EveryRowExceptLast` constraint is a constraint that is applied to every row except the last.
     It can reference cells from the current row, or the next row
   -/
   | EveryRowExceptLast (β α : TypePair) [ProvableType F α] [ProvableType F β]:
-      FormalCircuit F β α -> CellAssignment M 2 -> TableConstraint F M
+      FormalCircuit F β α -> CellAssignment M 2 -> TableOperation F M
 
 
 
@@ -152,7 +281,7 @@ inductive TableConstraint
 -/
 def table_constraints_hold
     (F : Type) [Field F] (M : ℕ+) (N : ℕ)
-    (constraints : List (TableConstraint F M)) (trace: TraceOfLength M N F) : Prop :=
+    (constraints : List (TableOperation F M)) (trace: TraceOfLength M N F) : Prop :=
   foldl constraints trace.val constraints
   where
   /--
@@ -172,10 +301,10 @@ def table_constraints_hold
   `cs_iterator` is walked inductively for every row.
   Once the `cs_iterator` is empty, we start again on the rest of the trace with the initial constraints `cs`
   -/
-  foldl (cs : List (TableConstraint F M)) : Trace M F -> (cs_iterator: List (TableConstraint F M)) -> Prop
+  foldl (cs : List (TableOperation F M)) : Trace M F -> (cs_iterator: List (TableOperation F M)) -> Prop
 
     -- if the trace has at least two rows and the constraint is a "every row except last" constraint, we apply the constraint
-    | trace +> curr +> next, (TableConstraint.EveryRowExceptLast β α circuit assignment)::rest =>
+    | trace +> curr +> next, (TableOperation.EveryRowExceptLast β α circuit assignment)::rest =>
         let env : ℕ -> F := fun x =>
           match assignment x with
           | ⟨⟨0, _⟩, j⟩ => curr j
@@ -186,7 +315,7 @@ def table_constraints_hold
 
     -- if the trace has at least one row and the constraint is a boundary constraint, we apply the constraint if the
     -- index is the same as the length of the remaining trace
-    | trace +> row, (TableConstraint.Boundary β α circuit assignment idx)::rest =>
+    | trace +> row, (TableOperation.Boundary β α circuit assignment idx)::rest =>
         let env : ℕ -> F := fun x =>
           match assignment x with
           | ⟨⟨0, _⟩, j⟩ => row j
@@ -199,7 +328,7 @@ def table_constraints_hold
           others
 
     -- if the trace has at least one row and the constraint is a "every row" constraint, we apply the constraint
-    | trace +> row, (TableConstraint.EveryRow (β :=β) (α:=α) circuit assignment)::rest =>
+    | trace +> row, (TableOperation.EveryRow (β :=β) (α:=α) circuit assignment)::rest =>
         let env : ℕ -> F := fun x =>
           match assignment x with
           | ⟨⟨0, _⟩, j⟩ => row j
@@ -209,7 +338,7 @@ def table_constraints_hold
 
     -- if the trace has not enough rows for the "every row except last" constraint, we skip the constraint
     -- TODO: this is fine if the trace length M is >= 2, but we should check this somehow
-    | trace, (TableConstraint.EveryRowExceptLast _ _ _ _)::rest =>
+    | trace, (TableOperation.EveryRowExceptLast _ _ _ _)::rest =>
         foldl cs trace rest
 
     -- if the cs_iterator is empty, we start again with the initial constraints on the next row
@@ -218,125 +347,3 @@ def table_constraints_hold
 
     -- if the trace is empty, we are done
     | <+>, _ => True
-
-
-inductive TableOperation (F : Type) [Field F] (M W : ℕ+) where
-  /--
-    Add some witnessed variable to the context
-    TODO: there should be the possibility to work with ProvableType directly in-trace
-  -/
-  | Witness : CellOffset M W -> (compute : Unit → F) -> TableOperation F M W
-
-  /--
-    Allocate a subcircuit in the trace
-  -/
-  | Allocate: SubCircuit F -> TableOperation F M W
-
-  /--
-    Assign a variable to a cell in the trace
-  -/
-  | Assign : Variable F -> CellOffset M W -> TableOperation F M W
-
-structure TableContext (F : Type) (M W : ℕ+) where
-  subContext: Context F
-  assignment : CellAssignment M W
-
-@[simp]
-def TableContext.empty {F : Type} {M W : ℕ+} : TableContext F M W := ⟨
-  Context.empty,
-  -- TODO: is there a better way?
-  fun _ => ⟨0, 0⟩
-⟩
-
-namespace TableOperation
-
-@[simp]
-def update_context {F : Type} {M W : ℕ+} [Field F] (ctx: TableContext F M W) : TableOperation F M W → TableContext F M W
-  | Witness offset _ => {
-      subContext := ⟨ ctx.subContext.offset + 1 ⟩,
-      assignment := fun x => if x = ctx.subContext.offset then offset else ctx.assignment x
-    }
-  | Allocate { ops, .. } => {
-      subContext := ⟨ ctx.subContext.offset + PreOperation.witness_length ops ⟩,
-      assignment := ctx.assignment
-    }
-  | Assign v offset => {
-      subContext := ctx.subContext,
-      assignment := fun x => if x = v.index then offset else ctx.assignment x
-    }
-
-instance {F : Type} {M W : ℕ+} [Field F] [Repr F] : ToString (TableOperation F M W) where
-  toString
-    | Witness offset _ => "(Witness " ++ reprStr offset ++ ")"
-    | Allocate {ops, ..} => "(Allocate " ++ reprStr ops ++ ")"
-    | Assign v offset => "(Assign " ++ reprStr v ++ " " ++ reprStr offset ++ ")"
-
-@[simp]
-def Table (F : Type) [Field F] (M W : ℕ+) (α : Type) :=
-  TableContext F M W → (TableContext F M W × List (TableOperation F M W)) × α
-
-namespace Table
-instance (F : Type) [Field F] (M W : ℕ+): Monad (Table F M W) where
-  pure a ctx := ((ctx, []), a)
-  bind f g ctx :=
-    let ((ctx', ops), a) := f ctx
-    let ((ctx'', ops'), b) := g a ctx'
-    ((ctx'', ops ++ ops'), b)
-
-
-def as_table_operation {α: Type} {F : Type} {M W : ℕ+} [Field F]
-  (f : TableContext F M W -> TableOperation F M W × α) : Table F M W α :=
-  fun ctx =>
-  let (op, a) := f ctx
-  let ctx' := update_context ctx op
-  ((ctx', [op]), a)
-
-def operations {α : Type} {F : Type} {M W : ℕ+} [Field F] (table : Table F M W α) : List (TableOperation F M W) :=
-  let ((_, ops), _) := table TableContext.empty
-  ops
-
-def output {α : Type} {F : Type} {M W : ℕ+} [Field F] (table : Table F M W α) : α :=
-  let ((_, _), a) := table TableContext.empty
-  a
-
-
-@[simp]
-def witness_cell {F : Type} {M W : ℕ+} [Field F] (off : CellOffset M W) (compute : Unit → F): Table F M W (Variable F) :=
-  as_table_operation fun ctx =>
-  (TableOperation.Witness off compute, ⟨ ctx.subContext.offset, compute ⟩)
-
-@[simp]
-def subcircuit
-    {F : Type} {M W : ℕ+} [Field F]
-    {α β : TypePair} [ProvableType F β] [ProvableType F α]
-    (circuit: FormalCircuit F β α) (b: β.var) : Table F M W α.var :=
-  as_table_operation fun ctx =>
-  let ⟨ a, subcircuit ⟩ := Circuit.formal_circuit_to_subcircuit ctx.subContext circuit b
-  (TableOperation.Allocate subcircuit, a)
-
-def assign {F : Type} {M W : ℕ+} [Field F] (v: Variable F) (off : CellOffset M W) : Table F M W Unit :=
-  as_table_operation fun _ =>
-  (TableOperation.Assign v off, ())
-
-end Table
-
-section Example
-#eval!
-  let p := 1009
-  let p_prime := Fact.mk prime_1009
-  let p_non_zero := Fact.mk (by norm_num : p ≠ 0)
-  let p_large_enough := Fact.mk (by norm_num : p > 512)
-  let asd : Table (F p) 3 1 _ := do
-    let x <- Table.witness_cell ⟨0, 0⟩ (fun _ => (10 : F p))
-    let y <- Table.witness_cell ⟨0, 1⟩ (fun _ => (20 : F p))
-    let add8Inputs : (Add8.Inputs p).var := ⟨x, y⟩
-    let z : Expression (F p) <- Table.subcircuit Add8.circuit add8Inputs
-    let z_var : Variable (F p) := match z with
-      | var v => v
-      | _ => Variable.mk 42 (fun _ => 42)
-    Table.assign z_var ⟨0, 2⟩
-    return z
-  asd.operations
-
-
-end Example

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -30,6 +30,7 @@ namespace Trace
 /--
   The length of a trace is the number of rows it contains.
 -/
+@[simp]
 def len {M : ℕ+} {F : Type} : Trace M F -> ℕ
   | <+> => 0
   | rest +> _ => Nat.succ rest.len
@@ -50,10 +51,43 @@ def everyRowTwoRowsInduction {M : ℕ+} {F : Type} {P : Trace M F → Sort*}
     (everyRowTwoRowsInduction zero one more (rest))
     (everyRowTwoRowsInduction zero one more (rest +> curr))
 
-def getLe {M :ℕ+} {F : Type}:
+lemma len_le_succ {M : ℕ+} {F : Type} (trace : Trace M F) (row : Row M F) : trace.len ≤ (trace +> row).len :=
+  match trace with
+  | <+> => by simp [Trace.len]
+  | (rest +> row) =>
+    let ih := len_le_succ rest row
+    by simp [Trace.len, ih, Nat.le_succ]
+
+lemma len_ge_succ_of_ge {M : ℕ+} {N : ℕ} {F : Type} (trace : Trace M F) (row : Row M F) (h : trace.len ≥ N) : (trace +> row).len ≥ N :=
+  match trace with
+  | <+> => by simp [Trace.len] at *; simp [h]
+  | (rest +> row) => by simp [Trace.len] at *; linarith
+
+def everyRowTwoRowsInduction' {M : ℕ+} {F : Type} {P : (t : Trace M F) → t.len ≥ 2 → Sort*}
+    (base : ∀ first second (h : (<+> +> first +> second).len ≥ 2), P (<+> +> first +> second) h)
+    (more : ∀ curr next : Row M F,
+      ∀ (rest : Trace M F) (h : rest.len ≥ 2),
+        P rest h ->
+        P (rest +> curr) (len_ge_succ_of_ge _ _ h) →
+        P (rest +> curr +> next) (len_ge_succ_of_ge _ _ (len_ge_succ_of_ge _ _ h)))
+    : ∀ (trace : Trace M F) (h : trace.len ≥ 2), P trace h
+  -- the cases where the trace is empty or has only one row are trivial,
+  -- since the length is greater than 2
+  | <+> => by intro h; contradiction
+  | <+> +> first => by intro h; contradiction
+  | <+> +> first +> second => fun h => base first second h
+  | rest +> curr +> next =>
+      let ih' := (everyRowTwoRowsInduction' base more (rest))
+      let ih'' := (everyRowTwoRowsInduction' base more (rest +> curr))
+      (Nat.lt_or_ge 2 rest.len).by_cases
+        (by sorry)
+        (by sorry)
+
+@[simp]
+def getLeFromBottom {M :ℕ+} {F : Type}:
     (trace : Trace M F) -> (row : Fin trace.len) -> (col : Fin M) -> F
   | _ +> currRow, ⟨0, _⟩, j => currRow j
-  | rest +> _, ⟨i + 1, h⟩, j => getLe rest ⟨i, Nat.le_of_succ_le_succ h⟩ j
+  | rest +> _, ⟨i + 1, h⟩, j => getLeFromBottom rest ⟨i, Nat.le_of_succ_le_succ h⟩ j
 
 end Trace
 
@@ -65,15 +99,21 @@ def TraceOfLength (F : Type) (M : ℕ+) (N : ℕ) : Type := { env : Trace M F //
 
 namespace TraceOfLength
 
+@[simp]
 def get {N: ℕ+} {M : ℕ} {F : Type} : (env : TraceOfLength F N M) -> (i : Fin M) -> (j : Fin N) -> F
-  | ⟨env, h⟩, i, j => env.getLe (by rw [←h] at i; exact i) j
+  | ⟨env, h⟩, i, j => env.getLeFromBottom ⟨
+      M - 1 - i,
+      by rw [h]; apply Nat.sub_one_sub_lt_of_lt; exact i.is_lt
+    ⟩ j
 
 /--
   Apply a proposition to every row in the trace
 -/
+@[simp]
 def forAllRowsOfTrace {N: ℕ+} {M : ℕ} {F : Type} (trace : TraceOfLength F N M) (prop : Row N F -> Prop) : Prop :=
   inner trace.val prop
   where
+  @[simp]
   inner : Trace N F -> (Row N F -> Prop) -> Prop
     | <+>, _ => true
     | rest +> row, prop => prop row ∧ inner rest prop
@@ -81,6 +121,7 @@ def forAllRowsOfTrace {N: ℕ+} {M : ℕ} {F : Type} (trace : TraceOfLength F N 
 /--
   Apply a proposition to every row in the trace except the last one
 -/
+@[simp]
 def forAllRowsOfTraceExceptLast {N: ℕ+} {M : ℕ} {F : Type} (trace : TraceOfLength F N M) (prop : Row N F -> Prop) : Prop :=
   inner trace.val prop
   where
@@ -93,9 +134,11 @@ def forAllRowsOfTraceExceptLast {N: ℕ+} {M : ℕ} {F : Type} (trace : TraceOfL
 /--
   Apply a proposition, which could be dependent on the row index, to every row of the trace
 -/
+@[simp]
 def forAllRowsOfTraceWithIndex {N: ℕ+} {M : ℕ} {F : Type} (trace : TraceOfLength F N M) (prop : Row N F -> ℕ -> Prop) : Prop :=
   inner trace.val prop
   where
+  @[simp]
   inner : Trace N F -> (Row N F -> ℕ -> Prop) -> Prop
     | <+>, _ => true
     | rest +> row, prop => (prop row rest.len) ∧ inner rest prop
@@ -218,6 +261,7 @@ def assignment {α : Type} {F : Type} {M W : ℕ+} [Field F] (table : TableConst
   let ((ctx, _), _) := table TableContext.empty
   ctx.assignment
 
+@[simp]
 def constraints_hold_on_window {F : Type} {M W : ℕ+} [Field F]
     (table : TableConstraint F M W Unit) (window: TraceOfLength F M W) : Prop :=
   let ((ctx, ops), ()) := table TableContext.empty
@@ -230,12 +274,14 @@ def constraints_hold_on_window {F : Type} {M W : ℕ+} [Field F]
   -- then we fold over allocated sub-circuits
   -- lifting directly to the soundness of the sub-circuit
   foldl ops env
-  where foldl : List (TableConstraintOperation F M W) -> (env: ℕ -> F) -> Prop
-    | [], _ => true
-    | op :: ops, env =>
-      match op with
-      | TableConstraintOperation.Allocate {soundness ..} => soundness env ∧ foldl ops env
-      | _ => foldl ops env
+  where
+  @[simp]
+  foldl : List (TableConstraintOperation F M W) -> (env: ℕ -> F) -> Prop
+  | [], _ => true
+  | op :: ops, env =>
+    match op with
+    | TableConstraintOperation.Allocate {soundness ..} => soundness env ∧ foldl ops env
+    | _ => foldl ops env
 
 def output {α : Type} {F : Type} {M W : ℕ+} [Field F] (table : TableConstraint F M W α) : α :=
   let ((_, _), a) := table TableContext.empty
@@ -308,30 +354,31 @@ inductive TableOperation (F : Type) [Field F] (M : ℕ+) where
   environment is derived from the `CellAssignment` functions. Intuitively, if a variable `x`
   is assigned to a field element in the trace `y: F` using a `CellAssignment` function, then ` env x = y`
 -/
+@[simp]
 def table_constraints_hold
     {F : Type} [Field F] {M : ℕ+} {N : ℕ}
     (constraints : List (TableOperation F M)) (trace: TraceOfLength F M N) : Prop :=
   foldl constraints trace.val constraints
   where
   /--
-  The foldl function applies the constraints to the trace inductively on the trace
+    The foldl function applies the constraints to the trace inductively on the trace
 
-  We want to write something like:
-  ```
-  for row in trace:
-    for constraint in constraints:
-      apply constraint to row
-  ```
-  in this exact order, so that the row-inductive structure is at the top-level.
+    We want to write something like:
+    ```
+    for row in trace:
+      for constraint in constraints:
+        apply constraint to row
+    ```
+    in this exact order, so that the row-inductive structure is at the top-level.
 
-  We do double induction: first on the trace, then on the constraints: we apply every constraint to the current row, and
-  then recurse on the rest of the trace.
-  `cs` is the list of constraints that we have to apply and it is never changed during the induction
-  `cs_iterator` is walked inductively for every row.
-  Once the `cs_iterator` is empty, we start again on the rest of the trace with the initial constraints `cs`
+    We do double induction: first on the trace, then on the constraints: we apply every constraint to the current row, and
+    then recurse on the rest of the trace.
+    `cs` is the list of constraints that we have to apply and it is never changed during the induction
+    `cs_iterator` is walked inductively for every row.
+    Once the `cs_iterator` is empty, we start again on the rest of the trace with the initial constraints `cs`
   -/
+  @[simp]
   foldl (cs : List (TableOperation F M)) : Trace M F -> (cs_iterator: List (TableOperation F M)) -> Prop
-
     -- if the trace has at least two rows and the constraint is a "every row except last" constraint, we apply the constraint
     | trace +> curr +> next, (TableOperation.EveryRowExceptLast constraint)::rest =>
         let others := foldl cs (trace +> curr +> next) rest
@@ -401,39 +448,35 @@ def add8Table : List (TableOperation (F p) 3) := [
   TableOperation.EveryRow add8_inline
 ]
 
-def assumptions {N : ℕ} (trace : TraceOfLength (F p) 3 N) : Prop :=
+def assumptions_add8 {N : ℕ} (trace : TraceOfLength (F p) 3 N) : Prop :=
   trace.forAllRowsOfTrace (fun row => (row 0).val < 256 ∧ (row 1).val < 256)
 
 
-def spec {N : ℕ} (trace : TraceOfLength (F p) 3 N) : Prop :=
+def spec_add8 {N : ℕ} (trace : TraceOfLength (F p) 3 N) : Prop :=
   trace.forAllRowsOfTrace (fun row => (row 2).val = ((row 0).val + (row 1).val) % 256)
 
 def formal_add8_table : FormalTable (F:=(F p)) := {
   M := 3,
   constraints := add8Table,
-  assumptions := assumptions,
-  spec := spec,
+  assumptions := assumptions_add8,
+  spec := spec_add8,
   soundness := by
     intro N trace
-    simp [assumptions]
-    simp [table_constraints_hold, add8Table, spec, table_constraints_hold.foldl]
-    simp [TraceOfLength.forAllRowsOfTrace]
+    simp [assumptions_add8]
+    simp [add8Table, spec_add8]
 
     induction trace.val with
     | empty => {
-      simp [table_constraints_hold.foldl, TraceOfLength.forAllRowsOfTrace.inner]
+      simp
     }
     | cons rest row ih => {
       -- simplify induction
-      simp [table_constraints_hold.foldl, TraceOfLength.forAllRowsOfTrace.inner]
+      simp
       intros lookup_x lookup_y lookup_rest h_curr h_rest
       specialize ih lookup_rest h_rest
       simp [ih]
 
       -- now we prove a local property about the current row
-      simp [TableConstraint.constraints_hold_on_window] at h_curr
-      simp [TableConstraint.constraints_hold_on_window.foldl] at h_curr
-
       -- TODO: simp should suffice, but couldn't get it to work
       have h_varx : ((add8_inline (p:=p) { subContext := { offset := 0 }, assignment := fun _ ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
         := by rfl
@@ -443,8 +486,6 @@ def formal_add8_table : FormalTable (F:=(F p)) := {
         := by rfl
 
       simp [ProvableType.from_values] at h_curr
-      simp [TraceOfLength.get] at h_curr
-      simp [Trace.getLe, CellOffset.column] at h_curr
       rw [h_varx, h_vary, h_varz] at h_curr
 
       -- and now it is easy!
@@ -468,14 +509,135 @@ def fib_relation : TwoRowsConstraint (F p) 2 := do
   let x_next <- TableConstraint.get_cell (CellOffset.next 0)
   TableConstraint.assertion Equality.circuit ⟨y, x_next⟩
 
+def boundary_fib : SingleRowConstraint (F p) 2 := do
+  let x <- TableConstraint.get_cell (CellOffset.curr 0)
+  let y <- TableConstraint.get_cell (CellOffset.curr 1)
+  TableConstraint.assertion Equality.circuit ⟨x, 0⟩
+  TableConstraint.assertion Equality.circuit ⟨y, 1⟩
+
 def fib_table : List (TableOperation (F p) 2) := [
-  TableOperation.Boundary 0 (do
-    let x <- TableConstraint.get_cell (CellOffset.curr 0)
-    let y <- TableConstraint.get_cell (CellOffset.curr 1)
-    TableConstraint.assertion Equality.circuit ⟨x, 0⟩
-    TableConstraint.assertion Equality.circuit ⟨y, 1⟩
-  ),
+  TableOperation.Boundary 0 boundary_fib,
   TableOperation.EveryRowExceptLast fib_relation,
 ]
+
+def assumptions_fib {N : ℕ} (trace : TraceOfLength (F p) 2 N) : Prop :=
+  N > 2 ∧
+  trace.forAllRowsOfTrace (fun row => (row 1).val < 256)
+
+def fib8 : ℕ -> ℕ
+  | 0 => 0
+  | 1 => 1
+  | (n + 2) => (fib8 n + fib8 (n + 1)) % 256
+
+def spec_fib {N : ℕ} (trace : TraceOfLength (F p) 2 N) : Prop :=
+  trace.forAllRowsOfTraceWithIndex (λ row index =>
+    ((row 0).val = fib8 index) ∧ ((row 1).val = fib8 (index + 1)))
+
+
+-- heavy lifting to transform constraints into specs
+-- also this proof is quite heavy computationally to check for Lean
+lemma constraints_hold_sim (curr : Row 2 (F p)) (next : Row 2 (F p)) :
+    TableConstraint.constraints_hold_on_window fib_relation ⟨<+> +> curr +> next, by simp⟩ →
+    (ZMod.val (curr 0) < 256 → ZMod.val (curr 1) < 256 → ZMod.val (next 1) = (ZMod.val (curr 0) + ZMod.val (curr 1)) % 256) ∧ curr 1 = next 0
+    := by
+  intro h
+  simp [Circuit.formal_assertion_to_subcircuit] at h
+  simp [fib_table, ProvableType.from_values] at h
+
+  -- TODO: we should have a better way to do this
+  have var1 : ((fib_relation (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
+    := by rfl
+  have var2 : ((fib_relation (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 1).column = 1
+    := by rfl
+  have var3 : ((fib_relation (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 2).column = 1
+    := by rfl
+  have var4 : ((fib_relation (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 4).column = 0
+    := by rfl
+  have var5 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
+    := by rfl
+  have var6 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 1).column = 1
+    := by rfl
+
+  rw [var1, var2, var3] at h
+
+  simp [Add8.circuit, Add8.assumptions, Add8.spec] at h
+  simp [PreOperation.to_flat_operations, PreOperation.witness_length] at h
+  rw [var4] at h
+  simp [Equality.circuit, Equality.spec] at h
+  assumption
+
+
+def formal_fib_table : FormalTable (F:=(F p)) := {
+  M := 2,
+  constraints := fib_table,
+  assumptions := assumptions_fib,
+  spec := spec_fib,
+  soundness := by
+    intro N trace
+    simp [assumptions_fib]
+    simp [fib_table, spec_fib]
+
+    intro N_assumption
+
+    induction' trace.val using Trace.everyRowTwoRowsInduction with first_row curr next rest _ ih2
+    · simp
+    · intro lookup_h
+      simp [fib_table]
+      intros boundary1 boundary2
+      simp [Circuit.formal_assertion_to_subcircuit, Equality.circuit, Equality.spec] at boundary1 boundary2
+
+      have var1 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
+        := by rfl
+      have var2 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 1).column = 1
+        := by rfl
+
+      rw [var1] at boundary1
+      rw [var2] at boundary2
+      simp [fib8]
+      simp [boundary1, boundary2]
+      apply ZMod.val_one
+    · intro lookup_h
+      simp at lookup_h
+      -- first of all, we prove the inductive part of the spec
+      unfold TraceOfLength.forAllRowsOfTraceWithIndex.inner
+      intros constraints_hold
+      specialize ih2 lookup_h.right
+
+      unfold table_constraints_hold.foldl at constraints_hold
+      simp only [Trace.len, Nat.succ_ne_zero, ite_false] at constraints_hold
+      unfold table_constraints_hold.foldl at constraints_hold
+      unfold table_constraints_hold.foldl at constraints_hold
+      simp only at constraints_hold
+      specialize ih2 constraints_hold.right
+      simp only [ih2]
+
+      simp at ih2
+      let ⟨curr_fib0, curr_fib1⟩ := ih2.left
+
+      -- lift the constraints to specs
+      let constraints_hold := constraints_hold_sim curr next constraints_hold.left
+      have ⟨add_holds, eq_holds⟩ := constraints_hold
+
+      -- and finally now we prove the actual relations, this is fortunately very easy
+      -- now that we have the specs
+
+      have lookup_first_col : (curr 0).val < 256 := by
+        -- TODO: this is true also by induction over `rest`
+        sorry
+
+      specialize add_holds lookup_first_col lookup_h.right.left
+
+      have spec1 : (next 0).val = fib8 (rest.len + 1) := by
+        apply_fun ZMod.val at eq_holds
+        rw [curr_fib1] at eq_holds
+        exact eq_holds.symm
+
+      have spec2 : (next 1).val = fib8 (rest.len + 2) := by
+        simp [fib8]
+        rw [curr_fib0, curr_fib1] at add_holds
+        assumption
+
+      simp [spec1, spec2]
+}
 
 end Example

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -3,12 +3,10 @@ import Mathlib.Data.ZMod.Basic
 import Clean.Utils.Primes
 import Clean.Utils.Vector
 import Clean.Circuit.Basic
+import Clean.Circuit.SubCircuit
 import Clean.Circuit.Expression
 import Clean.Circuit.Provable
 import Clean.Utils.Field
-
-import Clean.GadgetsNew.Add8.Addition8
-import Clean.GadgetsNew.Equality
 
 -- TODO: this should be something so that we can give names to the columns
 def Row (M : ℕ+) (F : Type) := Fin M -> F
@@ -261,6 +259,11 @@ def assignment {α : Type} {F : Type} {M W : ℕ+} [Field F] (table : TableConst
   let ((ctx, _), _) := table TableContext.empty
   ctx.assignment
 
+/--
+  A table constraint holds on a window of rows if the constraints hold on a suitable environment.
+  In particular, we construct the environment by taking directly the result of the assignment function
+  so that every variable evaluate to the trace cell value which is assigned to
+-/
 @[simp]
 def constraints_hold_on_window {F : Type} {M W : ℕ+} [Field F]
     (table : TableConstraint F M W Unit) (window: TraceOfLength F M W) : Prop :=
@@ -431,213 +434,3 @@ structure FormalTable {F : Type} [Field F] where
     assumptions trace ->
     table_constraints_hold constraints trace ->
     spec trace
-
-section Example
-variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
-variable [p_large_enough: Fact (p > 512)]
-
-def add8_inline : SingleRowConstraint (F p) 3 := do
-  let x <- TableConstraint.get_cell (CellOffset.curr 0)
-  let y <- TableConstraint.get_cell (CellOffset.curr 1)
-  let z : Expression (F p) <- TableConstraint.subcircuit Add8.circuit {x, y}
-
-  if let var z := z then
-    TableConstraint.assign z (CellOffset.curr 2)
-
-def add8Table : List (TableOperation (F p) 3) := [
-  TableOperation.EveryRow add8_inline
-]
-
-def assumptions_add8 {N : ℕ} (trace : TraceOfLength (F p) 3 N) : Prop :=
-  trace.forAllRowsOfTrace (fun row => (row 0).val < 256 ∧ (row 1).val < 256)
-
-
-def spec_add8 {N : ℕ} (trace : TraceOfLength (F p) 3 N) : Prop :=
-  trace.forAllRowsOfTrace (fun row => (row 2).val = ((row 0).val + (row 1).val) % 256)
-
-def formal_add8_table : FormalTable (F:=(F p)) := {
-  M := 3,
-  constraints := add8Table,
-  assumptions := assumptions_add8,
-  spec := spec_add8,
-  soundness := by
-    intro N trace
-    simp [assumptions_add8]
-    simp [add8Table, spec_add8]
-
-    induction trace.val with
-    | empty => {
-      simp
-    }
-    | cons rest row ih => {
-      -- simplify induction
-      simp
-      intros lookup_x lookup_y lookup_rest h_curr h_rest
-      specialize ih lookup_rest h_rest
-      simp [ih]
-
-      -- now we prove a local property about the current row
-      -- TODO: simp should suffice, but couldn't get it to work
-      have h_varx : ((add8_inline (p:=p) { subContext := { offset := 0 }, assignment := fun _ ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
-        := by rfl
-      have h_vary : ((add8_inline (p:=p) { subContext := { offset := 0 }, assignment := fun _ ↦ { rowOffset := 0, column := 0 } }).1.1.2 1).column = 1
-        := by rfl
-      have h_varz : ((add8_inline (p:=p) { subContext := { offset := 0 }, assignment := fun _ ↦ { rowOffset := 0, column := 0 } }).1.1.2 2).column = 2
-        := by rfl
-
-      simp [ProvableType.from_values] at h_curr
-      rw [h_varx, h_vary, h_varz] at h_curr
-
-      -- and now it is easy!
-      dsimp [Add8.circuit, Add8.assumptions] at h_curr
-      simp [lookup_x, lookup_y] at h_curr
-      assumption
-    }
-}
-
-/-
-  Fibonacci example
--/
-def fib_relation : TwoRowsConstraint (F p) 2 := do
-  let x <- TableConstraint.get_cell (CellOffset.curr 0)
-  let y <- TableConstraint.get_cell (CellOffset.curr 1)
-  let z : Expression (F p) <- TableConstraint.subcircuit Add8.circuit {x, y}
-
-  if let var z := z then
-    TableConstraint.assign z (CellOffset.next 1)
-
-  let x_next <- TableConstraint.get_cell (CellOffset.next 0)
-  TableConstraint.assertion Equality.circuit ⟨y, x_next⟩
-
-def boundary_fib : SingleRowConstraint (F p) 2 := do
-  let x <- TableConstraint.get_cell (CellOffset.curr 0)
-  let y <- TableConstraint.get_cell (CellOffset.curr 1)
-  TableConstraint.assertion Equality.circuit ⟨x, 0⟩
-  TableConstraint.assertion Equality.circuit ⟨y, 1⟩
-
-def fib_table : List (TableOperation (F p) 2) := [
-  TableOperation.Boundary 0 boundary_fib,
-  TableOperation.EveryRowExceptLast fib_relation,
-]
-
-def assumptions_fib {N : ℕ} (trace : TraceOfLength (F p) 2 N) : Prop :=
-  N > 2 ∧
-  trace.forAllRowsOfTrace (fun row => (row 1).val < 256)
-
-def fib8 : ℕ -> ℕ
-  | 0 => 0
-  | 1 => 1
-  | (n + 2) => (fib8 n + fib8 (n + 1)) % 256
-
-def spec_fib {N : ℕ} (trace : TraceOfLength (F p) 2 N) : Prop :=
-  trace.forAllRowsOfTraceWithIndex (λ row index =>
-    ((row 0).val = fib8 index) ∧ ((row 1).val = fib8 (index + 1)))
-
-
--- heavy lifting to transform constraints into specs
--- also this proof is quite heavy computationally to check for Lean
-lemma constraints_hold_sim (curr : Row 2 (F p)) (next : Row 2 (F p)) :
-    TableConstraint.constraints_hold_on_window fib_relation ⟨<+> +> curr +> next, by simp⟩ →
-    (ZMod.val (curr 0) < 256 → ZMod.val (curr 1) < 256 → ZMod.val (next 1) = (ZMod.val (curr 0) + ZMod.val (curr 1)) % 256) ∧ curr 1 = next 0
-    := by
-  intro h
-  simp [Circuit.formal_assertion_to_subcircuit] at h
-  simp [fib_table, ProvableType.from_values] at h
-
-  -- TODO: we should have a better way to do this
-  have var1 : ((fib_relation (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
-    := by rfl
-  have var2 : ((fib_relation (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 1).column = 1
-    := by rfl
-  have var3 : ((fib_relation (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 2).column = 1
-    := by rfl
-  have var4 : ((fib_relation (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 4).column = 0
-    := by rfl
-  have var5 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
-    := by rfl
-  have var6 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 1).column = 1
-    := by rfl
-
-  rw [var1, var2, var3] at h
-
-  simp [Add8.circuit, Add8.assumptions, Add8.spec] at h
-  simp [PreOperation.to_flat_operations, PreOperation.witness_length] at h
-  rw [var4] at h
-  simp [Equality.circuit, Equality.spec] at h
-  assumption
-
-
-def formal_fib_table : FormalTable (F:=(F p)) := {
-  M := 2,
-  constraints := fib_table,
-  assumptions := assumptions_fib,
-  spec := spec_fib,
-  soundness := by
-    intro N trace
-    simp [assumptions_fib]
-    simp [fib_table, spec_fib]
-
-    intro N_assumption
-
-    induction' trace.val using Trace.everyRowTwoRowsInduction with first_row curr next rest _ ih2
-    · simp
-    · intro lookup_h
-      simp [fib_table]
-      intros boundary1 boundary2
-      simp [Circuit.formal_assertion_to_subcircuit, Equality.circuit, Equality.spec] at boundary1 boundary2
-
-      have var1 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
-        := by rfl
-      have var2 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 1).column = 1
-        := by rfl
-
-      rw [var1] at boundary1
-      rw [var2] at boundary2
-      simp [fib8]
-      simp [boundary1, boundary2]
-      apply ZMod.val_one
-    · intro lookup_h
-      simp at lookup_h
-      -- first of all, we prove the inductive part of the spec
-      unfold TraceOfLength.forAllRowsOfTraceWithIndex.inner
-      intros constraints_hold
-      specialize ih2 lookup_h.right
-
-      unfold table_constraints_hold.foldl at constraints_hold
-      simp only [Trace.len, Nat.succ_ne_zero, ite_false] at constraints_hold
-      unfold table_constraints_hold.foldl at constraints_hold
-      unfold table_constraints_hold.foldl at constraints_hold
-      simp only at constraints_hold
-      specialize ih2 constraints_hold.right
-      simp only [ih2]
-
-      simp at ih2
-      let ⟨curr_fib0, curr_fib1⟩ := ih2.left
-
-      -- lift the constraints to specs
-      let constraints_hold := constraints_hold_sim curr next constraints_hold.left
-      have ⟨add_holds, eq_holds⟩ := constraints_hold
-
-      -- and finally now we prove the actual relations, this is fortunately very easy
-      -- now that we have the specs
-
-      have lookup_first_col : (curr 0).val < 256 := by
-        -- TODO: this is true also by induction over `rest`
-        sorry
-
-      specialize add_holds lookup_first_col lookup_h.right.left
-
-      have spec1 : (next 0).val = fib8 (rest.len + 1) := by
-        apply_fun ZMod.val at eq_holds
-        rw [curr_fib1] at eq_holds
-        exact eq_holds.symm
-
-      have spec2 : (next 1).val = fib8 (rest.len + 2) := by
-        simp [fib8]
-        rw [curr_fib0, curr_fib1] at add_holds
-        assumption
-
-      simp [spec1, spec2]
-}
-
-end Example

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -218,6 +218,3 @@ def table_constraints_hold
     | <+>, _ => True
 
 end Table
-
-
-section Example

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -80,6 +80,9 @@ def forAllRowsOfTrace (trace : TraceOfLength N M (F p)) (prop : Row N (F p) -> P
     | <+>, _ => true
     | rest +> row, prop => prop row ∧ inner rest prop
 
+/--
+  Apply a proposition to every row in the trace except the last one
+-/
 def forAllRowsOfTraceExceptLast (trace : TraceOfLength N M (F p)) (prop : Row N (F p) -> Prop) : Prop :=
   inner trace.val prop
   where
@@ -98,3 +101,33 @@ def forAllRowsOfTraceWithIndex (trace : TraceOfLength N M (F p)) (prop : Row N (
   inner : Trace N (F p) -> (Row N (F p) -> ℕ -> Prop) -> Prop
     | <+>, _ => true
     | rest +> row, prop => (prop row rest.len) ∧ inner rest prop
+
+/--
+  A cell offset is an offset in a table that points to a specific cell in a row.
+  It is used to define a relative position in the trace.
+  `W` is the size of the "vertical window", which means that we can reference at most
+  `W` rows above the current row.
+  To make sure that the vertical offset is bounded, it is represented as a `Fin W`.
+-/
+structure CellOffset (M W: ℕ+) where
+  rowOffset: Fin W
+  column: Fin M
+deriving Repr
+
+@[reducible]
+def CellAssignment (F : Type) (M W: ℕ+) := Variable F -> Option (CellOffset M W)
+
+inductive TableOperation
+    (F : Type) [Field F]
+    {β α : TypePair} [ProvableType F α] [ProvableType F β]
+    (M : ℕ+) where
+  | Boundary: FormalCircuit F β α -> CellAssignment F M 1 -> (row : ℕ) -> TableOperation F M
+  | EveryRow: FormalCircuit F β α -> CellAssignment F M 1 -> TableOperation F M
+  | EveryRowExceptLast: FormalCircuit F β α -> CellAssignment F M 2 -> TableOperation F M
+
+
+
+end Table
+
+
+section Example

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -115,8 +115,8 @@ deriving Repr
 
 namespace CellOffset
 
-def curr {M : ℕ+} (j : Fin M) : CellOffset M 1 := ⟨0, j⟩
-def next {M : ℕ+} (j : Fin M) : CellOffset M 1 := ⟨1, j⟩
+def curr {M W : ℕ+} (j : Fin M) : CellOffset M W := ⟨0, j⟩
+def next {M W: ℕ+} (j : Fin M) : CellOffset M W := ⟨1, j⟩
 
 end CellOffset
 
@@ -354,8 +354,7 @@ variable [p_large_enough: Fact (p > 512)]
 def add8_inline : SingleRowConstraint (F p) 3 := do
   let x <- TableConstraint.witness_cell (CellOffset.curr 0) (fun _ => (10 : F p))
   let y <- TableConstraint.witness_cell (CellOffset.curr 1) (fun _ => (20 : F p))
-  let add8Inputs : (Add8.Inputs p).var := ⟨x, y⟩
-  let z : Expression (F p) <- TableConstraint.subcircuit Add8.circuit add8Inputs
+  let z : Expression (F p) <- TableConstraint.subcircuit Add8.circuit {x, y}
 
   --TODO: Is this ok? Gadgets return an `Expression` but we need a `Variable`
   if let var z := z then
@@ -417,6 +416,18 @@ theorem soundness (N : ℕ): ∀ (trace : TraceOfLength (F p) 3 N),
       simp [lookup_x, lookup_y] at h_curr
       assumption
     }
+
+def fib_relation : TwoRowsConstraint (F p) 2 := do
+  let x <- TableConstraint.witness_cell (CellOffset.curr 0) (fun _ => (10 : F p))
+  let y <- TableConstraint.witness_cell (CellOffset.curr 1) (fun _ => (20 : F p))
+  let add8Inputs : (Add8.Inputs p).var := ⟨x, y⟩
+  let z : Expression (F p) <- TableConstraint.subcircuit Add8.circuit add8Inputs
+
+  if let var z := z then
+    TableConstraint.assign z (CellOffset.next 1)
+  -- TODO: we also need to enforce assertion-like constraints, like this:
+  -- TableConstraint.subcircuit Equality {CellOffset.curr 1, CellOffset.curr 0}
+  -- but maybe requires a new operation
 
 
 end Example

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -1,0 +1,100 @@
+import Mathlib.Algebra.Field.Basic
+import Mathlib.Data.ZMod.Basic
+import Clean.Utils.Primes
+import Clean.Utils.Vector
+import Clean.Circuit.Basic
+import Clean.Circuit.Expression
+import Clean.Circuit.Provable
+import Clean.Utils.Field
+
+
+def Row (M : ℕ+) (F : Type) := Fin M -> F
+
+/--
+  A trace is an inductive list of rows. It can be viewed as a structured
+  environment that maps cells to field elements.
+-/
+inductive Trace (M : ℕ+) (F : Type) :=
+  /-- An empty trace -/
+  | empty : Trace M F
+  /-- Add a row to the end of the trace -/
+  | cons (rest: Trace M F) (row: Row M F) : Trace M F
+
+@[inherit_doc] notation:67 "<+>" => Trace.empty
+@[inherit_doc] infixl:67 " +> " => Trace.cons
+
+namespace Trace
+/--
+  The length of a trace is the number of rows it contains.
+-/
+def len {M : ℕ+} {F : Type} : Trace M F -> ℕ
+  | <+> => 0
+  | rest +> _ => Nat.succ rest.len
+
+/--
+  Induction principle that applies for every row in the trace, where the inductive step takes into
+  acount the previous two rows.
+-/
+def everyRowTwoRowsInduction {M : ℕ+} {F : Type} {P : Trace M F → Sort*}
+    (zero : P (<+>))
+    (one : ∀ row : Row M F, P (empty +> row))
+    (more : ∀ curr next : Row M F,
+      ∀ rest : Trace M F, P (rest) -> P (rest +> curr) → P (rest +> curr +> next))
+    : ∀ trace, P trace
+  | <+> => zero
+  | <+> +> first => one first
+  | rest +> curr +> _ => more _ _ _
+    (everyRowTwoRowsInduction zero one more (rest))
+    (everyRowTwoRowsInduction zero one more (rest +> curr))
+
+def getLe {M :ℕ+} {F : Type}:
+    (trace : Trace M F) -> (row : Fin trace.len) -> (col : Fin M) -> F
+  | _ +> currRow, ⟨0, _⟩, j => currRow j
+  | rest +> _, ⟨i + 1, h⟩, j => getLe rest ⟨i, Nat.le_of_succ_le_succ h⟩ j
+
+end Trace
+
+/--
+  A trace of length M is a trace with exactly M rows.
+-/
+def TraceOfLength (M : ℕ+) (N : ℕ) (F : Type) : Type := { env : Trace M F // env.len = N }
+
+namespace TraceOfLength
+
+def get {N: ℕ+} {M : ℕ} {F : Type} : (env : TraceOfLength N M F) -> (i : Fin M) -> (j : Fin N) -> F
+  | ⟨env, h⟩, i, j => env.getLe (by rw [←h] at i; exact i) j
+
+end TraceOfLength
+
+
+section Table
+variable (N : ℕ+) (M : ℕ) (p : ℕ) [Fact p.Prime]
+
+/--
+  Apply a proposition to every row in the trace
+-/
+def forAllRowsOfTrace (trace : TraceOfLength N M (F p)) (prop : Row N (F p) -> Prop) : Prop :=
+  inner trace.val prop
+  where
+  inner : Trace N (F p) -> (Row N (F p) -> Prop) -> Prop
+    | <+>, _ => true
+    | rest +> row, prop => prop row ∧ inner rest prop
+
+def forAllRowsOfTraceExceptLast (trace : TraceOfLength N M (F p)) (prop : Row N (F p) -> Prop) : Prop :=
+  inner trace.val prop
+  where
+  inner : Trace N (F p) -> (Row N (F p) -> Prop) -> Prop
+    | <+>, _ => true
+    | <+> +> _, _ => true
+    | rest +> curr +> _, prop => prop curr ∧ inner (rest +> curr) prop
+
+
+/--
+  Apply a proposition, which could be dependent on the row index, to every row of the trace
+-/
+def forAllRowsOfTraceWithIndex (trace : TraceOfLength N M (F p)) (prop : Row N (F p) -> ℕ -> Prop) : Prop :=
+  inner trace.val prop
+  where
+  inner : Trace N (F p) -> (Row N (F p) -> ℕ -> Prop) -> Prop
+    | <+>, _ => true
+    | rest +> row, prop => (prop row rest.len) ∧ inner rest prop

--- a/Clean/TablesNew/Addition8.lean
+++ b/Clean/TablesNew/Addition8.lean
@@ -1,0 +1,69 @@
+import Clean.Utils.Vector
+import Clean.Circuit.Basic
+import Clean.Table.Basic
+import Clean.GadgetsNew.Add8.Addition8
+
+namespace Addition8Table
+variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
+variable [p_large_enough: Fact (p > 512)]
+
+def add8_inline : SingleRowConstraint (F p) 3 := do
+  let x <- TableConstraint.get_cell (CellOffset.curr 0)
+  let y <- TableConstraint.get_cell (CellOffset.curr 1)
+  let z : Expression (F p) <- TableConstraint.subcircuit Add8.circuit {x, y}
+
+  if let var z := z then
+    TableConstraint.assign z (CellOffset.curr 2)
+
+def add8Table : List (TableOperation (F p) 3) := [
+  TableOperation.EveryRow add8_inline
+]
+
+def assumptions_add8 {N : ℕ} (trace : TraceOfLength (F p) 3 N) : Prop :=
+  trace.forAllRowsOfTrace (fun row => (row 0).val < 256 ∧ (row 1).val < 256)
+
+
+def spec_add8 {N : ℕ} (trace : TraceOfLength (F p) 3 N) : Prop :=
+  trace.forAllRowsOfTrace (fun row => (row 2).val = ((row 0).val + (row 1).val) % 256)
+
+def formal_add8_table : FormalTable (F:=(F p)) := {
+  M := 3,
+  constraints := add8Table,
+  assumptions := assumptions_add8,
+  spec := spec_add8,
+  soundness := by
+    intro N trace
+    simp [assumptions_add8]
+    simp [add8Table, spec_add8]
+
+    induction trace.val with
+    | empty => {
+      simp
+    }
+    | cons rest row ih => {
+      -- simplify induction
+      simp
+      intros lookup_x lookup_y lookup_rest h_curr h_rest
+      specialize ih lookup_rest h_rest
+      simp [ih]
+
+      -- now we prove a local property about the current row
+      -- TODO: simp should suffice, but couldn't get it to work
+      have h_varx : ((add8_inline (p:=p) { subContext := { offset := 0 }, assignment := fun _ ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
+        := by rfl
+      have h_vary : ((add8_inline (p:=p) { subContext := { offset := 0 }, assignment := fun _ ↦ { rowOffset := 0, column := 0 } }).1.1.2 1).column = 1
+        := by rfl
+      have h_varz : ((add8_inline (p:=p) { subContext := { offset := 0 }, assignment := fun _ ↦ { rowOffset := 0, column := 0 } }).1.1.2 2).column = 2
+        := by rfl
+
+      simp [ProvableType.from_values] at h_curr
+      rw [h_varx, h_vary, h_varz] at h_curr
+
+      -- and now it is easy!
+      dsimp [Add8.circuit, Add8.assumptions] at h_curr
+      simp [lookup_x, lookup_y] at h_curr
+      assumption
+    }
+}
+
+end Addition8Table

--- a/Clean/TablesNew/Fibonacci8.lean
+++ b/Clean/TablesNew/Fibonacci8.lean
@@ -95,7 +95,6 @@ lemma constraints_hold_lift (curr : Row 2 (F p)) (next : Row 2 (F p)) :
   rw [var1, var2, var3] at h
 
   simp [Add8.circuit, Add8.assumptions, Add8.spec] at h
-  simp [PreOperation.to_flat_operations, PreOperation.witness_length] at h
   rw [var4] at h
   simp [Equality.circuit, Equality.spec] at h
   assumption
@@ -119,9 +118,9 @@ def formal_fib_table : FormalTable (F:=(F p)) := {
       intros boundary1 boundary2
       simp [Circuit.formal_assertion_to_subcircuit, Equality.circuit, Equality.spec] at boundary1 boundary2
 
-      have var1 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
+      have var1 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun _ ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
         := by rfl
-      have var2 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 1).column = 1
+      have var2 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun _ ↦ { rowOffset := 0, column := 0 } }).1.1.2 1).column = 1
         := by rfl
 
       rw [var1] at boundary1

--- a/Clean/TablesNew/Fibonacci8.lean
+++ b/Clean/TablesNew/Fibonacci8.lean
@@ -1,0 +1,156 @@
+import Clean.Utils.Vector
+import Clean.Circuit.Basic
+import Clean.Table.Basic
+import Clean.GadgetsNew.Add8.Addition8
+import Clean.GadgetsNew.Equality
+
+namespace Fibonacci8Table
+variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
+variable [p_large_enough: Fact (p > 512)]
+
+/-
+  Fibonacci example
+-/
+def fib_relation : TwoRowsConstraint (F p) 2 := do
+  let x <- TableConstraint.get_cell (CellOffset.curr 0)
+  let y <- TableConstraint.get_cell (CellOffset.curr 1)
+  let z : Expression (F p) <- TableConstraint.subcircuit Add8.circuit {x, y}
+
+  if let var z := z then
+    TableConstraint.assign z (CellOffset.next 1)
+
+  let x_next <- TableConstraint.get_cell (CellOffset.next 0)
+  TableConstraint.assertion Equality.circuit ⟨y, x_next⟩
+
+def boundary_fib : SingleRowConstraint (F p) 2 := do
+  let x <- TableConstraint.get_cell (CellOffset.curr 0)
+  let y <- TableConstraint.get_cell (CellOffset.curr 1)
+  TableConstraint.assertion Equality.circuit ⟨x, 0⟩
+  TableConstraint.assertion Equality.circuit ⟨y, 1⟩
+
+def fib_table : List (TableOperation (F p) 2) := [
+  TableOperation.Boundary 0 boundary_fib,
+  TableOperation.EveryRowExceptLast fib_relation,
+]
+
+def assumptions_fib {N : ℕ} (trace : TraceOfLength (F p) 2 N) : Prop :=
+  N > 2 ∧
+  trace.forAllRowsOfTrace (fun row => (row 1).val < 256)
+
+def fib8 : ℕ -> ℕ
+  | 0 => 0
+  | 1 => 1
+  | (n + 2) => (fib8 n + fib8 (n + 1)) % 256
+
+def spec_fib {N : ℕ} (trace : TraceOfLength (F p) 2 N) : Prop :=
+  trace.forAllRowsOfTraceWithIndex (λ row index =>
+    ((row 0).val = fib8 index) ∧ ((row 1).val = fib8 (index + 1)))
+
+
+-- heavy lifting to transform constraints into specs
+-- also this proof is quite heavy computationally to check for Lean
+lemma constraints_hold_sim (curr : Row 2 (F p)) (next : Row 2 (F p)) :
+    TableConstraint.constraints_hold_on_window fib_relation ⟨<+> +> curr +> next, by simp⟩ →
+    (ZMod.val (curr 0) < 256 → ZMod.val (curr 1) < 256 → ZMod.val (next 1) = (ZMod.val (curr 0) + ZMod.val (curr 1)) % 256) ∧ curr 1 = next 0
+    := by
+  intro h
+  simp [Circuit.formal_assertion_to_subcircuit] at h
+  simp [fib_table, ProvableType.from_values] at h
+
+  -- TODO: we should have a better way to do this
+  have var1 : ((fib_relation (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
+    := by rfl
+  have var2 : ((fib_relation (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 1).column = 1
+    := by rfl
+  have var3 : ((fib_relation (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 2).column = 1
+    := by rfl
+  have var4 : ((fib_relation (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 4).column = 0
+    := by rfl
+  have var5 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
+    := by rfl
+  have var6 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 1).column = 1
+    := by rfl
+
+  rw [var1, var2, var3] at h
+
+  simp [Add8.circuit, Add8.assumptions, Add8.spec] at h
+  simp [PreOperation.to_flat_operations, PreOperation.witness_length] at h
+  rw [var4] at h
+  simp [Equality.circuit, Equality.spec] at h
+  assumption
+
+
+def formal_fib_table : FormalTable (F:=(F p)) := {
+  M := 2,
+  constraints := fib_table,
+  assumptions := assumptions_fib,
+  spec := spec_fib,
+  soundness := by
+    intro N trace
+    simp [assumptions_fib]
+    simp [fib_table, spec_fib]
+
+    intro N_assumption
+
+    induction' trace.val using Trace.everyRowTwoRowsInduction with first_row curr next rest _ ih2
+    · simp
+    · intro lookup_h
+      simp [fib_table]
+      intros boundary1 boundary2
+      simp [Circuit.formal_assertion_to_subcircuit, Equality.circuit, Equality.spec] at boundary1 boundary2
+
+      have var1 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0
+        := by rfl
+      have var2 : ((boundary_fib (p:=p) { subContext := { offset := 0 }, assignment := fun x ↦ { rowOffset := 0, column := 0 } }).1.1.2 1).column = 1
+        := by rfl
+
+      rw [var1] at boundary1
+      rw [var2] at boundary2
+      simp [fib8]
+      simp [boundary1, boundary2]
+      apply ZMod.val_one
+    · intro lookup_h
+      simp at lookup_h
+      -- first of all, we prove the inductive part of the spec
+      unfold TraceOfLength.forAllRowsOfTraceWithIndex.inner
+      intros constraints_hold
+      specialize ih2 lookup_h.right
+
+      unfold table_constraints_hold.foldl at constraints_hold
+      simp only [Trace.len, Nat.succ_ne_zero, ite_false] at constraints_hold
+      unfold table_constraints_hold.foldl at constraints_hold
+      unfold table_constraints_hold.foldl at constraints_hold
+      simp only at constraints_hold
+      specialize ih2 constraints_hold.right
+      simp only [ih2]
+
+      simp at ih2
+      let ⟨curr_fib0, curr_fib1⟩ := ih2.left
+
+      -- lift the constraints to specs
+      let constraints_hold := constraints_hold_sim curr next constraints_hold.left
+      have ⟨add_holds, eq_holds⟩ := constraints_hold
+
+      -- and finally now we prove the actual relations, this is fortunately very easy
+      -- now that we have the specs
+
+      have lookup_first_col : (curr 0).val < 256 := by
+        -- TODO: this is true also by induction over `rest`
+        sorry
+
+      specialize add_holds lookup_first_col lookup_h.right.left
+
+      have spec1 : (next 0).val = fib8 (rest.len + 1) := by
+        apply_fun ZMod.val at eq_holds
+        rw [curr_fib1] at eq_holds
+        exact eq_holds.symm
+
+      have spec2 : (next 1).val = fib8 (rest.len + 2) := by
+        simp [fib8]
+        rw [curr_fib0, curr_fib1] at add_holds
+        assumption
+
+      simp [spec1, spec2]
+}
+
+end Fibonacci8Table


### PR DESCRIPTION
- Moved the assignment operation outside of the circuit definition
- Defined a `TableConstraint` Monad that we can use to define constraints over concrete trace "windows", which are partial traces with a given number of columns and rows. For example a constraint that only references the current row has to be defined over a window of height 1. For accessing the next row the window height has to be 2 and so on.
- Defined what it means that the constraints hold over a full trace, by inductively make the table constraints hold over the windows
- Defined two example traces: add8 and Fibonacci8

This PR does not addresses the completeness direction for traces, which is still WIP
This PR also does not address foundational aspects of this construction, namely the allocation of internal variables as new columns in the trace.