### PR TITLE
Preserve Structure of `ProvableType`s

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -259,7 +259,7 @@ def witness (compute : Environment F → F) := do
 @[circuit_norm]
 def witness_vars (n: ℕ) (compute : Environment F → Vector F n) : Circuit F (Vector (Variable F) n) :=
   modifyGet fun ops =>
-    let vars: Vector (Variable F) n := .init (fun i => ⟨ ops.offset + i ⟩)
+    let vars := Vector.natInit n fun i => ⟨ ops.offset + i ⟩
     ⟨vars, .witness ops n compute⟩
 
 /-- Add a constraint. -/
@@ -568,7 +568,7 @@ attribute [circuit_norm] Vector.map_mk List.map_toArray List.map_cons List.map_n
 attribute [circuit_norm] Vector.append_singleton Vector.mk_append_mk Vector.push_mk
   Array.append_singleton Array.append_empty List.push_toArray
   List.nil_append List.cons_append List.append_toArray
-  Vector.init Vector.toArray_push Array.push_toList List.append_assoc
+  Vector.init Vector.natInit Vector.toArray_push Array.push_toList List.append_assoc
 
 -- simplify `vector.get 0` (which occurs in ProvableType definitions)
 -- TODO handle other small indices as well

--- a/Clean/Circuit/Expression.lean
+++ b/Clean/Circuit/Expression.lean
@@ -68,11 +68,12 @@ instance : Mul (Expression F) where
 instance : Coe F (Expression F) where
   coe f := const f
 
-instance : Coe (Variable F) (Expression F) where
-  coe x := var x
-
 instance : HMul F (Expression F) (Expression F) where
   hMul := fun f e => mul f e
+
+-- TODO probably should just make Variable F := ℕ
+instance {n: ℕ} : OfNat (Variable F) n where
+  ofNat := { index := n }
 end Expression
 
 instance [Field F] : CoeFun (Environment F) (fun _ => (Expression F) → F) where

--- a/Clean/Circuit/Expression.lean
+++ b/Clean/Circuit/Expression.lean
@@ -15,7 +15,7 @@ inductive Expression (F : Type) where
   | add : Expression F -> Expression F -> Expression F
   | mul : Expression F -> Expression F -> Expression F
 
-export Expression (var const)
+export Expression (var)
 
 structure Environment (F: Type) where
   get: ℕ → F
@@ -67,6 +67,9 @@ instance : Mul (Expression F) where
 
 instance : Coe F (Expression F) where
   coe f := const f
+
+instance {n: ℕ} [OfNat F n] : OfNat (Expression F) n where
+  ofNat := const (OfNat.ofNat n)
 
 instance : HMul F (Expression F) (Expression F) where
   hMul := fun f e => mul f e

--- a/Clean/Circuit/Extensions.lean
+++ b/Clean/Circuit/Extensions.lean
@@ -10,7 +10,7 @@ def witness {α: TypeMap} [ProvableType α] (compute : Environment F → α F) :
   let vars ← Circuit.witness_vars (size α) (fun env => compute env |> to_elements)
   return from_vars <| vars.map Expression.var
 
-def synthesize_var : Circuit F (Var α F) := witness (fun _ => synthesize_value)
+def synthesize_var : Circuit F (Var α F) := witness (fun _ => default)
 
 instance [Field F] : Inhabited (Circuit F (Var α F)) where
   default := synthesize_var

--- a/Clean/Circuit/Extensions.lean
+++ b/Clean/Circuit/Extensions.lean
@@ -4,8 +4,7 @@ import Clean.Circuit.Basic
 variable {F :Type} [Field F]
 variable {α β: TypeMap} [ProvableType α] [ProvableType β]
 
-namespace Provable
-
+namespace ProvableType
 @[circuit_norm]
 def witness {α: TypeMap} [ProvableType α] (compute : Environment F → α F) := do
   let vars ← Circuit.witness_vars (size α) (fun env => compute env |> to_elements)
@@ -15,7 +14,7 @@ def synthesize_var : Circuit F (Var α F) := witness (fun _ => synthesize_value)
 
 instance [Field F] : Inhabited (Circuit F (Var α F)) where
   default := synthesize_var
-end Provable
+end ProvableType
 
 @[circuit_norm]
 def assert_equal (a a': Var α F) : Circuit F Unit :=

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -12,7 +12,7 @@ import Clean.Circuit.SimpGadget
 @[reducible]
 def TypeMap := Type → Type
 
-def Var (M : TypeMap) (F : Type) := M (Expression F)
+@[reducible] def Var (M : TypeMap) (F : Type) := M (Expression F)
 
 variable {F : Type} [Field F]
 

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -140,7 +140,7 @@ def from_offset (α : TypeMap) [ProvableType α] (offset : Nat) : Var α F :=
   from_vars <| vars.map Expression.var
 end Provable
 
-export Provable (eval field)
+export Provable (eval const field)
 
 namespace ProvableStruct
 structure WithProvableType where
@@ -269,13 +269,11 @@ lemma eval_field {F : Type} [Field F] (env : Environment F) (x : Var Provable.fi
 namespace LawfulProvableType
 @[circuit_norm]
 lemma eval_const {F : Type} [Field F] {α: TypeMap} [LawfulProvableType α] (env : Environment F) (x : α F) :
-  eval env (Provable.const x) = x := by
-  simp [circuit_norm, Provable.const, eval]
-  rw [LawfulProvableType.to_elements_from_elements, Vector.map, Vector.map]
-  simp
-  have : Expression.eval env ∘ const = id := by
+  eval env (const x) = x := by
+  simp only [circuit_norm, const, eval]
+  rw [to_elements_from_elements, Vector.map_map]
+  have : Expression.eval env ∘ Expression.const = id := by
     funext
     simp only [Function.comp_apply, Expression.eval, id_eq]
-  simp [this]
-  exact LawfulProvableType.from_elements_to_elements x
+  rw [this, Vector.map_id_fun, id_eq, from_elements_to_elements]
 end LawfulProvableType

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -182,18 +182,19 @@ namespace ProvableStruct
 @[circuit_norm]
 def components_to_elements {F : Type} : (cs: List WithProvableType) → ProvableTypeList F cs → Vector F (combined_size' cs)
     | [], .nil => #v[]
-    | c :: cs, .cons a as => c.provable_type.to_elements a ++ components_to_elements cs as
+    | _ :: cs, .cons a as => to_elements a ++ components_to_elements cs as
 
 @[circuit_norm]
 def components_from_elements {F : Type} : (cs: List WithProvableType) → Vector F (combined_size' cs) → ProvableTypeList F cs
     | [], _ => .nil
-    | c :: cs, (v : Vector F (c.provable_type.size + combined_size' cs)) =>
-      let size := c.provable_type.size
-      have h_take : size ⊓ (size + combined_size' cs) = size := Nat.min_add_right
-      have h_drop : size + combined_size' cs - size = combined_size' cs := Nat.add_sub_self_left size (combined_size' cs)
-      let head : Vector F size := (v.take size).cast h_take
-      let tail : Vector F (combined_size' cs) := (v.drop size).cast h_drop
-      .cons (c.provable_type.from_elements head) (components_from_elements cs tail)
+    | c :: cs, (v : Vector F (size c.type + combined_size' cs)) =>
+      let head_size := size c.type
+      let tail_size := combined_size' cs
+      have h_head : head_size ⊓ (head_size + tail_size) = head_size := Nat.min_add_right
+      have h_tail : head_size + tail_size - head_size = tail_size := Nat.add_sub_self_left _ _
+      let head : Vector F head_size := (v.take head_size).cast h_head
+      let tail : Vector F tail_size := (v.drop head_size).cast h_tail
+      .cons (from_elements head) (components_from_elements cs tail)
 end ProvableStruct
 
 open ProvableStruct in

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -310,7 +310,7 @@ end LawfulProvableType
 def psize (α : TypeMap) [NonEmptyProvableType α] : ℕ+ :=
   ⟨ size α, NonEmptyProvableType.nonempty⟩
 
-instance {α: TypeMap} [NonEmptyProvableType α] : ProvableType (ProvableVector α n) where
+instance ProvableVector.instance {α: TypeMap} [NonEmptyProvableType α] : ProvableType (ProvableVector α n) where
   size := n * size α
   to_elements x := x.map to_elements |>.flatten
   from_elements v := v.toChunks (psize α) |>.map from_elements

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -28,13 +28,14 @@ class ProvableType (M : TypeMap) where
 class NonEmptyProvableType (M : TypeMap) extends ProvableType M where
   nonempty : size > 0 := by norm_num
 
-attribute [circuit_norm] ProvableType.size
--- attribute [circuit_norm] ProvableType.to_elements
--- attribute [circuit_norm] ProvableType.from_elements
+export ProvableType (size to_elements from_elements)
+
+attribute [circuit_norm] size
+-- tagged with low priority to prefer higher-level `Components` decompositions
+attribute [circuit_norm low] to_elements from_elements
 
 variable {M : TypeMap} [ProvableType M]
 
-export ProvableType (size to_elements from_elements)
 
 @[circuit_norm]
 def to_vars (var: M (Expression F)) := to_elements var
@@ -45,7 +46,8 @@ def from_vars (vars: Vector (Expression F) (size M)) := from_elements vars
 namespace Provable
 variable {α β γ: TypeMap} [ProvableType α] [ProvableType β] [ProvableType γ]
 
--- @[circuit_norm]
+-- tagged with low priority to prefer higher-level `Components` decompositions
+@[circuit_norm low]
 def eval (env: Environment F) (x: Var α F) : α F :=
   let vars := to_vars x
   let values := vars.map env
@@ -175,7 +177,7 @@ variable {α : TypeMap} [Components α] {F : Type} [Field F]
 def to_var_components (var: α (Expression F)) := to_components var
 def from_var_components (vars: ProvableTypeList (Expression F) (components α)) : α (Expression F) := from_components vars
 
-@[circuit_norm]
+@[circuit_norm ↓ high]
 def eval (env : Environment F) (var: α (Expression F)) : α F :=
   go_map (components α) (to_components var) |> from_components
   where
@@ -184,14 +186,12 @@ def eval (env : Environment F) (var: α (Expression F)) : α F :=
     | [], .nil => .nil
     | _ :: cs, .cons a as => .cons (Provable.eval env a) (go_map cs as)
 
-@[circuit_norm]
-lemma eval_components {α: TypeMap} [Components α] :  ∀ (env : Environment F) (x : Var α F),
+@[circuit_norm ↓ high]
+lemma eval_components {α: TypeMap} [Components α] : ∀ (env : Environment F) (x : Var α F),
     Provable.eval env x = eval env x := by
   sorry
 end Components
 
-@[circuit_norm]
+@[circuit_norm ↓ high]
 lemma eval_field {F : Type} [Field F] (env : Environment F) (x : Var Provable.field F) :
-  eval env x = x.eval env := by
-  simp [eval, Components.eval]
-  rfl
+  eval env x = x.eval env := by rfl

--- a/Clean/Gadgets/Addition32/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32/Addition32Full.lean
@@ -14,7 +14,7 @@ structure Inputs (F : Type) where
   carry_in: F
 
 instance : ProvableStruct Inputs where
-  components := [U32, U32, Provable.field]
+  components := [U32, U32, field]
   to_components := fun {x, y, carry_in} => .cons x ( .cons y ( .cons carry_in .nil))
   from_components := fun (.cons x ( .cons y ( .cons carry_in .nil))) => ⟨ x, y, carry_in ⟩
 
@@ -24,7 +24,7 @@ structure Outputs (F : Type) where
 deriving Repr
 
 instance : ProvableStruct Outputs where
-  components := [U32, Provable.field]
+  components := [U32, field]
   to_components := fun {z, carry_out} => .cons z ( .cons carry_out .nil)
   from_components := fun (.cons z ( .cons carry_out .nil)) => ⟨ z, carry_out ⟩
 

--- a/Clean/Gadgets/Addition32/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32/Addition32Full.lean
@@ -13,25 +13,20 @@ structure Inputs (F : Type) where
   y: U32 F
   carry_in: F
 
-instance : ProvableType Inputs where
-  size := size U32 + size U32 + 1
-  to_elements x :=
-    #v[x.x.x0, x.x.x1, x.x.x2, x.x.x3, x.y.x0, x.y.x1, x.y.x2, x.y.x3, x.carry_in]
-  from_elements v :=
-    let ⟨ .mk [x0, x1, x2, x3, y0, y1, y2, y3, carry_in], _ ⟩ := v
-    ⟨ ⟨ x0, x1, x2, x3 ⟩, ⟨ y0, y1, y2, y3 ⟩, carry_in ⟩
+instance : ProvableStruct Inputs where
+  components := [U32, U32, Provable.field]
+  to_components := fun {x, y, carry_in} => .cons x ( .cons y ( .cons carry_in .nil))
+  from_components := fun (.cons x ( .cons y ( .cons carry_in .nil))) => ⟨ x, y, carry_in ⟩
 
 structure Outputs (F : Type) where
   z: U32 F
   carry_out: F
 deriving Repr
 
-instance : ProvableType Outputs where
-  size := size U32 + 1
-  to_elements x := to_elements x.z ++ #v[x.carry_out]
-  from_elements v :=
-    let ⟨ .mk [z0, z1, z2, z3, carry_out], _ ⟩ := v
-    ⟨ ⟨ z0, z1, z2, z3 ⟩, carry_out ⟩
+instance : ProvableStruct Outputs where
+  components := [U32, Provable.field]
+  to_components := fun {z, carry_out} => .cons z ( .cons carry_out .nil)
+  from_components := fun (.cons z ( .cons carry_out .nil)) => ⟨ z, carry_out ⟩
 
 open Gadgets.Addition8FullCarry (add8_full_carry)
 
@@ -77,6 +72,7 @@ theorem soundness : Soundness (F p) assumptions spec := by
   let ⟨ y0, y1, y2, y3 ⟩ := y
   let ⟨ x0_var, x1_var, x2_var, x3_var ⟩ := x_var
   let ⟨ y0_var, y1_var, y2_var, y3_var ⟩ := y_var
+  simp only [circuit_norm, eval] at h_inputs
   have : x0_var.eval env = x0 := by injections h_inputs
   have : x1_var.eval env = x1 := by injections h_inputs
   have : x2_var.eval env = x2 := by injections h_inputs
@@ -120,7 +116,8 @@ theorem soundness : Soundness (F p) assumptions spec := by
 
   -- simplify output and spec
   set output := eval env (elaboratedCircuit.output _ i0)
-  have h_output : output = { z := U32.mk z0 z1 z2 z3, carry_out := c3 } := rfl
+  have h_output : output = { z := U32.mk z0 z1 z2 z3, carry_out := c3 } := by
+    simp only [output, circuit_norm, eval]; rfl
   rw [h_output]
   dsimp only [spec, U32.value, U32.is_normalized]
 
@@ -143,6 +140,7 @@ theorem completeness : Completeness (F p) Outputs assumptions := by
   let ⟨ y0, y1, y2, y3 ⟩ := y
   let ⟨ x0_var, x1_var, x2_var, x3_var ⟩ := x_var
   let ⟨ y0_var, y1_var, y2_var, y3_var ⟩ := y_var
+  simp only [circuit_norm, eval] at h_inputs
   have : x0_var.eval env = x0 := by injections
   have : x1_var.eval env = x1 := by injections
   have : x2_var.eval env = x2 := by injections

--- a/Clean/Gadgets/Addition8/Addition8.lean
+++ b/Clean/Gadgets/Addition8/Addition8.lean
@@ -32,7 +32,7 @@ def assumptions (input : Inputs (F p)) :=
   Compute the 8-bit addition of two numbers.
   Returns the sum.
 -/
-def circuit : FormalCircuit (F p) Inputs Provable.field where
+def circuit : FormalCircuit (F p) Inputs field where
   main := add8
   assumptions := assumptions
   spec := spec

--- a/Clean/Gadgets/Addition8/Addition8.lean
+++ b/Clean/Gadgets/Addition8/Addition8.lean
@@ -17,7 +17,7 @@ instance : ProvableType Inputs where
 
 def add8 (input : Var Inputs (F p)) := do
   let ⟨x, y⟩ := input
-  let z ← subcircuit Gadgets.Addition8Full.circuit { x, y, carry_in := const 0 }
+  let z ← subcircuit Gadgets.Addition8Full.circuit { x, y, carry_in := 0 }
   return z
 
 def spec (input : Inputs (F p)) (z: F p) :=

--- a/Clean/Gadgets/Addition8/Addition8Full.lean
+++ b/Clean/Gadgets/Addition8/Addition8Full.lean
@@ -3,7 +3,6 @@ import Clean.Gadgets.Addition8.Addition8FullCarry
 namespace Gadgets.Addition8Full
 variable {p : ℕ} [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
-open Provable (field)
 
 structure Inputs (F : Type) where
   x: F

--- a/Clean/Gadgets/Addition8/Addition8Full.lean
+++ b/Clean/Gadgets/Addition8/Addition8Full.lean
@@ -3,17 +3,18 @@ import Clean.Gadgets.Addition8.Addition8FullCarry
 namespace Gadgets.Addition8Full
 variable {p : ℕ} [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
+open Provable (field)
 
 structure Inputs (F : Type) where
   x: F
   y: F
   carry_in: F
 
-instance : ProvableType Inputs where
-  size := 3
-  to_elements s := #v[s.x, s.y, s.carry_in]
-  from_elements v :=
-    let ⟨ .mk [x, y, carry_in], _ ⟩ := v
+instance : Components Inputs where
+  components := [field, field, field]
+  to_components s := .cons s.x <| .cons s.y <| .cons s.carry_in .nil
+  from_components v :=
+    let .cons x (.cons y (.cons carry_in .nil)) := v
     ⟨ x, y, carry_in ⟩
 
 def add8_full (input : Var Inputs (F p)) := do
@@ -49,6 +50,7 @@ def circuit : FormalCircuit (F p) Inputs Provable.field where
     intro h_holds z
 
     -- characterize inputs
+    simp only [circuit_norm] at h_inputs
     have hx : x_var.eval env = x := by injection h_inputs
     have hy : y_var.eval env = y := by injection h_inputs
     have hcarry_in : carry_in_var.eval env = carry_in := by injection h_inputs
@@ -81,6 +83,7 @@ def circuit : FormalCircuit (F p) Inputs Provable.field where
     rintro as
 
     -- characterize inputs
+    simp only [circuit_norm] at h_inputs
     have hx : x_var.eval env = x := by injection h_inputs
     have hy : y_var.eval env = y := by injection h_inputs
     have hcarry_in : carry_in_var.eval env = carry_in := by injection h_inputs

--- a/Clean/Gadgets/Addition8/Addition8Full.lean
+++ b/Clean/Gadgets/Addition8/Addition8Full.lean
@@ -10,12 +10,10 @@ structure Inputs (F : Type) where
   y: F
   carry_in: F
 
-instance : Components Inputs where
+instance : ProvableStruct Inputs where
   components := [field, field, field]
-  to_components s := .cons s.x <| .cons s.y <| .cons s.carry_in .nil
-  from_components v :=
-    let .cons x (.cons y (.cons carry_in .nil)) := v
-    ⟨ x, y, carry_in ⟩
+  to_components := fun { x, y, carry_in } => .cons x <| .cons y <| .cons carry_in .nil
+  from_components := fun (.cons x (.cons y (.cons carry_in .nil))) => { x, y, carry_in }
 
 def add8_full (input : Var Inputs (F p)) := do
   let ⟨x, y, carry_in⟩ := input

--- a/Clean/Gadgets/Addition8/Addition8Full.lean
+++ b/Clean/Gadgets/Addition8/Addition8Full.lean
@@ -32,7 +32,7 @@ def spec (input : Inputs (F p)) (z: F p) :=
   Compute the 8-bit addition of two numbers with a carry-in bit.
   Returns the sum.
 -/
-def circuit : FormalCircuit (F p) Inputs Provable.field where
+def circuit : FormalCircuit (F p) Inputs field where
   main := add8_full
   assumptions := assumptions
   spec := spec

--- a/Clean/Gadgets/Addition8/Addition8Full.lean
+++ b/Clean/Gadgets/Addition8/Addition8Full.lean
@@ -12,7 +12,7 @@ structure Inputs (F : Type) where
 
 instance : ProvableStruct Inputs where
   components := [field, field, field]
-  to_components := fun { x, y, carry_in } => .cons x <| .cons y <| .cons carry_in .nil
+  to_components := fun { x, y, carry_in } => .cons x (.cons y (.cons carry_in .nil))
   from_components := fun (.cons x (.cons y (.cons carry_in .nil))) => { x, y, carry_in }
 
 def add8_full (input : Var Inputs (F p)) := do
@@ -55,7 +55,7 @@ def circuit : FormalCircuit (F p) Inputs Provable.field where
 
     -- simplify constraints hypothesis
     -- it's just the `subcircuit_soundness` of `Add8FullCarry.circuit`
-    simp only [add8_full, circuit_norm, subcircuit_norm, Addition8FullCarry.circuit] at h_holds
+    simp only [add8_full, circuit_norm, subcircuit_norm, Addition8FullCarry.circuit, eval] at h_holds
 
     -- rewrite input and ouput values
     rw [hx, hy, hcarry_in, ←(by rfl : z = env.get offset)] at h_holds
@@ -88,7 +88,7 @@ def circuit : FormalCircuit (F p) Inputs Provable.field where
 
     -- simplify assumptions and goal
     dsimp [assumptions] at as
-    simp only [circuit_norm, add8_full, subcircuit_norm]
+    simp only [circuit_norm, add8_full, subcircuit_norm, eval]
     rw [hx, hy, hcarry_in]
 
     -- the goal is just the `subcircuit_completeness` of `Add8FullCarry.circuit`, i.e. the assumptions must hold.

--- a/Clean/Gadgets/Addition8/Addition8FullCarry.lean
+++ b/Clean/Gadgets/Addition8/Addition8FullCarry.lean
@@ -43,7 +43,7 @@ def add8_full_carry (input : Var Inputs (F p)) : Circuit (F p) (Var Outputs (F p
   let carry_out ← witness (fun eval => floordiv (eval (x + y + carry_in)) 256)
   assertion Boolean.circuit carry_out
 
-  assert_zero (x + y + carry_in - z - carry_out * (const 256))
+  assert_zero (x + y + carry_in - z - carry_out * 256)
 
   return { z, carry_out }
 

--- a/Clean/Gadgets/Boolean.lean
+++ b/Clean/Gadgets/Boolean.lean
@@ -8,14 +8,14 @@ def assert_bool (x: Expression (F p)) := do
   assert_zero (x * (x - 1))
 
 inductive Boolean (F: Type) where
-  | private mk : (Variable F) → Boolean F
+  | private mk : Variable F → Boolean F
 
 namespace Boolean
 def var (b: Boolean (F p)) := Expression.var b.1
 
 def witness (compute : Environment (F p) → F p) := do
   let x ← witness_var compute
-  assert_bool x
+  assert_bool (Expression.var x)
   return Boolean.mk x
 
 instance : Coe (Boolean (F p)) (Expression (F p)) where

--- a/Clean/Gadgets/Boolean.lean
+++ b/Clean/Gadgets/Boolean.lean
@@ -24,10 +24,10 @@ instance : Coe (Boolean (F p)) (Expression (F p)) where
 def spec (x: F p) := x = 0 ∨ x = 1
 
 theorem equiv : ∀ {x: F p},
-  x * (x + -1 * 1) = 0 ↔ x = 0 ∨ x = 1 :=
+  x * (x + -1) = 0 ↔ x = 0 ∨ x = 1 :=
 by
   intro x
-  simp
+  rw [mul_eq_zero]
   show x = 0 ∨ x + -1 = 0 ↔ x = 0 ∨ x = 1
   suffices x + -1 = 0 ↔ x = 1 by tauto
   constructor
@@ -35,12 +35,10 @@ by
     show x = 1
     calc x
     _ = (x + -1) + 1 := by ring
-    _ = 1 := by simp only [h, zero_add]
+    _ = 1 := by rw [h, zero_add]
   · intro (h : x = 1)
     show x + -1 = 0
-    simp only [h, add_neg_cancel]
-
-open Provable (field)
+    rw [h, add_neg_cancel]
 
 /--
 Asserts that x = 0 ∨ x = 1 by adding the constraint x * (x - 1) = 0
@@ -53,14 +51,14 @@ def circuit : FormalAssertion (F p) field where
   soundness := by
     intro _ env x_var x hx _ h_holds
     change x_var.eval env = x at hx
-    dsimp only [circuit_norm, assert_bool] at h_holds
+    simp only [circuit_norm, assert_bool] at h_holds
     rw [hx] at h_holds
     apply equiv.mp h_holds
 
   completeness := by
     intro n env x_var _ x hx _ spec
     change x_var.eval env = x at hx
-    dsimp only [circuit_norm, assert_bool]
+    simp only [circuit_norm, assert_bool]
     rw [hx]
     apply equiv.mpr spec
 end Boolean

--- a/Clean/Gadgets/Equality/U32.lean
+++ b/Clean/Gadgets/Equality/U32.lean
@@ -17,12 +17,10 @@ structure Inputs (F : Type) where
   x: U32 F
   y: U32 F
 
-instance : ProvableType Inputs where
-  size := 8
-  to_elements s := #v[s.x.x0, s.x.x1, s.x.x2, s.x.x3, s.y.x0, s.y.x1, s.y.x2, s.y.x3]
-  from_elements v :=
-    let ⟨ .mk [x0, x1, x2, x3, y0, y1, y2, y3], _ ⟩ := v
-    ⟨ ⟨x0, x1, x2, x3⟩, ⟨y0, y1, y2, y3⟩ ⟩
+instance : ProvableStruct Inputs where
+  components := [U32, U32]
+  to_components := fun { x, y } => .cons x (.cons y .nil)
+  from_components := fun (.cons x (.cons y .nil)) => { x, y }
 
 def assert_eq (input : Var Inputs (F p)) := do
   let ⟨x, y⟩ := input
@@ -47,6 +45,7 @@ def circuit : FormalAssertion (F p) Inputs where
 
     dsimp only [circuit_norm, assert_eq] at h_holds
 
+    simp only [circuit_norm, eval] at h_inputs
     have hx0 : x0_var.eval env = x0 := by injections
     have hx1 : x1_var.eval env = x1 := by injections
     have hx2 : x2_var.eval env = x2 := by injections
@@ -71,6 +70,7 @@ def circuit : FormalAssertion (F p) Inputs where
     let ⟨⟨x0_var, x1_var, x2_var, x3_var⟩, ⟨y0_var, y1_var, y2_var, y3_var⟩⟩ := inputs_var
 
     -- characterize inputs
+    simp only [circuit_norm, eval] at h_inputs
     have hx0 : x0_var.eval env = x0 := by injection h_inputs; injections
     have hx1 : x1_var.eval env = x1 := by injection h_inputs; injections
     have hx2 : x2_var.eval env = x2 := by injection h_inputs; injections

--- a/Clean/Gadgets/Keccak/ThetaC.lean
+++ b/Clean/Gadgets/Keccak/ThetaC.lean
@@ -33,18 +33,22 @@ def theta_c (input : Var Inputs (F p)) : Circuit (F p) (Var Outputs (F p)) := do
   let c0 ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 2)⟩
   let c0 ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 3)⟩
   let c0 ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 4)⟩
+
   let c1 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 5), (state.get 6)⟩
   let c1 ← subcircuit Gadgets.Xor.circuit ⟨c1, (state.get 7)⟩
   let c1 ← subcircuit Gadgets.Xor.circuit ⟨c1, (state.get 8)⟩
   let c1 ← subcircuit Gadgets.Xor.circuit ⟨c1, (state.get 9)⟩
+
   let c2 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 10), (state.get 11)⟩
   let c2 ← subcircuit Gadgets.Xor.circuit ⟨c2, (state.get 12)⟩
   let c2 ← subcircuit Gadgets.Xor.circuit ⟨c2, (state.get 13)⟩
   let c2 ← subcircuit Gadgets.Xor.circuit ⟨c2, (state.get 14)⟩
+
   let c3 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 15), (state.get 16)⟩
   let c3 ← subcircuit Gadgets.Xor.circuit ⟨c3, (state.get 17)⟩
   let c3 ← subcircuit Gadgets.Xor.circuit ⟨c3, (state.get 18)⟩
   let c3 ← subcircuit Gadgets.Xor.circuit ⟨c3, (state.get 19)⟩
+
   let c4 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 20), (state.get 21)⟩
   let c4 ← subcircuit Gadgets.Xor.circuit ⟨c4, (state.get 22)⟩
   let c4 ← subcircuit Gadgets.Xor.circuit ⟨c4, (state.get 23)⟩

--- a/Clean/Gadgets/Keccak/ThetaC.lean
+++ b/Clean/Gadgets/Keccak/ThetaC.lean
@@ -13,7 +13,7 @@ open Xor (xor_u64)
 structure Inputs (F : Type) where
   state: Vector (U64 F) 25
 
-instance instProvableTypeInputs : ProvableType Inputs where
+instance : ProvableType Inputs where
   size := 25 * ProvableType.size U64
   to_elements x := sorry
   from_elements v := sorry
@@ -21,7 +21,7 @@ instance instProvableTypeInputs : ProvableType Inputs where
 structure Outputs (F : Type) where
   c : Vector (U64 F) 5
 
-instance instProvableTypeOutputs : ProvableType Outputs where
+instance  : ProvableType Outputs where
   size := 5 * ProvableType.size U64
   to_elements x := sorry
   from_elements v := sorry
@@ -29,30 +29,26 @@ instance instProvableTypeOutputs : ProvableType Outputs where
 def theta_c (input : Var Inputs (F p)) : Circuit (F p) (Var Outputs (F p)) := do
   let ⟨state⟩ := input
 
-  let ⟨c0⟩ ← subcircuit Gadgets.Xor.circuit ⟨(state.get 0), (state.get 1)⟩
-  let ⟨c0⟩ ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 2)⟩
-  let ⟨c0⟩ ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 3)⟩
-  let ⟨c0⟩ ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 4)⟩
-
-  let ⟨c1⟩ ← subcircuit Gadgets.Xor.circuit ⟨(state.get 5), (state.get 6)⟩
-  let ⟨c1⟩ ← subcircuit Gadgets.Xor.circuit ⟨c1, (state.get 7)⟩
-  let ⟨c1⟩ ← subcircuit Gadgets.Xor.circuit ⟨c1, (state.get 8)⟩
-  let ⟨c1⟩ ← subcircuit Gadgets.Xor.circuit ⟨c1, (state.get 9)⟩
-
-  let ⟨c2⟩ ← subcircuit Gadgets.Xor.circuit ⟨(state.get 10), (state.get 11)⟩
-  let ⟨c2⟩ ← subcircuit Gadgets.Xor.circuit ⟨c2, (state.get 12)⟩
-  let ⟨c2⟩ ← subcircuit Gadgets.Xor.circuit ⟨c2, (state.get 13)⟩
-  let ⟨c2⟩ ← subcircuit Gadgets.Xor.circuit ⟨c2, (state.get 14)⟩
-
-  let ⟨c3⟩ ← subcircuit Gadgets.Xor.circuit ⟨(state.get 15), (state.get 16)⟩
-  let ⟨c3⟩ ← subcircuit Gadgets.Xor.circuit ⟨c3, (state.get 17)⟩
-  let ⟨c3⟩ ← subcircuit Gadgets.Xor.circuit ⟨c3, (state.get 18)⟩
-  let ⟨c3⟩ ← subcircuit Gadgets.Xor.circuit ⟨c3, (state.get 19)⟩
-
-  let ⟨c4⟩ ← subcircuit Gadgets.Xor.circuit ⟨(state.get 20), (state.get 21)⟩
-  let ⟨c4⟩ ← subcircuit Gadgets.Xor.circuit ⟨c4, (state.get 22)⟩
-  let ⟨c4⟩ ← subcircuit Gadgets.Xor.circuit ⟨c4, (state.get 23)⟩
-  let ⟨c4⟩ ← subcircuit Gadgets.Xor.circuit ⟨c4, (state.get 24)⟩
+  let c0 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 0), (state.get 1)⟩
+  let c0 ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 2)⟩
+  let c0 ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 3)⟩
+  let c0 ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 4)⟩
+  let c1 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 5), (state.get 6)⟩
+  let c1 ← subcircuit Gadgets.Xor.circuit ⟨c1, (state.get 7)⟩
+  let c1 ← subcircuit Gadgets.Xor.circuit ⟨c1, (state.get 8)⟩
+  let c1 ← subcircuit Gadgets.Xor.circuit ⟨c1, (state.get 9)⟩
+  let c2 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 10), (state.get 11)⟩
+  let c2 ← subcircuit Gadgets.Xor.circuit ⟨c2, (state.get 12)⟩
+  let c2 ← subcircuit Gadgets.Xor.circuit ⟨c2, (state.get 13)⟩
+  let c2 ← subcircuit Gadgets.Xor.circuit ⟨c2, (state.get 14)⟩
+  let c3 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 15), (state.get 16)⟩
+  let c3 ← subcircuit Gadgets.Xor.circuit ⟨c3, (state.get 17)⟩
+  let c3 ← subcircuit Gadgets.Xor.circuit ⟨c3, (state.get 18)⟩
+  let c3 ← subcircuit Gadgets.Xor.circuit ⟨c3, (state.get 19)⟩
+  let c4 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 20), (state.get 21)⟩
+  let c4 ← subcircuit Gadgets.Xor.circuit ⟨c4, (state.get 22)⟩
+  let c4 ← subcircuit Gadgets.Xor.circuit ⟨c4, (state.get 23)⟩
+  let c4 ← subcircuit Gadgets.Xor.circuit ⟨c4, (state.get 24)⟩
   return { c := #v[c0, c1, c2, c3, c4] }
 
 def assumptions (input : Inputs (F p)) : Prop :=

--- a/Clean/Gadgets/Keccak/ThetaC.lean
+++ b/Clean/Gadgets/Keccak/ThetaC.lean
@@ -49,13 +49,10 @@ def spec (state : State (F p)) (out: Outputs (F p)) : Prop :=
   -- TODO
   true
 
-#eval! theta_c (p:=p_babybear) default |>.operations.local_length
-#eval! theta_c (p:=p_babybear) default |>.output
-
-def circuit : FormalCircuit (F p) State Outputs where
+-- #eval! theta_c (p:=p_babybear) default |>.operations.local_length
+-- #eval! theta_c (p:=p_babybear) default |>.output
+instance elaborated : ElaboratedCircuit (F p) State (Var Outputs (F p)) where
   main := theta_c
-  assumptions := assumptions
-  spec := spec
   local_length _ := 160
   output _ i0 := #v[
     var_from_offset U64 (i0 + 24),
@@ -64,6 +61,15 @@ def circuit : FormalCircuit (F p) State Outputs where
     var_from_offset U64 (i0 + 120),
     var_from_offset U64 (i0 + 152)
   ]
-  soundness := by sorry
-  completeness := by sorry
+
+theorem soundness : Soundness (F p) assumptions spec := by sorry
+
+theorem completeness : Completeness (F p) Outputs assumptions := by sorry
+
+def circuit : FormalCircuit (F p) State Outputs where
+  main := theta_c
+  assumptions
+  spec
+  soundness
+  completeness
 end Gadgets.Keccak.ThetaC

--- a/Clean/Gadgets/Keccak/ThetaC.lean
+++ b/Clean/Gadgets/Keccak/ThetaC.lean
@@ -7,7 +7,6 @@ namespace Gadgets.Keccak.ThetaC
 variable {p : ℕ} [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
-open Provable (field field2 fields)
 open FieldUtils (mod_256 floordiv)
 open Xor (xor_u64)
 

--- a/Clean/Gadgets/Keccak/ThetaC.lean
+++ b/Clean/Gadgets/Keccak/ThetaC.lean
@@ -15,6 +15,7 @@ open Xor (xor_u64)
 -- note: `reducible` is needed for type class inference, i.e. `ProvableType State`
 
 def theta_c (state : Var State (F p)) : Circuit (F p) (Var Outputs (F p)) := do
+  -- TODO would be nice to have a for loop of length 5 here
   let c0 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 0), (state.get 1)⟩
   let c0 ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 2)⟩
   let c0 ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 3)⟩
@@ -42,12 +43,24 @@ def theta_c (state : Var State (F p)) : Circuit (F p) (Var Outputs (F p)) := do
   return #v[c0, c1, c2, c3, c4]
 
 def assumptions (state : State (F p)) : Prop :=
-  -- TODO
-  true
+  ∀ i : Fin 25, state[i].is_normalized
 
 def spec (state : State (F p)) (out: Outputs (F p)) : Prop :=
-  -- TODO
-  true
+  let h_norm := out[0].is_normalized ∧ out[1].is_normalized ∧
+                out[2].is_normalized ∧ out[3].is_normalized ∧ out[4].is_normalized
+
+  let h_xor0 :=
+    out[0].value = (state[0].value |>.xor state[1].value |>.xor state[2].value |>.xor state[3].value |>.xor state[4].value)
+  let h_xor1 :=
+    out[1].value = (state[5].value |>.xor state[6].value |>.xor state[7].value |>.xor state[8].value |>.xor state[9].value)
+  let h_xor2 :=
+    out[2].value = (state[10].value |>.xor state[11].value |>.xor state[12].value |>.xor state[13].value |>.xor state[14].value)
+  let h_xor3 :=
+    out[3].value = (state[15].value |>.xor state[16].value |>.xor state[17].value |>.xor state[18].value |>.xor state[19].value)
+  let h_xor4 :=
+    out[4].value = (state[20].value |>.xor state[21].value |>.xor state[22].value |>.xor state[23].value |>.xor state[24].value)
+
+  h_norm ∧ (h_xor0 ∧ h_xor1 ∧ h_xor2 ∧ h_xor3 ∧ h_xor4)
 
 -- #eval! theta_c (p:=p_babybear) default |>.operations.local_length
 -- #eval! theta_c (p:=p_babybear) default |>.output
@@ -62,9 +75,112 @@ instance elaborated : ElaboratedCircuit (F p) State (Var Outputs (F p)) where
     var_from_offset U64 (i0 + 152)
   ]
 
-theorem soundness : Soundness (F p) assumptions spec := by sorry
+theorem soundness : Soundness (F p) assumptions spec := by
+  intro i0 env state_var state h_input state_norm h_holds
+  simp only [circuit_norm] at h_input
+  dsimp only [assumptions] at state_norm
+  dsimp only [circuit_norm, theta_c, Xor.circuit] at h_holds
+  simp only [circuit_norm, subcircuit_norm] at h_holds
+  dsimp only [Xor.assumptions, Xor.spec] at h_holds
+  simp [add_assoc, and_assoc] at h_holds
 
-theorem completeness : Completeness (F p) Outputs assumptions := by sorry
+  -- TODO: we desperately need some abstraction here
+  have s0 : eval env (state_var[0]) = state[0] := by rw [←h_input, Vector.getElem_map]
+  have s1 : eval env (state_var[1]) = state[1] := by rw [←h_input, Vector.getElem_map]
+  have s2 : eval env (state_var[2]) = state[2] := by rw [←h_input, Vector.getElem_map]
+  have s3 : eval env (state_var[@Fin.val 25 3]) = state[3] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s4 : eval env (state_var[@Fin.val 25 4]) = state[4] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s5 : eval env (state_var[@Fin.val 25 5]) = state[5] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s6 : eval env (state_var[@Fin.val 25 6]) = state[6] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s7 : eval env (state_var[@Fin.val 25 7]) = state[7] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s8 : eval env (state_var[@Fin.val 25 8]) = state[8] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s9 : eval env (state_var[@Fin.val 25 9]) = state[9] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s10 : eval env (state_var[@Fin.val 25 10]) = state[10] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s11 : eval env (state_var[@Fin.val 25 11]) = state[11] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s12 : eval env (state_var[@Fin.val 25 12]) = state[12] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s13 : eval env (state_var[@Fin.val 25 13]) = state[13] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s14 : eval env (state_var[@Fin.val 25 14]) = state[14] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s15 : eval env (state_var[@Fin.val 25 15]) = state[15] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s16 : eval env (state_var[@Fin.val 25 16]) = state[16] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s17 : eval env (state_var[@Fin.val 25 17]) = state[17] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s18 : eval env (state_var[@Fin.val 25 18]) = state[18] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s19 : eval env (state_var[@Fin.val 25 19]) = state[19] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s20 : eval env (state_var[@Fin.val 25 20]) = state[20] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s21 : eval env (state_var[@Fin.val 25 21]) = state[21] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s22 : eval env (state_var[@Fin.val 25 22]) = state[22] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s23 : eval env (state_var[@Fin.val 25 23]) = state[23] := by rw [←h_input, Vector.getElem_map]; rfl
+  have s24 : eval env (state_var[@Fin.val 25 24]) = state[24] := by rw [←h_input, Vector.getElem_map]; rfl
+  rw [s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13,
+      s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24] at h_holds
+  clear s0 s1 s2 s3 s4 s5 s6 s7 s8 s9 s10 s11 s12 s13 s14 s15 s16 s17
+    s18 s19 s20 s21 s22 s23 s24
+
+  simp [circuit_norm, spec]
+
+  -- TODO ideally we would do this proof once and not 5 times!
+  -- out0 spec
+  set out0 := eval env <| var_from_offset U64 (i0 + 24)
+  obtain ⟨ h00, h01, h02, h03, h_holds ⟩ := h_holds
+  obtain ⟨ xor00, norm00 ⟩ := h00 (state_norm 0) (state_norm 1)
+  obtain ⟨ xor01, norm01 ⟩ := h01 norm00 (state_norm 2)
+  obtain ⟨ xor02, norm02 ⟩ := h02 norm01 (state_norm 3)
+  obtain ⟨ xor0, norm0 ⟩ := h03 norm02 (state_norm 4)
+  rw [xor02, xor01, xor00] at xor0
+  clear h00 h01 h02 h03 norm00 norm01 norm02 xor00 xor01 xor02
+
+  -- out1 spec
+  set out1 := eval env <| var_from_offset U64 (i0 + 56)
+  obtain ⟨ h10, h11, h12, h13, h_holds ⟩ := h_holds
+  obtain ⟨ xor10, norm10 ⟩ := h10 (state_norm 5) (state_norm 6)
+  obtain ⟨ xor11, norm11 ⟩ := h11 norm10 (state_norm 7)
+  obtain ⟨ xor12, norm12 ⟩ := h12 norm11 (state_norm 8)
+  obtain ⟨ xor1, norm1 ⟩ := h13 norm12 (state_norm 9)
+  rw [xor12, xor11, xor10] at xor1
+  clear h10 h11 h12 h13 norm10 norm11 norm12 xor10 xor11 xor12
+
+  -- out2 spec
+  set out2 := eval env <| var_from_offset U64 (i0 + 88)
+  obtain ⟨ h20, h21, h22, h23, h_holds ⟩ := h_holds
+  obtain ⟨ xor20, norm20 ⟩ := h20 (state_norm 10) (state_norm 11)
+  obtain ⟨ xor21, norm21 ⟩ := h21 norm20 (state_norm 12)
+  obtain ⟨ xor22, norm22 ⟩ := h22 norm21 (state_norm 13)
+  obtain ⟨ xor2, norm2 ⟩ := h23 norm22 (state_norm 14)
+  rw [xor22, xor21, xor20] at xor2
+  clear h20 h21 h22 h23 norm20 norm21 norm22 xor20 xor21 xor22
+
+  -- out3 spec
+  set out3 := eval env <| var_from_offset U64 (i0 + 120)
+  obtain ⟨ h30, h31, h32, h33, h_holds ⟩ := h_holds
+  obtain ⟨ xor30, norm30 ⟩ := h30 (state_norm 15) (state_norm 16)
+  obtain ⟨ xor31, norm31 ⟩ := h31 norm30 (state_norm 17)
+  obtain ⟨ xor32, norm32 ⟩ := h32 norm31 (state_norm 18)
+  obtain ⟨ xor3, norm3 ⟩ := h33 norm32 (state_norm 19)
+  rw [xor32, xor31, xor30] at xor3
+  clear h30 h31 h32 h33 norm30 norm31 norm32 xor30 xor31 xor32
+
+  -- out4 spec
+  set out4 := eval env <| var_from_offset U64 (i0 + 152)
+  obtain ⟨ h40, h41, h42, h43 ⟩ := h_holds
+  obtain ⟨ xor40, norm40 ⟩ := h40 (state_norm 20) (state_norm 21)
+  obtain ⟨ xor41, norm41 ⟩ := h41 norm40 (state_norm 22)
+  obtain ⟨ xor42, norm42 ⟩ := h42 norm41 (state_norm 23)
+  obtain ⟨ xor4, norm4 ⟩ := h43 norm42 (state_norm 24)
+  rw [xor42, xor41, xor40] at xor4
+  clear h40 h41 h42 h43 norm40 norm41 norm42 xor40 xor41 xor42
+
+  exact ⟨
+    ⟨ norm0, norm1, norm2, norm3, norm4 ⟩,
+    ⟨ xor0, xor1, xor2, xor3, xor4 ⟩
+  ⟩
+
+theorem completeness : Completeness (F p) Outputs assumptions := by
+  intro i0 env state_var h_env state h_input h_assumptions
+  simp only [circuit_norm] at h_input
+  dsimp only [circuit_norm, theta_c, Xor.circuit]
+  simp only [circuit_norm, subcircuit_norm]
+  dsimp only [Xor.assumptions, Xor.spec]
+  simp [add_assoc]
+  sorry
 
 def circuit : FormalCircuit (F p) State Outputs where
   main := theta_c

--- a/Clean/Gadgets/Xor/ByteXorTable.lean
+++ b/Clean/Gadgets/Xor/ByteXorTable.lean
@@ -21,16 +21,19 @@ def ByteXorTable: Table (F p) where
 
 def ByteXorTable.soundness
     (x y z: F p) :
-    ByteXorTable.contains (#v[x, y, z]) → z.val = Nat.xor x.val y.val := by
+    ByteXorTable.contains #v[x, y, z] →
+    x.val < 256 ∧ y.val < 256 ∧ z.val = Nat.xor x.val y.val := by
   sorry
 
 def ByteXorTable.completeness
     (x y z: F p) :
-    z.val = Nat.xor x.val y.val → ByteXorTable.contains (#v[x, y, z]) := by
+    x.val < 256 ∧ y.val < 256 ∧ z.val = Nat.xor x.val y.val →
+    ByteXorTable.contains #v[x, y, z] := by
   sorry
 
 def ByteXorTable.equiv (x y z: F p) :
-    ByteXorTable.contains (#v[x, y, z]) ↔ z.val = Nat.xor x.val y.val :=
+    ByteXorTable.contains #v[x, y, z] ↔
+    x.val < 256 ∧ y.val < 256 ∧ z.val = Nat.xor x.val y.val :=
   ⟨ByteXorTable.soundness x y z, ByteXorTable.completeness x y z⟩
 
 def ByteXorLookup (x y z: Expression (F p)) : Lookup (F p) := {

--- a/Clean/Gadgets/Xor/ByteXorTable.lean
+++ b/Clean/Gadgets/Xor/ByteXorTable.lean
@@ -20,24 +20,20 @@ def ByteXorTable: Table (F p) where
     #v[from_byte x, from_byte y, from_byte (Nat.xor x y)]
 
 def ByteXorTable.soundness
-    (x y z: F p)
-    (hx : x.val < 256)
-    (hy : y.val < 256) :
+    (x y z: F p) :
     ByteXorTable.contains (#v[x, y, z]) → z.val = Nat.xor x.val y.val := by
   sorry
 
 def ByteXorTable.completeness
-    (x y z: F p)
-    (hx : x.val < 256)
-    (hy : y.val < 256) :
+    (x y z: F p) :
     z.val = Nat.xor x.val y.val → ByteXorTable.contains (#v[x, y, z]) := by
   sorry
 
-def ByteXorTable.equiv (x y z: F p) (hx : x.val < 256) (hy : y.val < 256) :
+def ByteXorTable.equiv (x y z: F p) :
     ByteXorTable.contains (#v[x, y, z]) ↔ z.val = Nat.xor x.val y.val :=
-  ⟨ByteXorTable.soundness x y z hx hy, ByteXorTable.completeness x y z hx hy⟩
+  ⟨ByteXorTable.soundness x y z, ByteXorTable.completeness x y z⟩
 
-def byte_xor_lookup (x y z: Expression (F p)) := lookup {
+def ByteXorLookup (x y z: Expression (F p)) : Lookup (F p) := {
   table := ByteXorTable
   entry := #v[x, y, z]
   index := fun env =>

--- a/Clean/Gadgets/Xor/Xor64.lean
+++ b/Clean/Gadgets/Xor/Xor64.lean
@@ -24,7 +24,7 @@ instance : ProvableStruct Inputs where
 
 def xor_u64 (input : Var Inputs (F p)) : Circuit (F p) (Var U64 (F p))  := do
   let ⟨x, y⟩ := input
-  let z ← Provable.witness (fun env =>
+  let z ← ProvableType.witness (fun env =>
     let z0 := Nat.xor (env x.x0).val (env y.x0).val
     let z1 := Nat.xor (env x.x1).val (env y.x1).val
     let z2 := Nat.xor (env x.x2).val (env y.x2).val

--- a/Clean/Gadgets/Xor/Xor64.lean
+++ b/Clean/Gadgets/Xor/Xor64.lean
@@ -142,7 +142,9 @@ theorem completeness : Completeness (F p) U64 assumptions := by
       xor_cast x2_byte y2_byte, xor_cast x3_byte y3_byte,
       xor_cast x4_byte y4_byte, xor_cast x5_byte y5_byte,
       xor_cast x6_byte y6_byte, xor_cast x7_byte y7_byte]
-  simp only [and_true]
+  simp only [x0_byte, y0_byte, x1_byte, y1_byte, x2_byte, y2_byte,
+    x3_byte, y3_byte, x4_byte, y4_byte, x5_byte, y5_byte,
+    x6_byte, y6_byte, x7_byte, y7_byte, and_true]
 
 def circuit : FormalCircuit (F p) Inputs U64 where
   main := xor_u64

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -311,12 +311,12 @@ def output {α: Type} (table : TableConstraint W S F α) : α :=
 @[table_norm, table_assignment_norm]
 def get_row (row : Fin W) : TableConstraint W S F (Var S F) :=
   modifyGet fun ctx =>
-    let vars : Vector ℕ _ := .init (fun i => ctx.offset + i)
+    let vars := Vector.natInit (size S) (fun i => ctx.offset + i)
     let ctx' : TableContext W S F := {
       circuit := ctx.circuit.witness (size S) (fun env => vars.map fun i => env.get i),
       assignment := ctx.assignment.push_row row
     }
-    (Provable.from_offset S ctx.offset, ctx')
+    (var_from_offset S ctx.offset, ctx')
 
 /--
   Get a fresh variable for each cell in the current row

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -482,8 +482,8 @@ structure FormalTable (F : Type) [Field F] (S : Type → Type) [ProvableType S] 
 
 -- add some important lemmas to simp sets
 attribute [table_norm] List.mapIdx List.mapIdx.go
-attribute [table_norm] size from_elements to_elements to_vars from_vars
-attribute [table_assignment_norm] to_elements
+attribute [table_norm low] size from_elements to_elements to_vars from_vars
+attribute [table_assignment_norm low] to_elements
 attribute [table_norm] Circuit.constraints_hold.soundness
 
 attribute [table_norm, table_assignment_norm] Vector.set? List.set_cons_succ List.set_cons_zero

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -359,7 +359,7 @@ def assign_next_row {W: ℕ+} (next : Var S F) : TableConstraint W S F Unit :=
     assign (.next i) (vars.get i)
 end TableConstraint
 
-export TableConstraint (window_env get_curr_row get_next_row assign assign_next_row assign_curr_row)
+export TableConstraint (window_env get_curr_row get_next_row assign_var assign assign_next_row assign_curr_row)
 
 @[reducible]
 def SingleRowConstraint (S : Type → Type) (F : Type) [Field F] [ProvableType S] := TableConstraint 1 S F Unit
@@ -513,4 +513,4 @@ macro_rules
     repeat rw [List.forM_cons]
     rw [List.forM_nil, bind_pure_unit]
     simp only [seval, to_vars, to_elements, Vector.get, Fin.cast_eq_self, Fin.val_zero, Fin.val_one, Fin.isValue,
-      List.getElem_toArray, List.getElem_cons_zero, List.getElem_cons_succ]))
+      List.getElem_toArray, List.getElem_cons_zero, List.getElem_cons_succ, Fin.succ_zero_eq_one]))

--- a/Clean/Tables/Addition8.lean
+++ b/Clean/Tables/Addition8.lean
@@ -56,7 +56,9 @@ def formal_add8_table : FormalTable (F p) RowType := {
         change Circuit.constraints_hold.soundness env _ at h_holds
 
         -- this is the slowest step, but still ok
-        simp [table_norm, circuit_norm, subcircuit_norm,  add8_inline, Gadgets.Addition8.circuit, ByteLookup] at h_holds
+        simp [table_norm, circuit_norm, subcircuit_norm, var_from_offset,
+          add8_inline, Gadgets.Addition8.circuit, ByteLookup
+        ] at h_holds
         change (_ ∧ _) ∧ (_ → _) at h_holds
 
         -- resolve assignment

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -20,13 +20,11 @@ structure RowType (F : Type) where
   x: U32 F
   y: U32 F
 
-instance : ProvableType RowType where
-  size := 8
-  to_elements s := #v[s.x.x0, s.x.x1, s.x.x2, s.x.x3, s.y.x0, s.y.x1, s.y.x2, s.y.x3]
-  from_elements v :=
-    -- TODO is it possible to define in terms of ProvableType.from_elements of the U32?
-    let ⟨ .mk [x0, x1, x2, x3, y0, y1, y2, y3], _ ⟩ := v
-    ⟨ ⟨ x0, x1, x2, x3 ⟩, ⟨ y0, y1, y2, y3 ⟩ ⟩
+instance : ProvableStruct RowType where
+  components := [U32, U32]
+  to_components := fun { x, y } => .cons x (.cons y .nil)
+  from_components := fun (.cons x (.cons y .nil)) => { x, y }
+  combined_size := 8 -- explicit size to enable casting indices to `Fin size`
 
 @[reducible]
 def next_row_off : RowType (CellOffset 2 RowType) := {
@@ -61,8 +59,8 @@ def recursive_relation : TwoRowsConstraint RowType (F p) := do
 -/
 def boundary : SingleRowConstraint RowType (F p) := do
   let row ← TableConstraint.get_curr_row
-  assertion Gadgets.Equality.U32.circuit ⟨row.x, ⟨0, 0, 0, 0⟩⟩
-  assertion Gadgets.Equality.U32.circuit ⟨row.y, ⟨1, 0, 0, 0⟩⟩
+  assertion Gadgets.Equality.U32.circuit ⟨row.x, Provable.const (U32.from_byte 0)⟩
+  assertion Gadgets.Equality.U32.circuit ⟨row.y, Provable.const (U32.from_byte 1)⟩
 
 /--
   The fib32 table is composed of the boundary and recursive relation constraints.
@@ -96,7 +94,7 @@ variable {α : Type}
 
 -- assignment copied from eval:
 -- #eval (recursive_relation (p:=p_babybear)).final_assignment.vars
-lemma fib_vars : (recursive_relation (p:=p)).final_assignment.vars =
+lemma fib_assignment : (recursive_relation (p:=p)).final_assignment.vars =
    #v[.input ⟨0, 0⟩, .input ⟨0, 1⟩, .input ⟨0, 2⟩, .input ⟨0, 3⟩, .input ⟨0, 4⟩, .input ⟨0, 5⟩, .input ⟨0, 6⟩,
       .input ⟨0, 7⟩, .input ⟨1, 0⟩, .input ⟨1, 1⟩, .input ⟨1, 2⟩, .input ⟨1, 3⟩, .input ⟨1, 4⟩, .input ⟨1, 5⟩,
       .input ⟨1, 6⟩, .input ⟨1, 7⟩, .input ⟨1, 4⟩, .aux 1, .input ⟨1, 5⟩, .aux 3, .input ⟨1, 6⟩, .aux 5,
@@ -106,92 +104,87 @@ lemma fib_vars : (recursive_relation (p:=p)).final_assignment.vars =
     simp only [circuit_norm, table_norm]
     rfl
 
-lemma fib_vars_curr (curr next : Row (F p) RowType) (aux_env : Environment (F p)) :
+lemma fib_vars (curr next : Row (F p) RowType) (aux_env : Environment (F p)) :
     let env := recursive_relation.window_env ⟨<+> +> curr +> next, rfl⟩ aux_env;
-    env.get 0 = curr.x.x0 ∧
-    env.get 1 = curr.x.x1 ∧
-    env.get 2 = curr.x.x2 ∧
-    env.get 3 = curr.x.x3 ∧
-    env.get 4 = curr.y.x0 ∧
-    env.get 5 = curr.y.x1 ∧
-    env.get 6 = curr.y.x2 ∧
-    env.get 7 = curr.y.x3
+    eval env (U32.mk (var ⟨0⟩) (var ⟨1⟩) (var ⟨2⟩) (var ⟨3⟩)) = curr.x ∧
+    eval env (U32.mk (var ⟨4⟩) (var ⟨5⟩) (var ⟨6⟩) (var ⟨7⟩)) = curr.y ∧
+    eval env (U32.mk (var ⟨8⟩) (var ⟨9⟩) (var ⟨10⟩) (var ⟨11⟩)) = next.x ∧
+    eval env (U32.mk (var ⟨16⟩) (var ⟨18⟩) (var ⟨20⟩) (var ⟨22⟩)) = next.y
   := by
   intro env
   dsimp only [env, window_env]
   have h_offset : (recursive_relation (p:=p)).final_assignment.offset = 24 := rfl
-  simp only [h_offset, reduceDIte, Nat.reduceLT]
-  rw [fib_vars]
-  simp
-  and_intros <;> rfl
-
-lemma fib_vars_next (curr next : Row (F p) RowType) (aux_env : Environment (F p)) :
-    let env := recursive_relation.window_env ⟨<+> +> curr +> next, rfl⟩ aux_env;
-    env.get 8 = next.x.x0 ∧
-    env.get 9 = next.x.x1 ∧
-    env.get 10 = next.x.x2 ∧
-    env.get 11 = next.x.x3 ∧
-    env.get 16 = next.y.x0 ∧
-    env.get 18 = next.y.x1 ∧
-    env.get 20 = next.y.x2 ∧
-    env.get 22 = next.y.x3
-  := by
-  intro env
-  dsimp only [env, window_env]
-  have h_offset : (recursive_relation (p:=p)).final_assignment.offset = 24 := rfl
-  simp only [h_offset, reduceDIte, Nat.reduceLT]
-  rw [fib_vars]
-  simp
+  simp only [h_offset]
+  rw [fib_assignment]
+  simp only [circuit_norm, eval, OfNat.ofNat, reduceDIte, Nat.reduceLT]
+  simp only [PNat.mk_ofNat, PNat.val_ofNat, Fin.ofNat'_eq_cast, Nat.cast_zero, Fin.isValue,
+    Nat.cast_one, Nat.cast_ofNat]
   and_intros <;> rfl
 
 /--
   Main lemma that shows that if the constraints hold over the two-row window,
   then the spec of add32 and equality are satisfied
 -/
-lemma lift_constraints (curr next : Row (F p) RowType) (aux_env : Environment (F p))
+lemma fib_constraints (curr next : Row (F p) RowType) (aux_env : Environment (F p))
   : recursive_relation.constraints_hold_on_window ⟨<+> +> curr +> next, rfl⟩ aux_env →
   curr.y = next.x ∧
   (curr.x.is_normalized → curr.y.is_normalized → next.y.value = (curr.x.value + curr.y.value) % 2^32 ∧ next.y.is_normalized)
    := by
   simp only [table_norm]
-  obtain ⟨ hcurr_x0, hcurr_x1, hcurr_x2, hcurr_x3, hcurr_y0, hcurr_y1, hcurr_y2, hcurr_y3 ⟩ := fib_vars_curr curr next aux_env
-  obtain ⟨ hnext_x0, hnext_x1, hnext_x2, hnext_x3, hnext_y0, hnext_y1, hnext_y2, hnext_y3 ⟩ := fib_vars_next curr next aux_env
+  obtain ⟨ hcurr_x, hcurr_y, hnext_x, hnext_y ⟩ := fib_vars curr next aux_env
   set env := recursive_relation.window_env  ⟨<+> +> curr +> next, rfl⟩ aux_env
-  dsimp only [table_norm, circuit_norm, recursive_relation, assign_U32,
+  simp only [table_norm, circuit_norm, recursive_relation, assign_U32,
     Gadgets.Equality.U32.circuit, Gadgets.Addition32Full.circuit
   ]
   rintro ⟨ ⟨_, h_add⟩, h_eq ⟩
-  simp only [table_norm, circuit_norm, subcircuit_norm] at h_add h_eq
+  -- TODO make this work with simp only [circuit_norm]
+  simp [circuit_norm] at h_add h_eq
+  simp only [table_norm, circuit_norm, subcircuit_norm, true_implies] at h_add h_eq
   simp [
     show (3 : Fin 8).val = 3 by rfl,
     show (4 : Fin 8).val = 4 by rfl,
     show (5 : Fin 8).val = 5 by rfl,
     show (6 : Fin 8).val = 6 by rfl,
     show (7 : Fin 8).val = 7 by rfl
-  ] at h_add
-  conv at h_eq =>
-    congr
-    · skip
-    · simp [
-        show (3 : Fin 8).val = 3 by rfl,
-        show (4 : Fin 8).val = 4 by rfl,
-        show (5 : Fin 8).val = 5 by rfl,
-        show (6 : Fin 8).val = 6 by rfl,
-        show (7 : Fin 8).val = 7 by rfl
-      ]
-  rw [hcurr_x0, hcurr_x1, hcurr_x2, hcurr_x3, hcurr_y0, hcurr_y1, hcurr_y2, hcurr_y3, hnext_y0, hnext_y1, hnext_y2, hnext_y3] at h_add
-  rw [hcurr_y0, hcurr_y1, hcurr_y2, hcurr_y3, hnext_x0, hnext_x1, hnext_x2, hnext_x3] at h_eq
+  ] at h_add h_eq
+  rw [hcurr_x, hcurr_y, hnext_y] at h_add
+  rw [hcurr_y, hnext_x] at h_eq
+  clear hcurr_x hcurr_y hnext_x hnext_y
   constructor
-  · rw [Gadgets.Equality.U32.spec, true_implies] at h_eq
+  · rw [Gadgets.Equality.U32.spec] at h_eq
     exact h_eq
   rw [Gadgets.Addition32Full.assumptions, Gadgets.Addition32Full.spec] at h_add
-  change curr.x.is_normalized ∧ curr.y.is_normalized ∧ (0 = 0 ∨ 0 = 1) → _ at h_add
   intro h_norm_x h_norm_y
   specialize h_add ⟨ h_norm_x, h_norm_y, Or.inl rfl ⟩
   rw [ZMod.val_zero, add_zero] at h_add
-  change next.y.value = (curr.x.value + curr.y.value) % 2^32 ∧ _ ∧ next.y.is_normalized ∧ _ at h_add
   obtain ⟨ h_add_mod, _, h_norm_next_y, _ ⟩ := h_add
   exact ⟨h_add_mod, h_norm_next_y⟩
+
+lemma boundary_constraints (first_row : Row (F p) RowType) (aux_env : Environment (F p)) :
+  Circuit.constraints_hold.soundness (window_env boundary ⟨<+> +> first_row, rfl⟩ aux_env) boundary.operations →
+  first_row.x.value = fib32 0 ∧ first_row.y.value = fib32 1 ∧ first_row.x.is_normalized ∧ first_row.y.is_normalized
+  := by
+  set env := boundary.window_env ⟨<+> +> first_row, rfl⟩ aux_env
+  simp only [table_norm, boundary, circuit_norm, Gadgets.Equality.U32.circuit]
+  -- TODO make this work with simp only [circuit_norm]
+  simp [circuit_norm]
+  simp only [subcircuit_norm, Gadgets.Equality.U32.spec]
+  rw [
+    show (3 : Fin 8).val = 3 by rfl,
+    show (4 : Fin 8).val = 4 by rfl,
+    show (5 : Fin 8).val = 5 by rfl,
+    show (6 : Fin 8).val = 6 by rfl,
+    show (7 : Fin 8).val = 7 by rfl,
+  ]
+  simp [circuit_norm]
+  have hx : eval env (U32.mk (var ⟨0⟩) (var ⟨1⟩) (var ⟨2⟩) (var ⟨3⟩)) = first_row.x := by rfl
+  have hy : eval env (U32.mk (var ⟨4⟩) (var ⟨5⟩) (var ⟨6⟩) (var ⟨7⟩)) = first_row.y := by rfl
+  rw [hx, hy]
+  clear hx hy
+  intro x_zero y_one
+  rw [x_zero, y_one]
+  simp only [U32.from_byte_is_normalized, U32.from_byte_value, fib32]
+  trivial
 
 /--
   Definition of the formal table for fibonacci32
@@ -214,39 +207,7 @@ def formal_fib32_table : FormalTable (F p) RowType := {
 
     -- base case 2
     · simp [table_norm]
-      set env := boundary.window_env ⟨<+> +> first_row, rfl⟩ (envs 0 0)
-      simp only [table_norm, boundary, circuit_norm, Gadgets.Equality.U32.circuit]
-      simp only [subcircuit_norm, Gadgets.Equality.U32.spec]
-      -- TODO it's annoying how we end up reasoning about the individual parts of the U32
-      -- even though the gadget we used was about equality of entire U32s
-      simp [circuit_norm]
-      -- TODO find simp set that handles these identities?
-      simp only [
-        show (3 : Fin 8).val = 3 by rfl,
-        show (4 : Fin 8).val = 4 by rfl,
-        show (5 : Fin 8).val = 5 by rfl,
-        show (6 : Fin 8).val = 6 by rfl,
-        show (7 : Fin 8).val = 7 by rfl,
-      ]
-      have hx0 : env.get 0 = first_row.x.x0 := rfl
-      have hx1 : env.get 1 = first_row.x.x1 := rfl
-      have hx2 : env.get 2 = first_row.x.x2 := rfl
-      have hx3 : env.get 3 = first_row.x.x3 := rfl
-      have hy0 : env.get 4 = first_row.y.x0 := rfl
-      have hy1 : env.get 5 = first_row.y.x1 := rfl
-      have hy2 : env.get 6 = first_row.y.x2 := rfl
-      have hy3 : env.get 7 = first_row.y.x3 := rfl
-      rw [hx0, hx1, hx2, hx3, hy0, hy1, hy2, hy3]
-      clear hx0 hx1 hx2 hx3 hy0 hy1 hy2 hy3
-
-      intros b0 b1 b2 b3 b4 b5 b6 b7
-      simp only [U32.value, fib32]
-      simp [b0, b1, b2, b3, b4, b5, b6, b7]
-
-      simp [ZMod.val_one]
-      simp only [U32.is_normalized, b0, b1, b2, b3, b4, b5, b6, b7]
-      simp only [ZMod.val_zero, ZMod.val_one, Nat.ofNat_pos, and_self]
-      trivial
+      apply boundary_constraints first_row (envs 0 0)
 
     -- inductive step
     · -- first of all, we prove the inductive part of the spec
@@ -267,7 +228,7 @@ def formal_fib32_table : FormalTable (F p) RowType := {
 
       -- simplfy constraints
       simp at constraints_hold
-      have ⟨ eq_spec, add_spec ⟩ := lift_constraints curr next (envs 1 (rest.len + 1)) constraints_hold
+      have ⟨ eq_spec, add_spec ⟩ := fib_constraints curr next (envs 1 (rest.len + 1)) constraints_hold
 
       -- and now we can reason at high level with U32s
       specialize add_spec curr_normalized_x curr_normalized_y

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -115,7 +115,7 @@ lemma fib_vars (curr next : Row (F p) RowType) (aux_env : Environment (F p)) :
   have h_offset : (recursive_relation (p:=p)).final_assignment.offset = 24 := rfl
   simp only [h_offset]
   rw [fib_assignment]
-  simp only [circuit_norm, eval, OfNat.ofNat, reduceDIte, Nat.reduceLT]
+  simp only [circuit_norm, eval, OfNat.ofNat, reduceDIte, Nat.reduceLT, var_from_offset, Vector.natInit, Nat.reduceAdd]
   simp only [PNat.mk_ofNat, PNat.val_ofNat, Fin.ofNat'_eq_cast, Nat.cast_zero, Fin.isValue,
     Nat.cast_one, Nat.cast_ofNat]
   and_intros <;> rfl

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -59,8 +59,8 @@ def recursive_relation : TwoRowsConstraint RowType (F p) := do
 -/
 def boundary : SingleRowConstraint RowType (F p) := do
   let row ← TableConstraint.get_curr_row
-  assertion Gadgets.Equality.U32.circuit ⟨row.x, Provable.const (U32.from_byte 0)⟩
-  assertion Gadgets.Equality.U32.circuit ⟨row.y, Provable.const (U32.from_byte 1)⟩
+  assertion Gadgets.Equality.U32.circuit ⟨row.x, const (U32.from_byte 0)⟩
+  assertion Gadgets.Equality.U32.circuit ⟨row.y, const (U32.from_byte 1)⟩
 
 /--
   The fib32 table is composed of the boundary and recursive relation constraints.

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -91,7 +91,6 @@ def spec {N : ℕ} (trace : TraceOfLength (F p) RowType N) : Prop :=
 
 variable {α : Type}
 
-
 -- assignment copied from eval:
 -- #eval (recursive_relation (p:=p_babybear)).final_assignment.vars
 lemma fib_assignment : (recursive_relation (p:=p)).final_assignment.vars =
@@ -106,9 +105,9 @@ lemma fib_assignment : (recursive_relation (p:=p)).final_assignment.vars =
 
 lemma fib_vars (curr next : Row (F p) RowType) (aux_env : Environment (F p)) :
     let env := recursive_relation.window_env ⟨<+> +> curr +> next, rfl⟩ aux_env;
-    eval env (U32.mk (var ⟨0⟩) (var ⟨1⟩) (var ⟨2⟩) (var ⟨3⟩)) = curr.x ∧
-    eval env (U32.mk (var ⟨4⟩) (var ⟨5⟩) (var ⟨6⟩) (var ⟨7⟩)) = curr.y ∧
-    eval env (U32.mk (var ⟨8⟩) (var ⟨9⟩) (var ⟨10⟩) (var ⟨11⟩)) = next.x ∧
+    eval env (var_from_offset U32 0) = curr.x ∧
+    eval env (var_from_offset U32 4) = curr.y ∧
+    eval env (var_from_offset U32 8) = next.x ∧
     eval env (U32.mk (var ⟨16⟩) (var ⟨18⟩) (var ⟨20⟩) (var ⟨22⟩)) = next.y
   := by
   intro env
@@ -139,14 +138,7 @@ lemma fib_constraints (curr next : Row (F p) RowType) (aux_env : Environment (F 
   rintro ⟨ ⟨_, h_add⟩, h_eq ⟩
   -- TODO make this work with simp only [circuit_norm]
   simp [circuit_norm] at h_add h_eq
-  simp only [table_norm, circuit_norm, subcircuit_norm, true_implies] at h_add h_eq
-  simp [
-    show (3 : Fin 8).val = 3 by rfl,
-    show (4 : Fin 8).val = 4 by rfl,
-    show (5 : Fin 8).val = 5 by rfl,
-    show (6 : Fin 8).val = 6 by rfl,
-    show (7 : Fin 8).val = 7 by rfl
-  ] at h_add h_eq
+  simp only [table_norm, circuit_norm, subcircuit_norm, true_implies, Nat.reduceAdd] at h_add h_eq
   rw [hcurr_x, hcurr_y, hnext_y] at h_add
   rw [hcurr_y, hnext_x] at h_eq
   clear hcurr_x hcurr_y hnext_x hnext_y
@@ -169,16 +161,9 @@ lemma boundary_constraints (first_row : Row (F p) RowType) (aux_env : Environmen
   -- TODO make this work with simp only [circuit_norm]
   simp [circuit_norm]
   simp only [subcircuit_norm, Gadgets.Equality.U32.spec]
-  rw [
-    show (3 : Fin 8).val = 3 by rfl,
-    show (4 : Fin 8).val = 4 by rfl,
-    show (5 : Fin 8).val = 5 by rfl,
-    show (6 : Fin 8).val = 6 by rfl,
-    show (7 : Fin 8).val = 7 by rfl,
-  ]
   simp [circuit_norm]
-  have hx : eval env (U32.mk (var ⟨0⟩) (var ⟨1⟩) (var ⟨2⟩) (var ⟨3⟩)) = first_row.x := by rfl
-  have hy : eval env (U32.mk (var ⟨4⟩) (var ⟨5⟩) (var ⟨6⟩) (var ⟨7⟩)) = first_row.y := by rfl
+  have hx : eval env (var_from_offset U32 0) = first_row.x := by rfl
+  have hy : eval env (var_from_offset U32 4) = first_row.y := by rfl
   rw [hx, hy]
   clear hx hy
   intro x_zero y_one

--- a/Clean/Tables/Fibonacci8.lean
+++ b/Clean/Tables/Fibonacci8.lean
@@ -133,7 +133,7 @@ def formal_fib_table : FormalTable (F p) RowType := {
 
       simp [fib_table, fib_relation, circuit_norm, table_norm, table_assignment_norm, copy_to_var,
           Gadgets.Addition8.circuit, Gadgets.Equality.Field.circuit] at constraints_hold
-      simp [circuit_norm, subcircuit_norm, Trace.getLeFromBottom, eval] at constraints_hold
+      simp [circuit_norm, subcircuit_norm, Trace.getLeFromBottom, eval, var_from_offset] at constraints_hold
       dsimp only [Gadgets.Addition8.assumptions, Gadgets.Addition8.spec, Gadgets.Equality.Field.spec] at constraints_hold
 
       have hx_curr : env.get 0 = curr.x := by rfl

--- a/Clean/Tables/Fibonacci8.lean
+++ b/Clean/Tables/Fibonacci8.lean
@@ -37,7 +37,7 @@ def fib_relation : TwoRowsConstraint RowType (F p) := do
   let curr ← TableConstraint.get_curr_row
   let next_x ← copy_to_var curr.y
   let next_y ← subcircuit Gadgets.Addition8.circuit { x := curr.x, y := curr.y }
-  assign (.next 0) next_x
+  assign_var (.next 0) next_x
   assign (.next 1) next_y
 
 /--
@@ -133,7 +133,7 @@ def formal_fib_table : FormalTable (F p) RowType := {
 
       simp [fib_table, fib_relation, circuit_norm, table_norm, table_assignment_norm, copy_to_var,
           Gadgets.Addition8.circuit, Gadgets.Equality.Field.circuit] at constraints_hold
-      simp [circuit_norm, subcircuit_norm, Trace.getLeFromBottom] at constraints_hold
+      simp [circuit_norm, subcircuit_norm, Trace.getLeFromBottom, eval] at constraints_hold
       dsimp only [Gadgets.Addition8.assumptions, Gadgets.Addition8.spec, Gadgets.Equality.Field.spec] at constraints_hold
 
       have hx_curr : env.get 0 = curr.x := by rfl

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -45,7 +45,7 @@ lemma ext {x y : U32 (F p)}
   Witness a 32-bit unsigned integer.
 -/
 def witness (compute : Environment (F p) → U32 (F p)) := do
-  let ⟨ x0, x1, x2, x3 ⟩ ← Provable.witness compute
+  let ⟨ x0, x1, x2, x3 ⟩ ← ProvableType.witness compute
 
   lookup (ByteLookup x0)
   lookup (ByteLookup x1)

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -24,6 +24,9 @@ instance : LawfulProvableType U32 where
     let ⟨ .mk [x0, x1, x2, x3], _ ⟩ := v
     ⟨ x0, x1, x2, x3 ⟩
 
+instance : NonEmptyProvableType U32 where
+  nonempty := by simp only [size, Nat.reduceGT]
+
 omit [Fact (Nat.Prime p)] p_large_enough in
 /--
   Extensionality principle for U32

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -1,6 +1,5 @@
 import Clean.Gadgets.ByteLookup
 import Clean.Circuit.Extensions
-import Clean.Gadgets.ByteLookup
 
 section
 variable {p : ℕ} [Fact p.Prime] [p_large_enough: Fact (p > 512)]
@@ -18,7 +17,7 @@ deriving Repr
 
 namespace U32
 
-instance : ProvableType U32 where
+instance : LawfulProvableType U32 where
   size := 4
   to_elements x := #v[x.x0, x.x1, x.x2, x.x3]
   from_elements v :=
@@ -104,9 +103,17 @@ def wrapping_add (x y: U32 (F p)) : U32 (F p) :=
   let val_out := (val_x + val_y) % 2^32
   U32.decompose_nat val_out
 
+def from_byte (x: Fin 256) : U32 (F p) :=
+  ⟨ x.val, 0, 0, 0 ⟩
 
-lemma wrapping_add_correct (x y z: U32 (F p)) :
-    x.wrapping_add y = z ↔ z.value = (x.value + y.value) % 2^32 := by
-  sorry
+lemma from_byte_value {x : Fin 256} : (from_byte x).value (p:=p) = x := by
+  simp [value, from_byte]
+  apply FieldUtils.val_lt_p x
+  linarith [x.is_lt, p_large_enough.elim]
+
+lemma from_byte_is_normalized {x : Fin 256} : (from_byte x).is_normalized (p:=p) := by
+  simp [is_normalized, from_byte]
+  rw [FieldUtils.val_lt_p x]
+  repeat linarith [x.is_lt, p_large_enough.elim]
 end U32
 end

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -17,8 +17,7 @@ structure U64 (T: Type) where
   x6 : T
   x7 : T
 
-
-instance : ProvableType U64 where
+instance : LawfulProvableType U64 where
   size := 8
   to_elements x := #v[x.x0, x.x1, x.x2, x.x3, x.x4, x.x5, x.x6, x.x7]
   from_elements v :=

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -24,6 +24,9 @@ instance : LawfulProvableType U64 where
     let ⟨.mk [v0, v1, v2, v3, v4, v5, v6, v7], _⟩ := v
     ⟨ v0, v1, v2, v3, v4, v5, v6, v7 ⟩
 
+instance : NonEmptyProvableType U64 where
+  nonempty := by simp only [size, Nat.reduceGT]
+
 instance (T: Type) [Repr T] : Repr (U64 T) where
   reprPrec x _ := "⟨" ++ repr x.x0 ++ ", " ++ repr x.x1 ++ ", " ++ repr x.x2 ++ ", " ++ repr x.x3 ++ ", " ++ repr x.x4 ++ ", " ++ repr x.x5 ++ ", " ++ repr x.x6 ++ ", " ++ repr x.x7 ++ "⟩"
 

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -54,7 +54,7 @@ lemma ext {x y : U64 (F p)}
   Witness a 64-bit unsigned integer.
 -/
 def witness (compute : Environment (F p) → U64 (F p)) := do
-  let ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ ← Provable.witness compute
+  let ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ ← ProvableType.witness compute
 
   lookup (Gadgets.ByteLookup x0)
   lookup (Gadgets.ByteLookup x1)

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -11,6 +11,9 @@ def len (_: Vector α n) : ℕ := n
 def cons (a: α) (v: Vector α n) : Vector α (n + 1) :=
   ⟨ .mk (a :: v.toList), by simp ⟩
 
+theorem toList_cons {a: α} {v: Vector α n} : (cons a v).toList = a :: v.toList := by
+  simp [cons]
+
 def get_eq {n} (v: Vector α n) (i: Fin n) : v.get i = v.toArray[i.val] := by
   simp only [get, List.get_eq_getElem, Fin.coe_cast]
 
@@ -59,8 +62,8 @@ def induct {motive : {n: ℕ} → Vector α n → Prop}
 
 /- induction principle for Vector.push -/
 def induct_push {motive : {n: ℕ} → Vector α n → Prop}
-  (h0: motive #v[])
-  (h1: ∀ {n: ℕ} {as: Vector α n} (a: α), motive as → motive (as.push a))
+  (nil: motive #v[])
+  (push: ∀ {n: ℕ} {as: Vector α n} (a: α), motive as → motive (as.push a))
   {n: ℕ} (v: Vector α n) : motive v := by
   match v with
   | ⟨ .mk [], prop ⟩ =>
@@ -71,8 +74,8 @@ def induct_push {motive : {n: ℕ} → Vector α n → Prop}
     have : as.length + 1 = n := by rw [←h, Array.size_toArray, List.length_cons]
     subst this
     obtain ⟨ as', a', ih ⟩ := exists_push (xs := ⟨.mk (a :: as), rfl⟩)
-    have ih' : motive as' := induct_push h0 h1 as'
-    have h' := h1 a' ih'
+    have ih' : motive as' := induct_push nil push as'
+    have h' := push a' ih'
     rwa [ih]
 
 @[simp]
@@ -135,4 +138,71 @@ theorem cast_drop_append_of_eq_length {v : Vector α n} {w : Vector α m} :
     List.drop_append_of_le_length (Nat.le_of_eq hv_length.symm),
     List.drop_of_length_le (Nat.le_of_eq hv_length), List.nil_append,
     List.take_of_length_le (Nat.le_of_eq hw_length), List.toArray_toList]
+end Vector
+
+-- helpers for `Vector.toChunks`
+/--
+The composition `m * n = n + ... + n` (where `n > 0`)
+-/
+def Composition.ofProductLength (m: ℕ+) {α : Type} {l : List α} (hl : l.length = n * m.val) : Composition l.length := {
+  blocks := List.replicate n m.val
+  blocks_pos hi := (List.mem_replicate.mp hi).right ▸ m.pos
+  blocks_sum := hl ▸ List.sum_replicate_nat _ _
+}
+
+theorem Composition.ofProductLength_mem_length {m: ℕ+} {α : Type} {l : List α} {hl : l.length = n * m.val}
+  (comp : Composition l.length) (hcomp : comp = Composition.ofProductLength m hl) :
+  ∀ li ∈ l.splitWrtComposition comp, li.length = m := by
+  intro li hli
+  let l_split := l.splitWrtComposition comp
+  have hli_length : li.length ∈ l_split.map List.length := List.mem_map_of_mem _ hli
+  have hli_length_replicate : li.length ∈ List.replicate n m.val := by
+    have map_length := List.map_length_splitWrtComposition l comp
+    rw [map_length, hcomp, Composition.ofProductLength] at hli_length
+    exact hli_length
+  exact List.mem_replicate.mp hli_length_replicate |>.right
+
+namespace Vector
+/-- Split a vector into equally-sized chunks. -/
+def toChunks (m: ℕ+) {α : Type} (v : Vector α (n*m)) : Vector (Vector α m) n :=
+  let comp := Composition.ofProductLength m v.length_toList
+  let list : List (Vector α m) := v.toList.splitWrtComposition comp
+    |>.attachWith (List.length · = m) (comp.ofProductLength_mem_length rfl)
+    |>.map fun ⟨ l, hl ⟩ => .mk (.mk l) hl
+  .mk (.mk list) (by
+    simp only [Array.length_toList, Composition.ofProductLength, Array.size_toArray,
+      List.length_map, List.length_attachWith, List.length_splitWrtComposition, list, comp]
+    rw [←Composition.blocks_length, List.length_replicate]
+  )
+
+theorem flatten_toChunks {α : Type} (m: ℕ+) (v : Vector α (n*m)) :
+    (v.toChunks m).flatten = v := by
+  -- simp can reduce the statement to lists and use `List.flatten_splitWrtComposition`!
+  simp [toChunks]
+
+theorem toChunks_flatten {α : Type} (m: ℕ+) (v : Vector (Vector α m) n) :
+    v.flatten.toChunks m = v := by
+  simp only [toChunks]
+  rw [←Vector.toArray_inj,←Array.toList_inj]
+  simp only
+  let v_list_list := v.toList.map (Array.toList ∘ toArray)
+  have h_flatten : v.flatten.toList = v_list_list.flatten := by
+    rw [Vector.flatten_mk, Array.toList_flatten, Array.toList_map, List.map_map]
+  have h_length : v.flatten.toList.length = n * ↑m := by rw [Array.length_toList, size_toArray]
+  have h_flatten_length : v_list_list.flatten.length = n * ↑m := by rw [←h_flatten, h_length]
+  have h' : (v.flatten.toList.splitWrtComposition (Composition.ofProductLength m h_length)) = v_list_list := by
+    rw [← v_list_list.splitWrtComposition_flatten (Composition.ofProductLength m h_flatten_length)]
+    congr 1
+    · rw [h_length, h_flatten_length]
+    congr
+    · simp [h_flatten]
+    simp only [List.map_map, Composition.ofProductLength, v_list_list]
+    clear *-
+    induction v using Vector.induct
+    case nil => rfl
+    case cons xs x hi => rw [List.replicate_succ, Vector.toList_cons, List.map_cons, hi,
+      Function.comp_apply, Function.comp_apply, Array.length_toList, size_toArray]
+  simp only [h', v_list_list]
+  rw [List.map_attachWith, List.pmap_map]
+  simp
 end Vector

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -1,7 +1,7 @@
 import Mathlib.Tactic
 import Init.Data.List.Find
 
-variable {α β : Type} {n : ℕ}
+variable {α β : Type} {n m : ℕ}
 
 def fromList (l: List α) : Vector α l.length := ⟨ .mk l, rfl ⟩
 
@@ -96,4 +96,25 @@ instance [Inhabited α] {n: ℕ} : Inhabited (Vector α n) where
 
 -- some simp tagging because we use Vectors a lot
 attribute [simp] Vector.append Vector.get Array.getElem_append
+
+-- two complementary theorems about `Vector.take` and `Vector.drop` on appended vectors
+theorem cast_take_append_of_eq_length {v : Vector α n} {w : Vector α m} :
+    (v ++ w |>.take n |>.cast Nat.min_add_right) = v := by
+  have hv_length : v.toList.length = n := by rw [Array.length_toList, size_toArray]
+  rw [cast_mk, ←toArray_inj, take_eq_extract, toArray_extract, toArray_append,
+    ← Array.toArray_toList (_ ++ _), List.extract_toArray, Array.toList_append,
+    List.extract_eq_drop_take, List.drop_zero, Nat.sub_zero,
+    List.take_append_of_le_length (Nat.le_of_eq hv_length.symm),
+    List.take_of_length_le (Nat.le_of_eq hv_length), List.toArray_toList]
+
+theorem cast_drop_append_of_eq_length {v : Vector α n} {w : Vector α m} :
+    (v ++ w |>.drop n |>.cast (Nat.add_sub_self_left n m)) = w := by
+  have hv_length : v.toList.length = n := by rw [Array.length_toList, size_toArray]
+  have hw_length : w.toList.length = m := by rw [Array.length_toList, size_toArray]
+  rw [drop_eq_cast_extract, cast_cast, cast_mk, ←toArray_inj, toArray_extract, toArray_append,
+    ← Array.toArray_toList (_ ++ _), List.extract_toArray, Array.toList_append,
+    List.extract_eq_drop_take, Nat.add_sub_self_left,
+    List.drop_append_of_le_length (Nat.le_of_eq hv_length.symm),
+    List.drop_of_length_le (Nat.le_of_eq hv_length), List.nil_append,
+    List.take_of_length_le (Nat.le_of_eq hw_length), List.toArray_toList]
 end Vector

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -82,6 +82,24 @@ def init {n} (create: Fin n → α) : Vector α n :=
   | k + 1 =>
     (init (fun i : Fin k => create i)).push (create k)
 
+theorem cast_init {n} {create: Fin n → α} (h : n = m) :
+    init create = (init (n:=m) (fun i => create (i.cast h.symm))).cast h.symm := by
+  subst h; simp
+
+@[simp]
+def natInit (n: ℕ) (create: ℕ → α) : Vector α n :=
+  match n with
+  | 0 => #v[]
+  | k + 1 => natInit k create |>.push (create k)
+
+theorem cast_natInit {n} {create: ℕ → α} (h : n = m) :
+    natInit n create = (natInit m create).cast h.symm := by
+  subst h; simp
+
+theorem natInit_add_eq_append {n m} (create: ℕ → α) :
+    natInit (n + m) create = natInit n create ++ natInit m (fun i => create (n + i)) := by
+  sorry
+
 def finRange (n : ℕ) : Vector (Fin n) n :=
   ⟨ .mk (List.finRange n), List.length_finRange n ⟩
 

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -101,7 +101,9 @@ theorem cast_natInit {n} {create: ℕ → α} (h : n = m) :
 
 theorem natInit_add_eq_append {n m} (create: ℕ → α) :
     natInit (n + m) create = natInit n create ++ natInit m (fun i => create (n + i)) := by
-  sorry
+  induction m with
+  | zero => simp only [Nat.add_zero, natInit, append_empty]
+  | succ m ih => simp only [natInit, Nat.add_eq, append_push, ih]
 
 def finRange (n : ℕ) : Vector (Fin n) n :=
   ⟨ .mk (List.finRange n), List.length_finRange n ⟩

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -143,8 +143,9 @@ theorem cast_drop_append_of_eq_length {v : Vector α n} {w : Vector α m} :
 end Vector
 
 -- helpers for `Vector.toChunks`
+
 /--
-The composition `m * n = n + ... + n` (where `n > 0`)
+The composition `n * m = m + ... + m` (where `m > 0`)
 -/
 def Composition.ofProductLength (m: ℕ+) {α : Type} {l : List α} (hl : l.length = n * m.val) : Composition l.length := {
   blocks := List.replicate n m.val


### PR DESCRIPTION
This PR adds several ways to preserve the structure of provable types inside proofs, so that we can reason at a high level about types like U32 or U64, and not about their individual field elements (bytes).

Using this, I managed to both significantly simplify the fib32 proof, and to prove soundness of the Keccak 'theta' gadget (with some lower level gaps). clean scales fairly easily to both of these examples now!

## Details

* add `ProvableStruct`, a way to specify a `ProvableType` from it's _higher-level components_
  * example from `Addition32Full`:
```lean
structure Inputs (F : Type) where
  x: U32 F
  y: U32 F
  carry_in: F

instance : ProvableStruct Inputs where
  components := [U32, U32, field]
  to_components := fun {x, y, carry_in} => .cons x ( .cons y ( .cons carry_in .nil))
  from_components := fun (.cons x ( .cons y ( .cons carry_in .nil))) => ⟨ x, y, carry_in ⟩
```
* add `ProvableVector` to talk about vectors of high-level types
  * example from `ThetaC`:
```lean
@[reducible] def State := ProvableVector U64 25
@[reducible] def Outputs := ProvableVector U64 5
```
* Remove `ProvableType.eval` and similar operations from `circuit_norm`, to prevent unfolding into individual field elements. Instead, add theorems like `ProvableType.eval env x = ProvableStruct.eval env x` to the simp set, which will only unfold the high-level `ProvableStruct` structure
* add a new `LawfulProvableType` class which adds the requirement that `to_elements` and `from_elements` are inverses. this enables to prove an additional theorem which was useful in simplification:
```lean
theorem eval_const {F : Type} [Field F] {α: TypeMap} [LawfulProvableType α]
  (env : Environment F) (x : α F) :
    eval env (const x) = x
```