### PR TITLE
Decouple witness generation and variables

### DIFF
--- a/Clean/Circuit/Expression.lean
+++ b/Clean/Circuit/Expression.lean
@@ -4,8 +4,6 @@ variable {F: Type}
 
 structure Variable (F : Type) where
   index: ℕ
-  witness: Unit → F
-
 instance : Repr (Variable F) where
   reprPrec v _ := "x" ++ repr v.index
 
@@ -19,13 +17,6 @@ export Expression (var const)
 
 namespace Expression
 variable [Field F]
-
-@[simp]
-def eval : Expression F → F
-  | var v => v.witness ()
-  | const c => c
-  | add x y => eval x + eval y
-  | mul x y => eval x * eval y
 
 /--
 Evaluate expression given an external `environment` that determines the assignment
@@ -74,9 +65,6 @@ instance : Coe F (Expression F) where
 
 instance : Coe (Variable F) (Expression F) where
   coe x := var x
-
-instance : Coe (Expression F) F where
-  coe x := x.eval
 
 instance : HMul F (Expression F) (Expression F) where
   hMul := fun f e => mul f e

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -34,13 +34,6 @@ namespace Provable
 variable {α β γ: TypePair} [ProvableType F α] [ProvableType F β] [ProvableType F γ]
 
 @[simp]
-def eval (F: Type) [Field F] [ProvableType F α] (x: α.var) : α.value :=
-  let n := ProvableType.size F α
-  let vars : Vector (Expression F) n := ProvableType.to_vars x
-  let values := vars.map (fun v => v.eval)
-  ProvableType.from_values values
-
-@[simp]
 def eval_env (env: ℕ → F) (x: α.var) : α.value :=
   let n := ProvableType.size F α
   let vars : Vector (Expression F) n := ProvableType.to_vars x

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -37,6 +37,14 @@ namespace Vector
     let i' : Fin v.1.length := Fin.cast v.prop.symm i
     v.val.get i'
 
+  @[simp]
+  def push (v: Vector α n) (a: α) : Vector α (n + 1) :=
+    ⟨ a :: v.val, by simp [v.prop] ⟩
+
+  @[simp]
+  def append {m} (v: Vector α n) (w: Vector α m) : Vector α (n + m) :=
+    ⟨ v.val ++ w.val, by simp [v.prop, w.prop] ⟩
+
   -- map over monad
   def mapM {M : Type → Type} {n} [Monad M] (v : Vector (M α) n) : M (Vector α n) :=
     match (v : Vector (M α) n) with


### PR DESCRIPTION
- [ ] Add a default environment which represents the assignment of variables to field elements given by the default witness generator
- [ ] Prove new foundational theorems
- [ ] Fix all the gadget proofs