### PR TITLE
Keccak permutation and `foldl` loops

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -237,19 +237,19 @@ def Circuit (F : Type) [Field F] := StateM (OperationsList F)
 namespace Circuit
 @[reducible, circuit_norm]
 def final_offset (circuit: Circuit F α) (offset: ℕ) : ℕ :=
-  circuit offset |>.snd.offset
+  circuit ⟨ offset, .empty offset ⟩ |>.snd.offset
 
 @[reducible, circuit_norm]
 def operations (circuit: Circuit F α) (offset := 0) : Operations F (circuit.final_offset offset) :=
-  circuit offset |>.snd.withLength
+  circuit ⟨ offset, .empty offset ⟩ |>.snd.withLength
 
 @[reducible, circuit_norm]
 def output (circuit: Circuit F α) (offset := 0) : α :=
-  circuit offset |>.fst
+  circuit ⟨ offset, .empty offset ⟩ |>.fst
 
 @[reducible, circuit_norm]
 def local_length (circuit: Circuit F α) (offset := 0) : ℕ :=
-  (circuit.operations offset).local_length
+  circuit ⟨ offset, .empty offset ⟩ |>.snd.withLength.local_length
 
 -- core operations we can do in a circuit
 

--- a/Clean/Circuit/Lawful.lean
+++ b/Clean/Circuit/Lawful.lean
@@ -198,6 +198,9 @@ example :
   ConstantLawfulCircuits add := by infer_constant_lawful_circuits
 end
 
+def ConstantLawfulCircuits.constant_output {circuit : α → Circuit F β} [Inhabited α] (lawful : ConstantLawfulCircuits circuit) :=
+  ∀ (x : α) (n : ℕ), output circuit x n = output circuit default n
+
 -- characterize various properties of lawful circuits
 
 -- helper lemma needed right below

--- a/Clean/Circuit/Lawful.lean
+++ b/Clean/Circuit/Lawful.lean
@@ -121,6 +121,9 @@ instance ConstantLawfulCircuits.to_single (circuit : α → Circuit F β) (a : �
   offset_independent := offset_independent a
   append_only := append_only a
 
+instance LawfulCircuit.from_constants {circuit : α → Circuit F β} (lawful : ConstantLawfulCircuits circuit) (a : α) :
+    LawfulCircuit (circuit a) := ConstantLawfulCircuits.to_single circuit a |>.toLawfulCircuit
+
 syntax "infer_lawful_circuit" : tactic
 
 macro_rules

--- a/Clean/Circuit/Lawful.lean
+++ b/Clean/Circuit/Lawful.lean
@@ -274,6 +274,10 @@ theorem completeness_eq {circuit : Circuit F α} [lawful : LawfulCircuit circuit
   LawfulCircuit.operations_eq' (Circuit.constraints_hold.completeness env)
 end LawfulCircuit
 
+theorem ConstantLawfulCircuits.final_offset_eq {circuit : α → Circuit F β} [lawful : ConstantLawfulCircuits circuit] (a : α) (n : ℕ) :
+    (circuit a).final_offset n = n + lawful.local_length := by
+  simp only [circuit_norm, offset_independent]
+
 namespace Circuit.constraints_hold
 variable {env : Environment F} {n : ℕ} {prop : Operations.Condition F}
 

--- a/Clean/Circuit/Lawful.lean
+++ b/Clean/Circuit/Lawful.lean
@@ -274,9 +274,15 @@ theorem completeness_eq {circuit : Circuit F α} [lawful : LawfulCircuit circuit
   LawfulCircuit.operations_eq' (Circuit.constraints_hold.completeness env)
 end LawfulCircuit
 
-theorem ConstantLawfulCircuits.final_offset_eq {circuit : α → Circuit F β} [lawful : ConstantLawfulCircuits circuit] (a : α) (n : ℕ) :
-    (circuit a).final_offset n = n + lawful.local_length := by
-  simp only [circuit_norm, offset_independent]
+namespace ConstantLawfulCircuits
+theorem final_offset_eq {circuit : α → Circuit F β} [lawful : ConstantLawfulCircuits circuit] :
+    ∀ (a : α) (n : ℕ), (circuit a).final_offset n = n + lawful.local_length := by
+  intros; apply offset_independent
+
+theorem local_length_eq {circuit : α → Circuit F β} [lawful : ConstantLawfulCircuits circuit] :
+    ∀ (a : α) (n : ℕ), (circuit a).local_length n = lawful.local_length := by
+  intros; apply LawfulCircuit.local_length_eq
+end ConstantLawfulCircuits
 
 namespace Circuit.constraints_hold
 variable {env : Environment F} {n : ℕ} {prop : Operations.Condition F}

--- a/Clean/Circuit/Lawful.lean
+++ b/Clean/Circuit/Lawful.lean
@@ -275,9 +275,19 @@ theorem completeness_eq {circuit : Circuit F α} [lawful : LawfulCircuit circuit
 end LawfulCircuit
 
 namespace ConstantLawfulCircuits
+theorem output_eq {circuit : α → Circuit F β} [lawful : ConstantLawfulCircuits circuit] :
+    ∀ (a : α) (n : ℕ), (circuit a).output n = lawful.output a n := by
+  intros; apply output_independent
+
 theorem final_offset_eq {circuit : α → Circuit F β} [lawful : ConstantLawfulCircuits circuit] :
     ∀ (a : α) (n : ℕ), (circuit a).final_offset n = n + lawful.local_length := by
   intros; apply offset_independent
+
+theorem initial_offset_eq {circuit : α → Circuit F β} [lawful : ConstantLawfulCircuits circuit] :
+    ∀ (a : α) (n : ℕ), ((circuit a).operations n).initial_offset = n := by
+  intro a n
+  have : LawfulCircuit (circuit a) := lawful.to_single _ _ |>.toLawfulCircuit
+  apply LawfulCircuit.initial_offset_eq
 
 theorem local_length_eq {circuit : α → Circuit F β} [lawful : ConstantLawfulCircuits circuit] :
     ∀ (a : α) (n : ℕ), (circuit a).local_length n = lawful.local_length := by

--- a/Clean/Circuit/Lawful.lean
+++ b/Clean/Circuit/Lawful.lean
@@ -209,8 +209,8 @@ lemma OperationsList.withLength_eq {F: Type} [Field F] {ops : OperationsList F} 
 namespace LawfulCircuit
 -- slightly different way to state the append-only principle, which deals with the type dependency
 lemma append_only' {circuit : Circuit F α} [lawful : LawfulCircuit circuit] :
-    ∀ ops: OperationsList F,
-      (circuit ops).snd.withLength = ops.withLength ++ (lawful.offset_independent ops ▸ operations ops.offset) := by
+  ∀ ops: OperationsList F,
+    (circuit ops).snd.withLength = ops.withLength ++ (lawful.offset_independent ops ▸ operations ops.offset) := by
   intro ops
   apply OperationsList.withLength_eq
   simp only [append_only ops]

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -517,7 +517,7 @@ def foldl {m : ℕ} [Inhabited β] [Inhabited α] (xs : Vector α m) (init : β)
 section
 variable {env : Environment F} {m n : ℕ} [NeZero m] [Nonempty β] {body : Fin m → Circuit F β} {lawful : ConstantLawfulCircuits body}
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma mapFinRange.soundness :
   constraints_hold.soundness env (mapFinRange m body lawful |>.operations n) ↔
     ∀ i : Fin m, constraints_hold.soundness env (body i |>.operations (n + i*(body 0).local_length)) := by
@@ -525,7 +525,7 @@ lemma mapFinRange.soundness :
   rw [LawfulCircuit.local_length_eq]
   trivial
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma mapFinRange.completeness :
   constraints_hold.completeness env (mapFinRange m body lawful |>.operations n) ↔
     ∀ i : Fin m, constraints_hold.completeness env (body i |>.operations (n + i*(body 0).local_length)) := by
@@ -533,7 +533,7 @@ lemma mapFinRange.completeness :
   rw [LawfulCircuit.local_length_eq]
   trivial
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma mapFinRange.uses_local_witnesses :
   env.uses_local_witnesses_completeness (mapFinRange m body lawful |>.operations n) ↔
     ∀ i : Fin m, env.uses_local_witnesses_completeness (body i |>.operations (n + i*(body 0).local_length)) := by
@@ -541,7 +541,7 @@ lemma mapFinRange.uses_local_witnesses :
   rw [LawfulCircuit.local_length_eq]
   trivial
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma mapFinRange.local_length_eq :
     (mapFinRange m body lawful).local_length n = m * (body 0).local_length := by
   let lawful_loop : ConstantLawfulCircuit (mapFinRange m body lawful) := .from_mapM_vector _ lawful
@@ -550,13 +550,13 @@ lemma mapFinRange.local_length_eq :
   rw [LawfulCircuit.local_length_eq]
   ac_rfl
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma mapFinRange.initial_offset_eq :
     (mapFinRange m body lawful |>.operations n).initial_offset = n := by
   let lawful_loop : ConstantLawfulCircuit (mapFinRange m body lawful) := .from_mapM_vector _ lawful
   rw [LawfulCircuit.initial_offset_eq]
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma mapFinRange.output_eq :
   (mapFinRange m body lawful).output n =
     Vector.mapFinRange m fun i => (body i).output (n + i*(body 0).local_length) := by
@@ -573,7 +573,7 @@ section
 variable {env : Environment F} {m n : ℕ} [Inhabited α] [Nonempty β] {xs : Vector α m}
   {body : α → Circuit F β} {lawful : ConstantLawfulCircuits body}
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma map.soundness :
   constraints_hold.soundness env (map xs body lawful |>.operations n) ↔
     ∀ i : Fin m, constraints_hold.soundness env (body xs[i.val] |>.operations (n + i*(body default).local_length)) := by
@@ -581,7 +581,7 @@ lemma map.soundness :
   rw [LawfulCircuit.local_length_eq]
   trivial
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma map.completeness :
   constraints_hold.completeness env (map xs body lawful |>.operations n) ↔
     ∀ i : Fin m, constraints_hold.completeness env (body xs[i.val] |>.operations (n + i*(body default).local_length)) := by
@@ -589,7 +589,7 @@ lemma map.completeness :
   rw [LawfulCircuit.local_length_eq]
   trivial
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma map.uses_local_witnesses :
   env.uses_local_witnesses_completeness (map xs body lawful |>.operations n) ↔
     ∀ i : Fin m, env.uses_local_witnesses_completeness (body xs[i.val] |>.operations (n + i*(body default).local_length)) := by
@@ -597,7 +597,7 @@ lemma map.uses_local_witnesses :
   rw [LawfulCircuit.local_length_eq]
   trivial
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma map.local_length_eq :
     (map xs body lawful).local_length n = m * (body default).local_length := by
   let lawful_loop : ConstantLawfulCircuit (map xs body lawful) := .from_mapM_vector _ lawful
@@ -607,13 +607,13 @@ lemma map.local_length_eq :
   ac_rfl
 
 omit [Inhabited α] in
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma map.initial_offset_eq :
     (map xs body lawful |>.operations n).initial_offset = n := by
   let lawful_loop : ConstantLawfulCircuit (map xs body lawful) := .from_mapM_vector _ lawful
   rw [LawfulCircuit.initial_offset_eq]
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma map.output_eq :
   (map xs body lawful).output n =
     xs.mapIdx fun i x => (body x).output (n + i*(body default).local_length) := by
@@ -630,7 +630,7 @@ variable {env : Environment F} {m n : ℕ} [Inhabited β] [Inhabited α] {xs : V
   {body : β → α → Circuit F β} {init : β} {lawful : ConstantLawfulCircuits fun (t : β × α) => body t.1 t.2}
   {const_out : lawful.constant_output}
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma foldl.soundness [NeZero m] :
   constraints_hold.soundness env (foldl xs init body lawful const_out |>.operations n) ↔
     constraints_hold.soundness env (body init (xs[0]'(NeZero.pos m)) |>.operations n) ∧
@@ -639,7 +639,7 @@ lemma foldl.soundness [NeZero m] :
       constraints_hold.soundness env (body acc xs[i + 1] |>.operations (n + (i + 1)*(body default default).local_length)) := by
   simp only [constraints_hold.soundness_iff_forAll, foldl, constraints_hold.foldM_vector_forAll_const const_out]
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma foldl.completeness [NeZero m] :
   constraints_hold.completeness env (foldl xs init body lawful const_out |>.operations n) ↔
     constraints_hold.completeness env (body init (xs[0]'(NeZero.pos m)) |>.operations n) ∧
@@ -648,7 +648,7 @@ lemma foldl.completeness [NeZero m] :
       constraints_hold.completeness env (body acc xs[i + 1] |>.operations (n + (i + 1)*(body default default).local_length)) := by
   simp only [constraints_hold.completeness_iff_forAll, foldl, constraints_hold.foldM_vector_forAll_const const_out]
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma foldl.uses_local_witnesses [NeZero m] :
   env.uses_local_witnesses_completeness (foldl xs init body lawful const_out |>.operations n) ↔
     env.uses_local_witnesses_completeness (body init (xs[0]'(NeZero.pos m)) |>.operations n) ∧
@@ -657,7 +657,7 @@ lemma foldl.uses_local_witnesses [NeZero m] :
       env.uses_local_witnesses_completeness (body acc xs[i + 1] |>.operations (n + (i + 1)*(body default default).local_length)) := by
   simp only [env.uses_local_witnesses_completeness_iff_forAll, foldl, constraints_hold.foldM_vector_forAll_const const_out]
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma foldl.local_length_eq :
     (foldl xs init body lawful const_out).local_length n = m * (body default default).local_length := by
   let lawful_loop : ConstantLawfulCircuits (foldl xs · body lawful const_out) := .from_foldlM_vector xs lawful
@@ -666,13 +666,13 @@ lemma foldl.local_length_eq :
   rw [←lawful.local_length_eq (default, default) 0]
   ac_rfl
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma foldl.initial_offset_eq :
     (foldl xs init body lawful const_out |>.operations n).initial_offset = n := by
   let lawful_loop : ConstantLawfulCircuits (foldl xs · body lawful const_out) := .from_foldlM_vector xs lawful
   apply lawful_loop.initial_offset_eq
 
-@[circuit_norm]
+@[circuit_norm ↓]
 lemma foldl.output_eq [NeZero m] :
   (foldl xs init body lawful const_out).output n =
     (body default (xs[m-1]'(Nat.pred_lt (NeZero.ne m)))).output (n + (m - 1)*(body default default).local_length) := by

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -578,6 +578,27 @@ variable {env : Environment F} {m n : ℕ} [Inhabited β] [Inhabited α] {xs : V
   {body : β → α → Circuit F β} {init : β} {lawful : ConstantLawfulCircuits fun (t : β × α) => body t.1 t.2}
 
 @[circuit_norm]
+lemma foldl.soundness :
+  constraints_hold.soundness env (foldl xs init body lawful |>.operations n) ↔
+    ∀ i : Fin m, constraints_hold.soundness env (body (foldlAcc n xs body init i) xs[i.val] |>.operations (n + i*(body default default).local_length)) := by
+  rw [lawful.local_length_eq (default, default) 0]
+  simp only [constraints_hold.soundness_iff_forAll, foldl, constraints_hold.foldM_vector_forAll]
+
+@[circuit_norm]
+lemma foldl.completeness :
+  constraints_hold.completeness env (foldl xs init body lawful |>.operations n) ↔
+    ∀ i : Fin m, constraints_hold.completeness env (body (foldlAcc n xs body init i) xs[i.val] |>.operations (n + i*(body default default).local_length)) := by
+  rw [lawful.local_length_eq (default, default) 0]
+  simp only [constraints_hold.completeness_iff_forAll, foldl, constraints_hold.foldM_vector_forAll]
+
+@[circuit_norm]
+lemma foldl.uses_local_witnesses :
+  env.uses_local_witnesses_completeness (foldl xs init body lawful |>.operations n) ↔
+    ∀ i : Fin m, env.uses_local_witnesses_completeness (body (foldlAcc n xs body init i) xs[i.val] |>.operations (n + i*(body default default).local_length)) := by
+  rw [lawful.local_length_eq (default, default) 0]
+  simp only [env.uses_local_witnesses_completeness_iff_forAll, foldl, constraints_hold.foldM_vector_forAll]
+
+@[circuit_norm]
 lemma foldl.local_length_eq :
     (foldl xs init body lawful).local_length n = m * (body default default).local_length := by
   let lawful_loop : ConstantLawfulCircuits (foldl xs · body lawful) := .from_foldlM_vector xs lawful

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -639,17 +639,23 @@ lemma foldl.soundness [NeZero m] :
       constraints_hold.soundness env (body acc xs[i + 1] |>.operations (n + (i + 1)*(body default default).local_length)) := by
   simp only [constraints_hold.soundness_iff_forAll, foldl, constraints_hold.foldM_vector_forAll_const const_out]
 
--- @[circuit_norm]
-lemma foldl.completeness :
+@[circuit_norm]
+lemma foldl.completeness [NeZero m] :
   constraints_hold.completeness env (foldl xs init body lawful const_out |>.operations n) ↔
-    ∀ i : Fin m, constraints_hold.completeness env (body (foldlAcc n xs body init i) xs[i.val] |>.operations (n + i*(body default default).local_length)) := by
-  simp only [constraints_hold.completeness_iff_forAll, foldl, constraints_hold.foldM_vector_forAll]
+    constraints_hold.completeness env (body init (xs[0]'(NeZero.pos m)) |>.operations n) ∧
+    ∀ (i : ℕ) (hi : i + 1 < m),
+      let acc := (body default xs[i]).output (n + i*(body default default).local_length);
+      constraints_hold.completeness env (body acc xs[i + 1] |>.operations (n + (i + 1)*(body default default).local_length)) := by
+  simp only [constraints_hold.completeness_iff_forAll, foldl, constraints_hold.foldM_vector_forAll_const const_out]
 
--- @[circuit_norm]
-lemma foldl.uses_local_witnesses :
+@[circuit_norm]
+lemma foldl.uses_local_witnesses [NeZero m] :
   env.uses_local_witnesses_completeness (foldl xs init body lawful const_out |>.operations n) ↔
-    ∀ i : Fin m, env.uses_local_witnesses_completeness (body (foldlAcc n xs body init i) xs[i.val] |>.operations (n + i*(body default default).local_length)) := by
-  simp only [env.uses_local_witnesses_completeness_iff_forAll, foldl, constraints_hold.foldM_vector_forAll]
+    env.uses_local_witnesses_completeness (body init (xs[0]'(NeZero.pos m)) |>.operations n) ∧
+    ∀ (i : ℕ) (hi : i + 1 < m),
+      let acc := (body default xs[i]).output (n + i*(body default default).local_length);
+      env.uses_local_witnesses_completeness (body acc xs[i + 1] |>.operations (n + (i + 1)*(body default default).local_length)) := by
+  simp only [env.uses_local_witnesses_completeness_iff_forAll, foldl, constraints_hold.foldM_vector_forAll_const const_out]
 
 @[circuit_norm]
 lemma foldl.local_length_eq :

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -129,29 +129,6 @@ instance ConstantLawfulCircuit.from_mapM_vector {circuit : α → Circuit F β} 
       congr
       simp [Vector.induct_push_push]
 
-
-instance ConstantLawfulCircuits.from_foldlM_vector' [Inhabited β] {circuit : β → α → Circuit F β}
-  (xs : Vector α m) (lawful : ConstantLawfulCircuits fun (z, x) => circuit z x) :
-    ConstantLawfulCircuits (xs.foldlM circuit) := by
-  apply ConstantLawfulCircuits.from_constant_length (.from_foldlM_vector (fun z x =>
-    lawful.to_single _ (z, x) |>.toLawfulCircuit) xs)
-  intro init n
-  simp only [←LawfulCircuit.final_offset_eq, Circuit.final_offset]
-  suffices h : ∀ ops init,
-    (xs.foldlM circuit init ops).2.offset = ops.offset + ((xs.foldlM circuit default).final_offset 0) by rw [h]
-  induction xs using Vector.induct
-  case nil => intros; rfl
-  case cons x xs ih =>
-    intro ops init
-    rw [Vector.foldlM_toList, Vector.foldlM_toList, Vector.cons, List.foldlM_cons, List.foldlM_cons]
-    simp only [←Vector.foldlM_toList]
-    show (xs.foldlM circuit ..).2.offset = _ + (xs.foldlM circuit ..).2.offset
-    rw [ih, ih]
-    let prod_circuit := fun (z, x) => circuit z x
-    show (prod_circuit (init, x) _).2.offset + _ = ops.offset + ((prod_circuit (default, x) _).2.offset + _)
-    simp only [ConstantLawfulCircuits.offset_independent]
-    ac_rfl
-
 lemma ConstantLawfulCircuits.from_foldlM_vector.offset_independent {circuit : β → α → Circuit F β} [Inhabited β]
   (xs : Vector α m) (lawful : ConstantLawfulCircuits fun (acc, x) => circuit acc x) (init : β) (ops : OperationsList F) :
     (xs.foldlM circuit init ops).2.offset = ops.offset + lawful.local_length * m := by

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -535,6 +535,31 @@ section
 variable {env : Environment F} {m n : ℕ} [Inhabited β] [Inhabited α] {xs : Vector α m}
   {body : β → α → Circuit F β} {init : β} {lawful : ConstantLawfulCircuits fun (t : β × α) => body t.1 t.2}
 
+@[circuit_norm]
+lemma foldl.local_length_eq :
+    (foldl xs init body lawful).local_length n = m * (body default default).local_length := by
+  let lawful_loop : ConstantLawfulCircuits (foldl xs · body lawful) := .from_foldlM_vector xs lawful
+  rw [lawful_loop.local_length_eq]
+  simp only [lawful_loop, lawful_norm]
+  rw [←lawful.local_length_eq (default, default) 0]
+  ac_rfl
+
+omit [Inhabited α] in
+@[circuit_norm]
+lemma foldl.initial_offset_eq :
+    (foldl xs init body lawful |>.operations n).initial_offset = n := by
+  let lawful_loop : ConstantLawfulCircuits (foldl xs · body lawful) := .from_foldlM_vector xs lawful
+  apply lawful_loop.initial_offset_eq
+
+@[circuit_norm]
+lemma foldl.output_eq :
+  (foldl xs init body lawful).output n =
+    Fin.foldl m (fun acc i => (body acc xs[i.val]).output (n + i*(body default default).local_length)) init := by
+  let lawful_loop : ConstantLawfulCircuits (foldl xs · body lawful) := .from_foldlM_vector xs lawful
+  rw [lawful_loop.output_eq]
+  simp only [lawful_loop, lawful_norm, ←lawful.output_eq]
+  rw [lawful.local_length_eq (default, default) 0]
+  ac_rfl
 end
 
 end Circuit

--- a/Clean/Gadgets/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition.lean
@@ -70,7 +70,7 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) assumpt
   intro i0 env x_var x h_input x_byte h_holds
   simp only [id_eq, circuit_norm] at h_input
   simp [circuit_norm, elaborated, byte_decomposition, ByteLookup, ByteTable.equiv, h_input] at h_holds
-  simp [circuit_norm, spec, eval, Outputs, elaborated, var_from_offset, h_input]
+  simp [circuit_norm, spec, eval, Outputs, elaborated, var_from_offset, h_input, Vector.mapRange]
   obtain ⟨⟨low_byte, high_byte⟩, c⟩ := h_holds
 
   have pow_val_field : ZMod.val (2 : F p) ^ offset.val < 256 := by

--- a/Clean/Gadgets/Keccak/KeccakRound.lean
+++ b/Clean/Gadgets/Keccak/KeccakRound.lean
@@ -6,7 +6,6 @@ import Clean.Specs.Keccak256
 
 namespace Gadgets.Keccak256.KeccakRound
 variable {p : ℕ} [Fact p.Prime] [Fact (p > 2^16 + 2^8)]
-instance : Fact (p > 512) := .mk (by linarith [‹Fact (p > _)›.elim])
 open Specs.Keccak256
 
 def main (rc : UInt64) (state : Var KeccakState (F p)) : Circuit (F p) (Var KeccakState (F p)) := do

--- a/Clean/Gadgets/Keccak/KeccakRound.lean
+++ b/Clean/Gadgets/Keccak/KeccakRound.lean
@@ -4,7 +4,7 @@ import Clean.Gadgets.Keccak.Chi
 import Clean.Gadgets.Keccak.KeccakState
 import Clean.Specs.Keccak256
 
-namespace Gadgets.Keccak256.RoundFunction
+namespace Gadgets.Keccak256.KeccakRound
 variable {p : ℕ} [Fact p.Prime] [Fact (p > 2^16 + 2^8)]
 instance : Fact (p > 512) := .mk (by linarith [‹Fact (p > _)›.elim])
 open Specs.Keccak256
@@ -106,4 +106,4 @@ def circuit (rc : UInt64) : FormalCircuit (F p) KeccakState KeccakState := {
   soundness := soundness rc,
   completeness := completeness rc,
 }
-end Gadgets.Keccak256.RoundFunction
+end Gadgets.Keccak256.KeccakRound

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -1,0 +1,16 @@
+import Clean.Gadgets.Keccak.KeccakRound
+import Clean.Specs.Keccak256
+
+namespace Gadgets.Keccak256.Permutation
+variable {p : ℕ} [Fact p.Prime] [Fact (p > 2^16 + 2^8)]
+open Specs.Keccak256
+
+def main (state : Var KeccakState (F p)) : Circuit (F p) (Var KeccakState (F p)) :=
+  roundConstants.foldlM (fun state rc => subcircuit (KeccakRound.circuit rc) state) state
+
+def assumptions (state : KeccakState (F p)) := state.is_normalized
+
+def spec (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
+  out_state.is_normalized
+  ∧ out_state.value = keccak_f state.value
+end Gadgets.Keccak256.Permutation

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -1,6 +1,5 @@
 import Clean.Gadgets.Keccak.KeccakRound
 import Clean.Specs.Keccak256
-import Clean.Utils.Misc
 
 namespace Gadgets.Keccak256.Permutation
 variable {p : ℕ} [Fact p.Prime] [Fact (p > 2^16 + 2^8)]
@@ -29,21 +28,19 @@ instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where
   output _ i0 := state_var i0 23
 
   local_length_eq state i0 := by
-    simp only [main, Circuit.foldl.local_length_eq]
+    rw [main, Circuit.foldl.local_length_eq]
     simp only [circuit_norm, KeccakRound.circuit]
   initial_offset_eq state i0 := by
-    simp only [main, Circuit.foldl.initial_offset_eq]
+    rw [main, Circuit.foldl.initial_offset_eq]
   output_eq state i0 := by
-    simp only [main, state_var, Circuit.foldl.output_eq, circuit_norm, KeccakRound.circuit]
-    rw [Fin.foldl_const_succ]
-    simp +arith only [Nat.cast_ofNat, Fin.coe_ofNat_eq_mod]
+    simp only [main, state_var, circuit_norm, KeccakRound.circuit]
 
 theorem soundness : Soundness (F p) elaborated assumptions spec := by
   intro n env initial_state_var initial_state h_input h_assumptions h_holds
 
   -- simplify
   dsimp only [elaborated, main] at h_holds
-  simp only [Circuit.foldl.soundness] at h_holds
+  rw [Circuit.foldl.soundness] at h_holds
   simp only [circuit_norm, subcircuit_norm, spec,
     KeccakRound.circuit, KeccakRound.elaborated,
     KeccakRound.spec, KeccakRound.assumptions] at h_holds ⊢

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -16,19 +16,65 @@ def spec (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
   out_state.is_normalized
   ∧ out_state.value = keccak_f state.value
 
+/-- state in the ith round, starting from offset n -/
+def state_var (n : ℕ) (i : ℕ) : Var KeccakState (F p) :=
+  Vector.mapRange 25 (fun j => var_from_offset U64 (n + i * 1528 + j * 16 + 1128))
+  |>.set 0 (var_from_offset U64 (n + i * 1528 + 1520))
+
+set_option linter.constructorNameAsVariable false
+
 instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where
-  main := main
+  main
   local_length _ := 36672
-  output _ i0 := (Vector.mapRange 25 fun i => var_from_offset U64 (i0 + i*16 + 36272)).set 0 (var_from_offset U64 (i0 + 36664))
+  output _ i0 := state_var i0 23
 
   local_length_eq state i0 := by
-    simp only [main, circuit_norm, KeccakRound.circuit]
+    simp only [main, Circuit.foldl.local_length_eq]
+    simp only [circuit_norm, KeccakRound.circuit]
   initial_offset_eq state i0 := by
-    simp only [main, circuit_norm]
+    simp only [main, Circuit.foldl.initial_offset_eq]
   output_eq state i0 := by
-    simp only [main, circuit_norm, KeccakRound.circuit]
-    rw [Fin.foldl_const]
+    simp only [main, state_var, Circuit.foldl.output_eq, circuit_norm, KeccakRound.circuit]
+    rw [Fin.foldl_const_succ]
     simp +arith only [Nat.cast_ofNat, Fin.coe_ofNat_eq_mod]
-    ac_rfl
+
+theorem soundness : Soundness (F p) elaborated assumptions spec := by
+  intro n env initial_state_var initial_state h_input h_assumptions h_holds
+
+  -- simplify
+  dsimp only [elaborated, main] at h_holds
+  simp only [Circuit.foldl.soundness] at h_holds
+  simp only [circuit_norm, subcircuit_norm, spec,
+    KeccakRound.circuit, KeccakRound.elaborated,
+    KeccakRound.spec, KeccakRound.assumptions] at h_holds ⊢
+  simp only [zero_add, h_input] at h_holds
+  obtain ⟨ h_init, h_succ ⟩ := h_holds
+  specialize h_init h_assumptions
+
+  -- clean up formulation
+  let state (i : ℕ) : KeccakState (F p) := eval env (state_var n i)
+
+  change (state 0).is_normalized ∧
+    (state 0).value = keccak_round initial_state.value roundConstants[0]
+  at h_init
+
+  change ∀ (i : ℕ) (hi : i + 1 < 24), (state i).is_normalized → (state (i + 1)).is_normalized ∧
+    (state (i + 1)).value = keccak_round (state i).value roundConstants[i + 1]
+  at h_succ
+
+  -- inductive proof
+  have h_norm (i : ℕ) (hi : i < 24) :
+    (state i).is_normalized ∧ (state i).value =
+        Fin.foldl (i + 1) (fun state j => keccak_round state roundConstants[↑j]) initial_state.value := by
+    induction i with
+    | zero => simp [Fin.foldl_succ, h_init]
+    | succ i ih =>
+      have hi' : i < 24 := Nat.lt_of_succ_lt hi
+      specialize ih hi'
+      specialize h_succ i hi ih.left
+      use h_succ.left
+      rw [h_succ.right, Fin.foldl_succ_last, ih.right]
+      simp
+  exact h_norm 23 (by norm_num)
 
 end Gadgets.Keccak256.Permutation

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -62,7 +62,7 @@ theorem soundness : Soundness (F p) elaborated assumptions spec := by
   -- inductive proof
   have h_norm (i : ℕ) (hi : i < 24) :
     (state i).is_normalized ∧ (state i).value =
-        Fin.foldl (i + 1) (fun state j => keccak_round state roundConstants[↑j]) initial_state.value := by
+      Fin.foldl (i + 1) (fun state j => keccak_round state roundConstants[↑j]) initial_state.value := by
     induction i with
     | zero => simp [Fin.foldl_succ, h_init]
     | succ i ih =>

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -20,6 +20,7 @@ def state_var (n : ℕ) (i : ℕ) : Var KeccakState (F p) :=
   Vector.mapRange 25 (fun j => var_from_offset U64 (n + i * 1528 + j * 16 + 1128))
   |>.set 0 (var_from_offset U64 (n + i * 1528 + 1520))
 
+-- NOTE: this linter times out and blows up memory usage
 set_option linter.constructorNameAsVariable false
 
 instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -119,6 +119,7 @@ def circuit : FormalCircuit (F p) KeccakState KeccakState where
   spec
   soundness
   -- TODO why does this time out??
+  -- TODO: `inferInstance` in `FormalCircuit` might be slow, shouldn't be necessary in latest Lean
   -- completeness
   completeness := by sorry
 

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -1,5 +1,6 @@
 import Clean.Gadgets.Keccak.KeccakRound
 import Clean.Specs.Keccak256
+import Clean.Utils.Misc
 
 namespace Gadgets.Keccak256.Permutation
 variable {p : ℕ} [Fact p.Prime] [Fact (p > 2^16 + 2^8)]
@@ -14,4 +15,20 @@ def assumptions (state : KeccakState (F p)) := state.is_normalized
 def spec (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
   out_state.is_normalized
   ∧ out_state.value = keccak_f state.value
+
+instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where
+  main := main
+  local_length _ := 36672
+  output _ i0 := (Vector.mapRange 25 fun i => var_from_offset U64 (i0 + i*16 + 36272)).set 0 (var_from_offset U64 (i0 + 36664))
+
+  local_length_eq state i0 := by
+    simp only [main, circuit_norm, KeccakRound.circuit]
+  initial_offset_eq state i0 := by
+    simp only [main, circuit_norm]
+  output_eq state i0 := by
+    simp only [main, circuit_norm, KeccakRound.circuit]
+    rw [Fin.foldl_const]
+    simp +arith only [Nat.cast_ofNat, Fin.coe_ofNat_eq_mod]
+    ac_rfl
+
 end Gadgets.Keccak256.Permutation

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -6,7 +6,8 @@ variable {p : ℕ} [Fact p.Prime] [Fact (p > 2^16 + 2^8)]
 open Specs.Keccak256
 
 def main (state : Var KeccakState (F p)) : Circuit (F p) (Var KeccakState (F p)) :=
-  roundConstants.foldlM (fun state rc => subcircuit (KeccakRound.circuit rc) state) state
+  .foldl roundConstants state
+    fun state rc => subcircuit (KeccakRound.circuit rc) state
 
 def assumptions (state : KeccakState (F p)) := state.is_normalized
 

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -28,20 +28,15 @@ instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where
   local_length _ := 36672
   output _ i0 := state_var i0 23
 
-  local_length_eq state i0 := by
-    rw [main, Circuit.foldl.local_length_eq]
-    simp only [circuit_norm, KeccakRound.circuit]
-  initial_offset_eq state i0 := by
-    rw [main, Circuit.foldl.initial_offset_eq]
-  output_eq state i0 := by
-    simp only [main, state_var, circuit_norm, KeccakRound.circuit]
+  local_length_eq state i0 := by simp only [main, circuit_norm, KeccakRound.circuit]
+  initial_offset_eq state i0 := by simp only [main, circuit_norm]
+  output_eq state i0 := by simp only [main, state_var, circuit_norm, KeccakRound.circuit]
 
 theorem soundness : Soundness (F p) elaborated assumptions spec := by
   intro n env initial_state_var initial_state h_input h_assumptions h_holds
 
   -- simplify
   dsimp only [elaborated, main] at h_holds
-  rw [Circuit.foldl.soundness] at h_holds
   simp only [circuit_norm, subcircuit_norm, spec,
     KeccakRound.circuit, KeccakRound.elaborated,
     KeccakRound.spec, KeccakRound.assumptions] at h_holds ⊢
@@ -79,9 +74,6 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   intro n env initial_state_var h_env initial_state h_input h_assumptions
 
   dsimp only [elaborated, main, assumptions] at h_assumptions h_env ⊢
-  rw [Circuit.foldl.completeness]
-  rw [Circuit.foldl.uses_local_witnesses] at h_env
-
   simp only [h_input, h_assumptions, circuit_norm, subcircuit_norm, spec,
     KeccakRound.circuit, KeccakRound.elaborated,
     KeccakRound.spec, KeccakRound.assumptions, zero_add, forall_const, true_and] at h_env ⊢
@@ -112,9 +104,6 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
       exact h_succ.left
   exact h_norm i hi'
 
--- TODO
--- set_option maxHeartbeats 800000
-
 def circuit : FormalCircuit (F p) KeccakState KeccakState where
   assumptions
   spec
@@ -122,6 +111,6 @@ def circuit : FormalCircuit (F p) KeccakState KeccakState where
   -- TODO why does this time out??
   -- TODO: `inferInstance` in `FormalCircuit` might be slow, shouldn't be necessary in latest Lean
   -- completeness
-  completeness := by sorry
+  completeness := by simp only [completeness]
 
 end Gadgets.Keccak256.Permutation

--- a/Clean/Specs/Keccak256.lean
+++ b/Clean/Specs/Keccak256.lean
@@ -24,13 +24,13 @@ def bits2bytes (x : Nat) : Nat :=
   (x + 7) / 8
 
 def theta_c (state : Vector ℕ 25) : Vector ℕ 5 :=
-    #v[
-      state[0] ^^^ state[1] ^^^ state[2] ^^^ state[3] ^^^ state[4],
-      state[5] ^^^ state[6] ^^^ state[7] ^^^ state[8] ^^^ state[9],
-      state[10] ^^^ state[11] ^^^ state[12] ^^^ state[13] ^^^ state[14],
-      state[15] ^^^ state[16] ^^^ state[17] ^^^ state[18] ^^^ state[19],
-      state[20] ^^^ state[21] ^^^ state[22] ^^^ state[23] ^^^ state[24]
-    ]
+  #v[
+    state[0] ^^^ state[1] ^^^ state[2] ^^^ state[3] ^^^ state[4],
+    state[5] ^^^ state[6] ^^^ state[7] ^^^ state[8] ^^^ state[9],
+    state[10] ^^^ state[11] ^^^ state[12] ^^^ state[13] ^^^ state[14],
+    state[15] ^^^ state[16] ^^^ state[17] ^^^ state[18] ^^^ state[19],
+    state[20] ^^^ state[21] ^^^ state[22] ^^^ state[23] ^^^ state[24]
+  ]
 
 def theta_d (c : Vector ℕ 5) : Vector ℕ 5 :=
   #v[
@@ -40,7 +40,6 @@ def theta_d (c : Vector ℕ 5) : Vector ℕ 5 :=
     c[2] ^^^ (rot_left64 c[4] 1),
     c[3] ^^^ (rot_left64 c[0] 1)
   ]
-
 
 def theta_xor (state : Vector ℕ 25) (d : Vector ℕ 5) : Vector ℕ 25 :=
   #v[
@@ -136,7 +135,6 @@ def chi (b : Vector ℕ 25) : Vector ℕ 25 :=
 
 def iota (state : Vector ℕ 25) (rc : UInt64) : Vector ℕ 25 :=
   state.set 0 ((state.get 0) ^^^ rc.val)
-
 
 def keccak_round (state : Vector ℕ 25) (rc : UInt64) : Vector ℕ 25 :=
   let theta_state := theta state

--- a/Clean/Utils/Misc.lean
+++ b/Clean/Utils/Misc.lean
@@ -1,0 +1,16 @@
+/-
+Miscellaneous utility lemmas/methods that don't fit anywhere else.
+-/
+import Mathlib.Tactic
+
+theorem Fin.foldl_const {α : Type} (n : ℕ) (f : Fin (n + 1) → α) (init : α) :
+    Fin.foldl (n + 1) (fun _ i => f i) init = f n := by
+  induction n generalizing init with
+  | zero => rfl
+  | succ n ih =>
+    let f' (i : Fin (n + 1)) := f (i.succ)
+    rw [Fin.foldl_succ]
+    show Fin.foldl (n + 1) (fun x i ↦ f' i) _ = _
+    rw [ih]
+    simp only [f']
+    rw [Fin.natCast_eq_last, Fin.succ_last, ←Fin.natCast_eq_last]

--- a/Clean/Utils/Misc.lean
+++ b/Clean/Utils/Misc.lean
@@ -2,8 +2,9 @@
 Miscellaneous utility lemmas/methods that don't fit anywhere else.
 -/
 import Mathlib.Tactic
+variable {α : Type}
 
-theorem Fin.foldl_const {α : Type} (n : ℕ) (f : Fin (n + 1) → α) (init : α) :
+theorem Fin.foldl_const_succ (n : ℕ) (f : Fin (n + 1) → α) (init : α) :
     Fin.foldl (n + 1) (fun _ i => f i) init = f n := by
   induction n generalizing init with
   | zero => rfl
@@ -14,3 +15,13 @@ theorem Fin.foldl_const {α : Type} (n : ℕ) (f : Fin (n + 1) → α) (init : �
     rw [ih]
     simp only [f']
     rw [Fin.natCast_eq_last, Fin.succ_last, ←Fin.natCast_eq_last]
+
+theorem Fin.foldl_const_zero (f : Fin 0 → α) (init : α) :
+    Fin.foldl 0 (fun _ i => f i) init = init := by
+  rfl
+
+theorem Fin.foldl_const (n : ℕ) (f : Fin n → α) (init : α) :
+  Fin.foldl n (fun _ i => f i) init = match n with
+    | 0 => init
+    | n + 1 => f n := by
+  split <;> simp [foldl_const_succ]

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -180,10 +180,8 @@ def mapRange (n: ℕ) (create: ℕ → α) : Vector α n :=
   | 0 => #v[]
   | k + 1 => mapRange k create |>.push (create k)
 
-@[simp]
 theorem mapRange_zero {create: ℕ → α} : mapRange 0 create = #v[] := rfl
 
-@[simp]
 theorem mapRange_succ {n} {create: ℕ → α} :
     mapRange (n + 1) create = (mapRange n create).push (create n) := rfl
 


### PR DESCRIPTION
* keccak permutation circuit, which applies the round function 24 times with different round constants
* foldl loop primitive, which is needed here because we apply the loop body to its own result from the last operation