### PR TITLE
Remove formal table assumptions

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -404,8 +404,9 @@ where
   initial_offset_eq: ∀ var, ∀ n, (main var |>.operations n).initial_offset = n := by intros; rfl
 
 @[circuit_norm]
-def subcircuit_soundness (circuit: FormalCircuit F β α) (b_var : Var β F) (a_var : Var α F) (env : Environment F) :=
+def subcircuit_soundness (circuit: FormalCircuit F β α) (b_var : Var β F) (offset: ℕ) (env : Environment F) :=
   let b := eval env b_var
+  let a_var := circuit.main b_var offset |>.fst
   let a := eval env a_var
   circuit.assumptions b → circuit.spec b a
 

--- a/Clean/Circuit/SubCircuit.lean
+++ b/Clean/Circuit/SubCircuit.lean
@@ -68,7 +68,7 @@ def formal_circuit_to_subcircuit (n: ℕ)
   have s: SubCircuit F n := by
     open FlatOperation in
     let flat_ops := to_flat_operations ops
-    let soundness := subcircuit_soundness circuit b_var a_var
+    let soundness := subcircuit_soundness circuit b_var n
     let completeness := subcircuit_completeness circuit b_var
     let initial_offset_eq := circuit.initial_offset_eq
     use flat_ops, soundness, completeness

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -450,8 +450,8 @@ structure FormalTable (F : Type) [Field F] (S : Type → Type) [NonEmptyProvable
   -- list of constraints that are applied over the table
   constraints : List (TableOperation S F)
 
-  -- assumptions for the table
-  assumptions {N : ℕ} : TraceOfLength F S N → Prop
+  -- optional assumption on the table length
+  assumption : ℕ → Prop := fun _ => True
 
   -- specification for the table
   spec {N : ℕ} : TraceOfLength F S N → Prop
@@ -460,6 +460,6 @@ structure FormalTable (F : Type) [Field F] (S : Type → Type) [NonEmptyProvable
   -- the constraints hold implies that the spec holds
   soundness :
     ∀ (N : ℕ) (trace: TraceOfLength F S N),
-    assumptions trace →
+    assumption N →
     table_constraints_hold constraints trace →
     spec trace

--- a/Clean/Tables/Addition8.lean
+++ b/Clean/Tables/Addition8.lean
@@ -43,24 +43,20 @@ def add8_inline : SingleRowConstraint RowType (F p) := do
   if let var z := z then
     TableConstraint.assign z (.curr 2)
 
-def add8Table : List (TableOperation RowType (F p)) := [
+def add8_table : List (TableOperation RowType (F p)) := [
   TableOperation.EveryRow add8_inline
 ]
-
-def assumptions_add8 {N : ℕ} (trace : TraceOfLength (F p) RowType N) : Prop :=
-  trace.forAllRowsOfTrace (fun row => row.x.val < 256 ∧ row.y.val < 256)
-
 
 def spec_add8 {N : ℕ} (trace : TraceOfLength (F p) RowType N) : Prop :=
   trace.forAllRowsOfTrace (fun row => (row.z.val = (row.x.val + row.y.val) % 256))
 
 
 def formal_add8_table : FormalTable (F p) RowType := {
-  constraints := add8Table,
+  constraints := add8_table,
   spec := spec_add8,
   soundness := by
     intro N trace _
-    simp only [TraceOfLength.forAllRowsOfTrace, table_constraints_hold, add8Table, spec_add8]
+    simp only [TraceOfLength.forAllRowsOfTrace, table_constraints_hold, add8_table, spec_add8]
 
     induction trace.val with
     | empty => {

--- a/Clean/Tables/Addition8.lean
+++ b/Clean/Tables/Addition8.lean
@@ -21,7 +21,7 @@ instance : NonEmptyProvableType RowType where
 
 def byte_lookup_circuit : FormalAssertion (F p) Provable.field where
   main x := byte_lookup x
-  assumptions _ := true
+  assumptions _ := True
   spec x := x.val < 256
   soundness := by
     intro _ env x_var x hx _ h_holds
@@ -97,8 +97,6 @@ def formal_add8_table : FormalTable (F p) RowType := {
         byte_lookup_circuit, circuit_norm] at lookup_x lookup_y
 
       simp only [h_x, h_y, h_z, h_z', table_norm, CellOffset.column] at h_curr lookup_x lookup_y
-      specialize lookup_x trivial
-      specialize lookup_y trivial
       simp at lookup_x lookup_y
 
       dsimp [Gadgets.Addition8.circuit, Gadgets.Addition8.assumptions, Gadgets.Addition8.spec] at h_curr

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -77,12 +77,6 @@ def fib32_table : List (TableOperation RowType (F p)) := [
 ]
 
 /--
-  We assume that the trace length is at least 2.
--/
-def assumptions {N : ℕ} (_ : TraceOfLength (F p) RowType N) : Prop :=
-  N ≥ 2
-
-/--
   Specification for fibonacci32: for each row with index i
   - the first U32 value is the i-th fibonacci number
   - the second U32 value is the (i+1)-th fibonacci number
@@ -278,11 +272,10 @@ lemma lift_rec_eq (curr : Row (F p) RowType) (next : Row (F p) RowType)
 -/
 def formal_fib32_table : FormalTable (F p) RowType := {
   constraints := fib32_table,
-  assumptions := assumptions,
   spec := spec,
   soundness := by
     intro N trace
-    simp only [assumptions, gt_iff_lt, Fin.isValue, and_imp, Fin.isValue, fib32_table, spec]
+    simp only [gt_iff_lt, Fin.isValue, and_imp, Fin.isValue, fib32_table, spec]
     rw [TraceOfLength.forAllRowsOfTraceWithIndex, table_constraints_hold]
     intro _N_assumption
 

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -77,24 +77,22 @@ def fib32_table : List (TableOperation RowType (F p)) := [
 ]
 
 /--
-  We assume that the trace length is at least 2 and that,
-  using lookups, the second U32 value is normalized.
+  We assume that the trace length is at least 2.
 -/
-def assumptions {N : ℕ} (trace : TraceOfLength (F p) RowType N) : Prop :=
-  N ≥ 2 ∧
-  trace.forAllRowsOfTrace (fun row => (row.y).is_normalized)
+def assumptions {N : ℕ} (_ : TraceOfLength (F p) RowType N) : Prop :=
+  N ≥ 2
 
 /--
   Specification for fibonacci32: for each row with index i
   - the first U32 value is the i-th fibonacci number
   - the second U32 value is the (i+1)-th fibonacci number
-  - the first U32 value is normalized
+  - both U32 values are normalized
 -/
 def spec {N : ℕ} (trace : TraceOfLength (F p) RowType N) : Prop :=
-  trace.forAllRowsOfTraceWithIndex (λ row index =>
+  trace.forAllRowsOfTraceWithIndex (fun row index =>
     (row.x.value = fib32 index) ∧
     (row.y.value = fib32 (index + 1)) ∧
-    row.x.is_normalized
+    row.x.is_normalized ∧ row.y.is_normalized
   )
 
 
@@ -285,7 +283,7 @@ def formal_fib32_table : FormalTable (F p) RowType := {
   soundness := by
     intro N trace
     simp only [assumptions, gt_iff_lt, Fin.isValue, and_imp, Fin.isValue, fib32_table, spec]
-    rw [TraceOfLength.forAllRowsOfTraceWithIndex, TraceOfLength.forAllRowsOfTrace, table_constraints_hold]
+    rw [TraceOfLength.forAllRowsOfTraceWithIndex, table_constraints_hold]
     intro _N_assumption
 
     /-
@@ -296,8 +294,7 @@ def formal_fib32_table : FormalTable (F p) RowType := {
     · simp [table_norm]
 
     -- base case 2
-    · intro _
-      simp only [table_norm]
+    · simp only [table_norm]
       simp [table_norm, Circuit.formal_assertion_to_subcircuit, Circuit.subassertion_soundness, circuit_norm]
 
       rw [
@@ -323,17 +320,15 @@ def formal_fib32_table : FormalTable (F p) RowType := {
       simp only [U32.value, fib32]
       rw [b0, b1, b2, b3, b4, b5, b6, b7]
       simp [ZMod.val_one]
-      simp only [U32.is_normalized, b0, b1, b2, b3]
-      simp only [ZMod.val_zero, Nat.ofNat_pos, and_self]
+      simp only [U32.is_normalized, b0, b1, b2, b3, b4, b5, b6, b7]
+      simp only [ZMod.val_zero, ZMod.val_one, Nat.ofNat_pos, and_self]
+      trivial
 
     -- inductive step
-    · intro lookup_h
-      simp only [TraceOfLength.forAllRowsOfTrace.inner, Fin.isValue] at lookup_h
-
-      -- first of all, we prove the inductive part of the spec
+    · -- first of all, we prove the inductive part of the spec
       unfold TraceOfLength.forAllRowsOfTraceWithIndex.inner
       intros constraints_hold
-      specialize ih2 lookup_h.right
+      -- specialize ih2 lookup_h.right
 
       unfold table_constraints_hold.foldl at constraints_hold
       simp only [Trace.len, Nat.succ_ne_zero, ite_false] at constraints_hold
@@ -344,7 +339,7 @@ def formal_fib32_table : FormalTable (F p) RowType := {
       simp only [ih2, and_self]
 
       simp only [Fin.isValue, and_true] at ih2
-      let ⟨curr_fib0, curr_fib1, curr_normalized_x⟩ := ih2.left
+      let ⟨curr_fib0, curr_fib1, curr_normalized_x, curr_normalized_y⟩ := ih2.left
 
       simp only [and_true]
 
@@ -353,11 +348,11 @@ def formal_fib32_table : FormalTable (F p) RowType := {
       have eq_spec := lift_rec_eq curr next constraints_hold.left
 
       -- and now we can reason at high level with U32s
-      specialize add_spec curr_normalized_x lookup_h.right.left
+      specialize add_spec curr_normalized_x curr_normalized_y
       simp only [fib32, Nat.reducePow]
       rw [←curr_fib0, ←curr_fib1, ←eq_spec]
       simp only [curr_fib1, Trace.len, Nat.succ_eq_add_one, add_spec,
-        Nat.reducePow, lookup_h, and_self]
+        Nat.reducePow, and_self, curr_normalized_y]
 }
 
 end Tables.Fibonacci32

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -321,7 +321,6 @@ def formal_fib32_table : FormalTable (F p) RowType := {
     · -- first of all, we prove the inductive part of the spec
       unfold TraceOfLength.forAllRowsOfTraceWithIndex.inner
       intros constraints_hold
-      -- specialize ih2 lookup_h.right
 
       unfold table_constraints_hold.foldl at constraints_hold
       simp only [Trace.len, Nat.succ_ne_zero, ite_false] at constraints_hold


### PR DESCRIPTION
This PR removes the ability to require assumptions on the entire table in the `FormalTable` soundness proof. Only an assumption on the number of rows is allowed.

It turns out that this works well for all our currently defined tables. In the `Addition8` table, extra byte lookups have to be added on the inputs. In the fibonacci tables, what used to be an assumption naturally follows from the induction hypothesis, if added to the spec.

No assumptions leads to stronger statements for individual tables, but decreases flexibility somewhat when combining tables. Scenarios could arise where constraints have to be duplicated just because we can't have assumptions on the inputs. If this turns out to be the case it will be easy to add assumptions back in.