### PR TITLE
Fix 32-bit addition assumptions

### DIFF
--- a/Clean.lean
+++ b/Clean.lean
@@ -1,5 +1,5 @@
 import Clean.Examples.Add8Operations
-import Clean.Gadgets.Addition32Full
+import Clean.Gadgets.Addition32.Addition32Full
 import Clean.Tables.Addition8
 import Clean.Tables.Fibonacci8
 import Clean.Tables.Fibonacci32

--- a/Clean/Gadgets/Addition32/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32/Addition32Full.lean
@@ -1,5 +1,6 @@
 import Clean.Gadgets.Addition8.Addition8FullCarry
 import Clean.Types.U32
+import Clean.Gadgets.Addition32.Theorems
 
 namespace Gadgets.Addition32Full
 variable {p : ℕ} [Fact p.Prime]
@@ -87,37 +88,6 @@ def spec (input : (Inputs p).value) (out: (Outputs p).value) :=
   ∧ z.is_normalized ∧ (carry_out = 0 ∨ carry_out = 1)
 
 
-lemma lift_val1 {x y b : (F p)} (x_byte : x.val < 256) (y_byte : y.val < 256) (b_bool : b = 0 ∨ b = 1) :
-    (x + y + b).val = (x.val + y.val + b.val) := by
-  calc (x + y + b).val
-  _ = (b + x + y).val := by ring_nf
-  _ = b.val + x.val + y.val := by
-    rw [FieldUtils.byte_sum_and_bit_do_not_wrap _ _ _ x_byte y_byte]
-    apply FieldUtils.boolean_lt_2
-    exact b_bool
-  _ = x.val + y.val + b.val := by ring
-
-lemma lift_val2 {x b : (F p)} (x_byte : x.val < 256) (b_bool : b = 0 ∨ b = 1) :
-    (b * 256 + x).val = (b.val * 256 + x.val) := by
-  rcases b_bool with b_zero | b_one
-  · rw [b_zero]
-    simp only [zero_mul, zero_add, ZMod.val_zero]
-  · rw [b_one, ZMod.val_one]
-    simp
-    rw [add_comm 256 _]
-    rw [FieldUtils.byte_plus_256_do_not_wrap]
-    rw [add_comm]
-    assumption
-
-omit p_large_enough in
-lemma zify_bool {b : (F p)} (b_bool : b = 0 ∨ b = 1) : (↑(b.val) : ℤ) = 0 ∨ (↑(b.val) : ℤ) = 1  := by
-  rcases b_bool with b_zero | b_one
-  · rw [b_zero]
-    simp only [ZMod.val_zero, CharP.cast_eq_zero, zero_ne_one, or_false]
-  · rw [b_one, ZMod.val_one]
-    simp only [Nat.cast_one, one_ne_zero, or_true]
-
-
 theorem soundness : Soundness (F p) (Inputs p) (Outputs p) add32_full assumptions spec := by
   rintro i0 env ⟨ x_var, y_var, carry_in_var ⟩ ⟨ x, y, carry_in ⟩ h_inputs as h
 
@@ -177,101 +147,17 @@ theorem soundness : Soundness (F p) (Inputs p) (Outputs p) add32_full assumption
   rw [h_output]
   dsimp only [spec, U32.value, U32.is_normalized]
 
-  -- get rid of the boolean carry_out
-  simp only [c3_bool, and_true]
-
-  -- lift everything to Z
+  -- get rid of the boolean carry_out and noramlized output
+  simp only [c3_bool, z0_byte, z1_byte, z2_byte, z3_byte, and_self, and_true]
   rw [add_neg_eq_iff_eq_add] at h0 h1 h2 h3
-  apply_fun ZMod.val at h0 h1 h2 h3
-  rw [lift_val1 x0_byte y0_byte carry_in_bool, lift_val2 z0_byte c0_bool] at h0
-  rw [lift_val1 x1_byte y1_byte c0_bool, lift_val2 z1_byte c1_bool] at h1
-  rw [lift_val1 x2_byte y2_byte c1_bool, lift_val2 z2_byte c2_bool] at h2
-  rw [lift_val1 x3_byte y3_byte c2_bool, lift_val2 z3_byte c3_bool] at h3
 
-  have c0_bool := zify_bool c0_bool
-  have c1_bool := zify_bool c1_bool
-  have c2_bool := zify_bool c2_bool
-  have c3_bool := zify_bool c3_bool
-  have carry_in_bool := zify_bool carry_in_bool
-
-  have x0_pos : 0 ≤ x0.val := by exact Nat.zero_le _
-  have y0_pos : 0 ≤ y0.val := by exact Nat.zero_le _
-  have x1_pos : 0 ≤ x1.val := by exact Nat.zero_le _
-  have y1_pos : 0 ≤ y1.val := by exact Nat.zero_le _
-  have x2_pos : 0 ≤ x2.val := by exact Nat.zero_le _
-  have y2_pos : 0 ≤ y2.val := by exact Nat.zero_le _
-  have x3_pos : 0 ≤ x3.val := by exact Nat.zero_le _
-  have y3_pos : 0 ≤ y3.val := by exact Nat.zero_le _
-  have z0_pos : 0 ≤ z0.val := by exact Nat.zero_le _
-  have z1_pos : 0 ≤ z1.val := by exact Nat.zero_le _
-  have z2_pos : 0 ≤ z2.val := by exact Nat.zero_le _
-  have z3_pos : 0 ≤ z3.val := by exact Nat.zero_le _
-
-  zify at *
-
-  set x0 : ℤ := ↑(ZMod.val x0)
-  set x1 : ℤ := ↑(ZMod.val x1)
-  set x2 : ℤ := ↑(ZMod.val x2)
-  set x3 : ℤ := ↑(ZMod.val x3)
-  set y0 : ℤ := ↑(ZMod.val y0)
-  set y1 : ℤ := ↑(ZMod.val y1)
-  set y2 : ℤ := ↑(ZMod.val y2)
-  set y3 : ℤ := ↑(ZMod.val y3)
-  set z0 : ℤ := ↑(ZMod.val z0)
-  set z1 : ℤ := ↑(ZMod.val z1)
-  set z2 : ℤ := ↑(ZMod.val z2)
-  set z3 : ℤ := ↑(ZMod.val z3)
-  set c0 : ℤ := ↑(ZMod.val c0)
-  set c1 : ℤ := ↑(ZMod.val c1)
-  set c2 : ℤ := ↑(ZMod.val c2)
-  set c3 : ℤ := ↑(ZMod.val c3)
-  set carry_in : ℤ := ↑(ZMod.val carry_in)
-
-  -- now everything, assumptions and goal, is over Z
-
-  -- add up all the equations
-  set z := z0 + z1*256 + z2*256^2 + z3*256^3
-  set x := x0 + x1*256 + x2*256^2 + x3*256^3
-  set y := y0 + y1*256 + y2*256^2 + y3*256^3
-  let lhs := z + c3*2^32
-  let rhs₀ := x0 + y0 + carry_in + -1 * z0 + -1 * (c0 * 256) -- h0 expression
-  let rhs₁ := x1 + y1 + c0 + -1 * z1 + -1 * (c1 * 256) -- h1 expression
-  let rhs₂ := x2 + y2 + c1 + -1 * z2 + -1 * (c2 * 256) -- h2 expression
-  let rhs₃ := x3 + y3 + c2 + -1 * z3 + -1 * (c3 * 256) -- h3 expression
-
-  have h_add := calc z + c3*2^32
-    -- substitute equations
-    _ = lhs + 0 + 256*0 + 256^2*0 + 256^3*0 := by ring
-    _ = lhs + rhs₀ + 256*rhs₁ + 256^2*rhs₂ + 256^3*rhs₃ := by
-      simp only [rhs₀, rhs₁, rhs₂, rhs₃]
-      simp only [h0, h1, h2, h3]
-      ring
-    -- simplify
-    _ = x + y + carry_in := by ring
-
-
-  have z_lt_2_32 : z < 2^32 := by dsimp only [z]; linarith
-  have z_pos : 0 ≤ z := by dsimp [z]; linarith
-  simp only [z0_byte, z1_byte, z2_byte, z3_byte, and_self, and_true]
-
-  rcases c3_bool with c3_zero | c3_one
-  · rw [c3_zero] at h_add
-    simp only [Int.reducePow, zero_mul, add_zero] at h_add
-    have sum_pos : 0 ≤ x + y + carry_in := by
-      rcases carry_in_bool with c_zero | c_one
-      · rw [c_zero]; linarith
-      · rw [c_one]; linarith
-    rw [Int.emod_eq_of_lt sum_pos (by linarith)]
-    rw [Int.ediv_eq_zero_of_lt sum_pos (by linarith)]
-    simp only [h_add, c3_zero, and_self]
-  · simp only [c3_one, one_mul] at h_add
-    rw [←h_add, Int.add_emod_self, Int.emod_eq_of_lt z_pos (by linarith)]
-    rw [
-      show z + 2^32 = z + 2^32 * 1 from rfl,
-      Int.add_mul_ediv_left _ _ (by linarith),
-      Int.ediv_eq_zero_of_lt z_pos z_lt_2_32
-    ]
-    simp only [c3_one, zero_add, and_self]
+  -- apply the main soundness theorem
+  apply Gadgets.Addition32.Theorems.add32_soundness
+    x0_byte x1_byte x2_byte x3_byte
+    y0_byte y1_byte y2_byte y3_byte
+    z0_byte z1_byte z2_byte z3_byte
+    carry_in_bool c0_bool c1_bool c2_bool c3_bool
+    h0 h1 h2 h3
 
 
 theorem completeness : Completeness (F p) (Inputs p) (Outputs p) add32_full assumptions := by

--- a/Clean/Gadgets/Addition32/Theorems.lean
+++ b/Clean/Gadgets/Addition32/Theorems.lean
@@ -1,0 +1,151 @@
+import Clean.Gadgets.Addition8.Addition8FullCarry
+import Clean.Types.U32
+import Clean.Utils.Field
+
+variable {p : ℕ} [Fact p.Prime]
+variable [p_large_enough: Fact (p > 512)]
+
+namespace Gadgets.Addition32.Theorems
+
+lemma lift_val1 {x y b : (F p)} (x_byte : x.val < 256) (y_byte : y.val < 256) (b_bool : b = 0 ∨ b = 1) :
+    (x + y + b).val = (x.val + y.val + b.val) := by
+  calc (x + y + b).val
+  _ = (b + x + y).val := by ring_nf
+  _ = b.val + x.val + y.val := by
+    rw [FieldUtils.byte_sum_and_bit_do_not_wrap _ _ _ x_byte y_byte]
+    apply FieldUtils.boolean_lt_2
+    exact b_bool
+  _ = x.val + y.val + b.val := by ring
+
+lemma lift_val2 {x b : (F p)} (x_byte : x.val < 256) (b_bool : b = 0 ∨ b = 1) :
+    (b * 256 + x).val = (b.val * 256 + x.val) := by
+  rcases b_bool with b_zero | b_one
+  · rw [b_zero]
+    simp only [zero_mul, zero_add, ZMod.val_zero]
+  · rw [b_one, ZMod.val_one]
+    simp
+    rw [add_comm 256 _]
+    rw [FieldUtils.byte_plus_256_do_not_wrap]
+    rw [add_comm]
+    assumption
+
+omit p_large_enough in
+lemma zify_bool {b : (F p)} (b_bool : b = 0 ∨ b = 1) : (↑(b.val) : ℤ) = 0 ∨ (↑(b.val) : ℤ) = 1  := by
+  rcases b_bool with b_zero | b_one
+  · rw [b_zero]
+    simp only [ZMod.val_zero, CharP.cast_eq_zero, zero_ne_one, or_false]
+  · rw [b_one, ZMod.val_one]
+    simp only [Nat.cast_one, one_ne_zero, or_true]
+
+
+theorem add32_soundness {x0 x1 x2 x3 y0 y1 y2 y3 carry_in c0 c1 c2 c3 z0 z1 z2 z3 : F p}
+    (x0_byte : x0.val < 256) (x1_byte : x1.val < 256) (x2_byte : x2.val < 256) (x3_byte : x3.val < 256)
+    (y0_byte : y0.val < 256) (y1_byte : y1.val < 256) (y2_byte : y2.val < 256) (y3_byte : y3.val < 256)
+    (z0_byte : z0.val < 256) (z1_byte : z1.val < 256) (z2_byte : z2.val < 256) (z3_byte : z3.val < 256)
+    (carry_in_bool : carry_in = 0 ∨ carry_in = 1) (c0_bool : c0 = 0 ∨ c0 = 1)
+    (c1_bool : c1 = 0 ∨ c1 = 1) (c2_bool : c2 = 0 ∨ c2 = 1) (c3_bool : c3 = 0 ∨ c3 = 1)
+    (h0 : x0 + y0 + carry_in = c0 * 256 + z0)
+    (h1 : x1 + y1 + c0 = c1 * 256 + z1)
+    (h2 : x2 + y2 + c1 = c2 * 256 + z2)
+    (h3 : x3 + y3 + c2 = c3 * 256 + z3) :
+    ZMod.val z0 + ZMod.val z1 * 256 + ZMod.val z2 * 256 ^ 2 + ZMod.val z3 * 256 ^ 3 =
+      (ZMod.val x0 + ZMod.val x1 * 256 + ZMod.val x2 * 256 ^ 2 + ZMod.val x3 * 256 ^ 3 +
+            (ZMod.val y0 + ZMod.val y1 * 256 + ZMod.val y2 * 256 ^ 2 + ZMod.val y3 * 256 ^ 3) +
+          ZMod.val carry_in) %
+        2 ^ 32 ∧
+    ZMod.val c3 =
+      (ZMod.val x0 + ZMod.val x1 * 256 + ZMod.val x2 * 256 ^ 2 + ZMod.val x3 * 256 ^ 3 +
+            (ZMod.val y0 + ZMod.val y1 * 256 + ZMod.val y2 * 256 ^ 2 + ZMod.val y3 * 256 ^ 3) +
+          ZMod.val carry_in) /
+        2 ^ 32
+  := by
+
+  apply_fun ZMod.val at h0 h1 h2 h3
+  rw [lift_val1 x0_byte y0_byte carry_in_bool, lift_val2 z0_byte c0_bool] at h0
+  rw [lift_val1 x1_byte y1_byte c0_bool, lift_val2 z1_byte c1_bool] at h1
+  rw [lift_val1 x2_byte y2_byte c1_bool, lift_val2 z2_byte c2_bool] at h2
+  rw [lift_val1 x3_byte y3_byte c2_bool, lift_val2 z3_byte c3_bool] at h3
+
+  have c0_bool := zify_bool c0_bool
+  have c1_bool := zify_bool c1_bool
+  have c2_bool := zify_bool c2_bool
+  have c3_bool := zify_bool c3_bool
+  have carry_in_bool := zify_bool carry_in_bool
+
+  have x0_pos : 0 ≤ x0.val := by exact Nat.zero_le _
+  have y0_pos : 0 ≤ y0.val := by exact Nat.zero_le _
+  have x1_pos : 0 ≤ x1.val := by exact Nat.zero_le _
+  have y1_pos : 0 ≤ y1.val := by exact Nat.zero_le _
+  have x2_pos : 0 ≤ x2.val := by exact Nat.zero_le _
+  have y2_pos : 0 ≤ y2.val := by exact Nat.zero_le _
+  have x3_pos : 0 ≤ x3.val := by exact Nat.zero_le _
+  have y3_pos : 0 ≤ y3.val := by exact Nat.zero_le _
+  have z0_pos : 0 ≤ z0.val := by exact Nat.zero_le _
+  have z1_pos : 0 ≤ z1.val := by exact Nat.zero_le _
+  have z2_pos : 0 ≤ z2.val := by exact Nat.zero_le _
+  have z3_pos : 0 ≤ z3.val := by exact Nat.zero_le _
+
+  zify at *
+
+  set x0 : ℤ := ↑(ZMod.val x0)
+  set x1 : ℤ := ↑(ZMod.val x1)
+  set x2 : ℤ := ↑(ZMod.val x2)
+  set x3 : ℤ := ↑(ZMod.val x3)
+  set y0 : ℤ := ↑(ZMod.val y0)
+  set y1 : ℤ := ↑(ZMod.val y1)
+  set y2 : ℤ := ↑(ZMod.val y2)
+  set y3 : ℤ := ↑(ZMod.val y3)
+  set z0 : ℤ := ↑(ZMod.val z0)
+  set z1 : ℤ := ↑(ZMod.val z1)
+  set z2 : ℤ := ↑(ZMod.val z2)
+  set z3 : ℤ := ↑(ZMod.val z3)
+  set c0 : ℤ := ↑(ZMod.val c0)
+  set c1 : ℤ := ↑(ZMod.val c1)
+  set c2 : ℤ := ↑(ZMod.val c2)
+  set c3 : ℤ := ↑(ZMod.val c3)
+  set carry_in : ℤ := ↑(ZMod.val carry_in)
+
+  -- now everything, assumptions and goal, is over Z
+
+  -- add up all the equations
+  set z := z0 + z1*256 + z2*256^2 + z3*256^3
+  set x := x0 + x1*256 + x2*256^2 + x3*256^3
+  set y := y0 + y1*256 + y2*256^2 + y3*256^3
+  let lhs := z + c3*2^32
+  let rhs₀ := x0 + y0 + carry_in + -1 * z0 + -1 * (c0 * 256) -- h0 expression
+  let rhs₁ := x1 + y1 + c0 + -1 * z1 + -1 * (c1 * 256) -- h1 expression
+  let rhs₂ := x2 + y2 + c1 + -1 * z2 + -1 * (c2 * 256) -- h2 expression
+  let rhs₃ := x3 + y3 + c2 + -1 * z3 + -1 * (c3 * 256) -- h3 expression
+
+  have h_add := calc z + c3*2^32
+    -- substitute equations
+    _ = lhs + 0 + 256*0 + 256^2*0 + 256^3*0 := by ring
+    _ = lhs + rhs₀ + 256*rhs₁ + 256^2*rhs₂ + 256^3*rhs₃ := by
+      simp only [rhs₀, rhs₁, rhs₂, rhs₃]
+      simp only [h0, h1, h2, h3]
+      ring
+    -- simplify
+    _ = x + y + carry_in := by ring
+
+
+  have z_lt_2_32 : z < 2^32 := by dsimp only [z]; linarith
+  have z_pos : 0 ≤ z := by dsimp [z]; linarith
+
+  rcases c3_bool with c3_zero | c3_one
+  · rw [c3_zero] at h_add
+    simp only [Int.reducePow, zero_mul, add_zero] at h_add
+    have sum_pos : 0 ≤ x + y + carry_in := by
+      rcases carry_in_bool with c_zero | c_one
+      · rw [c_zero]; linarith
+      · rw [c_one]; linarith
+    rw [Int.emod_eq_of_lt sum_pos (by linarith)]
+    rw [Int.ediv_eq_zero_of_lt sum_pos (by linarith)]
+    simp only [h_add, c3_zero, and_self]
+  · simp only [c3_one, one_mul] at h_add
+    rw [←h_add, Int.add_emod_self, Int.emod_eq_of_lt z_pos (by linarith)]
+    rw [
+      show z + 2^32 = z + 2^32 * 1 from rfl,
+      Int.add_mul_ediv_left _ _ (by linarith),
+      Int.ediv_eq_zero_of_lt z_pos z_lt_2_32
+    ]
+    simp only [c3_one, zero_add, and_self]

--- a/Clean/Gadgets/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32Full.lean
@@ -3,7 +3,7 @@ import Clean.Types.U32
 
 namespace Gadgets.Addition32Full
 variable {p : ℕ} [Fact p.Prime]
-variable [p_large_enough: Fact (p > 2*2^32)]
+variable [p_large_enough: Fact (p > 512)]
 
 open Provable (field field2 fields)
 open FieldUtils (mod_256 floordiv)
@@ -86,6 +86,38 @@ def spec (input : (Inputs p).value) (out: (Outputs p).value) :=
   ∧ carry_out.val = (x.value + y.value + carry_in.val) / 2^32
   ∧ z.is_normalized ∧ (carry_out = 0 ∨ carry_out = 1)
 
+
+lemma lift_val1 {x y b : (F p)} (x_byte : x.val < 256) (y_byte : y.val < 256) (b_bool : b = 0 ∨ b = 1) :
+    (x + y + b).val = (x.val + y.val + b.val) := by
+  calc (x + y + b).val
+  _ = (b + x + y).val := by ring_nf
+  _ = b.val + x.val + y.val := by
+    rw [FieldUtils.byte_sum_and_bit_do_not_wrap _ _ _ x_byte y_byte]
+    apply FieldUtils.boolean_lt_2
+    exact b_bool
+  _ = x.val + y.val + b.val := by ring
+
+lemma lift_val2 {x b : (F p)} (x_byte : x.val < 256) (b_bool : b = 0 ∨ b = 1) :
+    (b * 256 + x).val = (b.val * 256 + x.val) := by
+  rcases b_bool with b_zero | b_one
+  · rw [b_zero]
+    simp only [zero_mul, zero_add, ZMod.val_zero]
+  · rw [b_one, ZMod.val_one]
+    simp
+    rw [add_comm 256 _]
+    rw [FieldUtils.byte_plus_256_do_not_wrap]
+    rw [add_comm]
+    assumption
+
+omit p_large_enough in
+lemma zify_bool {b : (F p)} (b_bool : b = 0 ∨ b = 1) : (↑(b.val) : ℤ) = 0 ∨ (↑(b.val) : ℤ) = 1  := by
+  rcases b_bool with b_zero | b_one
+  · rw [b_zero]
+    simp only [ZMod.val_zero, CharP.cast_eq_zero, zero_ne_one, or_false]
+  · rw [b_one, ZMod.val_one]
+    simp only [Nat.cast_one, one_ne_zero, or_true]
+
+
 theorem soundness : Soundness (F p) (Inputs p) (Outputs p) add32_full assumptions spec := by
   rintro i0 env ⟨ x_var, y_var, carry_in_var ⟩ ⟨ x, y, carry_in ⟩ h_inputs as h
 
@@ -102,18 +134,29 @@ theorem soundness : Soundness (F p) (Inputs p) (Outputs p) add32_full assumption
   have : y2_var.eval env = y2 := by injections h_inputs
   have : y3_var.eval env = y3 := by injections h_inputs
   have : carry_in_var.eval env = carry_in := by injection h_inputs
+  clear h_inputs
 
   -- -- simplify assumptions
   dsimp only [assumptions, U32.is_normalized] at as
 
-  -- TODO: those are not used because we are assuming right now p > 2^32
-  have ⟨ _x_norm, _y_norm, carry_in_bool ⟩ := as
-  -- have ⟨ x0_byte, x1_byte, x2_byte, x3_byte ⟩ := x_norm
-  -- have ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm
+  have ⟨ x_norm, y_norm, carry_in_bool ⟩ := as
+  clear as
+  have ⟨ x0_byte, x1_byte, x2_byte, x3_byte ⟩ := x_norm
+  have ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm
+  clear x_norm y_norm
 
   -- -- simplify circuit
   dsimp [add32_full, Boolean.circuit, circuit_norm, Circuit.formal_assertion_to_subcircuit] at h
   simp only [true_implies, true_and, and_assoc] at h
+  rw [‹x0_var.eval env = x0›, ‹y0_var.eval env = y0›, ‹carry_in_var.eval env = carry_in›] at h
+  rw [‹x1_var.eval env = x1›, ‹y1_var.eval env = y1›] at h
+  rw [‹x2_var.eval env = x2›, ‹y2_var.eval env = y2›] at h
+  rw [‹x3_var.eval env = x3›, ‹y3_var.eval env = y3›] at h
+  repeat clear this
+  simp only [constraints_hold_flat, Expression.eval, mul_one, mul_eq_zero, and_true, neg_mul,
+    one_mul] at h
+  rw [ByteTable.equiv _, ByteTable.equiv _, ByteTable.equiv _, ByteTable.equiv _, Boolean.spec] at h
+  repeat rw [add_neg_eq_zero] at h
   set z0 := env.get i0
   set c0 := env.get (i0 + 1)
   set z1 := env.get (i0 + 2)
@@ -122,27 +165,74 @@ theorem soundness : Soundness (F p) (Inputs p) (Outputs p) add32_full assumption
   set c2 := env.get (i0 + 5)
   set z3 := env.get (i0 + 6)
   set c3 := env.get (i0 + 7)
-  rw [‹x0_var.eval env = x0›, ‹y0_var.eval env = y0›, ‹carry_in_var.eval env = carry_in›] at h
-  rw [‹x1_var.eval env = x1›, ‹y1_var.eval env = y1›] at h
-  rw [‹x2_var.eval env = x2›, ‹y2_var.eval env = y2›] at h
-  rw [‹x3_var.eval env = x3›, ‹y3_var.eval env = y3›] at h
-  rw [ByteTable.equiv z0, ByteTable.equiv z1, ByteTable.equiv z2, ByteTable.equiv z3] at h
-  have ⟨ z0_byte, _c0_bool, h0, z1_byte, _c1_bool, h1, z2_byte, _c2_bool, h2, z3_byte, c3_bool, h3 ⟩ := h
+  have ⟨ z0_byte, c0_bool, h0, z1_byte, c1_bool, h1, z2_byte, c2_bool, h2, z3_byte, c3_bool, h3 ⟩ := h
+  clear h
 
   -- simplify output and spec
   set main := add32_full ⟨⟨ x0_var, x1_var, x2_var, x3_var ⟩,⟨ y0_var, y1_var, y2_var, y3_var ⟩,carry_in_var⟩
   set output := eval env (main.output i0)
   have h_output : output = { z := U32.mk z0 z1 z2 z3, carry_out := c3 } := by
-    dsimp [output, from_values, to_vars]
-    simp only [SubCircuit.witness_length, FlatOperation.witness_length, add_zero]
+    dsimp [output, circuit_norm]
 
   rw [h_output]
   dsimp only [spec, U32.value, U32.is_normalized]
 
-  -- -- add up all the equations
-  let z := z0 + z1*256 + z2*256^2 + z3*256^3
-  let x := x0 + x1*256 + x2*256^2 + x3*256^3
-  let y := y0 + y1*256 + y2*256^2 + y3*256^3
+  -- get rid of the boolean carry_out
+  simp only [c3_bool, and_true]
+
+  -- lift everything to Z
+  rw [add_neg_eq_iff_eq_add] at h0 h1 h2 h3
+  apply_fun ZMod.val at h0 h1 h2 h3
+  rw [lift_val1 x0_byte y0_byte carry_in_bool, lift_val2 z0_byte c0_bool] at h0
+  rw [lift_val1 x1_byte y1_byte c0_bool, lift_val2 z1_byte c1_bool] at h1
+  rw [lift_val1 x2_byte y2_byte c1_bool, lift_val2 z2_byte c2_bool] at h2
+  rw [lift_val1 x3_byte y3_byte c2_bool, lift_val2 z3_byte c3_bool] at h3
+
+  have c0_bool := zify_bool c0_bool
+  have c1_bool := zify_bool c1_bool
+  have c2_bool := zify_bool c2_bool
+  have c3_bool := zify_bool c3_bool
+  have carry_in_bool := zify_bool carry_in_bool
+
+  have x0_pos : 0 ≤ x0.val := by exact Nat.zero_le _
+  have y0_pos : 0 ≤ y0.val := by exact Nat.zero_le _
+  have x1_pos : 0 ≤ x1.val := by exact Nat.zero_le _
+  have y1_pos : 0 ≤ y1.val := by exact Nat.zero_le _
+  have x2_pos : 0 ≤ x2.val := by exact Nat.zero_le _
+  have y2_pos : 0 ≤ y2.val := by exact Nat.zero_le _
+  have x3_pos : 0 ≤ x3.val := by exact Nat.zero_le _
+  have y3_pos : 0 ≤ y3.val := by exact Nat.zero_le _
+  have z0_pos : 0 ≤ z0.val := by exact Nat.zero_le _
+  have z1_pos : 0 ≤ z1.val := by exact Nat.zero_le _
+  have z2_pos : 0 ≤ z2.val := by exact Nat.zero_le _
+  have z3_pos : 0 ≤ z3.val := by exact Nat.zero_le _
+
+  zify at *
+
+  set x0 : ℤ := ↑(ZMod.val x0)
+  set x1 : ℤ := ↑(ZMod.val x1)
+  set x2 : ℤ := ↑(ZMod.val x2)
+  set x3 : ℤ := ↑(ZMod.val x3)
+  set y0 : ℤ := ↑(ZMod.val y0)
+  set y1 : ℤ := ↑(ZMod.val y1)
+  set y2 : ℤ := ↑(ZMod.val y2)
+  set y3 : ℤ := ↑(ZMod.val y3)
+  set z0 : ℤ := ↑(ZMod.val z0)
+  set z1 : ℤ := ↑(ZMod.val z1)
+  set z2 : ℤ := ↑(ZMod.val z2)
+  set z3 : ℤ := ↑(ZMod.val z3)
+  set c0 : ℤ := ↑(ZMod.val c0)
+  set c1 : ℤ := ↑(ZMod.val c1)
+  set c2 : ℤ := ↑(ZMod.val c2)
+  set c3 : ℤ := ↑(ZMod.val c3)
+  set carry_in : ℤ := ↑(ZMod.val carry_in)
+
+  -- now everything, assumptions and goal, is over Z
+
+  -- add up all the equations
+  set z := z0 + z1*256 + z2*256^2 + z3*256^3
+  set x := x0 + x1*256 + x2*256^2 + x3*256^3
+  set y := y0 + y1*256 + y2*256^2 + y3*256^3
   let lhs := z + c3*2^32
   let rhs₀ := x0 + y0 + carry_in + -1 * z0 + -1 * (c0 * 256) -- h0 expression
   let rhs₁ := x1 + y1 + c0 + -1 * z1 + -1 * (c1 * 256) -- h1 expression
@@ -152,37 +242,37 @@ theorem soundness : Soundness (F p) (Inputs p) (Outputs p) add32_full assumption
   have h_add := calc z + c3*2^32
     -- substitute equations
     _ = lhs + 0 + 256*0 + 256^2*0 + 256^3*0 := by ring
-    _ = lhs + rhs₀ + 256*rhs₁ + 256^2*rhs₂ + 256^3*rhs₃ := by dsimp [rhs₀, rhs₁, rhs₂, rhs₃]; rw [h0, h1, h2, h3]
+    _ = lhs + rhs₀ + 256*rhs₁ + 256^2*rhs₂ + 256^3*rhs₃ := by
+      simp only [rhs₀, rhs₁, rhs₂, rhs₃]
+      simp only [h0, h1, h2, h3]
+      ring
     -- simplify
     _ = x + y + carry_in := by ring
 
-  -- move added equation into Nat
-  let z_nat := z0.val + z1.val*256 + z2.val*256^2 + z3.val*256^3
-  let x_nat := x0.val + x1.val*256 + x2.val*256^2 + x3.val*256^3
-  let y_nat := y0.val + y1.val*256 + y2.val*256^2 + y3.val*256^3
 
-  have : c3.val < 2 := FieldUtils.boolean_lt_2 c3_bool
-  have : carry_in.val < 2 := FieldUtils.boolean_lt_2 carry_in_bool
+  have z_lt_2_32 : z < 2^32 := by dsimp only [z]; linarith
+  have z_pos : 0 ≤ z := by dsimp [z]; linarith
+  simp only [z0_byte, z1_byte, z2_byte, z3_byte, and_self, and_true]
 
-  have h_add_nat := calc z_nat + c3.val*2^32
-    _ = (z + c3*2^32).val := by dsimp only [z_nat]; field_to_nat_u32
-    _ = (x + y + carry_in).val := congrArg ZMod.val h_add
-    _ = x_nat + y_nat + carry_in.val := by dsimp only [x_nat, y_nat]; field_to_nat_u32
+  rcases c3_bool with c3_zero | c3_one
+  · rw [c3_zero] at h_add
+    simp only [Int.reducePow, zero_mul, add_zero] at h_add
+    have sum_pos : 0 ≤ x + y + carry_in := by
+      rcases carry_in_bool with c_zero | c_one
+      · rw [c_zero]; linarith
+      · rw [c_one]; linarith
+    rw [Int.emod_eq_of_lt sum_pos (by linarith)]
+    rw [Int.ediv_eq_zero_of_lt sum_pos (by linarith)]
+    simp only [h_add, c3_zero, and_self]
+  · simp only [c3_one, one_mul] at h_add
+    rw [←h_add, Int.add_emod_self, Int.emod_eq_of_lt z_pos (by linarith)]
+    rw [
+      show z + 2^32 = z + 2^32 * 1 from rfl,
+      Int.add_mul_ediv_left _ _ (by linarith),
+      Int.ediv_eq_zero_of_lt z_pos z_lt_2_32
+    ]
+    simp only [c3_one, zero_add, and_self]
 
-  -- show that lhs splits into low and high 32 bits
-  have : z_nat < 2^32 := by dsimp only [z_nat]; linarith
-
-  have h_low : z_nat = (x_nat + y_nat + carry_in.val) % 2^32 := by
-    suffices h : z_nat = z_nat % 2^32 by
-      rw [← h_add_nat, ← Nat.add_mod_mod, ← Nat.mul_mod_mod]
-      simpa using h
-    rw [Nat.mod_eq_of_lt ‹z_nat < 2^32›]
-
-  have h_high : c3.val = (x_nat + y_nat + carry_in.val) / 2^32 := by
-    rw [← h_add_nat, Nat.add_mul_div_right _ _ (by norm_num)]
-    rw [Nat.div_eq_of_lt ‹z_nat < 2^32›, zero_add]
-
-  exact ⟨ h_low, h_high, ⟨ z0_byte, z1_byte, z2_byte, z3_byte ⟩, c3_bool ⟩
 
 theorem completeness : Completeness (F p) (Inputs p) (Outputs p) add32_full assumptions := by
   rintro i0 env ⟨ x_var, y_var, carry_in_var ⟩ henv  ⟨ x, y, carry_in ⟩ h_inputs as
@@ -287,11 +377,12 @@ theorem completeness : Completeness (F p) (Inputs p) (Outputs p) add32_full assu
     x.val < 256 → y.val < 256 → c_in = 0 ∨ c_in = 1 →
     ByteTable.contains (vec [z]) ∧ (c_out = 0 ∨ c_out = 1) ∧ x + y + c_in + -1 * z + -1 * (c_out * 256) = 0
   := by
-    intro _ _ hc
+    intro x_byte y_byte hc
     have : z.val < 256 := hz ▸ FieldUtils.mod_256_lt (x + y + c_in)
     use ByteTable.completeness z this
-    have : c_in.val < 2 := FieldUtils.boolean_lt_2 hc
-    have : (x + y + c_in).val < 512 := by field_to_nat_u32
+    have carry_lt_2 : c_in.val < 2 := FieldUtils.boolean_lt_2 hc
+    have : (x + y + c_in).val < 512 :=
+      FieldUtils.byte_sum_and_bit_lt_512 x y c_in x_byte y_byte carry_lt_2
     use (hc_out ▸ FieldUtils.floordiv_bool this)
     rw [FieldUtils.mod_add_div_256 (x + y + c_in), hz, hc_out]
     ring

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -1,17 +1,15 @@
 import Clean.Utils.Vector
 import Clean.Circuit.Basic
 import Clean.Table.Basic
-import Clean.Gadgets.Addition32Full
+import Clean.Gadgets.Addition32.Addition32Full
 import Clean.Gadgets.Equality.U32
 import Clean.Types.U32
 
 
 namespace Tables.Fibonacci32
 variable {p : ℕ}
-variable [p_large_enough: Fact (p > 2*2^32)]
+variable [p_large_enough: Fact (p > 512)]
 
-lemma p_large_enough' : Fact (p > 512) := by
-  apply Fact.mk; linarith [p_large_enough.elim]
 
 variable [Fact p.Prime]
 

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -4,7 +4,7 @@ import Clean.Circuit.Extensions
 section
 variable {p : ℕ} [Fact p.Prime]
 -- TODO: this assumption is false in practice, need to change some proofs to not need it
-variable [p_large_enough: Fact (p > 2*2^32)]
+variable [p_large_enough: Fact (p > 512)]
 
 instance : NeZero p := ⟨‹Fact p.Prime›.elim.ne_zero⟩
 instance : Fact (p > 512) := by apply Fact.mk; linarith [p_large_enough.elim]
@@ -36,6 +36,23 @@ instance : ProvableType (F p) (u32 (p:=p)) where
   from_values v :=
     let ⟨ [x0, x1, x2, x3], _ ⟩ := v
     ⟨ x0, x1, x2, x3 ⟩
+
+omit [Fact (Nat.Prime p)] p_large_enough in
+/--
+  Extensionality pronciple for U32
+-/
+@[ext]
+lemma ext {x y : U32 (F p)}
+    (h0 : x.x0 = y.x0)
+    (h1 : x.x1 = y.x1)
+    (h2 : x.x2 = y.x2)
+    (h3 : x.x3 = y.x3)
+    : x = y :=
+  by match x, y with
+  | ⟨ x0, x1, x2, x3 ⟩, ⟨ y0, y1, y2, y3 ⟩ =>
+    simp only [h0, h1, h2, h3] at *
+    simp only [h0, h1, h2, h3]
+
 
 /--
   Witness a 32-bit unsigned integer.
@@ -105,26 +122,7 @@ lemma wrapping_add_correct (x y z: U32 (F p)) :
   sorry
 
 -- U32-related tactic and lemmas
-
 lemma val_eq_256 : (256 : F p).val = 256 := FieldUtils.val_lt_p 256 (by linarith [p_large_enough.elim])
-lemma val_eq_256p2 : (256^2 : F p).val = 256^2 := by ring_nf; exact FieldUtils.val_lt_p (256^2) (by linarith [p_large_enough.elim])
-lemma val_eq_256p3 : (256^3 : F p).val = 256^3 := by ring_nf; exact FieldUtils.val_lt_p (256^3) (by linarith [p_large_enough.elim])
-lemma val_eq_256p4 : (256^4 : F p).val = 256^4 := by ring_nf; exact FieldUtils.val_lt_p (256^4) (by linarith [p_large_enough.elim])
-lemma val_eq_2p32 : (2^32 : F p).val = 2^32 := by have := val_eq_256p4 (p:=p); ring_nf at *; assumption
-
-
-omit [Fact (Nat.Prime p)] p_large_enough in
-@[ext]
-lemma ext {x y : U32 (F p)}
-    (h0 : x.x0 = y.x0)
-    (h1 : x.x1 = y.x1)
-    (h2 : x.x2 = y.x2)
-    (h3 : x.x3 = y.x3)
-    : x = y :=
-  by match x, y with
-  | ⟨ x0, x1, x2, x3 ⟩, ⟨ y0, y1, y2, y3 ⟩ =>
-    simp only [h0, h1, h2, h3] at *
-    simp only [h0, h1, h2, h3]
 
 /--
 tactic script to fully rewrite a ZMod expression to its Nat version, given that
@@ -142,26 +140,22 @@ expected context:
 if no sufficient inequalities are in the context, then the tactic will leave an equation of the form `expr : Nat < p` unsolved.
 
 note: this version is optimized for uint32 arithmetic:
-- specifically handles field constants 256, 256^2, 256^3, 256^4 = 2^32
-- expects `[Fact (p > 2*256^4)]` in the context
+- specifically handles field constants 256
+- expects `[Fact (p > 512)]` in the context
 -/
-syntax "field_to_nat_u32" : tactic
+syntax "field_to_nat" : tactic
 macro_rules
-  | `(tactic|field_to_nat_u32) =>
+  | `(tactic|field_to_nat) =>
     `(tactic|(
       repeat rw [ZMod.val_add] -- (a + b).val = (a.val + b.val) % p
       repeat rw [ZMod.val_mul] -- (a * b).val = (a.val * b.val) % p
       repeat rw [U32.val_eq_256]
-      repeat rw [U32.val_eq_256p2]
-      repeat rw [U32.val_eq_256p3]
-      repeat rw [U32.val_eq_256p4]
-      repeat rw [U32.val_eq_2p32]
       simp only [Nat.reducePow, Nat.add_mod_mod, Nat.mod_add_mod, Nat.mul_mod_mod, Nat.mod_mul_mod]
       rw [Nat.mod_eq_of_lt _]
-      repeat linarith [‹Fact (_ > 2 * 2^32)›.elim]))
+      repeat linarith [‹Fact (_ > 512)›.elim]))
 
-lemma value_eq {x0 x1 x2 x3: F p} (h0 : x0.val < 256) (h1 : x1.val < 256) (h2 : x2.val < 256) (h3 : x3.val < 256) :
-  (x0 + x1 * 256 + x2 * 256^2 + x3 * 256^3).val = x0.val + x1.val * 256 + x2.val * 256^2 + x3.val * 256^3 := by
-  field_to_nat_u32
+-- lemma value_eq {x0 x1 x2 x3: F p} (h0 : x0.val < 256) (h1 : x1.val < 256) (h2 : x2.val < 256) (h3 : x3.val < 256) :
+--   (x0 + x1 * 256 + x2 * 256^2 + x3 * 256^3).val = x0.val + x1.val * 256 + x2.val * 256^2 + x3.val * 256^3 := by
+--   field_to_nat_u32
 end U32
 end

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -39,7 +39,7 @@ instance : ProvableType (F p) (u32 (p:=p)) where
 
 omit [Fact (Nat.Prime p)] p_large_enough in
 /--
-  Extensionality pronciple for U32
+  Extensionality principle for U32
 -/
 @[ext]
 lemma ext {x y : U32 (F p)}
@@ -154,8 +154,5 @@ macro_rules
       rw [Nat.mod_eq_of_lt _]
       repeat linarith [‹Fact (_ > 512)›.elim]))
 
--- lemma value_eq {x0 x1 x2 x3: F p} (h0 : x0.val < 256) (h1 : x1.val < 256) (h2 : x2.val < 256) (h3 : x3.val < 256) :
---   (x0 + x1 * 256 + x2 * 256^2 + x3 * 256^3).val = x0.val + x1.val * 256 + x2.val * 256^2 + x3.val * 256^3 := by
---   field_to_nat_u32
 end U32
 end

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -81,6 +81,28 @@ theorem byte_sum_and_bit_do_not_wrap' (x y b: F p) [p_large_enough: Fact (p > 51
   rw [sum_do_not_wrap_around (x + y) b sum_lt_p,
     byte_sum_do_not_wrap x y hx hy]
 
+
+theorem byte_sum_and_bit_lt_512 (x y b: F p) [p_large_enough: Fact (p > 512)]:
+    x.val < 256 -> y.val < 256 -> b.val < 2 -> (x + y + b).val < 512 := by
+  intros hx hy hb
+  have sum_bound := byte_sum_le_bound x y hx hy
+  have sum_lt_512 : b.val + (x + y).val < 512 := by
+    apply Nat.le_sub_one_of_lt at sum_bound
+    apply Nat.le_sub_one_of_lt at hb
+    simp at sum_bound
+    simp at hb
+    apply Nat.lt_add_one_of_le
+    apply Nat.add_le_add hb sum_bound
+  have asd : b.val + (x + y).val = (b + x + y).val := by
+    rw [byte_sum_do_not_wrap x y hx hy]
+    rw [show b + x + y = x + y + b by ring]
+    rw [byte_sum_and_bit_do_not_wrap' x y b hx hy hb]
+    rw [show x.val + y.val + b.val = b.val + (x.val + y.val) by ring]
+  rw [asd] at sum_lt_512
+  rw [show b + x + y = x + y + b by ring] at sum_lt_512
+  exact sum_lt_512
+
+
 theorem byte_plus_256_do_not_wrap (x: F p) [p_large_enough: Fact (p > 512)]:
     x.val < 256 -> (x + 256).val = x.val + 256 := by
   intro hx


### PR DESCRIPTION
Addresses #53

The general proof technique is the same, but lifted to the integers using `zify`.
Actually, we do not even need to go back to the naturals, as we can lift both the assumptions and the goal to the integers.