### PR TITLE
Infer constant lawful circuit

### DIFF
--- a/Clean/Circuit/Expression.lean
+++ b/Clean/Circuit/Expression.lean
@@ -81,3 +81,9 @@ end Expression
 
 instance [Field F] : CoeFun (Environment F) (fun _ => (Expression F) → F) where
   coe env x := x.eval env
+
+instance [Field F] : Inhabited F where
+  default := 0
+
+instance [Field F] : Inhabited (Expression F) where
+  default := .const 0

--- a/Clean/Circuit/Extensions.lean
+++ b/Clean/Circuit/Extensions.lean
@@ -1,5 +1,5 @@
 /- This file contains possible additions to the Circuit DSL that aren't currently used -/
-import Clean.Circuit.Basic
+import Clean.Circuit.Lawful
 
 variable {F :Type} [Field F]
 variable {α β: TypeMap} [ProvableType α] [ProvableType β]
@@ -14,6 +14,9 @@ def synthesize_var : Circuit F (Var α F) := witness (fun _ => default)
 
 instance [Field F] : Inhabited (Circuit F (Var α F)) where
   default := synthesize_var
+
+instance {α: TypeMap} [ProvableType α] : ConstantLawfulCircuits (witness (α:=α) (F:=F)) := by
+  infer_constant_lawful_circuits
 end ProvableType
 
 @[circuit_norm]

--- a/Clean/Circuit/Lawful.lean
+++ b/Clean/Circuit/Lawful.lean
@@ -185,38 +185,6 @@ example :
   ConstantLawfulCircuits add := by infer_constant_lawful_circuits
 end
 
--- constant version of `bind`
-open LawfulCircuit in
-instance ConstantLawfulCircuit.from_bind {f: Circuit F α} {g : α → Circuit F β}
-    (f_lawful : ConstantLawfulCircuit f) (g_lawful : ConstantLawfulCircuits g) : ConstantLawfulCircuit (f >>= g) where
-  output n :=
-    let a := output f n
-    g_lawful.output a (n + local_length f)
-
-  local_length := local_length f + g_lawful.local_length
-  final_offset n := final_offset f n + g_lawful.local_length
-  local_length_eq n := by
-    show final_offset f n + g_lawful.local_length = _
-    rw [local_length_eq, add_assoc]
-
-  operations n :=
-    let a := output f n
-    let ops_f := f_lawful.operations n
-    let ops_g := g_lawful.operations a (final_offset f n)
-    ops_f ++ ops_g
-
-  output_independent ops := by
-    show (g _ _).1 = _
-    rw [g_lawful.output_independent, output_independent, offset_independent, local_length_eq]
-
-  offset_independent ops := by
-    show (g _ _).2.offset = _
-    rw [g_lawful.offset_independent, offset_independent]
-
-  append_only ops := by
-    show (g _ _).2 = _
-    rw [g_lawful.append_only, output_independent, append_only, Operations.append_assoc]
-
 -- characterize various properties of lawful circuits
 
 -- helper lemma needed right below

--- a/Clean/Circuit/Lawful.lean
+++ b/Clean/Circuit/Lawful.lean
@@ -147,12 +147,17 @@ end
 -- `ConstantLawfulCircuit(s)` can be proved from `LawfulCircuit` by adding the requirement that `final_offset` is `n` plus a constant.
 -- the latter can usually be proved by rfl!
 open LawfulCircuit in
-instance ConstantLawfulCircuits.from_constant_length {circuit : α → Circuit F β} [Inhabited α] (lawful : ∀ a, LawfulCircuit (circuit a))
-  (h_length : ∀ (a : α) (n : ℕ), final_offset (circuit a) n = n + final_offset (circuit default) 0) :
-    ConstantLawfulCircuits circuit where
+def ConstantLawfulCircuit.from_constant_length {circuit : Circuit F α} (lawful : LawfulCircuit circuit)
+  (h_length : ∀ n, final_offset circuit n = n + final_offset circuit 0) : ConstantLawfulCircuit circuit where
+  local_length := final_offset circuit 0
+  local_length_eq := h_length
+
+open LawfulCircuit in
+def ConstantLawfulCircuits.from_constant_length {circuit : α → Circuit F β} [Inhabited α] (lawful : ∀ a, LawfulCircuit (circuit a))
+  (h_length : ∀ a n, final_offset (circuit a) n = n + final_offset (circuit default) 0) : ConstantLawfulCircuits circuit where
 
   output a n := LawfulCircuit.output (circuit a) n
-  local_length := LawfulCircuit.final_offset (circuit default) 0
+  local_length := final_offset (circuit default) 0
   operations a n := h_length a n ▸ LawfulCircuit.operations n
 
   output_independent a ops := LawfulCircuit.output_independent ops

--- a/Clean/Examples/Add32LawfulCircuit.lean
+++ b/Clean/Examples/Add32LawfulCircuit.lean
@@ -5,21 +5,23 @@ open Gadgets.Addition8FullCarry (add8_full_carry)
 open Gadgets.Addition32Full (add32_full Inputs)
 
 @[reducible] def p := p_babybear
--- `infer_lawful_circuit` seems to work for all circuits
-instance (input : Var Inputs (F p)) : LawfulCircuit (add32_full input) := by infer_lawful_circuit
 
-@[reducible] def circuit32 input := add32_full (p:=p_babybear) input
+-- `infer_lawful_circuit` / `infer_constant_lawful_circuits` seem to work for all circuits
+instance : ConstantLawfulCircuits (add32_full (p:=p)) := by infer_constant_lawful_circuits
+
+@[reducible] def circuit32 input := add32_full (p:=p) input
 #eval LawfulCircuit.final_offset (circuit32 default) 0
 #eval LawfulCircuit.output (circuit32 default) 0
 
 example : LawfulCircuit.final_offset (circuit32 default) 0 = 8 := by
   dsimp only [LawfulCircuit.final_offset, ConstantLawfulCircuits.local_length, Boolean.circuit]
+
 example : LawfulCircuit.output (circuit32 default) 0
     = { z := { x0 := var ⟨0⟩, x1 := var ⟨2⟩, x2 := var ⟨4⟩, x3 := var ⟨6⟩ }, carry_out := var ⟨7⟩ } := by
   dsimp only [LawfulCircuit.final_offset, ConstantLawfulCircuits.local_length, LawfulCircuit.output, ConstantLawfulCircuits.output, Boolean.circuit]
 
 open OperationsFrom in
-example (input : Var Inputs (F p_babybear)) (env) (i0 : ℕ) :
+example (input : Var Inputs (F p)) (env) (i0 : ℕ) :
     Circuit.constraints_hold.soundness env ((circuit32 input).operations i0) := by
   let ⟨ x, y, carry_in ⟩ := input
   let ⟨ x0, x1, x2, x3 ⟩ := x


### PR DESCRIPTION
Small follow-up to #71

Adds a tactic to automatically infer `ConstantLawfulCircuits`, which could be useful for loops where this stronger property is needed