### PR TITLE
Loop simplification

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -594,7 +594,7 @@ attribute [circuit_norm] Vector.map_mk List.map_toArray List.map_cons List.map_n
 attribute [circuit_norm] Vector.append_singleton Vector.mk_append_mk Vector.push_mk
   Array.append_singleton Array.append_empty List.push_toArray
   List.nil_append List.cons_append List.append_toArray
-  Vector.mapFinRange Vector.mapRange Vector.toArray_push Array.push_toList List.append_assoc
+  Vector.mapRange_zero Vector.mapRange_succ Vector.toArray_push Array.push_toList List.append_assoc
   Vector.eq_mk Vector.mk_eq
 
 -- simplify `vector.get 0` (which occurs in ProvableType definitions)

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -597,8 +597,14 @@ attribute [circuit_norm] Vector.append_singleton Vector.mk_append_mk Vector.push
   Vector.mapRange_zero Vector.mapRange_succ Vector.toArray_push Array.push_toList List.append_assoc
   Vector.eq_mk Vector.mk_eq
 
--- simplify `vector.get 0` (which occurs in ProvableType definitions)
--- TODO handle other small indices as well
+-- simplify Vector.mapFinRange
+attribute [circuit_norm] Vector.mapFinRange_succ Vector.mapFinRange_zero
+    Nat.cast_zero Nat.cast_one Nat.cast_ofNat Fin.coe_eq_castSucc Fin.reduceCastSucc
+
+-- simplify stuff like (3 : Fin 8).val = 3 % 8
+attribute [circuit_norm] Fin.coe_ofNat_eq_mod
+
+-- simplify `vector.get i` (which occurs in ProvableType definitions) and similar
 attribute [circuit_norm] Vector.get Fin.val_eq_zero List.getElem_toArray
   List.getElem_cons_zero Fin.cast_eq_self List.getElem_cons_succ
   Vector.getElem_mk Vector.getElem_toArray Vector.getElem_map Fin.getElem_fin

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -556,14 +556,14 @@ def FlatOperation.witness_generators : (l: List (FlatOperation F)) → Vector (E
     let ws := witness_generators ops
     match op with
     | witness m compute =>
-      ⟨ (Vector.mapFinRange (fun i env => (compute env).get i)).toArray ++ ws.toArray, by
+      ⟨ (Vector.mapFinRange m (fun i env => (compute env).get i)).toArray ++ ws.toArray, by
         simp only [Array.size_append, Vector.size_toArray, witness_length]; ac_rfl⟩
     | assert _ | lookup _ =>
       ⟨ ws.toArray, by simp only [ws.size_toArray, witness_length]⟩
 
 def Operations.witness_generators {n: ℕ} : (ops: Operations F n) → Vector (Environment F → F) ops.local_length
   | .empty _ => #v[]
-  | .witness ops _ c => witness_generators ops ++ Vector.mapFinRange (fun i env => (c env).get i)
+  | .witness ops m c => witness_generators ops ++ Vector.mapFinRange m (fun i env => (c env).get i)
   | .assert ops _ => witness_generators ops
   | .lookup ops _ => witness_generators ops
   | .subcircuit ops s => witness_generators ops ++ (s.local_length_eq ▸ FlatOperation.witness_generators s.ops)

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -357,23 +357,29 @@ section
 variable {env : Environment F} {m n : ℕ} [Nonempty β] {body : Fin m → Circuit F β} {lawful : ConstantLawfulCircuits body}
 
 @[circuit_norm]
-lemma mapFinRangeM.soundness :
+lemma mapFinRange.soundness :
   constraints_hold.soundness env (mapFinRange m body lawful |>.operations n) ↔
     ∀ i : Fin m, constraints_hold.soundness env (body i |>.operations (n + i*lawful.local_length)) := by
   apply Circuit.constraints_hold.mapFinRangeM_soundness
 
 @[circuit_norm]
-lemma mapFinRangeM.completeness :
+lemma mapFinRange.completeness :
   constraints_hold.completeness env (mapFinRange m body lawful |>.operations n) ↔
     ∀ i : Fin m, constraints_hold.completeness env (body i |>.operations (n + i*lawful.local_length)) := by
   apply Circuit.constraints_hold.mapFinRangeM_completeness
 
 @[circuit_norm]
-lemma mapFinRangeM.local_length :
+lemma mapFinRange.local_length_eq :
     (mapFinRange m body lawful |>.operations n).local_length = lawful.local_length * m := by
   let lawful_loop : ConstantLawfulCircuit (mapFinRange m body lawful) := .from_mapM_vector _ lawful
   rw [LawfulCircuit.local_length_eq]
   simp only [lawful_loop, lawful_norm]
+
+@[circuit_norm]
+lemma mapFinRange.initial_offset_eq :
+    (mapFinRange m body lawful |>.operations n).initial_offset = n := by
+  let lawful_loop : ConstantLawfulCircuit (mapFinRange m body lawful) := .from_mapM_vector _ lawful
+  rw [LawfulCircuit.initial_offset_eq]
 end
 
 end Circuit

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -380,6 +380,17 @@ lemma mapFinRange.initial_offset_eq :
     (mapFinRange m body lawful |>.operations n).initial_offset = n := by
   let lawful_loop : ConstantLawfulCircuit (mapFinRange m body lawful) := .from_mapM_vector _ lawful
   rw [LawfulCircuit.initial_offset_eq]
+
+@[circuit_norm]
+lemma mapFinRange.output_eq :
+  (mapFinRange m body lawful).output n =
+    Vector.mapFinRange (fun i => (body i).output (n + lawful.local_length * i)) := by
+  let lawful_loop : ConstantLawfulCircuit (mapFinRange m body lawful) := .from_mapM_vector _ lawful
+  rw [LawfulCircuit.output_eq]
+  simp only [lawful_loop, lawful_norm]
+  ext i hi
+  rw [Vector.getElem_mapIdx, Vector.getElem_finRange, Vector.getElem_mapFinRange, LawfulCircuit.output_eq]
+  rfl
 end
 
 end Circuit

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -349,20 +349,32 @@ end constraints_hold
 
 -- Loop constructs designed to simplify under `circuit_norm`
 
-def mapFinRangeM (m : ℕ) (body : Fin m → Circuit F β)
+def mapFinRange (m : ℕ) [Nonempty β] (body : Fin m → Circuit F β)
     (_lawful : ConstantLawfulCircuits body := by infer_constant_lawful_circuits) : Circuit F (Vector β m) :=
   Vector.mapFinRangeM m body
 
+section
+variable {env : Environment F} {m n : ℕ} [Nonempty β] {body : Fin m → Circuit F β} {lawful : ConstantLawfulCircuits body}
+
 @[circuit_norm]
-lemma mapFinRangeM.soundness {env : Environment F} {m : ℕ} {body : Fin m → Circuit F β} {lawful : ConstantLawfulCircuits body} :
-  constraints_hold.soundness env (mapFinRangeM m body lawful |>.operations n) ↔
+lemma mapFinRangeM.soundness :
+  constraints_hold.soundness env (mapFinRange m body lawful |>.operations n) ↔
     ∀ i : Fin m, constraints_hold.soundness env (body i |>.operations (n + i*lawful.local_length)) := by
   apply Circuit.constraints_hold.mapFinRangeM_soundness
 
 @[circuit_norm]
-lemma mapFinRangeM.completeness {env : Environment F} {m : ℕ} {body : Fin m → Circuit F β} {lawful : ConstantLawfulCircuits body} :
-  constraints_hold.completeness env (mapFinRangeM m body lawful |>.operations n) ↔
+lemma mapFinRangeM.completeness :
+  constraints_hold.completeness env (mapFinRange m body lawful |>.operations n) ↔
     ∀ i : Fin m, constraints_hold.completeness env (body i |>.operations (n + i*lawful.local_length)) := by
   apply Circuit.constraints_hold.mapFinRangeM_completeness
+
+@[circuit_norm]
+lemma mapFinRangeM.local_length :
+    (mapFinRange m body lawful |>.operations n).local_length = lawful.local_length * m := by
+  let lawful_loop : ConstantLawfulCircuit (mapFinRange m body lawful) := .from_mapM_vector _ lawful
+  rw [LawfulCircuit.local_length_eq]
+  simp only [lawful_loop, lawful_norm]
+end
+
 end Circuit
 end

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -346,5 +346,23 @@ theorem mapFinRangeM_completeness {n : ℕ} :
   simp only [completeness_iff_generic, mapFinRangeM_generic]
 end
 end constraints_hold
+
+-- Loop constructs designed to simplify under `circuit_norm`
+
+def mapFinRangeM (m : ℕ) (body : Fin m → Circuit F β)
+    (_lawful : ConstantLawfulCircuits body := by infer_constant_lawful_circuits) : Circuit F (Vector β m) :=
+  Vector.mapFinRangeM m body
+
+@[circuit_norm]
+lemma mapFinRangeM.soundness {env : Environment F} {m : ℕ} {body : Fin m → Circuit F β} {lawful : ConstantLawfulCircuits body} :
+  constraints_hold.soundness env (mapFinRangeM m body lawful |>.operations n) ↔
+    ∀ i : Fin m, constraints_hold.soundness env (body i |>.operations (n + i*lawful.local_length)) := by
+  apply Circuit.constraints_hold.mapFinRangeM_soundness
+
+@[circuit_norm]
+lemma mapFinRangeM.completeness {env : Environment F} {m : ℕ} {body : Fin m → Circuit F β} {lawful : ConstantLawfulCircuits body} :
+  constraints_hold.completeness env (mapFinRangeM m body lawful |>.operations n) ↔
+    ∀ i : Fin m, constraints_hold.completeness env (body i |>.operations (n + i*lawful.local_length)) := by
+  apply Circuit.constraints_hold.mapFinRangeM_completeness
 end Circuit
 end

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -390,7 +390,7 @@ lemma mapFinRange.initial_offset_eq :
 @[circuit_norm]
 lemma mapFinRange.output_eq :
   (mapFinRange m body lawful).output n =
-    Vector.mapFinRange (fun i => (body i).output (n + (body 0 |>.operations n).local_length * i)) := by
+    Vector.mapFinRange m fun i => (body i).output (n + (body 0 |>.operations n).local_length * i) := by
   let lawful_loop : ConstantLawfulCircuit (mapFinRange m body lawful) := .from_mapM_vector _ lawful
   rw [LawfulCircuit.output_eq]
   simp only [lawful_loop, lawful_norm]

--- a/Clean/Gadgets/Addition32/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32/Addition32Full.lean
@@ -58,7 +58,7 @@ def c := add32_full (p:=p_babybear) default
 #eval c.output
 ```
 -/
-instance elaboratedCircuit : ElaboratedCircuit (F p) Inputs (Var Outputs (F p)) where
+instance elaborated : ElaboratedCircuit (F p) Inputs (Var Outputs (F p)) where
   main := add32_full
   local_length _ := 8
   output _ i0 := {
@@ -73,35 +73,17 @@ theorem soundness : Soundness (F p) assumptions spec := by
   let ⟨ y0, y1, y2, y3 ⟩ := y
   let ⟨ x0_var, x1_var, x2_var, x3_var ⟩ := x_var
   let ⟨ y0_var, y1_var, y2_var, y3_var ⟩ := y_var
-  simp only [circuit_norm, eval] at h_inputs
-  have : x0_var.eval env = x0 := by injections h_inputs
-  have : x1_var.eval env = x1 := by injections h_inputs
-  have : x2_var.eval env = x2 := by injections h_inputs
-  have : x3_var.eval env = x3 := by injections h_inputs
-  have : y0_var.eval env = y0 := by injections h_inputs
-  have : y1_var.eval env = y1 := by injections h_inputs
-  have : y2_var.eval env = y2 := by injections h_inputs
-  have : y3_var.eval env = y3 := by injections h_inputs
-  have : carry_in_var.eval env = carry_in := by injection h_inputs
-  clear h_inputs
+  simp only [circuit_norm, eval, Inputs.mk.injEq, U32.mk.injEq] at h_inputs
 
   -- simplify assumptions
   dsimp only [assumptions, U32.is_normalized] at as
-
-  have ⟨ x_norm, y_norm, carry_in_bool ⟩ := as
-  clear as
-  have ⟨ x0_byte, x1_byte, x2_byte, x3_byte ⟩ := x_norm
-  have ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm
-  clear x_norm y_norm
+  obtain ⟨ x_norm, y_norm, carry_in_bool ⟩ := as
+  obtain ⟨ x0_byte, x1_byte, x2_byte, x3_byte ⟩ := x_norm
+  obtain ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm
 
   -- simplify circuit
   simp only [circuit_norm, subcircuit_norm, add32_full, add8_full_carry, Boolean.circuit, ByteLookup] at h
-  simp only [Boolean.spec, true_and, true_implies, and_assoc, add_zero] at h
-  rw [‹x0_var.eval env = x0›, ‹y0_var.eval env = y0›, ‹carry_in_var.eval env = carry_in›] at h
-  rw [‹x1_var.eval env = x1›, ‹y1_var.eval env = y1›] at h
-  rw [‹x2_var.eval env = x2›, ‹y2_var.eval env = y2›] at h
-  rw [‹x3_var.eval env = x3›, ‹y3_var.eval env = y3›] at h
-  repeat clear this
+  simp only [Boolean.spec, true_and, true_implies, and_assoc, add_zero, h_inputs] at h
   rw [ByteTable.equiv, ByteTable.equiv, ByteTable.equiv, ByteTable.equiv] at h
   repeat rw [add_neg_eq_zero] at h
   set z0 := env.get i0
@@ -116,7 +98,7 @@ theorem soundness : Soundness (F p) assumptions spec := by
   clear h
 
   -- simplify output and spec
-  set output := eval env (elaboratedCircuit.output _ i0)
+  set output := eval env (elaborated.output _ i0)
   have h_output : output = { z := U32.mk z0 z1 z2 z3, carry_out := c3 } := by
     simp only [output, circuit_norm, eval]; rfl
   rw [h_output]
@@ -141,16 +123,7 @@ theorem completeness : Completeness (F p) Outputs assumptions := by
   let ⟨ y0, y1, y2, y3 ⟩ := y
   let ⟨ x0_var, x1_var, x2_var, x3_var ⟩ := x_var
   let ⟨ y0_var, y1_var, y2_var, y3_var ⟩ := y_var
-  simp only [circuit_norm, eval] at h_inputs
-  have : x0_var.eval env = x0 := by injections
-  have : x1_var.eval env = x1 := by injections
-  have : x2_var.eval env = x2 := by injections
-  have : x3_var.eval env = x3 := by injections
-  have : y0_var.eval env = y0 := by injections
-  have : y1_var.eval env = y1 := by injections
-  have : y2_var.eval env = y2 := by injections
-  have : y3_var.eval env = y3 := by injections
-  have : carry_in_var.eval env = carry_in := by injections
+  simp only [circuit_norm, eval, Inputs.mk.injEq, U32.mk.injEq] at h_inputs
 
   -- simplify assumptions
   dsimp [assumptions, U32.is_normalized] at as
@@ -160,20 +133,13 @@ theorem completeness : Completeness (F p) Outputs assumptions := by
 
   -- simplify circuit
   simp only [circuit_norm, subcircuit_norm,
-    add32_full, add8_full_carry, Boolean.circuit
+    add32_full, add8_full_carry, Boolean.circuit,
+    h_inputs
   ] at henv ⊢
   simp only [true_and, and_assoc]
-  rw [‹x0_var.eval env = x0›, ‹y0_var.eval env = y0›, ‹carry_in_var.eval env = carry_in›]
-  rw [‹x1_var.eval env = x1›, ‹y1_var.eval env = y1›]
-  rw [‹x2_var.eval env = x2›, ‹y2_var.eval env = y2›]
-  rw [‹x3_var.eval env = x3›, ‹y3_var.eval env = y3›]
 
   -- characterize local witnesses
   simp only [forall_const, true_and, and_true, and_assoc] at henv
-  rw [‹x0_var.eval env = x0›, ‹y0_var.eval env = y0›, ‹carry_in_var.eval env = carry_in›,
-      ‹x1_var.eval env = x1›, ‹y1_var.eval env = y1›, ‹x2_var.eval env = x2›, ‹y2_var.eval env = y2›,
-      ‹x3_var.eval env = x3›, ‹y3_var.eval env = y3›] at henv
-  repeat clear this
   obtain ⟨ hz0, hc0, hz1, hc1, hz2, hc2, hz3, hc3 ⟩ := henv
 
   set z0 := env.get i0
@@ -209,9 +175,8 @@ theorem completeness : Completeness (F p) Outputs assumptions := by
   exact ⟨ z0_byte, c0_bool, h0, z1_byte, c1_bool, h1, z2_byte, c2_bool, h2, z3_byte, c3_bool, h3 ⟩
 
 def circuit : FormalCircuit (F p) Inputs Outputs where
-  main := add32_full
-  assumptions := assumptions
-  spec := spec
-  soundness := soundness
-  completeness := completeness
+  assumptions
+  spec
+  soundness
+  completeness
 end Gadgets.Addition32Full

--- a/Clean/Gadgets/Keccak/Chi.lean
+++ b/Clean/Gadgets/Keccak/Chi.lean
@@ -38,7 +38,7 @@ instance elaborated : ElaboratedCircuit (F p) KeccakState (Var KeccakState (F p)
 
 -- rewrite the chi spec as a loop
 lemma chi_loop (state : Vector ℕ 25) :
-    Specs.Keccak256.chi state = .mapFinRange fun i => state[i] ^^^ ((not64 state[i + 5]) &&& state[i + 10]) := by
+    Specs.Keccak256.chi state = .mapFinRange 25 fun i => state[i] ^^^ ((not64 state[i + 5]) &&& state[i + 10]) := by
   rw [Specs.Keccak256.chi, Vector.mapFinRange, Vector.finRange, Vector.map_mk, Vector.eq_mk, List.map_toArray]
   rfl
 

--- a/Clean/Gadgets/Keccak/Chi.lean
+++ b/Clean/Gadgets/Keccak/Chi.lean
@@ -32,10 +32,8 @@ instance lawful (state : Var KeccakState (F p)) : ConstantLawfulCircuit (main st
 instance elaborated : ElaboratedCircuit (F p) KeccakState (Var KeccakState (F p)) where
   main
   local_length _ := 400
-  local_length_eq state i0 := by
-    simp only [main, circuit_norm, lawful_norm, Not.circuit, And.And64.circuit, Xor.circuit]
-
-  initial_offset_eq state i := LawfulCircuit.initial_offset_eq (main state) i
+  local_length_eq state i0 := by simp only [main, circuit_norm]; ac_rfl
+  initial_offset_eq state i := by simp only [main, circuit_norm]
 
   output _ i0 := Vector.mapRange 25 fun i => var_from_offset U64 (i0 + i*16 + 8)
   output_eq state i := by

--- a/Clean/Gadgets/Keccak/Chi.lean
+++ b/Clean/Gadgets/Keccak/Chi.lean
@@ -13,7 +13,7 @@ open Bitwise (not64)
 open Not (not64_bytewise not64_bytewise_value)
 
 def main (state : Var KeccakState (F p)) : Circuit (F p) (Var KeccakState (F p)) :=
-  Vector.mapFinRangeM 25 fun i => do
+  .mapFinRangeM 25 fun i => do
     let state_not ← subcircuit Not.circuit (state.get (i + 5))
     let state_and ← subcircuit And.And64.circuit ⟨state_not, state.get (i + 10)⟩
     subcircuit Xor.circuit ⟨state.get i, state_and⟩
@@ -70,10 +70,8 @@ theorem soundness : Soundness (F p) assumptions spec := by
       specialize h ⟨ i', hi'⟩
       simp_all [KeccakState.value]
 
-  -- simplify constraints using mapM theory
-  simp only [elaborated, main] at h_holds
-  rw [Circuit.constraints_hold.mapFinRangeM_soundness (lawfulFin := by infer_constant_lawful_circuits)] at h_holds
-  simp only [circuit_norm, lawful_norm, subcircuit_norm, Xor.circuit, And.And64.circuit, Not.circuit,
+  -- simplify constraints
+  simp only [main, circuit_norm, lawful_norm, subcircuit_norm, Xor.circuit, And.And64.circuit, Not.circuit,
     Xor.assumptions, Xor.spec, And.And64.assumptions, And.And64.spec, Nat.reduceAdd] at h_holds
 
   intro i
@@ -89,10 +87,8 @@ theorem soundness : Soundness (F p) assumptions spec := by
 theorem completeness : Completeness (F p) KeccakState assumptions := by
   intro i env state_var h_env state h_input state_norm
 
-  -- simplify constraints using mapM theory
-  simp only [elaborated, main]
-  rw [Circuit.constraints_hold.mapFinRangeM_completeness (lawfulFin := by infer_constant_lawful_circuits)]
-  simp only [circuit_norm, lawful_norm, subcircuit_norm, Xor.circuit, And.And64.circuit, Not.circuit,
+  -- simplify constraints
+  simp only [main, circuit_norm, lawful_norm, subcircuit_norm, Xor.circuit, And.And64.circuit, Not.circuit,
     Xor.assumptions, Xor.spec, And.And64.assumptions, And.And64.spec, Nat.reduceAdd]
   intro i
 

--- a/Clean/Gadgets/Keccak/Chi.lean
+++ b/Clean/Gadgets/Keccak/Chi.lean
@@ -29,12 +29,11 @@ def spec (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
 instance elaborated : ElaboratedCircuit (F p) KeccakState (Var KeccakState (F p)) where
   main
   local_length _ := 400
+  output _ i0 := Vector.mapRange 25 fun i => var_from_offset U64 (i0 + i*16 + 8)
+
   local_length_eq state i0 := by simp only [main, circuit_norm, Xor.circuit, And.And64.circuit, Not.circuit]
   initial_offset_eq state i := by simp only [main, circuit_norm]
-
-  output _ i0 := Vector.mapRange 25 fun i => var_from_offset U64 (i0 + i*16 + 8)
-  output_eq state i := by
-    simp only [main, circuit_norm, Xor.circuit, And.And64.circuit, Not.circuit]
+  output_eq state i := by simp only [main, circuit_norm, Xor.circuit, And.And64.circuit, Not.circuit]
 
 -- rewrite the chi spec as a loop
 lemma chi_loop (state : Vector ℕ 25) :

--- a/Clean/Gadgets/Keccak/Chi.lean
+++ b/Clean/Gadgets/Keccak/Chi.lean
@@ -13,7 +13,7 @@ open Bitwise (not64)
 open Not (not64_bytewise not64_bytewise_value)
 
 def main (state : Var KeccakState (F p)) : Circuit (F p) (Var KeccakState (F p)) :=
-  .mapFinRangeM 25 fun i => do
+  .mapFinRange 25 fun i => do
     let state_not ← subcircuit Not.circuit (state.get (i + 5))
     let state_and ← subcircuit And.And64.circuit ⟨state_not, state.get (i + 10)⟩
     subcircuit Xor.circuit ⟨state.get i, state_and⟩
@@ -33,8 +33,7 @@ instance elaborated : ElaboratedCircuit (F p) KeccakState (Var KeccakState (F p)
   main
   local_length _ := 400
   local_length_eq state i0 := by
-    rw [LawfulCircuit.local_length_eq]
-    simp only [lawful_norm, Not.circuit, And.And64.circuit, Xor.circuit]
+    simp only [main, circuit_norm, lawful_norm, Not.circuit, And.And64.circuit, Xor.circuit]
 
   initial_offset_eq state i := LawfulCircuit.initial_offset_eq (main state) i
 
@@ -85,7 +84,7 @@ theorem soundness : Soundness (F p) assumptions spec := by
   simp_all [KeccakState.value]
 
 theorem completeness : Completeness (F p) KeccakState assumptions := by
-  intro i env state_var h_env state h_input state_norm
+  intro i0 env state_var h_env state h_input state_norm
 
   -- simplify constraints
   simp only [main, circuit_norm, lawful_norm, subcircuit_norm, Xor.circuit, And.And64.circuit, Not.circuit,

--- a/Clean/Gadgets/Keccak/Chi.lean
+++ b/Clean/Gadgets/Keccak/Chi.lean
@@ -37,9 +37,10 @@ instance elaborated : ElaboratedCircuit (F p) KeccakState (Var KeccakState (F p)
 
   output _ i0 := Vector.mapRange 25 fun i => var_from_offset U64 (i0 + i*16 + 8)
   output_eq state i := by
-    rw [LawfulCircuit.output_eq]
-    simp only [lawful_norm, lawful, Xor.circuit, And.And64.circuit, Not.circuit]
-    simp [Vector.finRange, List.finRange, Vector.range_succ, Array.range]
+    simp only [main, circuit_norm, lawful_norm, Xor.circuit, And.And64.circuit, Not.circuit]
+    simp only [Vector.mapFinRange_succ, Vector.mapFinRange_zero, Vector.push_mk, List.push_toArray, List.nil_append, List.cons_append]
+    simp only [Nat.cast_zero, Nat.cast_one, Nat.cast_ofNat, Fin.coe_eq_castSucc, Fin.reduceCastSucc]
+    rfl
 
 -- rewrite the chi spec as a loop
 lemma chi_loop (state : Vector ℕ 25) :

--- a/Clean/Gadgets/Keccak/Chi.lean
+++ b/Clean/Gadgets/Keccak/Chi.lean
@@ -24,9 +24,6 @@ def spec (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
   out_state.is_normalized
   ∧ out_state.value = Specs.Keccak256.chi state.value
 
-instance lawful (state : Var KeccakState (F p)) : ConstantLawfulCircuit (main state) :=
-  .from_mapM_vector _ (by infer_constant_lawful_circuits)
-
 -- #eval! main (p:=p_babybear) default |>.operations.local_length
 -- #eval! main (p:=p_babybear) default |>.output
 instance elaborated : ElaboratedCircuit (F p) KeccakState (Var KeccakState (F p)) where
@@ -38,9 +35,6 @@ instance elaborated : ElaboratedCircuit (F p) KeccakState (Var KeccakState (F p)
   output _ i0 := Vector.mapRange 25 fun i => var_from_offset U64 (i0 + i*16 + 8)
   output_eq state i := by
     simp only [main, circuit_norm, lawful_norm, Xor.circuit, And.And64.circuit, Not.circuit]
-    simp only [Vector.mapFinRange_succ, Vector.mapFinRange_zero, Vector.push_mk, List.push_toArray, List.nil_append, List.cons_append]
-    simp only [Nat.cast_zero, Nat.cast_one, Nat.cast_ofNat, Fin.coe_eq_castSucc, Fin.reduceCastSucc]
-    rfl
 
 -- rewrite the chi spec as a loop
 lemma chi_loop (state : Vector ℕ 25) :

--- a/Clean/Gadgets/Keccak/Chi.lean
+++ b/Clean/Gadgets/Keccak/Chi.lean
@@ -29,12 +29,12 @@ def spec (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
 instance elaborated : ElaboratedCircuit (F p) KeccakState (Var KeccakState (F p)) where
   main
   local_length _ := 400
-  local_length_eq state i0 := by simp only [main, circuit_norm]; ac_rfl
+  local_length_eq state i0 := by simp only [main, circuit_norm, Xor.circuit, And.And64.circuit, Not.circuit]
   initial_offset_eq state i := by simp only [main, circuit_norm]
 
   output _ i0 := Vector.mapRange 25 fun i => var_from_offset U64 (i0 + i*16 + 8)
   output_eq state i := by
-    simp only [main, circuit_norm, lawful_norm, Xor.circuit, And.And64.circuit, Not.circuit]
+    simp only [main, circuit_norm, Xor.circuit, And.And64.circuit, Not.circuit]
 
 -- rewrite the chi spec as a loop
 lemma chi_loop (state : Vector ℕ 25) :
@@ -48,7 +48,7 @@ theorem soundness : Soundness (F p) assumptions spec := by
   simp only [assumptions, KeccakState.is_normalized, Fin.getElem_fin] at state_norm
 
   -- simplify goal
-  simp only [spec, lawful_norm]
+  simp only [spec, ElaboratedCircuit.output]
   rw [chi_loop, eval_vector, KeccakState.is_normalized, Vector.ext_iff]
   simp only [Fin.getElem_fin, Vector.getElem_map, Vector.getElem_mapFinRange, Vector.getElem_mapRange,
     KeccakState.value, Vector.map_map, Function.comp_apply]
@@ -63,7 +63,7 @@ theorem soundness : Soundness (F p) assumptions spec := by
       simp_all [KeccakState.value]
 
   -- simplify constraints
-  simp only [main, circuit_norm, lawful_norm, subcircuit_norm, Xor.circuit, And.And64.circuit, Not.circuit,
+  simp only [main, circuit_norm, subcircuit_norm, Xor.circuit, And.And64.circuit, Not.circuit,
     Xor.assumptions, Xor.spec, And.And64.assumptions, And.And64.spec, Nat.reduceAdd] at h_holds
 
   intro i
@@ -80,7 +80,7 @@ theorem completeness : Completeness (F p) KeccakState assumptions := by
   intro i0 env state_var h_env state h_input state_norm
 
   -- simplify constraints
-  simp only [main, circuit_norm, lawful_norm, subcircuit_norm, Xor.circuit, And.And64.circuit, Not.circuit,
+  simp only [main, circuit_norm, subcircuit_norm, Xor.circuit, And.And64.circuit, Not.circuit,
     Xor.assumptions, Xor.spec, And.And64.assumptions, And.And64.spec, Nat.reduceAdd]
   intro i
 

--- a/Clean/Gadgets/Keccak/KeccakState.lean
+++ b/Clean/Gadgets/Keccak/KeccakState.lean
@@ -29,4 +29,18 @@ def KeccakRow.is_normalized_iff (row : KeccakRow (F p)) :
     row[3].is_normalized ∧
     row[4].is_normalized := by
   simp [KeccakRow.is_normalized, IsEmpty.forall_iff, Fin.forall_fin_succ]
+
+-- many of our specs are of the form `state.is_normalized ∧ state.value = ...` and soundness proofs use this lemma
+omit [Fact (Nat.Prime p)] p_large_enough in
+lemma KeccakState.normalized_value_ext (state : KeccakState (F p)) (rhs : Vector ℕ 25) :
+  (∀ i : Fin 25, state[i.val].is_normalized ∧ state[i.val].value = rhs[i.val]) →
+    state.is_normalized ∧ state.value = rhs := by
+  intro h
+  constructor
+  · intro i
+    exact (h i).left
+  simp only [Vector.ext_iff, value, Vector.getElem_map]
+  intro i hi
+  exact (h ⟨ i, hi ⟩).right
+
 end Gadgets.Keccak256

--- a/Clean/Gadgets/Keccak/KeccakState.lean
+++ b/Clean/Gadgets/Keccak/KeccakState.lean
@@ -43,4 +43,15 @@ lemma KeccakState.normalized_value_ext (state : KeccakState (F p)) (rhs : Vector
   intro i hi
   exact (h ⟨ i, hi ⟩).right
 
+lemma KeccakRow.normalized_value_ext (row : KeccakRow (F p)) (rhs : Vector ℕ 5) :
+  (∀ i : Fin 5, row[i.val].is_normalized ∧ row[i.val].value = rhs[i.val]) →
+    row.is_normalized ∧ row.value = rhs := by
+  intro h
+  constructor
+  · intro i
+    exact (h i).left
+  simp only [Vector.ext_iff, value, Vector.getElem_map]
+  intro i hi
+  exact (h ⟨ i, hi ⟩).right
+
 end Gadgets.Keccak256

--- a/Clean/Gadgets/Keccak/ThetaC.lean
+++ b/Clean/Gadgets/Keccak/ThetaC.lean
@@ -59,16 +59,10 @@ theorem soundness : Soundness (F p) assumptions spec := by
     fun hi => state_norm ⟨ _, hi ⟩
   simp only [state_norm, and_self, forall_const, and_true] at h_holds
 
+  simp only [KeccakState.value, Vector.getElem_map]
   intro i
   specialize h_holds i
-  obtain ⟨ h0, h1, h2, h3 ⟩ := h_holds
-  obtain ⟨ xor0, norm0 ⟩ := h0
-  have ⟨ xor1, norm1 ⟩ := h1 norm0
-  have ⟨ xor2, norm2 ⟩ := h2 norm1
-  have ⟨ xor4, norm ⟩ := h3 norm2
-  clear h1 h2 h3 norm0 norm1 norm2
-  use norm
-  simp only [xor0, xor1, xor2, xor4, KeccakState.value, Vector.getElem_map]
+  aesop
 
 theorem completeness : Completeness (F p) KeccakRow assumptions := by
   intro i0 env state_var h_env state h_input h_assumptions

--- a/Clean/Gadgets/Keccak/ThetaC.lean
+++ b/Clean/Gadgets/Keccak/ThetaC.lean
@@ -47,7 +47,7 @@ theorem soundness : Soundness (F p) assumptions spec := by
 
   -- rewrite goal
   apply KeccakRow.normalized_value_ext
-  simp only [elaborated, theta_c_loop, eval_vector,
+  simp only [elaborated, theta_c_loop, eval_vector, KeccakState.value,
     Vector.getElem_map, Vector.getElem_mapFinRange, Vector.getElem_mapRange]
 
   -- simplify constraints
@@ -59,7 +59,6 @@ theorem soundness : Soundness (F p) assumptions spec := by
     fun hi => state_norm ⟨ _, hi ⟩
   simp only [state_norm, and_self, forall_const, and_true] at h_holds
 
-  simp only [KeccakState.value, Vector.getElem_map]
   intro i
   specialize h_holds i
   aesop

--- a/Clean/Gadgets/Keccak/ThetaC.lean
+++ b/Clean/Gadgets/Keccak/ThetaC.lean
@@ -37,7 +37,7 @@ instance elaborated : ElaboratedCircuit (F p) KeccakState (Var KeccakRow (F p)) 
 
 -- rewrite theta_c as a loop
 lemma theta_c_loop (state : Vector ℕ 25) :
-    Specs.Keccak256.theta_c state = .mapFinRange fun i =>
+    Specs.Keccak256.theta_c state = .mapFinRange 5 fun i =>
       state[5*i.val] ^^^ state[5*i.val + 1] ^^^ state[5*i.val + 2] ^^^ state[5*i.val + 3] ^^^ state[5*i.val + 4] := by
   rw [Specs.Keccak256.theta_c, Vector.mapFinRange, Vector.finRange, Vector.map_mk, Vector.eq_mk, List.map_toArray]
   rfl

--- a/Clean/Gadgets/Keccak/ThetaC.lean
+++ b/Clean/Gadgets/Keccak/ThetaC.lean
@@ -1,3 +1,4 @@
+import Clean.Circuit.Loops
 import Clean.Gadgets.Addition8.Addition8FullCarry
 import Clean.Types.U64
 import Clean.Gadgets.Addition32.Theorems
@@ -9,33 +10,13 @@ namespace Gadgets.Keccak256.ThetaC
 variable {p : ℕ} [Fact p.Prime] [Fact (p > 512)]
 open Gadgets.Keccak256 (KeccakState KeccakRow)
 
-def theta_c (state : Var KeccakState (F p)) : Circuit (F p) (Var KeccakRow (F p)) := do
-  -- TODO would be nice to have a for loop of length 5 here
-  let c0 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 0), (state.get 1)⟩
-  let c0 ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 2)⟩
-  let c0 ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 3)⟩
-  let c0 ← subcircuit Gadgets.Xor.circuit ⟨c0, (state.get 4)⟩
-
-  let c1 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 5), (state.get 6)⟩
-  let c1 ← subcircuit Gadgets.Xor.circuit ⟨c1, (state.get 7)⟩
-  let c1 ← subcircuit Gadgets.Xor.circuit ⟨c1, (state.get 8)⟩
-  let c1 ← subcircuit Gadgets.Xor.circuit ⟨c1, (state.get 9)⟩
-
-  let c2 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 10), (state.get 11)⟩
-  let c2 ← subcircuit Gadgets.Xor.circuit ⟨c2, (state.get 12)⟩
-  let c2 ← subcircuit Gadgets.Xor.circuit ⟨c2, (state.get 13)⟩
-  let c2 ← subcircuit Gadgets.Xor.circuit ⟨c2, (state.get 14)⟩
-
-  let c3 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 15), (state.get 16)⟩
-  let c3 ← subcircuit Gadgets.Xor.circuit ⟨c3, (state.get 17)⟩
-  let c3 ← subcircuit Gadgets.Xor.circuit ⟨c3, (state.get 18)⟩
-  let c3 ← subcircuit Gadgets.Xor.circuit ⟨c3, (state.get 19)⟩
-
-  let c4 ← subcircuit Gadgets.Xor.circuit ⟨(state.get 20), (state.get 21)⟩
-  let c4 ← subcircuit Gadgets.Xor.circuit ⟨c4, (state.get 22)⟩
-  let c4 ← subcircuit Gadgets.Xor.circuit ⟨c4, (state.get 23)⟩
-  let c4 ← subcircuit Gadgets.Xor.circuit ⟨c4, (state.get 24)⟩
-  return #v[c0, c1, c2, c3, c4]
+def main (state : Var KeccakState (F p)) : Circuit (F p) (Var KeccakRow (F p)) :=
+  .mapFinRange 5 fun i => do
+    let c ← subcircuit Gadgets.Xor.circuit ⟨state[5*i.val], state[5*i.val + 1]⟩
+    let c ← subcircuit Gadgets.Xor.circuit ⟨c, state[5*i.val + 2]⟩
+    let c ← subcircuit Gadgets.Xor.circuit ⟨c, state[5*i.val + 3]⟩
+    let c ← subcircuit Gadgets.Xor.circuit ⟨c, state[5*i.val + 4]⟩
+    return c
 
 def assumptions (state : KeccakState (F p)) := state.is_normalized
 
@@ -46,48 +27,53 @@ def spec (state : KeccakState (F p)) (out: KeccakRow (F p)) :=
 -- #eval! theta_c (p:=p_babybear) default |>.operations.local_length
 -- #eval! theta_c (p:=p_babybear) default |>.output
 instance elaborated : ElaboratedCircuit (F p) KeccakState (Var KeccakRow (F p)) where
-  main := theta_c
+  main
   local_length _ := 160
-  output _ i0 := #v[
-    var_from_offset U64 (i0 + 24),
-    var_from_offset U64 (i0 + 56),
-    var_from_offset U64 (i0 + 88),
-    var_from_offset U64 (i0 + 120),
-    var_from_offset U64 (i0 + 152)
-  ]
+  output _ i0 := .mapRange 5 fun i => var_from_offset U64 (i0 + i*32 + 24)
+
+  local_length_eq _ _ := by simp only [main, circuit_norm]; ac_rfl
+  initial_offset_eq _ _ := by simp only [main, circuit_norm]
+  output_eq _ _ := by simp only [main, circuit_norm, Xor.circuit]
+
+-- rewrite theta_c as a loop
+lemma theta_c_loop (state : Vector ℕ 25) :
+    Specs.Keccak256.theta_c state = .mapFinRange fun i =>
+      state[5*i.val] ^^^ state[5*i.val + 1] ^^^ state[5*i.val + 2] ^^^ state[5*i.val + 3] ^^^ state[5*i.val + 4] := by
+  rw [Specs.Keccak256.theta_c, Vector.mapFinRange, Vector.finRange, Vector.map_mk, Vector.eq_mk, List.map_toArray]
+  rfl
 
 theorem soundness : Soundness (F p) assumptions spec := by
   intro i0 env state_var state h_input state_norm h_holds
-  simp only [circuit_norm, subcircuit_norm, assumptions, eval_vector,
-    theta_c, Xor.circuit, Xor.assumptions, Xor.spec] at *
-  simp only [and_imp, and_assoc, add_assoc, Nat.reduceAdd, Nat.reduceMod] at h_holds
 
-  have s {i : ℕ} (hi : i < 25) : eval env state_var[i] = state[i] := by
-    rw [←h_input, Vector.getElem_map]
-  simp only [s] at h_holds
-  simp only [circuit_norm, spec, KeccakRow.is_normalized_iff,
-    KeccakRow.value, KeccakState.value, Specs.Keccak256.theta_c]
+  -- rewrite goal
+  apply KeccakRow.normalized_value_ext
+  simp only [elaborated, theta_c_loop, eval_vector,
+    Vector.getElem_map, Vector.getElem_mapFinRange, Vector.getElem_mapRange]
 
+  -- simplify constraints
+  simp only [circuit_norm, eval_vector, Vector.ext_iff] at h_input
+  simp only [circuit_norm, subcircuit_norm, h_input, eval_vector,
+    main, Xor.circuit, Xor.assumptions, Xor.spec] at h_holds
+  simp only [and_assoc, Nat.reduceAdd, Nat.reduceMod] at h_holds
   have state_norm : ∀ {i : ℕ} (hi : i < 25), state[i].is_normalized :=
     fun hi => state_norm ⟨ _, hi ⟩
+  simp only [state_norm, and_self, forall_const, and_true] at h_holds
 
-  repeat
-    first
-    | obtain⟨ h0, h1, h2, h3, h_holds ⟩ := h_holds
-    | obtain⟨ h0, h1, h2, h3 ⟩ := h_holds
-    obtain ⟨ xor0, norm0 ⟩ := h0 (state_norm _) (state_norm _)
-    obtain ⟨ xor1, norm1 ⟩ := h1 norm0 (state_norm _)
-    obtain ⟨ xor2, norm2 ⟩ := h2 norm1 (state_norm _)
-    obtain ⟨ xor, norm ⟩ := h3 norm2 (state_norm _)
-    rw [xor2, xor1, xor0] at xor
-    clear h0 h1 h2 h3 xor0 xor1 xor2 norm0 norm1 norm2
-
-  simp_all
+  intro i
+  specialize h_holds i
+  obtain ⟨ h0, h1, h2, h3 ⟩ := h_holds
+  obtain ⟨ xor0, norm0 ⟩ := h0
+  have ⟨ xor1, norm1 ⟩ := h1 norm0
+  have ⟨ xor2, norm2 ⟩ := h2 norm1
+  have ⟨ xor4, norm ⟩ := h3 norm2
+  clear h1 h2 h3 norm0 norm1 norm2
+  use norm
+  simp only [xor0, xor1, xor2, xor4, KeccakState.value, Vector.getElem_map]
 
 theorem completeness : Completeness (F p) KeccakRow assumptions := by
   intro i0 env state_var h_env state h_input h_assumptions
   simp only [circuit_norm, subcircuit_norm, assumptions, eval_vector,
-    theta_c, Xor.circuit, Xor.assumptions, Xor.spec] at h_input h_assumptions ⊢
+    main, Xor.circuit, Xor.assumptions, Xor.spec] at h_input h_assumptions ⊢
   simp only [add_assoc, Nat.reduceAdd, Nat.reduceMod]
 
   rw [KeccakState.is_normalized] at h_assumptions
@@ -102,12 +88,7 @@ theorem completeness : Completeness (F p) KeccakRow assumptions := by
   sorry
 
 def circuit : FormalCircuit (F p) KeccakState KeccakRow := {
-  elaborated with
-  main := theta_c
-  assumptions
-  spec
-  soundness
-  completeness
+  elaborated with assumptions, spec, soundness, completeness
 }
 
 end Gadgets.Keccak256.ThetaC

--- a/Clean/Gadgets/Keccak/ThetaC.lean
+++ b/Clean/Gadgets/Keccak/ThetaC.lean
@@ -68,17 +68,17 @@ theorem soundness : Soundness (F p) assumptions spec := by
   simp only [circuit_norm, spec, KeccakRow.is_normalized_iff,
     KeccakRow.value, KeccakState.value, Specs.Keccak256.theta_c]
 
-  have state_norm' : ∀ {i : ℕ} (hi : i < 25), state[i].is_normalized :=
+  have state_norm : ∀ {i : ℕ} (hi : i < 25), state[i].is_normalized :=
     fun hi => state_norm ⟨ _, hi ⟩
 
   repeat
     first
     | obtain⟨ h0, h1, h2, h3, h_holds ⟩ := h_holds
     | obtain⟨ h0, h1, h2, h3 ⟩ := h_holds
-    obtain ⟨ xor0, norm0 ⟩ := h0 (state_norm' _) (state_norm' _)
-    obtain ⟨ xor1, norm1 ⟩ := h1 norm0 (state_norm' _)
-    obtain ⟨ xor2, norm2 ⟩ := h2 norm1 (state_norm' _)
-    obtain ⟨ xor, norm ⟩ := h3 norm2 (state_norm' _)
+    obtain ⟨ xor0, norm0 ⟩ := h0 (state_norm _) (state_norm _)
+    obtain ⟨ xor1, norm1 ⟩ := h1 norm0 (state_norm _)
+    obtain ⟨ xor2, norm2 ⟩ := h2 norm1 (state_norm _)
+    obtain ⟨ xor, norm ⟩ := h3 norm2 (state_norm _)
     rw [xor2, xor1, xor0] at xor
     clear h0 h1 h2 h3 xor0 xor1 xor2 norm0 norm1 norm2
 

--- a/Clean/Gadgets/Keccak/ThetaD.lean
+++ b/Clean/Gadgets/Keccak/ThetaD.lean
@@ -55,11 +55,11 @@ theorem soundness : Soundness (F p) assumptions spec := by
   simp only [circuit_norm, eval_vector] at h_input
   dsimp only [assumptions] at state_norm
   dsimp only [circuit_norm, theta_d, Xor.circuit, Rotation64.circuit] at h_holds
-  simp only [circuit_norm, subcircuit_norm] at h_holds
-  dsimp only [Xor.assumptions, Xor.spec, Rotation64.assumptions, Rotation64.spec] at h_holds
-  simp [add_assoc, and_assoc, -Fin.val_zero, -Fin.val_one', -Fin.val_one, -Fin.val_two] at h_holds
+  simp only [circuit_norm, subcircuit_norm, Xor.assumptions, Xor.spec, Rotation64.assumptions, Rotation64.spec] at h_holds
+  simp only [circuit_norm, add_assoc, and_assoc, and_imp, Nat.reduceMod, Nat.reduceAdd,
+    zero_sub, Fin.coe_neg_one, Pi.ofNat_apply, Nat.cast_ofNat] at h_holds
 
-  have s (i : Fin 5) : eval env (state_var[i.val]) = state[i.val] := by
+  have s (i : ℕ) (hi : i < 5) : eval env (state_var[i]) = state[i] := by
     rw [←h_input, Vector.getElem_map]
 
   simp only [s] at h_holds
@@ -87,7 +87,6 @@ theorem soundness : Soundness (F p) assumptions spec := by
 
   simp only [circuit_norm, spec, KeccakRow.is_normalized_iff, KeccakRow.value, KeccakState.value]
   simp [Specs.Keccak256.theta_d, h_xor0, h_xor1, h_xor2, h_xor3, h_xor4, Specs.Keccak256.rol_u64, eval_vector]
-  get_elem_tactic
 
 theorem completeness : Completeness (F p) KeccakRow assumptions := by
   intro i0 env state_var h_env state h_input h_assumptions

--- a/Clean/Gadgets/Keccak/ThetaXor.lean
+++ b/Clean/Gadgets/Keccak/ThetaXor.lean
@@ -1,3 +1,4 @@
+import Clean.Circuit.Loops
 import Clean.Gadgets.Addition8.Addition8FullCarry
 import Clean.Types.U64
 import Clean.Gadgets.Xor.Xor64
@@ -18,44 +19,19 @@ instance : ProvableStruct Inputs where
   to_components := fun { state, d } => .cons state (.cons d .nil)
   from_components := fun (.cons state (.cons d .nil)) => { state, d }
 
-def theta_xor (inputs : Var Inputs (F p)) : Circuit (F p) (Var KeccakState (F p)) := do
-  let ⟨state, d⟩ := inputs
-  return #v[
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 0, d.get 0⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 1, d.get 0⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 2, d.get 0⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 3, d.get 0⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 4, d.get 0⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 5, d.get 1⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 6, d.get 1⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 7, d.get 1⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 8, d.get 1⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 9, d.get 1⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 10, d.get 2⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 11, d.get 2⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 12, d.get 2⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 13, d.get 2⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 14, d.get 2⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 15, d.get 3⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 16, d.get 3⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 17, d.get 3⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 18, d.get 3⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 19, d.get 3⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 20, d.get 4⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 21, d.get 4⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 22, d.get 4⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 23, d.get 4⟩,
-    ←subcircuit Gadgets.Xor.circuit ⟨state.get 24, d.get 4⟩
-  ]
+def theta_xor (inputs : Var Inputs (F p)) : Circuit (F p) (Var KeccakState (F p)) :=
+  let { state, d } := inputs
+  .mapFinRange 25 fun i =>
+    subcircuit Gadgets.Xor.circuit ⟨state[i.val], d[i.val / 5]⟩
 
 instance elaborated : ElaboratedCircuit (F p) Inputs (Var KeccakState (F p)) where
   main := theta_xor
   local_length _ := 200
   output _ i0 := var_from_offset KeccakState i0
-  output_eq _ i := by
-    simp only [var_from_offset_vector, theta_xor, Xor.circuit]
-    simp only [circuit_norm]
-    rfl
+
+  local_length_eq _ n := by simp only [theta_xor, circuit_norm]; ac_rfl
+  initial_offset_eq _ i := by simp only [theta_xor, circuit_norm]
+  output_eq _ i := by simp only [theta_xor, circuit_norm, Xor.circuit, var_from_offset_vector]
 
 def assumptions (inputs : Inputs (F p)) : Prop :=
   let ⟨state, d⟩ := inputs
@@ -66,8 +42,18 @@ def spec (inputs : Inputs (F p)) (out: KeccakState (F p)) : Prop :=
   out.is_normalized
   ∧ out.value = Specs.Keccak256.theta_xor state.value d.value
 
+-- rewrite theta_xor as a loop
+lemma theta_xor_loop (state : Vector ℕ 25) (d : Vector ℕ 5) :
+    Specs.Keccak256.theta_xor state d = .mapFinRange fun i => state[i.val] ^^^ d[i.val / 5] := by
+  rw [Specs.Keccak256.theta_xor, Vector.mapFinRange, Vector.finRange, Vector.map_mk, Vector.eq_mk, List.map_toArray]
+  rfl
+
 theorem soundness : Soundness (F p) assumptions spec := by
-  intro i0 env state_var ⟨state, d⟩ h_input ⟨state_norm, d_norm⟩ h_holds
+  intro i0 env ⟨state_var, d_var⟩ ⟨state, d⟩ h_input ⟨state_norm, d_norm⟩ h_holds
+  -- rewrite goal
+  simp only [spec, elaborated, theta_xor_loop, var_from_offset_vector, eval_vector]
+
+  -- simplify constraints
   simp only [circuit_norm, eval_vector, Inputs.mk.injEq] at h_input
   simp only [circuit_norm, subcircuit_norm, theta_xor, Xor.circuit, Rotation64.circuit,
     Xor.assumptions, Xor.spec, Rotation64.assumptions, Rotation64.spec] at h_holds
@@ -76,27 +62,31 @@ theorem soundness : Soundness (F p) assumptions spec := by
 
   obtain ⟨h_state, h_d⟩ := h_input
 
-  have s_d (i : ℕ) (hi : i < 5) : eval env (state_var.d[i]) = d[i] := by
-    rw [← h_d, Vector.getElem_map]
+  have s_d (i : ℕ) (hi : i < 5) : eval env d_var[i] = d[i] := by
+    rw [←h_d, Vector.getElem_map]
 
-  have s_state (i : ℕ) (hi : i < 25) : eval env (state_var.state[i]) = state[i] := by
-    rw [← h_state, Vector.getElem_map]
+  have s_state (i : ℕ) (hi : i < 25) : eval env state_var[i] = state[i] := by
+    rw [←h_state, Vector.getElem_map]
 
   simp only [s_d, s_state] at h_holds
-  simp [circuit_norm, spec, Specs.Keccak256.theta_xor, Fin.forall_fin_succ,
-    -Fin.val_zero, -Fin.val_one', -Fin.val_one, -Fin.val_two, var_from_offset_vector, eval_vector,
-    KeccakState.is_normalized, KeccakState.value, KeccakRow.value]
 
-  have state_norm : ∀ {i : ℕ} (hi : i < 25), state[i].is_normalized := fun hi => state_norm ⟨ _, hi ⟩
-  have d_norm : ∀ {i : ℕ} (hi : i < 5), d[i].is_normalized := fun hi => d_norm ⟨ _, hi ⟩
+  -- use assumptions
+  have d_norm (i : Fin 25) : d[i.val / 5].is_normalized := by
+    have hi' : i.val / 5 < 5 := by omega
+    exact d_norm ⟨_, hi'⟩
 
-  repeat
-    obtain ⟨ h, h_holds ⟩ := h_holds
-    obtain ⟨ xor, norm ⟩ := h (state_norm _) (d_norm _)
-    simp only [xor, norm, true_and]
+  replace h_holds := fun (i : Fin 25) => h_holds i (state_norm i) (d_norm i)
+  clear state_norm d_norm h_d h_state s_d s_state
 
-  have ⟨ xor, norm ⟩ := h_holds (state_norm _) (d_norm _)
-  exact ⟨norm, xor⟩
+  -- prove two goals individually
+  constructor
+  · intro i
+    rw [Fin.getElem_fin, Vector.getElem_map, Vector.getElem_mapRange, mul_comm]
+    exact (h_holds i).right
+  · simp only [Vector.ext_iff, KeccakState.value, KeccakRow.value]
+    intro i hi
+    simp only [Vector.getElem_map, Vector.getElem_mapRange, Vector.getElem_mapFinRange, mul_comm]
+    exact (h_holds ⟨ i, hi ⟩).left
 
 theorem completeness : Completeness (F p) KeccakState assumptions := by
   intro i0 env state_var h_env state h_input h_assumptions
@@ -104,7 +94,6 @@ theorem completeness : Completeness (F p) KeccakState assumptions := by
   dsimp only [circuit_norm, theta_xor, Xor.circuit, Rotation64.circuit]
   simp only [circuit_norm, subcircuit_norm]
   dsimp only [Xor.assumptions, Xor.spec]
-  simp [add_assoc]
   sorry
 
 def circuit : FormalCircuit (F p) Inputs KeccakState := {

--- a/Clean/Gadgets/Keccak/ThetaXor.lean
+++ b/Clean/Gadgets/Keccak/ThetaXor.lean
@@ -50,6 +50,7 @@ lemma theta_xor_loop (state : Vector ℕ 25) (d : Vector ℕ 5) :
 
 theorem soundness : Soundness (F p) assumptions spec := by
   intro i0 env ⟨state_var, d_var⟩ ⟨state, d⟩ h_input ⟨state_norm, d_norm⟩ h_holds
+
   -- rewrite goal
   apply KeccakState.normalized_value_ext
   simp only [elaborated, size, theta_xor_loop, var_from_offset_vector, eval_vector,
@@ -61,7 +62,7 @@ theorem soundness : Soundness (F p) assumptions spec := by
   simp only [circuit_norm, subcircuit_norm, theta_xor, h_input, Xor.circuit, Rotation64.circuit,
     Xor.assumptions, Xor.spec, Rotation64.assumptions, Rotation64.spec] at h_holds
 
-  -- use assumptions, and prove goal
+  -- use assumptions, prove goal
   intro i
   specialize h_holds i ⟨ state_norm i, d_norm ⟨i.val / 5, by omega⟩ ⟩
   exact ⟨ h_holds.right, h_holds.left ⟩

--- a/Clean/Gadgets/Keccak/ThetaXor.lean
+++ b/Clean/Gadgets/Keccak/ThetaXor.lean
@@ -44,7 +44,7 @@ def spec (inputs : Inputs (F p)) (out: KeccakState (F p)) : Prop :=
 
 -- rewrite theta_xor as a loop
 lemma theta_xor_loop (state : Vector ℕ 25) (d : Vector ℕ 5) :
-    Specs.Keccak256.theta_xor state d = .mapFinRange fun i => state[i.val] ^^^ d[i.val / 5] := by
+    Specs.Keccak256.theta_xor state d = .mapFinRange 25 fun i => state[i.val] ^^^ d[i.val / 5] := by
   rw [Specs.Keccak256.theta_xor, Vector.mapFinRange, Vector.finRange, Vector.map_mk, Vector.eq_mk, List.map_toArray]
   rfl
 

--- a/Clean/Gadgets/Keccak/ThetaXor.lean
+++ b/Clean/Gadgets/Keccak/ThetaXor.lean
@@ -54,29 +54,15 @@ theorem soundness : Soundness (F p) assumptions spec := by
   simp only [spec, elaborated, theta_xor_loop, var_from_offset_vector, eval_vector]
 
   -- simplify constraints
-  simp only [circuit_norm, eval_vector, Inputs.mk.injEq] at h_input
-  simp only [circuit_norm, subcircuit_norm, theta_xor, Xor.circuit, Rotation64.circuit,
+  simp only [circuit_norm, eval_vector, Inputs.mk.injEq, Vector.ext_iff] at h_input
+  simp only [circuit_norm, subcircuit_norm, theta_xor, h_input, Xor.circuit, Rotation64.circuit,
     Xor.assumptions, Xor.spec, Rotation64.assumptions, Rotation64.spec] at h_holds
-  simp only [Nat.zero_mod, and_imp, Nat.one_mod, Nat.reduceMod, add_assoc, Nat.reduceAdd, and_assoc,
-    Nat.mod_succ] at h_holds
-
-  obtain ⟨h_state, h_d⟩ := h_input
-
-  have s_d (i : ℕ) (hi : i < 5) : eval env d_var[i] = d[i] := by
-    rw [←h_d, Vector.getElem_map]
-
-  have s_state (i : ℕ) (hi : i < 25) : eval env state_var[i] = state[i] := by
-    rw [←h_state, Vector.getElem_map]
-
-  simp only [s_d, s_state] at h_holds
 
   -- use assumptions
-  have d_norm (i : Fin 25) : d[i.val / 5].is_normalized := by
-    have hi' : i.val / 5 < 5 := by omega
-    exact d_norm ⟨_, hi'⟩
+  have d_norm' (i : Fin 25) : d[i.val / 5].is_normalized := d_norm ⟨_, by omega⟩
 
-  replace h_holds := fun (i : Fin 25) => h_holds i (state_norm i) (d_norm i)
-  clear state_norm d_norm h_d h_state s_d s_state
+  replace h_holds := fun (i : Fin 25) => h_holds i ⟨ state_norm i, d_norm' i ⟩
+  clear state_norm d_norm d_norm' h_input
 
   -- prove two goals individually
   constructor

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -199,7 +199,7 @@ def push_var_input (assignment: CellAssignment W S) (off: CellOffset W S) : Cell
 
 @[table_assignment_norm]
 def push_row (assignment: CellAssignment W S) (row: Fin W) : CellAssignment W S :=
-  let row_vars : Vector (Cell W S) (size S) := .mapFinRange fun col => .input ⟨ row, col ⟩
+  let row_vars : Vector (Cell W S) (size S) := .mapFinRange _ fun col => .input ⟨ row, col ⟩
   {
     offset := assignment.offset + size S
     aux_length := assignment.aux_length

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -98,10 +98,8 @@ lemma fib_assignment : (recursive_relation (p:=p)).final_assignment.vars =
       .input ⟨0, 7⟩, .input ⟨1, 0⟩, .input ⟨1, 1⟩, .input ⟨1, 2⟩, .input ⟨1, 3⟩, .input ⟨1, 4⟩, .input ⟨1, 5⟩,
       .input ⟨1, 6⟩, .input ⟨1, 7⟩, .input ⟨1, 4⟩, .aux 1, .input ⟨1, 5⟩, .aux 3, .input ⟨1, 6⟩, .aux 5,
       .input ⟨1, 7⟩, .aux 7] := by
-  dsimp only [recursive_relation, table_assignment_norm, circuit_norm,
+  simp only [recursive_relation, table_assignment_norm, circuit_norm,
     Gadgets.Addition32Full.circuit, assign_U32]
-  simp only [circuit_norm, table_norm]
-  rfl
 
 lemma fib_vars (curr next : Row (F p) RowType) (aux_env : Environment (F p)) :
     let env := recursive_relation.window_env ⟨<+> +> curr +> next, rfl⟩ aux_env;

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -140,7 +140,28 @@ theorem induct_push_push {motive : {n: ℕ} → Vector α n → Sort u}
 def finRange (n : ℕ) : Vector (Fin n) n :=
   ⟨ .mk (List.finRange n), List.length_finRange n ⟩
 
+theorem finRange_zero : finRange 0 = #v[] := rfl
+
+theorem getElemFin_finRange {n} (i : Fin n) : (finRange n)[i] = i := by
+  simp [finRange, List.finRange]
+
+theorem getElem_finRange {n} (i : ℕ) (hi : i < n) : (finRange n)[i] = ⟨ i, hi ⟩ := by
+  simp [finRange, List.finRange]
+
+theorem finRange_succ {n} : finRange (n + 1) = ((finRange n).map Fin.castSucc).push n := by
+  ext i hi
+  simp only [getElem_finRange, getElem_push, getElem_map, Fin.castSucc_mk]
+  by_cases hi' : i < n <;> simp [hi']; linarith
+
 def mapFinRange {n} (create: Fin n → α) : Vector α n := finRange n |>.map create
+
+theorem mapFinRange_zero {create: Fin 0 → α} : mapFinRange create = #v[] := rfl
+
+theorem mapFinRange_succ {n} {create: Fin (n + 1) → α} :
+    mapFinRange create = (mapFinRange (n:=n) (fun i => create i)).push (create n) := by
+  rw [mapFinRange, mapFinRange, finRange_succ, map_push, map_map]
+  simp only [Fin.coe_eq_castSucc]
+  rfl
 
 theorem cast_mapFinRange {n} {create: Fin n → α} (h : n = m) :
     mapFinRange create = (mapFinRange (n:=m) (fun i => create (i.cast h.symm))).cast h.symm := by

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -153,26 +153,26 @@ theorem finRange_succ {n} : finRange (n + 1) = ((finRange n).map Fin.castSucc).p
   simp only [getElem_finRange, getElem_push, getElem_map, Fin.castSucc_mk]
   by_cases hi' : i < n <;> simp [hi']; linarith
 
-def mapFinRange {n} (create: Fin n → α) : Vector α n := finRange n |>.map create
+def mapFinRange (n: ℕ) (create: Fin n → α) : Vector α n := finRange n |>.map create
 
-theorem mapFinRange_zero {create: Fin 0 → α} : mapFinRange create = #v[] := rfl
+theorem mapFinRange_zero {create: Fin 0 → α} : mapFinRange 0 create = #v[] := rfl
 
 theorem mapFinRange_succ {n} {create: Fin (n + 1) → α} :
-    mapFinRange create = (mapFinRange (n:=n) (fun i => create i)).push (create n) := by
+    mapFinRange (n + 1) create = (mapFinRange n (fun i => create i)).push (create n) := by
   rw [mapFinRange, mapFinRange, finRange_succ, map_push, map_map]
   simp only [Fin.coe_eq_castSucc]
   rfl
 
 theorem cast_mapFinRange {n} {create: Fin n → α} (h : n = m) :
-    mapFinRange create = (mapFinRange (n:=m) (fun i => create (i.cast h.symm))).cast h.symm := by
+    mapFinRange n create = (mapFinRange m (fun i => create (i.cast h.symm))).cast h.symm := by
   subst h; simp
 
 theorem getElemFin_mapFinRange {n} {create: Fin n → α} :
-    ∀ i : Fin n, (mapFinRange create)[i] = create i := by
+    ∀ i : Fin n, (mapFinRange n create)[i] = create i := by
   simp [mapFinRange, finRange]
 
 theorem getElem_mapFinRange {n} {create: Fin n → α} :
-    ∀ (i : ℕ) (hi : i < n), (mapFinRange create)[i] = create ⟨ i, hi ⟩ := by
+    ∀ (i : ℕ) (hi : i < n), (mapFinRange n create)[i] = create ⟨ i, hi ⟩ := by
   simp [mapFinRange, finRange]
 
 def mapRange (n: ℕ) (create: ℕ → α) : Vector α n :=


### PR DESCRIPTION
closes #82 

* add loop construct `Circuit.mapFinRange`, i.e. a `for i=0...n` loop usable in a circuit
* make `mapFinRange` simplify smoothly with `circuit_norm`
* rewrite Chi, ThetaC and ThetaXor to use it