### PR TITLE
Add 64-bit rotation over byte limbs

### DIFF
--- a/Clean/Gadgets/ByteLookup.lean
+++ b/Clean/Gadgets/ByteLookup.lean
@@ -1,7 +1,7 @@
 import Clean.Circuit.Basic
 import Clean.Utils.Field
 
-section
+namespace Gadgets
 variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
@@ -46,4 +46,4 @@ def byte_lookup (x: Expression (F p)) := lookup {
     then ⟨x, h⟩
     else ⟨0, by show 0 < 256; norm_num⟩
 }
-end
+end Gadgets

--- a/Clean/Gadgets/Rotation64/ByteRotationTable.lean
+++ b/Clean/Gadgets/Rotation64/ByteRotationTable.lean
@@ -1,0 +1,86 @@
+import Clean.Circuit.Basic
+import Clean.Utils.Field
+import Clean.Gadgets.Rotation64.Theorems
+
+namespace Gadgets.Rotation64
+variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
+variable [p_large_enough: Fact (p > 512)]
+
+open Gadgets.Rotation64.Theorems (rot_right8)
+
+
+def from_byte (x: Fin 256) : F p :=
+  FieldUtils.nat_to_field x.val (by linarith [x.is_lt, p_large_enough.elim])
+
+def ByteRotationTable (offset : Fin 8) : Table (F p) where
+  name := "ByteRotation"
+  length := 256
+  arity := 2
+  row i := vec [from_byte i, from_byte (rot_right8 i offset)]
+
+def ByteRotationTable.soundness
+    (offset : Fin 8)
+    (x y: F p)
+    (hx : x.val < 256) : -- TODO: is hx necessary?
+    (ByteRotationTable offset).contains (vec [x, y]) → y.val = rot_right8 ⟨x.val, hx⟩ offset := by
+  dsimp only [Table.contains]
+  rintro ⟨ i, h: vec [x, y] = vec [from_byte i, from_byte (rot_right8 i offset)] ⟩
+  have list_eq : [x, y] = [from_byte i, from_byte (rot_right8 i offset)] := by injection h
+  have h_y : y = from_byte (rot_right8 i offset) := by
+    injection list_eq with list_eq tail_eq
+    injection tail_eq
+  have h_x : ⟨x.val, hx⟩ = i := by
+    have h : x = from_byte i := by injection list_eq with list_eq tail_eq
+    simp [from_byte] at h
+    apply_fun ZMod.val at h
+    apply_fun Fin.val
+    · simp only
+      rw [h, FieldUtils.val_of_nat_to_field_eq]
+    · apply Fin.val_injective
+  rw [h_y, h_x]
+  simp only [from_byte, Fin.cast_val_eq_self]
+  rw [FieldUtils.val_of_nat_to_field_eq]
+
+def ByteRotationTable.completeness
+    (offset : Fin 8)
+    (x y: F p)
+    (hx : x.val < 256):
+    y.val = rot_right8 ⟨x.val, hx⟩ offset → (ByteRotationTable offset).contains (vec [x, y]) := by
+  intro h
+  dsimp only [ByteRotationTable, Table.contains]
+  use x.val
+  simp [from_byte, Fin.val_natCast]
+  ext1
+  simp only [ZMod.natCast_val, List.cons.injEq, and_true]
+  have h_x' : x.val % 256 = x.val := by
+    apply (Nat.mod_eq_iff_lt (by linarith)).mpr
+    exact hx
+  constructor
+  · simp only [h_x']
+    rw [FieldUtils.nat_to_field_of_val_eq_iff]
+  · apply_fun ZMod.val
+    · rw [h, FieldUtils.val_of_nat_to_field_eq]
+      have h_x'' : (⟨x.val, hx⟩ : Fin 256) = ZMod.cast x := by
+        apply_fun Fin.val
+        · rw [← ZMod.natCast_val x, Fin.val_natCast]
+          simp only [h_x']
+        · apply Fin.val_injective
+      rw [h_x'']
+    · apply ZMod.val_injective
+
+def ByteRotationTable.equiv (offset : Fin 8) (x y: F p) (hx : x.val < 256) :
+    (ByteRotationTable offset).contains (vec [x, y]) ↔ y.val = rot_right8 ⟨x.val, hx⟩ offset :=
+  ⟨ByteRotationTable.soundness offset x y hx, ByteRotationTable.completeness offset x y hx⟩
+
+def byte_rotation_lookup (offset : Fin 8) (x y: Expression (F p)) := lookup {
+  table := ByteRotationTable offset
+  entry := vec [x, y]
+  -- to make this work, we need to pass an `eval` function to the callback!!
+  index := fun env =>
+    let x := x.eval env |>.val
+    if h : (x < 256)
+    then ⟨x, h⟩
+    else ⟨0, by show 0 < 256; norm_num⟩
+}
+
+end Gadgets.Rotation64

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -79,22 +79,50 @@ def rot64_circuit (offset : Fin 64) (input : (Inputs p).var) : Circuit (F p) (Ou
 
   -- apply the bit rotation
   let ⟨x0, x1, x2, x3, x4, x5, x6, x7⟩ := out
+
+
+
+  let x0_l ← witness (fun env => 0)
+  let x0_h ← witness (fun env => 0)
+  let x1_l ← witness (fun env => 0)
+  let x1_h ← witness (fun env => 0)
+  let x2_l ← witness (fun env => 0)
+  let x2_h ← witness (fun env => 0)
+  let x3_l ← witness (fun env => 0)
+  let x3_h ← witness (fun env => 0)
+  let x4_l ← witness (fun env => 0)
+  let x4_h ← witness (fun env => 0)
+  let x5_l ← witness (fun env => 0)
+  let x5_h ← witness (fun env => 0)
+  let x6_l ← witness (fun env => 0)
+  let x6_h ← witness (fun env => 0)
+  let x7_l ← witness (fun env => 0)
+  let x7_h ← witness (fun env => 0)
+
+  assert_zero (x0_l + ((2 : ℕ)^bit_offset : F p) * x0_h - x0)
+  assert_zero (x1_l + ((2 : ℕ)^bit_offset : F p) * x1_h - x1)
+  assert_zero (x2_l + ((2 : ℕ)^bit_offset : F p) * x2_h - x2)
+  assert_zero (x3_l + ((2 : ℕ)^bit_offset : F p) * x3_h - x3)
+  assert_zero (x4_l + ((2 : ℕ)^bit_offset : F p) * x4_h - x4)
+  assert_zero (x5_l + ((2 : ℕ)^bit_offset : F p) * x5_h - x5)
+  assert_zero (x6_l + ((2 : ℕ)^bit_offset : F p) * x6_h - x6)
+  assert_zero (x7_l + ((2 : ℕ)^bit_offset : F p) * x7_h - x7)
+
   let ⟨y0, y1, y2, y3, y4, y5, y6, y7⟩ ← U64.witness (fun env => U64.mk 0 0 0 0 0 0 0 0)
 
-  byte_rotation_lookup bit_offset x0 y0
-  byte_rotation_lookup bit_offset x1 y1
-  byte_rotation_lookup bit_offset x2 y2
-  byte_rotation_lookup bit_offset x3 y3
-  byte_rotation_lookup bit_offset x4 y4
-  byte_rotation_lookup bit_offset x5 y5
-  byte_rotation_lookup bit_offset x6 y6
-  byte_rotation_lookup bit_offset x7 y7
-
+  assert_zero (x1_l * ((2 : ℕ)^bit_offset : F p) + x0_h - y0)
+  assert_zero (x2_l * ((2 : ℕ)^bit_offset : F p) + x1_h - y1)
+  assert_zero (x3_l * ((2 : ℕ)^bit_offset : F p) + x2_h - y2)
+  assert_zero (x4_l * ((2 : ℕ)^bit_offset : F p) + x3_h - y3)
+  assert_zero (x5_l * ((2 : ℕ)^bit_offset : F p) + x4_h - y4)
+  assert_zero (x6_l * ((2 : ℕ)^bit_offset : F p) + x5_h - y5)
+  assert_zero (x7_l * ((2 : ℕ)^bit_offset : F p) + x6_h - y6)
+  assert_zero (x0_l * ((2 : ℕ)^bit_offset : F p) + x7_h - y7)
   return { z := ⟨ y0, y1, y2, y3, y4, y5, y6, y7 ⟩ }
 
+
+
 def assumptions (input : (Inputs p).value) := input.x.is_normalized
-
-
 
 def spec (offset : Fin 64) (input : (Inputs p).value) (out: (Outputs p).value) :=
   let ⟨x⟩ := input

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -76,14 +76,14 @@ def rot64_circuit (offset : Fin 64) (input : Var Inputs (F p)) : Circuit (F p) (
 
   let ⟨y0, y1, y2, y3, y4, y5, y6, y7⟩ ← U64.witness (fun env => U64.mk 0 0 0 0 0 0 0 0)
 
-  assert_zero (x1_l * ((2 : ℕ)^bit_offset : F p) + x0_h - y0)
-  assert_zero (x2_l * ((2 : ℕ)^bit_offset : F p) + x1_h - y1)
-  assert_zero (x3_l * ((2 : ℕ)^bit_offset : F p) + x2_h - y2)
-  assert_zero (x4_l * ((2 : ℕ)^bit_offset : F p) + x3_h - y3)
-  assert_zero (x5_l * ((2 : ℕ)^bit_offset : F p) + x4_h - y4)
-  assert_zero (x6_l * ((2 : ℕ)^bit_offset : F p) + x5_h - y5)
-  assert_zero (x7_l * ((2 : ℕ)^bit_offset : F p) + x6_h - y6)
-  assert_zero (x0_l * ((2 : ℕ)^bit_offset : F p) + x7_h - y7)
+  assert_zero (x1_l * ((2 : ℕ)^(8 - bit_offset) : F p) + x0_h - y0)
+  assert_zero (x2_l * ((2 : ℕ)^(8 - bit_offset) : F p) + x1_h - y1)
+  assert_zero (x3_l * ((2 : ℕ)^(8 - bit_offset) : F p) + x2_h - y2)
+  assert_zero (x4_l * ((2 : ℕ)^(8 - bit_offset) : F p) + x3_h - y3)
+  assert_zero (x5_l * ((2 : ℕ)^(8 - bit_offset) : F p) + x4_h - y4)
+  assert_zero (x6_l * ((2 : ℕ)^(8 - bit_offset) : F p) + x5_h - y5)
+  assert_zero (x7_l * ((2 : ℕ)^(8 - bit_offset) : F p) + x6_h - y6)
+  assert_zero (x0_l * ((2 : ℕ)^(8 - bit_offset) : F p) + x7_h - y7)
   return { z := ⟨ y0, y1, y2, y3, y4, y5, y6, y7 ⟩ }
 
 

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -1,0 +1,123 @@
+import Clean.Gadgets.Addition8.Addition8FullCarry
+import Clean.Types.U64
+
+namespace Gadgets.Rotation64
+variable {p : ℕ} [Fact p.Prime]
+variable [p_large_enough: Fact (p > 512)]
+
+structure InputStruct (F : Type) where
+  x: U64 F
+
+instance (F : Type) : StructuredElements InputStruct F where
+  size := StructuredElements.size U64 F
+  to_elements x := (StructuredElements.to_elements x.x)
+  from_elements v :=
+    let ⟨ [x0, x1, x2, x3, x4, x5, x6, x7], _ ⟩ := v
+    ⟨ ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ ⟩
+
+def Inputs (p : ℕ) : TypePair := ⟨
+  InputStruct (Expression (F p)),
+  InputStruct (F p)
+⟩
+
+@[simp]
+instance : ProvableType (F p) (Inputs p) where
+  size := 8
+  to_vars s := vec [s.x.x0, s.x.x1, s.x.x2, s.x.x3, s.x.x4, s.x.x5, s.x.x6, s.x.x7]
+  from_vars v :=
+    let ⟨ [x0, x1, x2, x3, x4, x5, x6, x7], _ ⟩ := v
+    ⟨ ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ ⟩
+  to_values s := vec [s.x.x0, s.x.x1, s.x.x2, s.x.x3, s.x.x4, s.x.x5, s.x.x6, s.x.x7]
+  from_values v :=
+    let ⟨ [x0, x1, x2, x3, x4, x5, x6, x7], _ ⟩ := v
+    ⟨ ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ ⟩
+
+
+structure OutputStruct (F : Type) where
+  z: U64 F
+
+instance (F : Type) : StructuredElements OutputStruct F where
+  size := StructuredElements.size U64 F
+  to_elements x := (StructuredElements.to_elements x.z)
+  from_elements v :=
+    let ⟨ [z0, z1, z2, z3, z4, z5, z6, z7], _ ⟩ := v
+    ⟨ ⟨ z0, z1, z2, z3, z4, z5, z6, z7 ⟩ ⟩
+
+def Outputs (p : ℕ) : TypePair := ⟨
+  OutputStruct (Expression (F p)),
+  OutputStruct (F p)
+⟩
+
+instance : ProvableType (F p) (Outputs p) where
+  size := 8
+  to_vars s := vec [s.z.x0, s.z.x1, s.z.x2, s.z.x3, s.z.x4, s.z.x5, s.z.x6, s.z.x7]
+  from_vars v :=
+    let ⟨ [z0, z1, z2, z3, z4, z5, z6, z7], _ ⟩ := v
+    ⟨ ⟨ z0, z1, z2, z3, z4, z5, z6, z7 ⟩ ⟩
+  to_values s := vec [s.z.x0, s.z.x1, s.z.x2, s.z.x3, s.z.x4, s.z.x5, s.z.x6, s.z.x7]
+  from_values v :=
+    let ⟨ [z0, z1, z2, z3, z4, z5, z6, z7], _ ⟩ := v
+    ⟨ ⟨ z0, z1, z2, z3, z4, z5, z6, z7 ⟩ ⟩
+
+def rot64_bytes (offset : Fin 8) (input : (Inputs p).var) : Circuit (F p) (Outputs p).var := do
+  let ⟨x0, x1, x2, x3 , x4, x5, x6, x7⟩ := input
+  let offset := offset.val
+
+  if offset = 0 then
+    return ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩
+  else if offset = 1 then
+    return ⟨ x1, x2, x3, x4, x5, x6, x7, x0 ⟩
+
+  return ⟨ x2, x3, x4, x5, x6, x7, x0, x1 ⟩
+
+def assumptions (input : (Inputs p).value) := input.x.is_normalized
+
+def rot64 (x : ℕ) (offset : ℕ) : ℕ :=
+  let offset := offset % 64
+  let low := x % (2^offset)
+  let high := x / (2^offset)
+  low * (2^(64 - offset)) + high
+
+def spec (offset : Fin 8) (input : (Inputs p).value) (out: (Outputs p).value) :=
+  let ⟨x⟩ := input
+  let ⟨y⟩ := out
+  y.value = rot64 x.value (offset.val * 8)
+
+
+theorem soundness (off : Fin 8) : Soundness (F p) (Inputs p) (Outputs p) (rot64_bytes off) assumptions (spec off) := by
+  rintro i0 env ⟨ x0_var, x1_var, x2_var, x3_var, x4_var, x5_var, x6_var, x7_var ⟩ ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ h_inputs as h
+
+  have h_x0 : x0_var.eval env = x0 := by injections h_inputs
+  have h_x1 : x1_var.eval env = x1 := by injections h_inputs
+  have h_x2 : x2_var.eval env = x2 := by injections h_inputs
+  have h_x3 : x3_var.eval env = x3 := by injections h_inputs
+  have h_x4 : x4_var.eval env = x4 := by injections h_inputs
+  have h_x5 : x5_var.eval env = x5 := by injections h_inputs
+  have h_x6 : x6_var.eval env = x6 := by injections h_inputs
+  have h_x7 : x7_var.eval env = x7 := by injections h_inputs
+  clear h_inputs
+
+  dsimp only [assumptions, U64.is_normalized] at as
+  fin_cases off
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure]
+    rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
+    simp [U64.value, rot64, Nat.mod_one]
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure]
+    rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
+    simp only [U64.value, rot64]
+    rw [
+      show (8%64) = 8 by norm_num,
+      show (64 - 8) = 56 by norm_num,
+    ]
+    sorry
+
+
+  sorry
+
+def circuit (off : Fin 8) : FormalCircuit (F p) (Inputs p) (Outputs p) where
+  main := rot64_bytes off
+  assumptions := assumptions
+  spec := spec off
+  soundness := soundness off
+  completeness := by sorry
+end Gadgets.Rotation64

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -1,12 +1,14 @@
 import Clean.Types.U64
 import Clean.Gadgets.Rotation64.Theorems
 import Clean.Gadgets.Rotation64.Rotation64Bytes
+import Clean.Gadgets.Rotation64.ByteRotationTable
 
 namespace Gadgets.Rotation64
 variable {p : ℕ} [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
 open Gadgets.Rotation64.Theorems (rot_right64 rot_right8)
+open Gadgets.Rotation64 (byte_rotation_lookup)
 
 structure InputStruct (F : Type) where
   x: U64 F
@@ -77,15 +79,18 @@ def rot64_circuit (offset : Fin 64) (input : (Inputs p).var) : Circuit (F p) (Ou
 
   -- apply the bit rotation
   let ⟨x0, x1, x2, x3, x4, x5, x6, x7⟩ := out
-  let ⟨z0, z1, z2, z3, z4, z5, z6, z7⟩ ← U64.witness (fun env => U64.mk 0 0 0 0 0 0 0 0)
+  let ⟨y0, y1, y2, y3, y4, y5, y6, y7⟩ ← U64.witness (fun env => U64.mk 0 0 0 0 0 0 0 0)
 
-  let bit_offset_fp : F p := 2 ^ bit_offset
-  let bit_offset_fp' : F p := 2 ^ (8 - bit_offset)
+  byte_rotation_lookup bit_offset x0 y0
+  byte_rotation_lookup bit_offset x1 y1
+  byte_rotation_lookup bit_offset x2 y2
+  byte_rotation_lookup bit_offset x3 y3
+  byte_rotation_lookup bit_offset x4 y4
+  byte_rotation_lookup bit_offset x5 y5
+  byte_rotation_lookup bit_offset x6 y6
+  byte_rotation_lookup bit_offset x7 y7
 
-
-
-
-  return { z := ⟨ z0, z1, z2, z3, z4, z5, z6, z7 ⟩ }
+  return { z := ⟨ y0, y1, y2, y3, y4, y5, y6, y7 ⟩ }
 
 def assumptions (input : (Inputs p).value) := input.x.is_normalized
 

--- a/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
@@ -4,7 +4,6 @@ import Clean.Gadgets.Rotation64.Theorems
 
 namespace Gadgets.Rotation64Bytes
 variable {p : ℕ} [Fact p.Prime]
-variable [p_large_enough: Fact (p > 512)]
 
 open Gadgets.Rotation64.Theorems (rot_right64)
 
@@ -60,6 +59,7 @@ def spec (offset : Fin 8) (input : Inputs (F p)) (out: Outputs (F p)) :=
   let ⟨y⟩ := out
   y.value = rot_right64 x.value (offset.val * 8)
 
+omit [Fact (Nat.Prime p)] in
 lemma soundnessCase1 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x1, x1 := x2, x2 := x3, x3 := x4, x4 := x5, x5 := x6, x6 := x7, x7 := x0 : U64 _}.value =
   rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 8 := by
   simp only [U64.value, rot_right64]
@@ -114,6 +114,7 @@ lemma soundnessCase1 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧
   rw [h, h']
   ring
 
+omit [Fact (Nat.Prime p)] in
 lemma soundnessCase2 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x2, x1 := x3, x2 := x4, x3 := x5, x4 := x6, x5 := x7, x6 := x0, x7 := x1 : U64 _}.value =
   rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 16 := by
   simp only [U64.value, rot_right64]
@@ -169,6 +170,7 @@ lemma soundnessCase2 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧
   rw [h, h']
   ring
 
+omit [Fact (Nat.Prime p)] in
 lemma soundnessCase3 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x3, x1 := x4, x2 := x5, x3 := x6, x4 := x7, x5 := x0, x6 := x1, x7 := x2 : U64 _}.value =
   rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 24 := by
   simp only [U64.value, rot_right64]
@@ -224,6 +226,7 @@ lemma soundnessCase3 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧
   rw [h, h']
   ring
 
+omit [Fact (Nat.Prime p)] in
 lemma soundnessCase4 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x4, x1 := x5, x2 := x6, x3 := x7, x4 := x0, x5 := x1, x6 := x2, x7 := x3 : U64 _}.value = rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 32 := by
   simp only [U64.value, rot_right64]
   rw [
@@ -279,6 +282,7 @@ lemma soundnessCase4 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧
   rw [h, h']
   ring
 
+omit [Fact (Nat.Prime p)] in
 lemma soundnessCase5 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x5, x1 := x6, x2 := x7, x3 := x0, x4 := x1, x5 := x2, x6 := x3, x7 := x4 : U64 _}.value = rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 40 := by
   simp only [U64.value, rot_right64]
   rw [
@@ -335,6 +339,7 @@ lemma soundnessCase5 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧
   rw [h, h']
   ring
 
+omit [Fact (Nat.Prime p)] in
 lemma soundnessCase6 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x6, x1 := x7, x2 := x0, x3 := x1, x4 := x2, x5 := x3, x6 := x4, x7 := x5 : U64 _}.value = rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 48 := by
   simp only [U64.value, rot_right64]
   rw [
@@ -393,6 +398,7 @@ lemma soundnessCase6 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧
   rw [h, h']
   ring
 
+omit [Fact (Nat.Prime p)] in
 lemma soundnessCase7 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x7, x1 := x0, x2 := x1, x3 := x2, x4 := x3, x5 := x4, x6 := x5, x7 := x6 : U64 _}.value = rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 56 := by
   simp only [U64.value, rot_right64]
   rw [
@@ -432,7 +438,6 @@ lemma soundnessCase7 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧
     repeat
       norm_num
       rw [Int.add_emod, Int.mul_emod]
-      try rw [show ((72057594037927936 : ℤ) % 72057594037927936) = 0 by rfl]
       norm_num
     have x6_lt : x6 < 72057594037927936 := by linarith
     rw [← Int.mod_eq_emod x6_pos (by norm_num), Int.mod_eq_of_lt x6_pos x6_lt]
@@ -451,7 +456,7 @@ lemma soundnessCase7 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧
   rw [h, h']
   ring
 
-theorem soundness (off : Fin 8) : Soundness (F p) (Inputs p) (Outputs p) (rot64_bytes off) assumptions (spec off) := by
+theorem soundness (off : Fin 8) : Soundness (F p) Inputs  Outputs (rot64_bytes off) assumptions (spec off) := by
   rintro i0 env ⟨ x0_var, x1_var, x2_var, x3_var, x4_var, x5_var, x6_var, x7_var ⟩ ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ h_inputs as h
 
   have h_x0 : x0_var.eval env = x0 := by injections h_inputs
@@ -467,49 +472,54 @@ theorem soundness (off : Fin 8) : Soundness (F p) (Inputs p) (Outputs p) (rot64_
 
   dsimp only [assumptions, U64.is_normalized] at as
   fin_cases off
-  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure]
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, monad_norm, StateT.pure, pure]
     rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
     simp [U64.value, rot_right64, Nat.mod_one]
 
-  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure]
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, monad_norm, StateT.pure, pure]
     rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
     exact soundnessCase1 x0 x1 x2 x3 x4 x5 x6 x7 as
 
-  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure]
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, monad_norm, StateT.pure, pure]
     rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
     exact soundnessCase2 x0 x1 x2 x3 x4 x5 x6 x7 as
 
-  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure, show (3 : Fin 8).val = 3 by rfl]
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, monad_norm, StateT.pure, pure, show (3 : Fin 8).val = 3 by rfl]
     rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
     exact soundnessCase3 x0 x1 x2 x3 x4 x5 x6 x7 as
 
-  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure, show (4 : Fin 8).val = 4 by rfl]
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, monad_norm, StateT.pure, pure, show (4 : Fin 8).val = 4 by rfl]
     rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
     exact soundnessCase4 x0 x1 x2 x3 x4 x5 x6 x7 as
 
-  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure, show (5 : Fin 8).val = 5 by rfl]
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, monad_norm, StateT.pure, pure, show (5 : Fin 8).val = 5 by rfl]
     rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
     exact soundnessCase5 x0 x1 x2 x3 x4 x5 x6 x7 as
 
-  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure, show (6 : Fin 8).val = 6 by rfl]
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, monad_norm, StateT.pure, pure, show (6 : Fin 8).val = 6 by rfl]
     rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
     exact soundnessCase6 x0 x1 x2 x3 x4 x5 x6 x7 as
 
-  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure, show (7 : Fin 8).val = 7 by rfl]
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, monad_norm, StateT.pure, pure, show (7 : Fin 8).val = 7 by rfl]
     rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
     exact soundnessCase7 x0 x1 x2 x3 x4 x5 x6 x7 as
 
-theorem completeness (off : Fin 8) : Completeness (F p) (Inputs p) (Outputs p) (rot64_bytes off) assumptions := by
-  rintro i0 env ⟨ x0_var, x1_var, x2_var, x3_var, x4_var, x5_var, x6_var, x7_var ⟩ henv ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ as
-  dsimp [assumptions, U64.is_normalized] at as
+theorem completeness (off : Fin 8) : Completeness (F p) Inputs Outputs (rot64_bytes off) assumptions := by
+  rintro i0 env ⟨ x0_var, x1_var, x2_var, x3_var, x4_var, x5_var, x6_var, x7_var ⟩ henv ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ _
   fin_cases off
   repeat
     · simp [circuit_norm]
 
-def circuit (off : Fin 8) : FormalCircuit (F p) (Inputs p) (Outputs p) where
+def circuit (off : Fin 8) : FormalCircuit (F p) Inputs Outputs where
   main := rot64_bytes off
   assumptions := assumptions
   spec := spec off
   soundness := soundness off
   completeness := completeness off
+  -- technical condition needed for subcircuit consistency. usually automatically proved by `rfl`.
+  initial_offset_eq: ∀ var, ∀ n, ((rot64_bytes off) var |>.operations n).initial_offset = n := by
+    intros
+    fin_cases off
+    repeat
+      rfl
 end Gadgets.Rotation64Bytes

--- a/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
@@ -6,7 +6,7 @@ namespace Gadgets.Rotation64Bytes
 variable {p : ℕ} [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
-open Gadgets.Rotation64.Theorems (rot64)
+open Gadgets.Rotation64.Theorems (rot_right64)
 
 structure InputStruct (F : Type) where
   x: U64 F
@@ -94,7 +94,7 @@ def assumptions (input : (Inputs p).value) := input.x.is_normalized
 def spec (offset : Fin 8) (input : (Inputs p).value) (out: (Outputs p).value) :=
   let ⟨x⟩ := input
   let ⟨y⟩ := out
-  y.value = rot64 x.value (offset.val * 8)
+  y.value = rot_right64 x.value (offset.val * 8)
 
 theorem soundness (off : Fin 8) : Soundness (F p) (Inputs p) (Outputs p) (rot64_bytes off) assumptions (spec off) := by
   rintro i0 env ⟨ x0_var, x1_var, x2_var, x3_var, x4_var, x5_var, x6_var, x7_var ⟩ ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ h_inputs as h
@@ -113,10 +113,10 @@ theorem soundness (off : Fin 8) : Soundness (F p) (Inputs p) (Outputs p) (rot64_
   fin_cases off
   · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure]
     rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
-    simp [U64.value, rot64, Nat.mod_one]
+    simp [U64.value, rot_right64, Nat.mod_one]
   · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure]
     rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
-    simp only [U64.value, rot64]
+    simp only [U64.value, rot_right64]
     rw [
       show (8%64) = 8 by norm_num,
       show (64 - 8) = 56 by norm_num,

--- a/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
@@ -533,10 +533,17 @@ theorem soundness (off : Fin 8) : Soundness (F p) (Inputs p) (Outputs p) (rot64_
     rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
     exact soundnessCase7 x0 x1 x2 x3 x4 x5 x6 x7 as
 
+theorem completeness (off : Fin 8) : Completeness (F p) (Inputs p) (Outputs p) (rot64_bytes off) assumptions := by
+  rintro i0 env ⟨ x0_var, x1_var, x2_var, x3_var, x4_var, x5_var, x6_var, x7_var ⟩ henv ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ as
+  dsimp [assumptions, U64.is_normalized] at as
+  fin_cases off
+  repeat
+    · simp [circuit_norm]
+
 def circuit (off : Fin 8) : FormalCircuit (F p) (Inputs p) (Outputs p) where
   main := rot64_bytes off
   assumptions := assumptions
   spec := spec off
   soundness := soundness off
-  completeness := by sorry
+  completeness := completeness off
 end Gadgets.Rotation64Bytes

--- a/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
@@ -8,57 +8,23 @@ variable [p_large_enough: Fact (p > 512)]
 
 open Gadgets.Rotation64.Theorems (rot_right64)
 
-structure InputStruct (F : Type) where
+structure Inputs (F : Type) where
   x: U64 F
 
-instance (F : Type) : StructuredElements InputStruct F where
-  size := StructuredElements.size U64 F
-  to_elements x := (StructuredElements.to_elements x.x)
+instance instProvableTypeInputs : ProvableType Inputs where
+  size := ProvableType.size U64
+  to_elements x := (ProvableType.to_elements x.x)
   from_elements v :=
     let ⟨ [x0, x1, x2, x3, x4, x5, x6, x7], _ ⟩ := v
     ⟨ ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ ⟩
 
-def Inputs (p : ℕ) : TypePair := ⟨
-  InputStruct (Expression (F p)),
-  InputStruct (F p)
-⟩
-
-@[simp]
-instance : ProvableType (F p) (Inputs p) where
-  size := 8
-  to_vars s := vec [s.x.x0, s.x.x1, s.x.x2, s.x.x3, s.x.x4, s.x.x5, s.x.x6, s.x.x7]
-  from_vars v :=
-    let ⟨ [x0, x1, x2, x3, x4, x5, x6, x7], _ ⟩ := v
-    ⟨ ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ ⟩
-  to_values s := vec [s.x.x0, s.x.x1, s.x.x2, s.x.x3, s.x.x4, s.x.x5, s.x.x6, s.x.x7]
-  from_values v :=
-    let ⟨ [x0, x1, x2, x3, x4, x5, x6, x7], _ ⟩ := v
-    ⟨ ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ ⟩
-
-
-structure OutputStruct (F : Type) where
+structure Outputs (F : Type) where
   z: U64 F
 
-instance (F : Type) : StructuredElements OutputStruct F where
-  size := StructuredElements.size U64 F
-  to_elements x := (StructuredElements.to_elements x.z)
+instance instProvableTypeOutputs : ProvableType Outputs where
+  size := ProvableType.size U64
+  to_elements x := (ProvableType.to_elements x.z)
   from_elements v :=
-    let ⟨ [z0, z1, z2, z3, z4, z5, z6, z7], _ ⟩ := v
-    ⟨ ⟨ z0, z1, z2, z3, z4, z5, z6, z7 ⟩ ⟩
-
-def Outputs (p : ℕ) : TypePair := ⟨
-  OutputStruct (Expression (F p)),
-  OutputStruct (F p)
-⟩
-
-instance : ProvableType (F p) (Outputs p) where
-  size := 8
-  to_vars s := vec [s.z.x0, s.z.x1, s.z.x2, s.z.x3, s.z.x4, s.z.x5, s.z.x6, s.z.x7]
-  from_vars v :=
-    let ⟨ [z0, z1, z2, z3, z4, z5, z6, z7], _ ⟩ := v
-    ⟨ ⟨ z0, z1, z2, z3, z4, z5, z6, z7 ⟩ ⟩
-  to_values s := vec [s.z.x0, s.z.x1, s.z.x2, s.z.x3, s.z.x4, s.z.x5, s.z.x6, s.z.x7]
-  from_values v :=
     let ⟨ [z0, z1, z2, z3, z4, z5, z6, z7], _ ⟩ := v
     ⟨ ⟨ z0, z1, z2, z3, z4, z5, z6, z7 ⟩ ⟩
 
@@ -66,7 +32,7 @@ instance : ProvableType (F p) (Outputs p) where
   Rotate the 64-bit integer by increments of 8 positions
   This gadget does not introduce constraints
 -/
-def rot64_bytes (offset : Fin 8) (input : (Inputs p).var) : Circuit (F p) (Outputs p).var := do
+def rot64_bytes (offset : Fin 8) (input : Var Inputs (F p)) : Circuit (F p) (Var Outputs (F p)) := do
   let ⟨x0, x1, x2, x3 , x4, x5, x6, x7⟩ := input
   let offset := offset.val
 
@@ -87,9 +53,9 @@ def rot64_bytes (offset : Fin 8) (input : (Inputs p).var) : Circuit (F p) (Outpu
   else
     return ⟨ x7, x0, x1, x2, x3, x4, x5, x6 ⟩
 
-def assumptions (input : (Inputs p).value) := input.x.is_normalized
+def assumptions (input : Inputs (F p)) := input.x.is_normalized
 
-def spec (offset : Fin 8) (input : (Inputs p).value) (out: (Outputs p).value) :=
+def spec (offset : Fin 8) (input : Inputs (F p)) (out: Outputs (F p)) :=
   let ⟨x⟩ := input
   let ⟨y⟩ := out
   y.value = rot_right64 x.value (offset.val * 8)

--- a/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
@@ -94,6 +94,397 @@ def spec (offset : Fin 8) (input : (Inputs p).value) (out: (Outputs p).value) :=
   let ⟨y⟩ := out
   y.value = rot_right64 x.value (offset.val * 8)
 
+lemma soundnessCase1 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x1, x1 := x2, x2 := x3, x3 := x4, x4 := x5, x5 := x6, x6 := x7, x7 := x0 : U64 _}.value =
+  rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 8 := by
+  simp only [U64.value, rot_right64]
+  rw [
+    show (8 % 64) = 8 by norm_num,
+    show (64 - 8) = 56 by norm_num,
+  ]
+  have x0_pos : 0 ≤ x0.val := by exact Nat.zero_le _
+  zify at *
+  set x0 : ℤ := x0.val.cast
+  set x1 : ℤ := x1.val.cast
+  set x2 : ℤ := x2.val.cast
+  set x3 : ℤ := x3.val.cast
+  set x4 : ℤ := x4.val.cast
+  set x5 : ℤ := x5.val.cast
+  set x6 : ℤ := x6.val.cast
+  set x7 : ℤ := x7.val.cast
+
+
+  have h : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) % 2 ^ 8 = x0 := by
+    repeat
+      norm_num
+      rw [Int.add_emod, Int.mul_emod]
+      try rw [show ((72057594037927936 : ℤ) % 256) = 0 by rfl]
+      try rw [show ((281474976710656 : ℤ) % 256) = 0 by rfl]
+      try rw [show ((1099511627776 : ℤ) % 256) = 0 by rfl]
+      try rw [show ((4294967296 : ℤ) % 256) = 0 by rfl]
+      try rw [show ((16777216 : ℤ) % 256) = 0 by rfl]
+      try rw [show ((65536 : ℤ) % 256) = 0 by rfl]
+      norm_num
+    rw [←Int.mod_eq_emod x0_pos (by norm_num), Int.mod_eq_of_lt x0_pos (by simp only [as])]
+
+
+  have h' : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) / 2 ^ 8 =
+      x1 + x2 * 256 + x3 * 256 ^ 2 + x4 * 256 ^ 3 + x5 * 256 ^ 4 + x6 * 256 ^ 5 + x7 * 256 ^ 6 := by
+
+    repeat
+      norm_num
+      rw [Int.add_ediv_of_dvd_right (by
+        rw [Int.dvd_iff_emod_eq_zero, Int.mul_emod]
+        try rw [show ((72057594037927936 : ℤ) % 256) = 0 by rfl]
+        try rw [show ((281474976710656 : ℤ) % 256) = 0 by rfl]
+        try rw [show ((1099511627776 : ℤ) % 256) = 0 by rfl]
+        try rw [show ((4294967296 : ℤ) % 256) = 0 by rfl]
+        try rw [show ((16777216 : ℤ) % 256) = 0 by rfl]
+        try rw [show ((65536 : ℤ) % 256) = 0 by rfl]
+        rfl)]
+      rw [Int.mul_ediv_assoc _ (by norm_num)]
+      norm_num
+    rw [Int.ediv_eq_zero_of_lt (by simp only [x0_pos]) (by simp only [as])]
+
+  rw [h, h']
+  ring
+
+lemma soundnessCase2 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x2, x1 := x3, x2 := x4, x3 := x5, x4 := x6, x5 := x7, x6 := x0, x7 := x1 : U64 _}.value =
+  rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 16 := by
+  simp only [U64.value, rot_right64]
+  rw [
+    show (16 % 64) = 16 by norm_num,
+    show (64 - 16) = 48 by norm_num,
+  ]
+  have x0_pos : 0 ≤ x0.val := by exact Nat.zero_le _
+  have x1_pos : 0 ≤ x1.val := by exact Nat.zero_le _
+  have x0_x1_pos : 0 ≤ x0.val + x1.val * 256 := by
+    exact Nat.le_add_right_of_le x0_pos
+  zify at *
+  set x0 : ℤ := x0.val.cast
+  set x1 : ℤ := x1.val.cast
+  set x2 : ℤ := x2.val.cast
+  set x3 : ℤ := x3.val.cast
+  set x4 : ℤ := x4.val.cast
+  set x5 : ℤ := x5.val.cast
+  set x6 : ℤ := x6.val.cast
+  set x7 : ℤ := x7.val.cast
+
+
+
+  have h : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) % 2 ^ 16 = x0 + x1 * 256 := by
+    repeat
+      norm_num
+      rw [Int.add_emod, Int.mul_emod]
+      try rw [show ((72057594037927936 : ℤ) % 65536) = 0 by rfl]
+      try rw [show ((281474976710656 : ℤ) % 65536) = 0 by rfl]
+      try rw [show ((1099511627776 : ℤ) % 65536) = 0 by rfl]
+      try rw [show ((4294967296 : ℤ) % 65536) = 0 by rfl]
+      try rw [show ((16777216 : ℤ) % 65536) = 0 by rfl]
+      norm_num
+    rw [←Int.mod_eq_emod x1_pos (by norm_num), Int.mod_eq_of_lt x1_pos (by linarith)]
+    rw [←Int.mod_eq_emod x0_x1_pos (by norm_num), Int.mod_eq_of_lt x0_x1_pos (by linarith)]
+
+  have h' : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) / 2 ^ 16 =
+      x2 + x3 * 256 + x4 * 256 ^ 2 + x5 * 256 ^ 3 + x6 * 256 ^ 4 + x7 * 256 ^ 5 := by
+    repeat
+      norm_num
+      rw [Int.add_ediv_of_dvd_right (by
+        rw [Int.dvd_iff_emod_eq_zero, Int.mul_emod]
+        try rw [show ((72057594037927936 : ℤ) % 65536) = 0 by rfl]
+        try rw [show ((281474976710656 : ℤ) % 65536) = 0 by rfl]
+        try rw [show ((1099511627776 : ℤ) % 65536) = 0 by rfl]
+        try rw [show ((4294967296 : ℤ) % 65536) = 0 by rfl]
+        try rw [show ((16777216 : ℤ) % 65536) = 0 by rfl]
+        rfl)]
+      rw [Int.mul_ediv_assoc _ (by norm_num)]
+      norm_num
+    rw [Int.ediv_eq_zero_of_lt (by simp only [x0_x1_pos]) (by linarith)]
+
+  rw [h, h']
+  ring
+
+lemma soundnessCase3 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x3, x1 := x4, x2 := x5, x3 := x6, x4 := x7, x5 := x0, x6 := x1, x7 := x2 : U64 _}.value =
+  rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 24 := by
+  simp only [U64.value, rot_right64]
+  rw [
+    show (24 % 64) = 24 by norm_num,
+    show (64 - 24) = 40 by norm_num,
+  ]
+  have x0_pos : 0 ≤ x0.val := by exact Nat.zero_le _
+  have x1_pos : 0 ≤ x1.val := by exact Nat.zero_le _
+  have x2_pos : 0 ≤ x2.val := by exact Nat.zero_le _
+  have x0_x1_pos : 0 ≤ x0.val + x1.val * 256 := by
+    exact Nat.le_add_right_of_le x0_pos
+  have x0_x1_x2_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 := by
+    exact Nat.le_add_right_of_le x0_x1_pos
+  zify at *
+  set x0 : ℤ := x0.val.cast
+  set x1 : ℤ := x1.val.cast
+  set x2 : ℤ := x2.val.cast
+  set x3 : ℤ := x3.val.cast
+  set x4 : ℤ := x4.val.cast
+  set x5 : ℤ := x5.val.cast
+  set x6 : ℤ := x6.val.cast
+  set x7 : ℤ := x7.val.cast
+
+  have h : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) % 2 ^ 24 = x0 + x1 * 256 + x2 * 256 ^ 2 := by
+    repeat
+      norm_num
+      rw [Int.add_emod, Int.mul_emod]
+      try rw [show ((72057594037927936 : ℤ) % 16777216) = 0 by rfl]
+      try rw [show ((281474976710656 : ℤ) % 16777216) = 0 by rfl]
+      try rw [show ((1099511627776 : ℤ) % 16777216) = 0 by rfl]
+      try rw [show ((4294967296 : ℤ) % 16777216) = 0 by rfl]
+      norm_num
+    have x2_lt : x2 < 16777216 := by linarith
+    rw [← Int.mod_eq_emod x2_pos (by norm_num), Int.mod_eq_of_lt x2_pos x2_lt]
+    rw [←Int.mod_eq_emod x0_x1_x2_pos (by norm_num), Int.mod_eq_of_lt x0_x1_x2_pos (by linarith)]
+
+  have h' : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) / 2 ^ 24 =
+      x3 + x4 * 256 + x5 * 256 ^ 2 + x6 * 256 ^ 3 + x7 * 256 ^ 4 := by
+    repeat
+      norm_num
+      rw [Int.add_ediv_of_dvd_right (by
+        rw [Int.dvd_iff_emod_eq_zero, Int.mul_emod]
+        try rw [show ((72057594037927936 : ℤ) % 16777216) = 0 by rfl]
+        try rw [show ((281474976710656 : ℤ) % 16777216) = 0 by rfl]
+        try rw [show ((1099511627776 : ℤ) % 16777216) = 0 by rfl]
+        try rw [show ((4294967296 : ℤ) % 16777216) = 0 by rfl]
+        rfl)]
+      rw [Int.mul_ediv_assoc _ (by norm_num)]
+      norm_num
+    rw [Int.ediv_eq_zero_of_lt (by simp only [x0_x1_x2_pos]) (by linarith)]
+
+  rw [h, h']
+  ring
+
+lemma soundnessCase4 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x4, x1 := x5, x2 := x6, x3 := x7, x4 := x0, x5 := x1, x6 := x2, x7 := x3 : U64 _}.value = rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 32 := by
+  simp only [U64.value, rot_right64]
+  rw [
+    show (32 % 64) = 32 by norm_num,
+    show (64 - 32) = 32 by norm_num,
+  ]
+  have x0_pos : 0 ≤ x0.val := by exact Nat.zero_le _
+  have x1_pos : 0 ≤ x1.val := by exact Nat.zero_le _
+  have x2_pos : 0 ≤ x2.val := by exact Nat.zero_le _
+  have x3_pos : 0 ≤ x3.val := by exact Nat.zero_le _
+  have x0_x1_pos : 0 ≤ x0.val + x1.val * 256 := by
+    exact Nat.le_add_right_of_le x0_pos
+  have x0_x1_x2_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 := by
+    exact Nat.le_add_right_of_le x0_x1_pos
+  have x0_x1_x2_x3_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 + x3.val * 16777216 := by
+    exact Nat.le_add_right_of_le x0_x1_x2_pos
+  zify at *
+  set x0 : ℤ := x0.val.cast
+  set x1 : ℤ := x1.val.cast
+  set x2 : ℤ := x2.val.cast
+  set x3 : ℤ := x3.val.cast
+  set x4 : ℤ := x4.val.cast
+  set x5 : ℤ := x5.val.cast
+  set x6 : ℤ := x6.val.cast
+  set x7 : ℤ := x7.val.cast
+
+  have h : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) % 2 ^ 32 = x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 := by
+    repeat
+      norm_num
+      rw [Int.add_emod, Int.mul_emod]
+      try rw [show ((72057594037927936 : ℤ) % 4294967296) = 0 by rfl]
+      try rw [show ((281474976710656 : ℤ) % 4294967296) = 0 by rfl]
+      try rw [show ((1099511627776 : ℤ) % 4294967296) = 0 by rfl]
+      norm_num
+    have x3_lt : x3 < 4294967296 := by linarith
+    rw [← Int.mod_eq_emod x3_pos (by norm_num), Int.mod_eq_of_lt x3_pos x3_lt]
+    rw [←Int.mod_eq_emod x0_x1_x2_x3_pos (by norm_num), Int.mod_eq_of_lt x0_x1_x2_x3_pos (by linarith)]
+
+  have h' : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) / 2 ^ 32 =
+      x4 + x5 * 256 + x6 * 256 ^ 2 + x7 * 256 ^ 3 := by
+    repeat
+      norm_num
+      rw [Int.add_ediv_of_dvd_right (by
+        rw [Int.dvd_iff_emod_eq_zero, Int.mul_emod]
+        try rw [show ((72057594037927936 : ℤ) % 4294967296) = 0 by rfl]
+        try rw [show ((281474976710656 : ℤ) % 4294967296) = 0 by rfl]
+        try rw [show ((1099511627776 : ℤ) % 4294967296) = 0 by rfl]
+        rfl)]
+      rw [Int.mul_ediv_assoc _ (by norm_num)]
+      norm_num
+    rw [Int.ediv_eq_zero_of_lt (by simp only [x0_x1_x2_x3_pos]) (by linarith)]
+
+  rw [h, h']
+  ring
+
+lemma soundnessCase5 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x5, x1 := x6, x2 := x7, x3 := x0, x4 := x1, x5 := x2, x6 := x3, x7 := x4 : U64 _}.value = rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 40 := by
+  simp only [U64.value, rot_right64]
+  rw [
+    show (40 % 64) = 40 by norm_num,
+    show (64 - 40) = 24 by norm_num,
+  ]
+  have x0_pos : 0 ≤ x0.val := by exact Nat.zero_le _
+  have x1_pos : 0 ≤ x1.val := by exact Nat.zero_le _
+  have x2_pos : 0 ≤ x2.val := by exact Nat.zero_le _
+  have x3_pos : 0 ≤ x3.val := by exact Nat.zero_le _
+  have x4_pos : 0 ≤ x4.val := by exact Nat.zero_le _
+  have x0_x1_pos : 0 ≤ x0.val + x1.val * 256 := by
+    exact Nat.le_add_right_of_le x0_pos
+  have x0_x1_x2_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 := by
+    exact Nat.le_add_right_of_le x0_x1_pos
+  have x0_x1_x2_x3_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 + x3.val * 16777216 := by
+    exact Nat.le_add_right_of_le x0_x1_x2_pos
+  have x0_x1_x2_x3_x4_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 + x3.val * 16777216 + x4.val * 4294967296 := by
+    exact Nat.le_add_right_of_le x0_x1_x2_x3_pos
+  zify at *
+  set x0 : ℤ := x0.val.cast
+  set x1 : ℤ := x1.val.cast
+  set x2 : ℤ := x2.val.cast
+  set x3 : ℤ := x3.val.cast
+  set x4 : ℤ := x4.val.cast
+  set x5 : ℤ := x5.val.cast
+  set x6 : ℤ := x6.val.cast
+  set x7 : ℤ := x7.val.cast
+
+  have h : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) % 2 ^ 40 = x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 := by
+    repeat
+      norm_num
+      rw [Int.add_emod, Int.mul_emod]
+      try rw [show ((72057594037927936 : ℤ) % 1099511627776) = 0 by rfl]
+      try rw [show ((281474976710656 : ℤ) % 1099511627776) = 0 by rfl]
+      norm_num
+    have x4_lt : x4 < 1099511627776 := by linarith
+    rw [← Int.mod_eq_emod x4_pos (by norm_num), Int.mod_eq_of_lt x4_pos x4_lt]
+    rw [←Int.mod_eq_emod x0_x1_x2_x3_x4_pos (by norm_num), Int.mod_eq_of_lt x0_x1_x2_x3_x4_pos (by linarith)]
+
+  have h' : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) / 2 ^ 40 =
+      x5 + x6 * 256 + x7 * 256 ^ 2 := by
+    repeat
+      norm_num
+      rw [Int.add_ediv_of_dvd_right (by
+        rw [Int.dvd_iff_emod_eq_zero, Int.mul_emod]
+        try rw [show ((72057594037927936 : ℤ) % 1099511627776) = 0 by rfl]
+        try rw [show ((281474976710656 : ℤ) % 1099511627776) = 0 by rfl]
+        rfl)]
+      rw [Int.mul_ediv_assoc _ (by norm_num)]
+      norm_num
+    rw [Int.ediv_eq_zero_of_lt (by simp only [x0_x1_x2_x3_x4_pos]) (by linarith)]
+
+  rw [h, h']
+  ring
+
+lemma soundnessCase6 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x6, x1 := x7, x2 := x0, x3 := x1, x4 := x2, x5 := x3, x6 := x4, x7 := x5 : U64 _}.value = rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 48 := by
+  simp only [U64.value, rot_right64]
+  rw [
+    show (48 % 64) = 48 by norm_num,
+    show (64 - 48) = 16 by norm_num,
+  ]
+  have x0_pos : 0 ≤ x0.val := by exact Nat.zero_le _
+  have x1_pos : 0 ≤ x1.val := by exact Nat.zero_le _
+  have x2_pos : 0 ≤ x2.val := by exact Nat.zero_le _
+  have x3_pos : 0 ≤ x3.val := by exact Nat.zero_le _
+  have x4_pos : 0 ≤ x4.val := by exact Nat.zero_le _
+  have x5_pos : 0 ≤ x5.val := by exact Nat.zero_le _
+  have x0_x1_pos : 0 ≤ x0.val + x1.val * 256 := by
+    exact Nat.le_add_right_of_le x0_pos
+  have x0_x1_x2_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 := by
+    exact Nat.le_add_right_of_le x0_x1_pos
+  have x0_x1_x2_x3_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 + x3.val * 16777216 := by
+    exact Nat.le_add_right_of_le x0_x1_x2_pos
+  have x0_x1_x2_x3_x4_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 + x3.val * 16777216 + x4.val * 4294967296 := by
+    exact Nat.le_add_right_of_le x0_x1_x2_x3_pos
+  have x0_x1_x2_x3_x4_x5_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 + x3.val * 16777216 + x4.val * 4294967296 + x5.val * 1099511627776 := by
+    exact Nat.le_add_right_of_le x0_x1_x2_x3_x4_pos
+  zify at *
+  set x0 : ℤ := x0.val.cast
+  set x1 : ℤ := x1.val.cast
+  set x2 : ℤ := x2.val.cast
+  set x3 : ℤ := x3.val.cast
+  set x4 : ℤ := x4.val.cast
+  set x5 : ℤ := x5.val.cast
+  set x6 : ℤ := x6.val.cast
+  set x7 : ℤ := x7.val.cast
+
+  have h : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) % 2 ^ 48 = x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 := by
+    repeat
+      norm_num
+      rw [Int.add_emod, Int.mul_emod]
+      try rw [show ((72057594037927936 : ℤ) % 281474976710656) = 0 by rfl]
+      try rw [show ((281474976710656 : ℤ) % 281474976710656) = 0 by rfl]
+      norm_num
+    have x5_lt : x5 < 281474976710656 := by linarith
+    rw [← Int.mod_eq_emod x5_pos (by norm_num), Int.mod_eq_of_lt x5_pos x5_lt]
+    rw [←Int.mod_eq_emod x0_x1_x2_x3_x4_x5_pos (by norm_num), Int.mod_eq_of_lt x0_x1_x2_x3_x4_x5_pos (by linarith)]
+
+  have h' : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) / 2 ^ 48 =
+      x6 + x7 * 256 := by
+    repeat
+      norm_num
+      rw [Int.add_ediv_of_dvd_right (by
+        rw [Int.dvd_iff_emod_eq_zero, Int.mul_emod]
+        try rw [show ((72057594037927936 : ℤ) % 281474976710656) = 0 by rfl]
+        rfl)]
+      rw [Int.mul_ediv_assoc _ (by norm_num)]
+      norm_num
+    rw [Int.ediv_eq_zero_of_lt (by simp only [x0_x1_x2_x3_x4_x5_pos]) (by linarith)]
+
+  rw [h, h']
+  ring
+
+lemma soundnessCase7 (x0 x1 x2 x3 x4 x5 x6 x7 : F p) (as : ZMod.val x0 < 256 ∧ ZMod.val x1 < 256 ∧ ZMod.val x2 < 256 ∧ ZMod.val x3 < 256 ∧ ZMod.val x4 < 256 ∧ ZMod.val x5 < 256 ∧ ZMod.val x6 < 256 ∧ ZMod.val x7 < 256) : { x0 := x7, x1 := x0, x2 := x1, x3 := x2, x4 := x3, x5 := x4, x6 := x5, x7 := x6 : U64 _}.value = rot_right64 { x0 := x0, x1 := x1, x2 := x2, x3 := x3, x4 := x4, x5 := x5, x6 := x6, x7 := x7 : U64 _}.value 56 := by
+  simp only [U64.value, rot_right64]
+  rw [
+    show (56 % 64) = 56 by norm_num,
+    show (64 - 56) = 8 by norm_num,
+  ]
+  have x0_pos : 0 ≤ x0.val := by exact Nat.zero_le _
+  have x1_pos : 0 ≤ x1.val := by exact Nat.zero_le _
+  have x2_pos : 0 ≤ x2.val := by exact Nat.zero_le _
+  have x3_pos : 0 ≤ x3.val := by exact Nat.zero_le _
+  have x4_pos : 0 ≤ x4.val := by exact Nat.zero_le _
+  have x5_pos : 0 ≤ x5.val := by exact Nat.zero_le _
+  have x6_pos : 0 ≤ x6.val := by exact Nat.zero_le _
+  have x0_x1_pos : 0 ≤ x0.val + x1.val * 256 := by
+    exact Nat.le_add_right_of_le x0_pos
+  have x0_x1_x2_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 := by
+    exact Nat.le_add_right_of_le x0_x1_pos
+  have x0_x1_x2_x3_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 + x3.val * 16777216 := by
+    exact Nat.le_add_right_of_le x0_x1_x2_pos
+  have x0_x1_x2_x3_x4_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 + x3.val * 16777216 + x4.val * 4294967296 := by
+    exact Nat.le_add_right_of_le x0_x1_x2_x3_pos
+  have x0_x1_x2_x3_x4_x5_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 + x3.val * 16777216 + x4.val * 4294967296 + x5.val * 1099511627776 := by
+    exact Nat.le_add_right_of_le x0_x1_x2_x3_x4_pos
+  have x0_x1_x2_x3_x4_x5_x6_pos : 0 ≤ x0.val + x1.val * 256 + x2.val * 65536 + x3.val * 16777216 + x4.val * 4294967296 + x5.val * 1099511627776 + x6.val * 281474976710656 := by
+    exact Nat.le_add_right_of_le x0_x1_x2_x3_x4_x5_pos
+  zify at *
+  set x0 : ℤ := x0.val.cast
+  set x1 : ℤ := x1.val.cast
+  set x2 : ℤ := x2.val.cast
+  set x3 : ℤ := x3.val.cast
+  set x4 : ℤ := x4.val.cast
+  set x5 : ℤ := x5.val.cast
+  set x6 : ℤ := x6.val.cast
+  set x7 : ℤ := x7.val.cast
+
+  have h : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) % 2 ^ 56 = x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 := by
+    repeat
+      norm_num
+      rw [Int.add_emod, Int.mul_emod]
+      try rw [show ((72057594037927936 : ℤ) % 72057594037927936) = 0 by rfl]
+      norm_num
+    have x6_lt : x6 < 72057594037927936 := by linarith
+    rw [← Int.mod_eq_emod x6_pos (by norm_num), Int.mod_eq_of_lt x6_pos x6_lt]
+    rw [←Int.mod_eq_emod x0_x1_x2_x3_x4_x5_x6_pos (by norm_num), Int.mod_eq_of_lt x0_x1_x2_x3_x4_x5_x6_pos (by linarith)]
+
+  have h' : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) / 2 ^ 56 = x7 := by
+    repeat
+      norm_num
+      rw [Int.add_ediv_of_dvd_right (by
+        rw [Int.dvd_iff_emod_eq_zero, Int.mul_emod]
+        rfl)]
+      rw [Int.mul_ediv_assoc _ (by norm_num)]
+      norm_num
+    rw [Int.ediv_eq_zero_of_lt (by simp only [x0_x1_x2_x3_x4_x5_x6_pos]) (by linarith)]
+
+  rw [h, h']
+  ring
+
 theorem soundness (off : Fin 8) : Soundness (F p) (Inputs p) (Outputs p) (rot64_bytes off) assumptions (spec off) := by
   rintro i0 env ⟨ x0_var, x1_var, x2_var, x3_var, x4_var, x5_var, x6_var, x7_var ⟩ ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ h_inputs as h
 
@@ -116,61 +507,31 @@ theorem soundness (off : Fin 8) : Soundness (F p) (Inputs p) (Outputs p) (rot64_
 
   · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure]
     rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
-    simp only [U64.value, rot_right64]
-    rw [
-      show (8%64) = 8 by norm_num,
-      show (64 - 8) = 56 by norm_num,
-    ]
-    have x0_pos : 0 ≤ x0.val := by exact Nat.zero_le _
-    zify at *
-    set x0 : ℤ := x0.val.cast
-    set x1 : ℤ := x1.val.cast
-    set x2 : ℤ := x2.val.cast
-    set x3 : ℤ := x3.val.cast
-    set x4 : ℤ := x4.val.cast
-    set x5 : ℤ := x5.val.cast
-    set x6 : ℤ := x6.val.cast
-    set x7 : ℤ := x7.val.cast
+    exact soundnessCase1 x0 x1 x2 x3 x4 x5 x6 x7 as
 
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure]
+    rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
+    exact soundnessCase2 x0 x1 x2 x3 x4 x5 x6 x7 as
 
-    have h : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) % 2 ^ 8 = x0 := by
-      repeat
-        norm_num
-        rw [Int.add_emod, Int.mul_emod]
-        try rw [show ((72057594037927936 : ℤ) % 256) = 0 by rfl]
-        try rw [show ((281474976710656 : ℤ) % 256) = 0 by rfl]
-        try rw [show ((1099511627776 : ℤ) % 256) = 0 by rfl]
-        try rw [show ((4294967296 : ℤ) % 256) = 0 by rfl]
-        try rw [show ((16777216 : ℤ) % 256) = 0 by rfl]
-        try rw [show ((65536 : ℤ) % 256) = 0 by rfl]
-        norm_num
-      rw [←Int.mod_eq_emod x0_pos (by norm_num), Int.mod_eq_of_lt x0_pos (by simp only [as])]
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure, show (3 : Fin 8).val = 3 by rfl]
+    rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
+    exact soundnessCase3 x0 x1 x2 x3 x4 x5 x6 x7 as
 
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure, show (4 : Fin 8).val = 4 by rfl]
+    rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
+    exact soundnessCase4 x0 x1 x2 x3 x4 x5 x6 x7 as
 
-    have h' : (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) / 2 ^ 8 =
-        x1 + x2 * 256 + x3 * 256 ^ 2 + x4 * 256 ^ 3 + x5 * 256 ^ 4 + x6 * 256 ^ 5 + x7 * 256 ^ 6 := by
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure, show (5 : Fin 8).val = 5 by rfl]
+    rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
+    exact soundnessCase5 x0 x1 x2 x3 x4 x5 x6 x7 as
 
-      repeat
-        norm_num
-        rw [Int.add_ediv_of_dvd_right (by
-          rw [Int.dvd_iff_emod_eq_zero, Int.mul_emod]
-          try rw [show ((72057594037927936 : ℤ) % 256) = 0 by rfl]
-          try rw [show ((281474976710656 : ℤ) % 256) = 0 by rfl]
-          try rw [show ((1099511627776 : ℤ) % 256) = 0 by rfl]
-          try rw [show ((4294967296 : ℤ) % 256) = 0 by rfl]
-          try rw [show ((16777216 : ℤ) % 256) = 0 by rfl]
-          try rw [show ((65536 : ℤ) % 256) = 0 by rfl]
-          try rw [show ((256 : ℤ) % 256) = 0 by rfl]
-          rfl)]
-        rw [Int.mul_ediv_assoc _ (by norm_num)]
-        norm_num
-      rw [Int.ediv_eq_zero_of_lt (by simp only [x0_pos]) (by simp only [as])]
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure, show (6 : Fin 8).val = 6 by rfl]
+    rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
+    exact soundnessCase6 x0 x1 x2 x3 x4 x5 x6 x7 as
 
-    rw [h, h']
-    ring
-
-
-  repeat sorry
+  · simp [circuit_norm, rot64_bytes, spec, circuit_norm, Circuit.output, pure, show (7 : Fin 8).val = 7 by rfl]
+    rw [h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7]
+    exact soundnessCase7 x0 x1 x2 x3 x4 x5 x6 x7 as
 
 def circuit (off : Fin 8) : FormalCircuit (F p) (Inputs p) (Outputs p) where
   main := rot64_bytes off

--- a/Clean/Gadgets/Rotation64/Theorems.lean
+++ b/Clean/Gadgets/Rotation64/Theorems.lean
@@ -1,0 +1,16 @@
+import Clean.Types.U64
+import Clean.Utils.Field
+
+variable {p : ℕ} [Fact p.Prime]
+variable [p_large_enough: Fact (p > 512)]
+
+namespace Gadgets.Rotation64.Theorems
+
+def rot64 (x : ℕ) (offset : ℕ) : ℕ :=
+  let offset := offset % 64
+  let low := x % (2^offset)
+  let high := x / (2^offset)
+  low * (2^(64 - offset)) + high
+
+
+end Gadgets.Rotation64.Theorems

--- a/Clean/Gadgets/Rotation64/Theorems.lean
+++ b/Clean/Gadgets/Rotation64/Theorems.lean
@@ -1,4 +1,3 @@
-import Clean.Types.U64
 import Clean.Utils.Field
 
 variable {p : ℕ} [Fact p.Prime]
@@ -6,7 +5,18 @@ variable [p_large_enough: Fact (p > 512)]
 
 namespace Gadgets.Rotation64.Theorems
 
-def rot64 (x : ℕ) (offset : ℕ) : ℕ :=
+def rot_right8 (x : Fin 256) (offset : Fin 8) : Fin 256 :=
+  let low := x % (2^offset.val)
+  let high := x / (2^offset.val)
+  low * (2^(8 - offset.val)) + high
+
+def rot_left8 (x : Fin 256) (offset : Fin 8) : Fin 256 :=
+  let low := x % (2^(8 - offset.val))
+  let high := x / (2^(8 - offset.val))
+  low * (2^offset.val) + high
+
+
+def rot_right64 (x : ℕ) (offset : ℕ) : ℕ :=
   let offset := offset % 64
   let low := x % (2^offset)
   let high := x / (2^offset)

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -2,12 +2,7 @@ import Clean.Gadgets.ByteLookup
 import Clean.Circuit.Extensions
 
 section
-variable {p : ℕ} [Fact p.Prime]
--- TODO: this assumption is false in practice, need to change some proofs to not need it
-variable [p_large_enough: Fact (p > 512)]
-
-instance : NeZero p := ⟨‹Fact p.Prime›.elim.ne_zero⟩
-instance : Fact (p > 512) := by apply Fact.mk; linarith [p_large_enough.elim]
+variable {p : ℕ} [Fact p.Prime] [p_large_enough: Fact (p > 512)]
 
 /--
   A 32-bit unsigned integer is represented using four limbs of 8 bits each.

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -1,5 +1,6 @@
 import Clean.Gadgets.ByteLookup
 import Clean.Circuit.Extensions
+import Clean.Gadgets.ByteLookup
 
 section
 variable {p : ℕ} [Fact p.Prime] [p_large_enough: Fact (p > 512)]
@@ -55,10 +56,10 @@ lemma ext {x y : U32 (F p)}
 def witness (compute : Environment (F p) → U32 (F p)) := do
   let ⟨ x0, x1, x2, x3 ⟩ ← Provable.witness u32 compute
 
-  byte_lookup x0
-  byte_lookup x1
-  byte_lookup x2
-  byte_lookup x3
+  Gadgets.byte_lookup x0
+  Gadgets.byte_lookup x1
+  Gadgets.byte_lookup x2
+  Gadgets.byte_lookup x3
 
   return U32.mk x0 x1 x2 x3
 

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -18,7 +18,7 @@ structure U64 (T: Type) where
   x7 : T
 
 
-instance {F : Type} : StructuredElements U64 F where
+instance : ProvableType U64 where
   size := 8
   to_elements x := vec [x.x0, x.x1, x.x2, x.x3, x.x4, x.x5, x.x6, x.x7]
   from_elements v :=
@@ -26,18 +26,6 @@ instance {F : Type} : StructuredElements U64 F where
     ⟨ v0, v1, v2, v3, v4, v5, v6, v7 ⟩
 
 namespace U64
-def u64 {p: ℕ} : TypePair := ⟨ U64 (Expression (F p)), U64 (F p) ⟩
-
-instance : ProvableType (F p) (u64 (p:=p)) where
-  size := 8
-  to_vars x := vec [x.x0, x.x1, x.x2, x.x3, x.x4, x.x5, x.x6, x.x7]
-  to_values x := vec [x.x0, x.x1, x.x2, x.x3, x.x4, x.x5, x.x6, x.x7]
-  from_vars v :=
-    let ⟨ [x0, x1, x2, x3, x4, x5, x6, x7], _ ⟩ := v
-    ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩
-  from_values v :=
-    let ⟨ [x0, x1, x2, x3, x4, x5, x6, x7], _ ⟩ := v
-    ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩
 
 omit [Fact (Nat.Prime p)] p_large_enough in
 /--
@@ -64,7 +52,7 @@ lemma ext {x y : U64 (F p)}
   Witness a 64-bit unsigned integer.
 -/
 def witness (compute : Environment (F p) → U64 (F p)) := do
-  let ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ ← Provable.witness u64 compute
+  let ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ ← Provable.witness compute
 
   Gadgets.byte_lookup x0
   Gadgets.byte_lookup x1

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -66,14 +66,14 @@ lemma ext {x y : U64 (F p)}
 def witness (compute : Environment (F p) → U64 (F p)) := do
   let ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ ← Provable.witness u64 compute
 
-  byte_lookup x0
-  byte_lookup x1
-  byte_lookup x2
-  byte_lookup x3
-  byte_lookup x4
-  byte_lookup x5
-  byte_lookup x6
-  byte_lookup x7
+  Gadgets.byte_lookup x0
+  Gadgets.byte_lookup x1
+  Gadgets.byte_lookup x2
+  Gadgets.byte_lookup x3
+  Gadgets.byte_lookup x4
+  Gadgets.byte_lookup x5
+  Gadgets.byte_lookup x6
+  Gadgets.byte_lookup x7
 
   return U64.mk x0 x1 x2 x3 x4 x5 x6 x7
 

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -1,0 +1,119 @@
+import Clean.Gadgets.ByteLookup
+import Clean.Circuit.Extensions
+
+section
+variable {p : ℕ} [Fact p.Prime] [p_large_enough: Fact (p > 512)]
+
+/--
+  A 64-bit unsigned integer is represented using eight limbs of 8 bits each.
+-/
+structure U64 (T: Type) where
+  x0 : T
+  x1 : T
+  x2 : T
+  x3 : T
+  x4 : T
+  x5 : T
+  x6 : T
+  x7 : T
+
+
+instance {F : Type} : StructuredElements U64 F where
+  size := 8
+  to_elements x := vec [x.x0, x.x1, x.x2, x.x3, x.x4, x.x5, x.x6, x.x7]
+  from_elements v :=
+    let ⟨[v0, v1, v2, v3, v4, v5, v6, v7], _⟩ := v
+    ⟨ v0, v1, v2, v3, v4, v5, v6, v7 ⟩
+
+namespace U32
+def u64 {p: ℕ} : TypePair := ⟨ U64 (Expression (F p)), U64 (F p) ⟩
+
+instance : ProvableType (F p) (u64 (p:=p)) where
+  size := 8
+  to_vars x := vec [x.x0, x.x1, x.x2, x.x3, x.x4, x.x5, x.x6, x.x7]
+  to_values x := vec [x.x0, x.x1, x.x2, x.x3, x.x4, x.x5, x.x6, x.x7]
+  from_vars v :=
+    let ⟨ [x0, x1, x2, x3, x4, x5, x6, x7], _ ⟩ := v
+    ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩
+  from_values v :=
+    let ⟨ [x0, x1, x2, x3, x4, x5, x6, x7], _ ⟩ := v
+    ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩
+
+omit [Fact (Nat.Prime p)] p_large_enough in
+/--
+  Extensionality principle for U64
+-/
+@[ext]
+lemma ext {x y : U64 (F p)}
+    (h0 : x.x0 = y.x0)
+    (h1 : x.x1 = y.x1)
+    (h2 : x.x2 = y.x2)
+    (h3 : x.x3 = y.x3)
+    (h4 : x.x4 = y.x4)
+    (h5 : x.x5 = y.x5)
+    (h6 : x.x6 = y.x6)
+    (h7 : x.x7 = y.x7)
+    : x = y :=
+  by match x, y with
+  | ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩, ⟨ y0, y1, y2, y3, y4, y5, y6, y7 ⟩ =>
+    simp only [h0, h1, h2, h3, h4, h5, h6, h7] at *
+    simp only [h0, h1, h2, h3, h4, h5, h6, h7]
+
+
+/--
+  Witness a 64-bit unsigned integer.
+-/
+def witness (compute : Environment (F p) → U64 (F p)) := do
+  let ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ ← Provable.witness u64 compute
+
+  byte_lookup x0
+  byte_lookup x1
+  byte_lookup x2
+  byte_lookup x3
+  byte_lookup x4
+  byte_lookup x5
+  byte_lookup x6
+  byte_lookup x7
+
+  return U64.mk x0 x1 x2 x3 x4 x5 x6 x7
+
+/--
+  A 64-bit unsigned integer is normalized if all its limbs are less than 256.
+-/
+def is_normalized (x: U64 (F p)) :=
+  x.x0.val < 256 ∧ x.x1.val < 256 ∧ x.x2.val < 256 ∧ x.x3.val < 256 ∧
+  x.x4.val < 256 ∧ x.x5.val < 256 ∧ x.x6.val < 256 ∧ x.x7.val < 256
+
+/--
+  Return the value of a 64-bit unsigned integer over the natural numbers.
+-/
+def value (x: U64 (F p)) :=
+  x.x0.val + x.x1.val * 256 + x.x2.val * 256^2 + x.x3.val * 256^3 +
+  x.x4.val * 256^4 + x.x5.val * 256^5 + x.x6.val * 256^6 + x.x7.val * 256^7
+
+/--
+  Return a 64-bit unsigned integer from a natural number, by decomposing
+  it into four limbs of 8 bits each.
+-/
+def decompose_nat (x: ℕ) : U64 (F p) :=
+  let x0 := FieldUtils.mod x 256 (by linarith [p_large_enough.elim])
+  let x1 := FieldUtils.mod (FieldUtils.floordiv x 256) 256 (by linarith [p_large_enough.elim])
+  let x2 := FieldUtils.mod (FieldUtils.floordiv x 256^2) 256 (by linarith [p_large_enough.elim])
+  let x3 := FieldUtils.mod (FieldUtils.floordiv x 256^3) 256 (by linarith [p_large_enough.elim])
+  let x4 := FieldUtils.mod (FieldUtils.floordiv x 256^4) 256 (by linarith [p_large_enough.elim])
+  let x5 := FieldUtils.mod (FieldUtils.floordiv x 256^5) 256 (by linarith [p_large_enough.elim])
+  let x6 := FieldUtils.mod (FieldUtils.floordiv x 256^6) 256 (by linarith [p_large_enough.elim])
+  let x7 := FieldUtils.mod (FieldUtils.floordiv x 256^7) 256 (by linarith [p_large_enough.elim])
+  ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩
+
+/--
+  Return a 64-bit unsigned integer from a natural number, by decomposing
+  it into four limbs of 8 bits each.
+-/
+def decompose_nat_expr (x: ℕ) : U64 (Expression (F p)) :=
+  let (⟨x0, x1, x2, x3, x4, x5, x6, x7⟩ : U64 (F p)) := decompose_nat x
+  ⟨ x0, x1, x2, x3 , x4, x5, x6, x7 ⟩
+
+
+end U32
+end

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -25,7 +25,7 @@ instance {F : Type} : StructuredElements U64 F where
     let ⟨[v0, v1, v2, v3, v4, v5, v6, v7], _⟩ := v
     ⟨ v0, v1, v2, v3, v4, v5, v6, v7 ⟩
 
-namespace U32
+namespace U64
 def u64 {p: ℕ} : TypePair := ⟨ U64 (Expression (F p)), U64 (F p) ⟩
 
 instance : ProvableType (F p) (u64 (p:=p)) where
@@ -115,5 +115,5 @@ def decompose_nat_expr (x: ℕ) : U64 (Expression (F p)) :=
   ⟨ x0, x1, x2, x3 , x4, x5, x6, x7 ⟩
 
 
-end U32
+end U64
 end

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -140,7 +140,19 @@ theorem nat_to_field_eq {n: ℕ} {lt: n < p} (x : F p) (hx: x = nat_to_field n l
 theorem nat_to_field_of_val_eq_iff {x : F p} {lt: x.val < p} : nat_to_field (x.val) lt = x := by
   cases p
   · exact False.elim (Nat.not_lt_zero x.val lt)
-  · dsimp only [nat_to_field]; aesop
+  · dsimp only [nat_to_field]; rfl
+
+theorem nat_to_field_eq_natcast {n: ℕ} {lt: n < p} : ↑n = FieldUtils.nat_to_field n lt := by
+  cases p with
+  | zero => exact False.elim (Nat.not_lt_zero n lt)
+  | succ n' => {
+    simp only [FieldUtils.nat_to_field]
+    rw [Fin.natCast_def]
+    apply_fun Fin.val
+    · simp only [Nat.mod_succ_eq_iff_lt, Nat.succ_eq_add_one]
+      exact lt
+    · apply Fin.val_injective
+  }
 
 theorem val_of_nat_to_field_eq {n: ℕ} {lt: n < p} : (nat_to_field n lt).val = n := by
   cases p


### PR DESCRIPTION
Addresses #54 

TODO:
- [X] Define U64
- [X] Define rotation gadget, which is composed of a byte rotation and a bit rotation
- [x] Prove byte rotation theorems
- [ ] Prove full rotation theorems