### PR TITLE
Improve simp sanity

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -76,7 +76,8 @@ def witnesses (env: Environment F) : (l: List (FlatOperation F)) → Vector F (w
     let ws := witnesses env ops
     match op with
     | witness m compute =>
-      ⟨ (compute env).val ++ ws.val, by simp [ws.prop, gadget_norm]; ac_rfl ⟩
+      ⟨ (compute env).val ++ ws.val, by simp only [ws.prop, gadget_norm,
+        List.length_append, Mathlib.Vector.length_val]; ac_rfl ⟩
     | assert _ | lookup _ =>
       ⟨ ws.val, by simp_all only [witness_length, ws.prop]⟩
 
@@ -87,7 +88,8 @@ def witness_generators : (l: List (FlatOperation F)) → Witness F (witness_leng
     let ws := witness_generators ops
     match op with
     | witness m compute =>
-      ⟨ (Vector.init (fun i env => (compute env).get i)).val ++ ws.val, by simp [ws.prop, gadget_norm]; ac_rfl ⟩
+      ⟨ (Vector.init (fun i env => (compute env).get i)).val ++ ws.val, by
+        simp only [ws.prop, gadget_norm, List.length_append, Mathlib.Vector.length_val]; ac_rfl⟩
     | assert _ | lookup _ =>
       ⟨ ws.val, by simp_all only [witness_length, ws.prop]⟩
 end FlatOperation
@@ -118,7 +120,7 @@ structure SubCircuit (F: Type) [Field F] (offset: ℕ) where
   implied_by_completeness : ∀ env, env.extends_vector (FlatOperation.witnesses env ops) offset →
     completeness env → FlatOperation.constraints_hold_flat env ops
 
-@[reducible, simp]
+@[reducible, simp, gadget_norm]
 def SubCircuit.witness_length (sc: SubCircuit F n) := FlatOperation.witness_length sc.ops
 
 @[reducible]

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -120,7 +120,7 @@ structure SubCircuit (F: Type) [Field F] (offset: ℕ) where
   implied_by_completeness : ∀ env, env.extends_vector (FlatOperation.witnesses env ops) offset →
     completeness env → FlatOperation.constraints_hold_flat env ops
 
-@[reducible, simp, gadget_norm]
+@[reducible, gadget_norm]
 def SubCircuit.witness_length (sc: SubCircuit F n) := FlatOperation.witness_length sc.ops
 
 @[reducible]
@@ -142,7 +142,7 @@ inductive Operations (F : Type) [Field F] : ℕ → Type where
   | subcircuit : {n : ℕ} → Operations F n → (s : SubCircuit F n) → Operations F (n + s.witness_length)
 
 namespace Operations
-@[reducible, simp]
+@[reducible, gadget_norm]
 def initial_offset {n: ℕ} : Operations F n → ℕ
   | .empty n => n
   | .witness ops _ _ => initial_offset ops

--- a/Clean/Circuit/Extensions.lean
+++ b/Clean/Circuit/Extensions.lean
@@ -6,12 +6,12 @@ variable {F :Type} [Field F]
 namespace Provable
 variable {α β: TypePair} [ProvableType F α] [ProvableType F β]
 
-@[simp]
+@[gadget_norm]
 def witness (α: TypePair) {F: Type} [Field F] [inst: ProvableType F α] (compute : Environment F → α.value) := do
   let vars ← Circuit.witness_vars inst.size (fun env => compute env |> to_values)
   return from_vars <| Vector.map Expression.var vars
 
-@[simp]
+@[gadget_norm]
 def assert_equal {F: Type} [Field F] [ProvableType F α] (a a': α.var) : Circuit F Unit :=
   let vars := to_vars a
   let vars' := to_vars a'

--- a/Clean/Circuit/Extensions.lean
+++ b/Clean/Circuit/Extensions.lean
@@ -6,12 +6,12 @@ variable {F :Type} [Field F]
 namespace Provable
 variable {α β: TypePair} [ProvableType F α] [ProvableType F β]
 
-@[gadget_norm]
+@[circuit_norm]
 def witness (α: TypePair) {F: Type} [Field F] [inst: ProvableType F α] (compute : Environment F → α.value) := do
   let vars ← Circuit.witness_vars inst.size (fun env => compute env |> to_values)
   return from_vars <| Vector.map Expression.var vars
 
-@[gadget_norm]
+@[circuit_norm]
 def assert_equal {F: Type} [Field F] [ProvableType F α] (a a': α.var) : Circuit F Unit :=
   let vars := to_vars a
   let vars' := to_vars a'

--- a/Clean/Circuit/SimpGadget.lean
+++ b/Clean/Circuit/SimpGadget.lean
@@ -4,4 +4,4 @@ import Lean.Meta.Tactic.Simp.RegisterCommand
 import Lean.LabelAttribute
 
 
-register_simp_attr gadget_norm
+register_simp_attr circuit_norm

--- a/Clean/Circuit/SimpGadget.lean
+++ b/Clean/Circuit/SimpGadget.lean
@@ -1,0 +1,7 @@
+import Mathlib.Init
+import Lean.Meta.Tactic.Simp.SimpTheorems
+import Lean.Meta.Tactic.Simp.RegisterCommand
+import Lean.LabelAttribute
+
+
+register_simp_attr gadget_norm

--- a/Clean/Circuit/SubCircuit.lean
+++ b/Clean/Circuit/SubCircuit.lean
@@ -170,7 +170,7 @@ def formal_assertion_to_subcircuit (n: ℕ)
 end Circuit
 
 /-- Include a subcircuit. -/
-@[gadget_norm]
+@[circuit_norm]
 def subcircuit (circuit: FormalCircuit F β α) (b: β.var) : Circuit F α.var := ⟨
   fun ops =>
     let ⟨ a, subcircuit ⟩ := Circuit.formal_circuit_to_subcircuit ops.offset circuit b
@@ -179,7 +179,7 @@ def subcircuit (circuit: FormalCircuit F β α) (b: β.var) : Circuit F α.var :
 ⟩
 
 /-- Include an assertion subcircuit. -/
-@[gadget_norm]
+@[circuit_norm]
 def assertion (circuit: FormalAssertion F β) (b: β.var) : Circuit F Unit := ⟨
   fun ops =>
     let subcircuit := Circuit.formal_assertion_to_subcircuit ops.offset circuit b

--- a/Clean/Circuit/SubCircuit.lean
+++ b/Clean/Circuit/SubCircuit.lean
@@ -58,7 +58,6 @@ theorem can_replace_subcircuits {n: ℕ} : ∀ {ops : Operations F n}, ∀ {env 
 /--
 Theorem and implementation that allows us to take a formal circuit and use it as a subcircuit.
 -/
-@[simp]
 def formal_circuit_to_subcircuit (n: ℕ)
   (circuit: FormalCircuit F β α) (b_var : β.var) : α.var × SubCircuit F n :=
   let res := circuit.main b_var |>.run n
@@ -117,7 +116,6 @@ def formal_circuit_to_subcircuit (n: ℕ)
 /--
 Theorem and implementation that allows us to take a formal assertion and use it as a subcircuit.
 -/
-@[simp]
 def formal_assertion_to_subcircuit (n: ℕ)
   (circuit: FormalAssertion F β) (b_var : β.var) : SubCircuit F n :=
   let res := circuit.main b_var |>.run n
@@ -172,7 +170,7 @@ def formal_assertion_to_subcircuit (n: ℕ)
 end Circuit
 
 /-- Include a subcircuit. -/
-@[simp]
+@[gadget_norm]
 def subcircuit (circuit: FormalCircuit F β α) (b: β.var) : Circuit F α.var := ⟨
   fun ops =>
     let ⟨ a, subcircuit ⟩ := Circuit.formal_circuit_to_subcircuit ops.offset circuit b
@@ -181,7 +179,7 @@ def subcircuit (circuit: FormalCircuit F β α) (b: β.var) : Circuit F α.var :
 ⟩
 
 /-- Include an assertion subcircuit. -/
-@[simp]
+@[gadget_norm]
 def assertion (circuit: FormalAssertion F β) (b: β.var) : Circuit F Unit := ⟨
   fun ops =>
     let subcircuit := Circuit.formal_assertion_to_subcircuit ops.offset circuit b

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -61,6 +61,7 @@ what follows are relationships between different ways of deriving local witness 
 and between different versions of `Environment.uses_local_witnesses`
 -/
 
+set_option trace.Meta.Tactic.simp.rewrite true
 /--
 The witness length from flat and nested operations is the same
 -/
@@ -69,7 +70,7 @@ lemma flat_witness_length_eq {n: ℕ} {ops: Operations F n} :
   induction ops with
   | empty => trivial
   | witness ops m c ih | assert ops c ih | lookup ops c ih | subcircuit ops _ ih =>
-    dsimp [to_flat_operations, Operations.local_length]
+    dsimp only [to_flat_operations, Operations.local_length, SubCircuit.witness_length]
     generalize to_flat_operations ops = flat_ops at *
     generalize ops.local_length = n at *
     induction flat_ops using FlatOperation.witness_length.induct generalizing n with
@@ -99,7 +100,7 @@ lemma flat_witness_eq_witness {n: ℕ} {ops: Operations F n} {env} :
   induction ops with
   | empty => trivial
   | witness ops m c ih | assert ops c ih | lookup ops c ih | subcircuit ops _ ih =>
-    dsimp [to_flat_operations, Operations.local_length, gadget_norm]
+    dsimp only [to_flat_operations, Operations.local_length, gadget_norm, Operations.local_witnesses, Vector.append]
     rw [←ih, witnesses_append]
     try simp only [witness_length, witnesses, Vector.get, List.get_eq_getElem, Fin.coe_cast,
       Vector.nil, List.append_nil, zero_add, subset_refl, Set.coe_inclusion]
@@ -160,7 +161,7 @@ lemma env_extends_subcircuit_inner {n: ℕ} {ops: Operations F n} {env: Environm
   simp only [SubCircuit.witnesses, Vector.get, List.get_eq_getElem, Fin.coe_cast]
   have lt1 : i < (witnesses env c.ops).val.length := by rw [(witnesses env c.ops).prop]; exact i.is_lt
   rw [List.getElem_append_right'' (ops.local_witnesses env).val lt1]
-  simp [Nat.add_comm]
+  simp only [Nat.add_comm, Mathlib.Vector.length_val]
 
 end Environment
 

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -61,7 +61,6 @@ what follows are relationships between different ways of deriving local witness 
 and between different versions of `Environment.uses_local_witnesses`
 -/
 
-set_option trace.Meta.Tactic.simp.rewrite true
 /--
 The witness length from flat and nested operations is the same
 -/
@@ -88,9 +87,9 @@ lemma witnesses_append {F} {a b: List (FlatOperation F)} {env} :
   induction a using FlatOperation.witness_length.induct with
   | case1 => simp only [List.nil_append, witness_length, witnesses, Vector.nil]
   | case2 _ _ _ ih =>
-    simp [List.cons_append, witness_length, witnesses, List.append_eq, ih]
+    simp only [List.cons_append, witness_length, witnesses, List.append_eq, ih, List.append_assoc]
   | case3 _ _ ih | case4 _ _ ih =>
-    simp [List.cons_append, witness_length, witnesses, List.append_eq, ih]
+    simp only [List.cons_append, witness_length, witnesses, List.append_eq, ih, Subtype.coe_eta]
 
 /--
 The witnesses created from flat and nested operations are the same
@@ -126,7 +125,9 @@ lemma env_extends_witness {n: ℕ} {ops: Operations F n} {env: Environment F} {m
   specialize h ⟨ i, by omega ⟩
   simp only [Fin.coe_cast, Fin.cast_mk] at h
   rw [h]
-  simp [List.getElem_append]
+  simp only [Vector.get, Vector.append.eq_1, Fin.cast_mk, List.get_eq_getElem, Mathlib.Vector.length_val,
+  Fin.is_lt, List.getElem_append, Fin.coe_cast]
+
 
 lemma env_extends_assert {n: ℕ} {ops: Operations F n} {env: Environment F} {c} :
   env.uses_local_witnesses (ops.assert c) → env.uses_local_witnesses ops := by
@@ -145,7 +146,9 @@ lemma env_extends_subcircuit {n: ℕ} {ops: Operations F n} {env: Environment F}
   specialize h ⟨ i, this ⟩
   simp only [Fin.coe_eq_castSucc, Fin.coe_castSucc] at h
   rw [h]
-  simp [List.getElem_append]
+  simp only [Vector.get, SubCircuit.witness_length, Vector.append.eq_1, Fin.cast_mk, List.get_eq_getElem,
+  Mathlib.Vector.length_val, Fin.is_lt, List.getElem_append, Fin.coe_cast]
+
 
 lemma env_extends_subcircuit_inner {n: ℕ} {ops: Operations F n} {env: Environment F} {c} :
   env.uses_local_witnesses (ops.subcircuit c) → env.extends_vector (witnesses env c.ops) n

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -23,7 +23,7 @@ theorem can_replace_soundness  {n: ℕ} {ops : Operations F n} {env} :
   induction ops with
   | empty => trivial
   | witness ops c ih | assert ops c ih | lookup ops c ih =>
-    cases ops <;> simp_all [constraints_hold.completeness, constraints_hold, gadget_norm]
+    cases ops <;> simp_all [constraints_hold.completeness, constraints_hold, circuit_norm]
   | subcircuit ops circuit ih =>
     dsimp only [constraints_hold.soundness]
     dsimp only [constraints_hold] at h
@@ -99,7 +99,7 @@ lemma flat_witness_eq_witness {n: ℕ} {ops: Operations F n} {env} :
   induction ops with
   | empty => trivial
   | witness ops m c ih | assert ops c ih | lookup ops c ih | subcircuit ops _ ih =>
-    dsimp only [to_flat_operations, Operations.local_length, gadget_norm, Operations.local_witnesses, Vector.append]
+    dsimp only [to_flat_operations, Operations.local_length, circuit_norm, Operations.local_witnesses, Vector.append]
     rw [←ih, witnesses_append]
     try simp only [witness_length, witnesses, Vector.get, List.get_eq_getElem, Fin.coe_cast,
       Vector.nil, List.append_nil, zero_add, subset_refl, Set.coe_inclusion]

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -23,7 +23,7 @@ theorem can_replace_soundness  {n: ℕ} {ops : Operations F n} {env} :
   induction ops with
   | empty => trivial
   | witness ops c ih | assert ops c ih | lookup ops c ih =>
-    cases ops <;> simp_all [constraints_hold.completeness, constraints_hold]
+    cases ops <;> simp_all [constraints_hold.completeness, constraints_hold, gadget_norm]
   | subcircuit ops circuit ih =>
     dsimp only [constraints_hold.soundness]
     dsimp only [constraints_hold] at h
@@ -99,7 +99,7 @@ lemma flat_witness_eq_witness {n: ℕ} {ops: Operations F n} {env} :
   induction ops with
   | empty => trivial
   | witness ops m c ih | assert ops c ih | lookup ops c ih | subcircuit ops _ ih =>
-    dsimp [to_flat_operations, Operations.local_length]
+    dsimp [to_flat_operations, Operations.local_length, gadget_norm]
     rw [←ih, witnesses_append]
     try simp only [witness_length, witnesses, Vector.get, List.get_eq_getElem, Fin.coe_cast,
       Vector.nil, List.append_nil, zero_add, subset_refl, Set.coe_inclusion]

--- a/Clean/Gadgets/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32Full.lean
@@ -96,7 +96,7 @@ theorem soundness : Soundness (F p) (Inputs p) (Outputs p) add32_full assumption
   have ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm
 
   -- -- simplify circuit
-  dsimp [add32_full, Boolean.circuit] at h
+  dsimp [add32_full, Boolean.circuit, gadget_norm, Circuit.formal_assertion_to_subcircuit] at h
   simp only [true_implies, true_and, and_assoc] at h
   set z0 := env.get i0
   set c0 := env.get (i0 + 1)
@@ -118,6 +118,7 @@ theorem soundness : Soundness (F p) (Inputs p) (Outputs p) add32_full assumption
   set output := eval env (main.output i0)
   have h_output : output = { z := U32.mk z0 z1 z2 z3, carry_out := c3 } := by
     dsimp [output, from_values, to_vars]
+    simp [Circuit.formal_assertion_to_subcircuit, FlatOperation.witness_length, OperationsList.from_offset, to_flat_operations, constraints_hold_flat, Expression.eval]
 
   rw [h_output]
   dsimp only [spec, U32.value, U32.is_normalized]
@@ -190,7 +191,7 @@ theorem completeness : Completeness (F p) (Inputs p) (Outputs p) add32_full assu
   have ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm
 
   -- simplify circuit
-  dsimp [add32_full, Boolean.circuit, Circuit.formal_assertion_to_subcircuit]
+  dsimp [add32_full, Boolean.circuit, Circuit.formal_assertion_to_subcircuit, gadget_norm]
   simp only [true_and, and_assoc]
   rw [‹x0_var.eval env = x0›, ‹y0_var.eval env = y0›, ‹carry_in_var.eval env = carry_in›]
   rw [‹x1_var.eval env = x1›, ‹y1_var.eval env = y1›]

--- a/Clean/Gadgets/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32Full.lean
@@ -91,9 +91,11 @@ theorem soundness : Soundness (F p) (Inputs p) (Outputs p) add32_full assumption
 
   -- -- simplify assumptions
   dsimp only [assumptions, U32.is_normalized] at as
-  have ⟨ x_norm, y_norm, carry_in_bool ⟩ := as
-  have ⟨ x0_byte, x1_byte, x2_byte, x3_byte ⟩ := x_norm
-  have ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm
+
+  -- TODO: those are not used because we are assuming right now p > 2^32
+  have ⟨ _x_norm, _y_norm, carry_in_bool ⟩ := as
+  -- have ⟨ x0_byte, x1_byte, x2_byte, x3_byte ⟩ := x_norm
+  -- have ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm
 
   -- -- simplify circuit
   dsimp [add32_full, Boolean.circuit, gadget_norm, Circuit.formal_assertion_to_subcircuit] at h
@@ -111,14 +113,14 @@ theorem soundness : Soundness (F p) (Inputs p) (Outputs p) add32_full assumption
   rw [‹x2_var.eval env = x2›, ‹y2_var.eval env = y2›] at h
   rw [‹x3_var.eval env = x3›, ‹y3_var.eval env = y3›] at h
   rw [ByteTable.equiv z0, ByteTable.equiv z1, ByteTable.equiv z2, ByteTable.equiv z3] at h
-  have ⟨ z0_byte, c0_bool, h0, z1_byte, c1_bool, h1, z2_byte, c2_bool, h2, z3_byte, c3_bool, h3 ⟩ := h
+  have ⟨ z0_byte, _c0_bool, h0, z1_byte, _c1_bool, h1, z2_byte, _c2_bool, h2, z3_byte, c3_bool, h3 ⟩ := h
 
   -- simplify output and spec
   set main := add32_full ⟨⟨ x0_var, x1_var, x2_var, x3_var ⟩,⟨ y0_var, y1_var, y2_var, y3_var ⟩,carry_in_var⟩
   set output := eval env (main.output i0)
   have h_output : output = { z := U32.mk z0 z1 z2 z3, carry_out := c3 } := by
     dsimp [output, from_values, to_vars]
-    simp [Circuit.formal_assertion_to_subcircuit, FlatOperation.witness_length, OperationsList.from_offset, to_flat_operations, constraints_hold_flat, Expression.eval]
+    simp only [FlatOperation.witness_length, add_zero]
 
   rw [h_output]
   dsimp only [spec, U32.value, U32.is_normalized]

--- a/Clean/Gadgets/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32Full.lean
@@ -98,7 +98,7 @@ theorem soundness : Soundness (F p) (Inputs p) (Outputs p) add32_full assumption
   -- have ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm
 
   -- -- simplify circuit
-  dsimp [add32_full, Boolean.circuit, gadget_norm, Circuit.formal_assertion_to_subcircuit] at h
+  dsimp [add32_full, Boolean.circuit, circuit_norm, Circuit.formal_assertion_to_subcircuit] at h
   simp only [true_implies, true_and, and_assoc] at h
   set z0 := env.get i0
   set c0 := env.get (i0 + 1)
@@ -193,7 +193,7 @@ theorem completeness : Completeness (F p) (Inputs p) (Outputs p) add32_full assu
   have ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm
 
   -- simplify circuit
-  dsimp [add32_full, Boolean.circuit, Circuit.formal_assertion_to_subcircuit, gadget_norm]
+  dsimp [add32_full, Boolean.circuit, Circuit.formal_assertion_to_subcircuit, circuit_norm]
   simp only [true_and, and_assoc]
   rw [‹x0_var.eval env = x0›, ‹y0_var.eval env = y0›, ‹carry_in_var.eval env = carry_in›]
   rw [‹x1_var.eval env = x1›, ‹y1_var.eval env = y1›]

--- a/Clean/Gadgets/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32Full.lean
@@ -90,7 +90,7 @@ theorem soundness : Soundness (F p) (Inputs p) (Outputs p) add32_full assumption
   have : carry_in_var.eval env = carry_in := by injection h_inputs
 
   -- -- simplify assumptions
-  dsimp [assumptions, U32.is_normalized] at as
+  dsimp only [assumptions, U32.is_normalized] at as
   have ⟨ x_norm, y_norm, carry_in_bool ⟩ := as
   have ⟨ x0_byte, x1_byte, x2_byte, x3_byte ⟩ := x_norm
   have ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm

--- a/Clean/Gadgets/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32Full.lean
@@ -120,7 +120,7 @@ theorem soundness : Soundness (F p) (Inputs p) (Outputs p) add32_full assumption
   set output := eval env (main.output i0)
   have h_output : output = { z := U32.mk z0 z1 z2 z3, carry_out := c3 } := by
     dsimp [output, from_values, to_vars]
-    simp only [FlatOperation.witness_length, add_zero]
+    simp only [SubCircuit.witness_length, FlatOperation.witness_length, add_zero]
 
   rw [h_output]
   dsimp only [spec, U32.value, U32.is_normalized]

--- a/Clean/Gadgets/Addition8/Addition8.lean
+++ b/Clean/Gadgets/Addition8/Addition8.lean
@@ -61,7 +61,7 @@ def circuit : FormalCircuit (F p) (Inputs p) (field (F p)) where
 
     -- simplify constraints hypothesis
     -- it's just the `subcircuit_soundness` of `Gadgets.Addition8Full.circuit`
-    dsimp [from_values, to_vars] at h_holds
+    dsimp [gadget_norm, from_values, to_vars] at h_holds
 
     -- rewrite input and ouput values
     rw [hx, hy] at h_holds
@@ -94,7 +94,7 @@ def circuit : FormalCircuit (F p) (Inputs p) (field (F p)) where
 
     -- simplify assumptions and goal
     dsimp [assumptions] at as
-    dsimp [from_values, to_vars]
+    dsimp [from_values, to_vars, gadget_norm]
     rw [hx, hy]
 
     -- the goal is just the `subcircuit_completeness` of `Gadgets.Addition8Full.circuit`, i.e. the assumptions must hold

--- a/Clean/Gadgets/Addition8/Addition8.lean
+++ b/Clean/Gadgets/Addition8/Addition8.lean
@@ -61,7 +61,7 @@ def circuit : FormalCircuit (F p) (Inputs p) (field (F p)) where
 
     -- simplify constraints hypothesis
     -- it's just the `subcircuit_soundness` of `Gadgets.Addition8Full.circuit`
-    dsimp [gadget_norm, from_values, to_vars] at h_holds
+    dsimp [circuit_norm, from_values, to_vars] at h_holds
 
     -- rewrite input and ouput values
     rw [hx, hy] at h_holds
@@ -94,7 +94,7 @@ def circuit : FormalCircuit (F p) (Inputs p) (field (F p)) where
 
     -- simplify assumptions and goal
     dsimp [assumptions] at as
-    dsimp [from_values, to_vars, gadget_norm]
+    dsimp [from_values, to_vars, circuit_norm]
     rw [hx, hy]
 
     -- the goal is just the `subcircuit_completeness` of `Gadgets.Addition8Full.circuit`, i.e. the assumptions must hold

--- a/Clean/Gadgets/Addition8/Addition8Full.lean
+++ b/Clean/Gadgets/Addition8/Addition8Full.lean
@@ -64,7 +64,7 @@ def circuit : FormalCircuit (F p) (Inputs p) (field (F p)) where
 
     -- simplify constraints hypothesis
     -- it's just the `subcircuit_soundness` of `Add8FullCarry.circuit`
-    dsimp at h_holds
+    dsimp [gadget_norm] at h_holds
 
     -- rewrite input and ouput values
     rw [hx, hy, hcarry_in] at h_holds
@@ -100,7 +100,7 @@ def circuit : FormalCircuit (F p) (Inputs p) (field (F p)) where
 
     -- simplify assumptions and goal
     dsimp [assumptions] at as
-    dsimp
+    dsimp [gadget_norm]
     rw [hx, hy, hcarry_in]
 
     -- the goal is just the `subcircuit_completeness` of `Add8FullCarry.circuit`, i.e. the assumptions must hold

--- a/Clean/Gadgets/Addition8/Addition8Full.lean
+++ b/Clean/Gadgets/Addition8/Addition8Full.lean
@@ -64,7 +64,7 @@ def circuit : FormalCircuit (F p) (Inputs p) (field (F p)) where
 
     -- simplify constraints hypothesis
     -- it's just the `subcircuit_soundness` of `Add8FullCarry.circuit`
-    dsimp [gadget_norm] at h_holds
+    dsimp [circuit_norm] at h_holds
 
     -- rewrite input and ouput values
     rw [hx, hy, hcarry_in] at h_holds
@@ -100,7 +100,7 @@ def circuit : FormalCircuit (F p) (Inputs p) (field (F p)) where
 
     -- simplify assumptions and goal
     dsimp [assumptions] at as
-    dsimp [gadget_norm]
+    dsimp [circuit_norm]
     rw [hx, hy, hcarry_in]
 
     -- the goal is just the `subcircuit_completeness` of `Add8FullCarry.circuit`, i.e. the assumptions must hold

--- a/Clean/Gadgets/Addition8/Addition8FullCarry.lean
+++ b/Clean/Gadgets/Addition8/Addition8FullCarry.lean
@@ -98,7 +98,7 @@ def circuit : FormalCircuit (F p) (Inputs p) (Outputs p) where
     have hcarry_in : carry_in_var.eval env = carry_in := by injection h_inputs
 
     -- simplify constraints hypothesis
-    dsimp [gadget_norm] at h_holds
+    dsimp [circuit_norm] at h_holds
     set z := env.get i0
     set carry_out := env.get (i0 + 1)
     rw [hx, hy, hcarry_in] at h_holds
@@ -142,7 +142,7 @@ def circuit : FormalCircuit (F p) (Inputs p) (Outputs p) where
     dsimp [assumptions] at as
 
     -- unfold goal, (re)introduce names for some of unfolded variables
-    dsimp [Boolean.circuit, assert_bool, gadget_norm]
+    dsimp [Boolean.circuit, assert_bool, circuit_norm]
     rw [hx, hy, hcarry_in]
     set z := env.get i0
     set carry_out := env.get (i0 + 1)
@@ -150,12 +150,12 @@ def circuit : FormalCircuit (F p) (Inputs p) (Outputs p) where
     -- simplify local witnesses
     have hz : z = mod_256 (x + y + carry_in) := by
       have henv0 := henv (0 : Fin 2)
-      dsimp [gadget_norm] at henv0
+      dsimp [circuit_norm] at henv0
       rwa [hx, hy, hcarry_in] at henv0
 
     have hcarry_out : carry_out = floordiv (x + y + carry_in) 256 := by
       have henv1 := henv (1 : Fin 2)
-      dsimp [gadget_norm] at henv1
+      dsimp [circuit_norm] at henv1
       rwa [hx, hy, hcarry_in] at henv1
 
     -- now it's just mathematics!

--- a/Clean/Gadgets/Addition8/Addition8FullCarry.lean
+++ b/Clean/Gadgets/Addition8/Addition8FullCarry.lean
@@ -98,7 +98,7 @@ def circuit : FormalCircuit (F p) (Inputs p) (Outputs p) where
     have hcarry_in : carry_in_var.eval env = carry_in := by injection h_inputs
 
     -- simplify constraints hypothesis
-    dsimp at h_holds
+    dsimp [gadget_norm] at h_holds
     set z := env.get i0
     set carry_out := env.get (i0 + 1)
     rw [hx, hy, hcarry_in] at h_holds
@@ -142,7 +142,7 @@ def circuit : FormalCircuit (F p) (Inputs p) (Outputs p) where
     dsimp [assumptions] at as
 
     -- unfold goal, (re)introduce names for some of unfolded variables
-    dsimp [Boolean.circuit, assert_bool]
+    dsimp [Boolean.circuit, assert_bool, gadget_norm]
     rw [hx, hy, hcarry_in]
     set z := env.get i0
     set carry_out := env.get (i0 + 1)
@@ -150,12 +150,12 @@ def circuit : FormalCircuit (F p) (Inputs p) (Outputs p) where
     -- simplify local witnesses
     have hz : z = mod_256 (x + y + carry_in) := by
       have henv0 := henv (0 : Fin 2)
-      dsimp at henv0
+      dsimp [gadget_norm] at henv0
       rwa [hx, hy, hcarry_in] at henv0
 
     have hcarry_out : carry_out = floordiv (x + y + carry_in) 256 := by
       have henv1 := henv (1 : Fin 2)
-      dsimp at henv1
+      dsimp [gadget_norm] at henv1
       rwa [hx, hy, hcarry_in] at henv1
 
     -- now it's just mathematics!

--- a/Clean/Gadgets/Addition8/Theorems.lean
+++ b/Clean/Gadgets/Addition8/Theorems.lean
@@ -96,7 +96,7 @@ theorem soundness (x y out carry_in carry_out: F p):
   rcases carry_out_bool with zero_carry | one_carry
   -- case with zero carry
   · rw [zero_carry] at h
-    simp [ZMod.val_add] at h
+    simp only [neg_mul, one_mul, zero_mul, mul_zero, add_zero] at h
     rw [←sub_eq_add_neg] at h
     have h_spec : carry_in + x + y - out = 0 := by
       rw [add_comm (x + y), ←add_assoc] at h
@@ -117,7 +117,7 @@ theorem soundness (x y out carry_in carry_out: F p):
 
   -- case with one carry
   · rw [one_carry] at h
-    simp [ZMod.val_add] at h
+    simp only [neg_mul, one_mul] at h
     -- rw [←sub_eq_add_neg, ←sub_eq_add_neg (carry_in + x + y)] at h
     have h_spec : carry_in + x + y - out - 256 = 0 := by
       rw [add_comm (x + y), ←add_assoc] at h
@@ -151,12 +151,12 @@ theorem completeness_add [p_neq_zero : NeZero p] (x y carry_in: F p) :
   simp
   rw [←sub_eq_add_neg, sub_eq_zero, add_eq_of_eq_sub]
   ring_nf
-  dsimp [FieldUtils.mod_256, FieldUtils.mod]
+  dsimp only [FieldUtils.mod_256, FieldUtils.mod, PNat.val_ofNat]
 
   -- lift everything to the naturals
   apply_fun ZMod.val
-  · simp [ZMod.val_add (FieldUtils.floordiv (x + y + carry_in) 256 * 256)]
-    dsimp [FieldUtils.floordiv]
+  · simp only [ZMod.val_add (FieldUtils.floordiv (x + y + carry_in) 256 * 256)]
+    dsimp only [FieldUtils.floordiv, PNat.val_ofNat]
     rw [ZMod.val_mul, FieldUtils.val_of_nat_to_field_eq, FieldUtils.val_of_nat_to_field_eq]
     repeat rw [ZMod.val_add]
     simp
@@ -164,7 +164,7 @@ theorem completeness_add [p_neq_zero : NeZero p] (x y carry_in: F p) :
     -- we need to show that the sum does not wrap around
     set T := ZMod.val x + ZMod.val y + ZMod.val carry_in
     have T_not_wrap : T % p = T := by
-      dsimp [T]
+      dsimp only
       rw [Nat.mod_eq_iff_lt p_neq_zero.out]
       have sum_bound := FieldUtils.byte_sum_le_bound x y as_x as_y
       have sum_lt_512 : (x + y).val + carry_in.val ≤ 511 := by
@@ -200,7 +200,7 @@ theorem completeness_bool [p_neq_zero : NeZero p] (x y carry_in: F p) :
     let carry_out := FieldUtils.floordiv (x + y + carry_in) 256
     carry_out = 0 ∨ carry_out = 1 := by
   intro as_x as_y carry_in_bound
-  dsimp [FieldUtils.floordiv]
+  dsimp only [FieldUtils.floordiv, PNat.val_ofNat]
 
   -- we show that the carry_out is either 0 or 1 by explicitly
   -- constructing the two cases

--- a/Clean/Gadgets/Boolean.lean
+++ b/Clean/Gadgets/Boolean.lean
@@ -35,10 +35,10 @@ by
     show x = 1
     calc x
     _ = (x + -1) + 1 := by ring
-    _ = 1 := by simp [h]
+    _ = 1 := by simp only [h, zero_add]
   · intro (h : x = 1)
     show x + -1 = 0
-    simp [h]
+    simp only [h, add_neg_cancel]
 
 open Provable (field)
 
@@ -53,14 +53,14 @@ def circuit : FormalAssertion (F p) (field (F p)) where
   soundness := by
     intro _ env x_var x hx _ h_holds
     change x_var.eval env = x at hx
-    dsimp [gadget_norm] at h_holds
+    dsimp only [Circuit.constraints_hold.soundness, Expression.eval, Expression.eval.eq_2] at h_holds
     rw [hx] at h_holds
     apply equiv.mp h_holds
 
   completeness := by
     intro n env x_var _ x hx _ spec
     change x_var.eval env = x at hx
-    dsimp [gadget_norm]
+    dsimp only [Circuit.constraints_hold.completeness, Expression.eval, Expression.eval.eq_2]
     rw [hx]
     apply equiv.mpr spec
 end Boolean

--- a/Clean/Gadgets/Boolean.lean
+++ b/Clean/Gadgets/Boolean.lean
@@ -53,14 +53,14 @@ def circuit : FormalAssertion (F p) (field (F p)) where
   soundness := by
     intro _ env x_var x hx _ h_holds
     change x_var.eval env = x at hx
-    dsimp at h_holds
+    dsimp [gadget_norm] at h_holds
     rw [hx] at h_holds
     apply equiv.mp h_holds
 
   completeness := by
     intro n env x_var _ x hx _ spec
     change x_var.eval env = x at hx
-    dsimp
+    dsimp [gadget_norm]
     rw [hx]
     apply equiv.mpr spec
 end Boolean

--- a/Clean/Gadgets/ByteLookup.lean
+++ b/Clean/Gadgets/ByteLookup.lean
@@ -15,7 +15,7 @@ def ByteTable : Table (F p) where
   row i := vec [from_byte i]
 
 def ByteTable.soundness (x: F p) : ByteTable.contains (vec [x]) → x.val < 256 := by
-  dsimp [Table.contains, ByteTable]
+  dsimp only [ByteTable, Table.contains]
   rintro ⟨ i, h: vec [x] = vec [from_byte i] ⟩
   have h' : x = from_byte i := by repeat injection h with h
   have h'' : x.val = i.val := FieldUtils.nat_to_field_eq x h'
@@ -24,13 +24,13 @@ def ByteTable.soundness (x: F p) : ByteTable.contains (vec [x]) → x.val < 256 
 
 def ByteTable.completeness (x: F p) : x.val < 256 → ByteTable.contains (vec [x]) := by
   intro h
-  dsimp [Table.contains, ByteTable]
+  dsimp only [ByteTable, Table.contains]
   use x.val
-  simp [from_byte]
+  simp only [from_byte, Fin.val_natCast]
   ext1
   have h' : (x.val) % 256 = x.val := by
     rw [Nat.mod_eq_iff_lt]; assumption; norm_num
-  simp [h']
+  simp only [h', List.cons.injEq, and_true]
   rw [FieldUtils.nat_to_field_of_val_eq_iff]
 
 def ByteTable.equiv (x: F p) : ByteTable.contains (vec [x]) ↔ x.val < 256 :=

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -52,12 +52,12 @@ def circuit : FormalAssertion (F p) (Inputs p) where
     let ⟨x, y⟩ := input
     let ⟨x_var, y_var⟩ := vars
 
-    dsimp [gadget_norm] at h_holds
+    dsimp only [Circuit.constraints_hold.soundness, Expression.eval, Expression.eval.eq_2] at h_holds
     have hx : x_var.eval env = x := by injection h_inputs
     have hy : y_var.eval env = y := by injection h_inputs
     rw [hx, hy] at h_holds
 
-    dsimp [spec]
+    dsimp only [spec]
     ring_nf at h_holds
     rw [sub_eq_zero] at h_holds
     assumption
@@ -72,7 +72,7 @@ def circuit : FormalAssertion (F p) (Inputs p) where
     have hx : x_var.eval env = x := by injection h_inputs
     have hy : y_var.eval env = y := by injection h_inputs
 
-    simp [gadget_norm, spec]
+    simp only [Circuit.constraints_hold.completeness, Expression.eval, neg_mul, one_mul]
     rw [hx, hy, spec]
     ring
 end Gadgets.Equality

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -52,7 +52,7 @@ def circuit : FormalAssertion (F p) (Inputs p) where
     let ⟨x, y⟩ := input
     let ⟨x_var, y_var⟩ := vars
 
-    dsimp at h_holds
+    dsimp [gadget_norm] at h_holds
     have hx : x_var.eval env = x := by injection h_inputs
     have hy : y_var.eval env = y := by injection h_inputs
     rw [hx, hy] at h_holds
@@ -72,7 +72,7 @@ def circuit : FormalAssertion (F p) (Inputs p) where
     have hx : x_var.eval env = x := by injection h_inputs
     have hy : y_var.eval env = y := by injection h_inputs
 
-    simp [spec]
+    simp [gadget_norm, spec]
     rw [hx, hy, spec]
     ring
 end Gadgets.Equality

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -52,8 +52,7 @@ def everyRowTwoRowsInduction {M : ℕ+} {F : Type} {P : Trace M F → Sort*}
 lemma len_le_succ {M : ℕ+} {F : Type} (trace : Trace M F) (row : Row M F) : trace.len ≤ (trace +> row).len :=
   match trace with
   | <+> => by simp only [len, Nat.succ_eq_add_one, zero_add, zero_le]
-  | (rest +> row) =>
-    let ih := len_le_succ rest row
+  | (rest +> _) =>
     by simp only [len, Nat.succ_eq_add_one, le_add_iff_nonneg_right, zero_le]
 
 lemma len_ge_succ_of_ge {M : ℕ+} {N : ℕ} {F : Type} (trace : Trace M F) (row : Row M F) (_h : trace.len ≥ N) : (trace +> row).len ≥ N :=

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -51,15 +51,17 @@ def everyRowTwoRowsInduction {M : ℕ+} {F : Type} {P : Trace M F → Sort*}
 
 lemma len_le_succ {M : ℕ+} {F : Type} (trace : Trace M F) (row : Row M F) : trace.len ≤ (trace +> row).len :=
   match trace with
-  | <+> => by simp [Trace.len]
+  | <+> => by simp only [len, Nat.succ_eq_add_one, zero_add, zero_le]
   | (rest +> row) =>
     let ih := len_le_succ rest row
-    by simp [Trace.len, ih, Nat.le_succ]
+    by simp only [len, Nat.succ_eq_add_one, le_add_iff_nonneg_right, zero_le]
 
 lemma len_ge_succ_of_ge {M : ℕ+} {N : ℕ} {F : Type} (trace : Trace M F) (row : Row M F) (_h : trace.len ≥ N) : (trace +> row).len ≥ N :=
   match trace with
-  | <+> => by simp [Trace.len] at *; simp [_h]
-  | (rest +> row) => by simp [Trace.len] at *; linarith
+  | <+> => by
+      simp only [len, ge_iff_le, nonpos_iff_eq_zero, Nat.succ_eq_add_one, zero_add] at *
+      simp only [_h, zero_le]
+  | (rest +> row) => by simp only [len, Nat.succ_eq_add_one, ge_iff_le] at *; linarith
 
 /--
   This induction principle states that if a trace length is at leas two, then to prove a property

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -270,7 +270,6 @@ def assignment {α : Type} {F : Type} {M W : ℕ+} [Field F] (table : TableConst
   In particular, we construct the environment by taking directly the result of the assignment function
   so that every variable evaluate to the trace cell value which is assigned to
 -/
-@[simp]
 def constraints_hold_on_window {F : Type} {M W : ℕ+} [Field F]
     (table : TableConstraint F M W Unit) (window: TraceOfLength F M W) : Prop :=
   let ((ctx, ops), ()) := table TableContext.empty
@@ -285,7 +284,6 @@ def constraints_hold_on_window {F : Type} {M W : ℕ+} [Field F]
   -- lifting directly to the soundness of the sub-circuit
   foldl ops env
   where
-  @[simp]
   foldl : List (TableConstraintOperation F M W) -> (env: Environment F) -> Prop
   | [], _ => true
   | op :: ops, env =>
@@ -297,17 +295,14 @@ def output {α : Type} {F : Type} {M W : ℕ+} [Field F] (table : TableConstrain
   let ((_, _), a) := table TableContext.empty
   a
 
-@[simp]
 def witness_cell {F : Type} {M W : ℕ+} [Field F] (off : CellOffset M W) (compute : Unit → F): TableConstraint F M W (Variable F) :=
   as_table_operation fun ctx =>
   (TableConstraintOperation.Witness off compute, ⟨ ctx.offset ⟩)
 
-@[simp]
 def get_cell {F : Type} {M W : ℕ+} [Field F] (off : CellOffset M W): TableConstraint F M W (Variable F) :=
   as_table_operation fun ctx =>
   (TableConstraintOperation.Witness off (fun _ => 0), ⟨ ctx.offset ⟩)
 
-@[simp]
 def subcircuit
     {F : Type} {M W : ℕ+} [Field F]
     {α β : TypePair} [ProvableType F β] [ProvableType F α]
@@ -316,7 +311,6 @@ def subcircuit
   let ⟨ a, subcircuit ⟩ := Circuit.formal_circuit_to_subcircuit ctx.offset circuit b
   (TableConstraintOperation.Allocate subcircuit, a)
 
-@[simp]
 def assertion
     {F : Type} {M W : ℕ+} [Field F]
     {β : TypePair} [ProvableType F β]

--- a/Clean/Table/SimpTable.lean
+++ b/Clean/Table/SimpTable.lean
@@ -1,0 +1,7 @@
+import Mathlib.Init
+import Lean.Meta.Tactic.Simp.SimpTheorems
+import Lean.Meta.Tactic.Simp.RegisterCommand
+import Lean.LabelAttribute
+
+
+register_simp_attr table_norm

--- a/Clean/Tables/Addition8.lean
+++ b/Clean/Tables/Addition8.lean
@@ -42,7 +42,7 @@ def formal_add8_table : FormalTable (F:=(F p)) := {
     }
     | cons rest row ih => {
       -- simplify induction
-      simp [gadget_norm, table_norm]
+      simp [circuit_norm, table_norm]
       intros lookup_x lookup_y lookup_rest h_curr h_rest
       specialize ih lookup_rest h_rest
       simp [ih]

--- a/Clean/Tables/Addition8.lean
+++ b/Clean/Tables/Addition8.lean
@@ -42,7 +42,8 @@ def formal_add8_table : FormalTable (F:=(F p)) := {
     }
     | cons rest row ih => {
       -- simplify induction
-      simp
+      simp [gadget_norm, TraceOfLength.forAllRowsOfTrace.inner, TableConstraint.constraints_hold_on_window,
+        TableConstraint.constraints_hold_on_window.foldl]
       intros lookup_x lookup_y lookup_rest h_curr h_rest
       specialize ih lookup_rest h_rest
       simp [ih]

--- a/Clean/Tables/Addition8.lean
+++ b/Clean/Tables/Addition8.lean
@@ -34,16 +34,15 @@ def formal_add8_table : FormalTable (F:=(F p)) := {
   soundness := by
     intro N trace
     simp [assumptions_add8]
-    simp [add8Table, spec_add8]
+    simp [add8Table, spec_add8, table_norm]
 
     induction trace.val with
     | empty => {
-      simp
+      simp [table_norm]
     }
     | cons rest row ih => {
       -- simplify induction
-      simp [gadget_norm, TraceOfLength.forAllRowsOfTrace.inner, TableConstraint.constraints_hold_on_window,
-        TableConstraint.constraints_hold_on_window.foldl]
+      simp [gadget_norm, table_norm]
       intros lookup_x lookup_y lookup_rest h_curr h_rest
       specialize ih lookup_rest h_rest
       simp [ih]

--- a/Clean/Tables/Fibonacci8.lean
+++ b/Clean/Tables/Fibonacci8.lean
@@ -82,8 +82,9 @@ lemma constraints_hold_lift (curr : Row 2 (F p)) (next : Row 2 (F p)) :
     (ZMod.val (curr 0) < 256 → ZMod.val (curr 1) < 256 → ZMod.val (next 1) = (ZMod.val (curr 0) + ZMod.val (curr 1)) % 256) ∧ curr 1 = next 0
     := by
   intro h
-  dsimp [Circuit.formal_assertion_to_subcircuit] at h
-  dsimp [fib_table, from_values, to_vars] at h
+  simp only [TableConstraint.constraints_hold_on_window] at h
+  dsimp only [TableConstraint.constraints_hold_on_window.foldl, TableConstraintOperation.update_context, Circuit.formal_assertion_to_subcircuit] at h
+  dsimp [fib_table, from_values, to_vars, gadget_norm] at h
 
   rw [var1, var2, var3] at h
 
@@ -108,10 +109,10 @@ def formal_fib_table : FormalTable (F:=(F p)) := {
     induction' trace.val using Trace.everyRowTwoRowsInduction with first_row curr next rest _ ih2
     · simp
     · intro _
-      simp [fib_table]
+      simp [TableConstraint.constraints_hold_on_window, TableConstraint.constraints_hold_on_window.foldl, fib_table]
       intros boundary1 boundary2
       simp [Circuit.formal_assertion_to_subcircuit, Gadgets.Equality.circuit, Gadgets.Equality.spec,
-        from_values, to_vars
+        from_values, to_vars, gadget_norm
       ] at boundary1 boundary2
 
       have var1 : ((boundary_fib (p:=p) { offset := 0, assignment := fun _ ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0

--- a/Clean/Tables/Fibonacci8.lean
+++ b/Clean/Tables/Fibonacci8.lean
@@ -82,7 +82,7 @@ lemma constraints_hold_lift (curr : Row 2 (F p)) (next : Row 2 (F p)) :
     (ZMod.val (curr 0) < 256 → ZMod.val (curr 1) < 256 → ZMod.val (next 1) = (ZMod.val (curr 0) + ZMod.val (curr 1)) % 256) ∧ curr 1 = next 0
     := by
   intros h
-  dsimp [fib_table, from_values, to_vars, gadget_norm, table_norm, Circuit.formal_assertion_to_subcircuit] at h
+  dsimp [fib_table, from_values, to_vars, circuit_norm, table_norm, Circuit.formal_assertion_to_subcircuit] at h
   rw [var1, var2, var3, var4] at h
   simp [Gadgets.Addition8.circuit, Gadgets.Addition8.assumptions, Gadgets.Addition8.spec] at h
   simp only [Fin.isValue, Gadgets.Equality.circuit, Gadgets.Equality.spec, true_implies] at h
@@ -105,7 +105,7 @@ def formal_fib_table : FormalTable (F:=(F p)) := {
       simp [table_norm, fib_table]
       intros boundary1 boundary2
       simp [Circuit.formal_assertion_to_subcircuit, Gadgets.Equality.circuit, Gadgets.Equality.spec,
-        from_values, to_vars, gadget_norm
+        from_values, to_vars, circuit_norm
       ] at boundary1 boundary2
 
       have var1 : ((boundary_fib (p:=p) { offset := 0, assignment := fun _ ↦ { rowOffset := 0, column := 0 } }).1.1.2 0).column = 0

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -75,6 +75,17 @@ def decompose_nat (x: ℕ) : U32 (F p) :=
   ⟨ x0, x1, x2, x3 ⟩
 
 /--
+  Return a 32-bit unsigned integer from a natural number, by decomposing
+  it into four limbs of 8 bits each.
+-/
+def decompose_nat_expr (x: ℕ) : U32 (Expression (F p)) :=
+  let x0 := FieldUtils.mod x 256 (by linarith [p_large_enough.elim])
+  let x1 := FieldUtils.mod (FieldUtils.floordiv x 256) 256 (by linarith [p_large_enough.elim])
+  let x2 := FieldUtils.mod (FieldUtils.floordiv x 256^2) 256 (by linarith [p_large_enough.elim])
+  let x3 := FieldUtils.mod (FieldUtils.floordiv x 256^3) 256 (by linarith [p_large_enough.elim])
+  ⟨ x0, x1, x2, x3 ⟩
+
+/--
   Add two 32-bit unsigned integers, wrapping around on overflow over 2^32.
 -/
 def wrapping_add (x y: U32 (F p)) : U32 (F p) :=
@@ -95,6 +106,16 @@ lemma val_eq_256p2 : (256^2 : F p).val = 256^2 := by ring_nf; exact FieldUtils.v
 lemma val_eq_256p3 : (256^3 : F p).val = 256^3 := by ring_nf; exact FieldUtils.val_lt_p (256^3) (by linarith [p_large_enough.elim])
 lemma val_eq_256p4 : (256^4 : F p).val = 256^4 := by ring_nf; exact FieldUtils.val_lt_p (256^4) (by linarith [p_large_enough.elim])
 lemma val_eq_2p32 : (2^32 : F p).val = 2^32 := by have := val_eq_256p4 (p:=p); ring_nf at *; assumption
+
+
+lemma const_to_field (x: ℕ) (asd : x < p) : const (FieldUtils.nat_to_field x asd) = (x : (F p))  := by
+  sorry
+
+lemma zero_u32 : ((decompose_nat_expr 0) : U32 (Expression (F p)))  = ⟨0, 0, 0, 0⟩ := by sorry
+lemma one_u32 : ((decompose_nat_expr 1) : U32 (Expression (F p)))  = ⟨1, 0, 0, 0⟩ := by sorry
+
+
+
 
 /--
 tactic script to fully rewrite a ZMod expression to its Nat version, given that

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -103,7 +103,7 @@ theorem val_lt_p {p : ℕ} (x: ℕ) : (x < p) → (x : F p).val = x := by
 theorem boolean_lt_2 {b : F p} (hb : b = 0 ∨ b = 1) : b.val < 2 := by
   rcases hb with h0 | h1
   · rw [h0]; simp
-  · rw [h1]; simp [ZMod.val_one]
+  · rw [h1]; simp only [ZMod.val_one, Nat.one_lt_ofNat]
 
 def nat_to_field (n: ℕ) (lt: n < p) : F p :=
   match p with
@@ -118,7 +118,7 @@ theorem nat_to_field_eq {n: ℕ} {lt: n < p} (x : F p) (hx: x = nat_to_field n l
 theorem nat_to_field_of_val_eq_iff {x : F p} {lt: x.val < p} : nat_to_field (x.val) lt = x := by
   cases p
   · exact False.elim (Nat.not_lt_zero x.val lt)
-  · dsimp [nat_to_field]; aesop
+  · dsimp only [nat_to_field]; aesop
 
 theorem val_of_nat_to_field_eq {n: ℕ} {lt: n < p} : (nat_to_field n lt).val = n := by
   cases p

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -28,7 +28,7 @@ def nil : Vector α 0 := ⟨ [], rfl ⟩
 
 @[simp]
 def cons (a: α) (v: Vector α n)  : Vector α (n + 1) :=
-  ⟨ a :: v.val, by simp [v.prop] ⟩
+  ⟨ a :: v.val, by simp only [List.length_cons, v.prop] ⟩
 
 @[simp]
 def map (f: α → β) (v: Vector α n) : Vector β n :=
@@ -60,11 +60,11 @@ theorem get_map {n} {f: α → β} {v: Vector α n} {i: Fin n} : get (map f v) i
 
 @[simp]
 def append {m} (v: Vector α n) (w: Vector α m) : Vector α (n + m) :=
-  ⟨ v.val ++ w.val, by simp [v.prop, w.prop] ⟩
+  ⟨ v.val ++ w.val, by simp only [List.length_append, v.prop, w.prop] ⟩
 
 @[simp]
 def push (v: Vector α n) (a: α) : Vector α (n + 1) :=
-  ⟨ v.val ++ [a], by simp [v.prop] ⟩
+  ⟨ v.val ++ [a], by simp only [List.length_append, v.prop, List.length_singleton] ⟩
 
 theorem push_of_len_succ {n: ℕ} (v: Vector α (n + 1)) : ∃ as: Vector α n, ∃ a: α, v = push as a := by
   match v with


### PR DESCRIPTION
- Add two custom simp sets for gadgets and traces, so that specific theorems are not included in the general-purpose simp set
- Replace most of `simp` with `simp only` in the core theorems