### PR TITLE
Lemma about lifting multiplication to Nat

### DIFF
--- a/Clean/Gadgets/And/And8.lean
+++ b/Clean/Gadgets/And/And8.lean
@@ -110,7 +110,7 @@ theorem soundness : Soundness (F p) elaborated assumptions spec := by
 
   -- crucial step: since 2 divides (2 * w).val, we can actually pull in .val
   have two_mul_val : (2 * w).val = 2 * w.val := FieldUtils.mul_nat_val_of_dvd w 2
-    (by norm_num) (by linarith [p_large_enough.elim])
+    (by linarith [p_large_enough.elim])
     ⟨ ZMod.val x &&& ZMod.val y, by rw [←two_and]; congr ⟩
 
   rw [two_mul_val, Nat.mul_left_cancel_iff (by linarith)] at two_and

--- a/Clean/Gadgets/And/And8.lean
+++ b/Clean/Gadgets/And/And8.lean
@@ -110,7 +110,7 @@ theorem soundness : Soundness (F p) elaborated assumptions spec := by
 
   -- crucial step: since 2 divides (2 * w).val, we can actually pull in .val
   have two_mul_val : (2 * w).val = 2 * w.val := FieldUtils.mul_nat_val_of_dvd w 2
-    (by linarith [p_large_enough.elim]) ⟨ _, two_and ⟩
+    (by linarith [p_large_enough.elim]) two_and
 
   rw [two_mul_val, Nat.mul_left_cancel_iff (by linarith)] at two_and
   exact two_and

--- a/Clean/Gadgets/And/And8.lean
+++ b/Clean/Gadgets/And/And8.lean
@@ -109,7 +109,7 @@ theorem soundness : Soundness (F p) elaborated assumptions spec := by
   clear two_and_field x_y_val x_y_z_val h_xor z_lt
 
   -- crucial step: since 2 divides (2 * w).val, we can actually pull in .val
-  have two_mul_val : (2 * w).val = 2 * w.val := FieldUtils.mul_nat_val_of_dvd w 2
+  have two_mul_val : (2 * w).val = 2 * w.val := FieldUtils.mul_nat_val_of_dvd 2
     (by linarith [p_large_enough.elim]) two_and
 
   rw [two_mul_val, Nat.mul_left_cancel_iff (by linarith)] at two_and

--- a/Clean/Gadgets/And/And8.lean
+++ b/Clean/Gadgets/And/And8.lean
@@ -110,8 +110,7 @@ theorem soundness : Soundness (F p) elaborated assumptions spec := by
 
   -- crucial step: since 2 divides (2 * w).val, we can actually pull in .val
   have two_mul_val : (2 * w).val = 2 * w.val := FieldUtils.mul_nat_val_of_dvd w 2
-    (by linarith [p_large_enough.elim])
-    ⟨ ZMod.val x &&& ZMod.val y, by rw [←two_and]; congr ⟩
+    (by linarith [p_large_enough.elim]) ⟨ _, two_and ⟩
 
   rw [two_mul_val, Nat.mul_left_cancel_iff (by linarith)] at two_and
   exact two_and

--- a/Clean/Gadgets/And/And8.lean
+++ b/Clean/Gadgets/And/And8.lean
@@ -108,22 +108,13 @@ theorem soundness : Soundness (F p) elaborated assumptions spec := by
 
   clear two_and_field x_y_val x_y_z_val h_xor z_lt
 
-  -- rewrite the goal to the form `(2 * w).val = (2 * v).val`,
-  -- where we can prove `(2 * v).val = 2 * v.val`
-  have and_byte : x.val &&& y.val < 256 := Nat.and_lt_two_pow (n:=8) x.val hy_byte
-  have p_large := p_large_enough.elim
+  -- crucial step: since 2 divides (2 * w).val, we can actually pull in .val
+  have two_mul_val : (2 * w).val = 2 * w.val := FieldUtils.mul_nat_val_of_dvd w 2
+    (by norm_num) (by linarith [p_large_enough.elim])
+    ⟨ ZMod.val x &&& ZMod.val y, by rw [←two_and]; congr ⟩
 
-  let v : F p := nat_to_field (x.val &&& y.val) (by linarith)
-  have v_val_eq : v.val = x.val &&& y.val := nat_to_field_eq v rfl
-  rw [←v_val_eq] at two_and ⊢
-  apply congrArg ZMod.val
-  rw [←mul_right_inj' two_non_zero]
-  apply ext
-  rw [two_and]
-
-  -- this is now easy
-  have rhs_lt : (2 : F p).val * v.val < p := by rw [v_val_eq, val_two]; linarith
-  rw [ZMod.val_mul_of_lt rhs_lt, val_two]
+  rw [two_mul_val, Nat.mul_left_cancel_iff (by linarith)] at two_and
+  exact two_and
 
 theorem completeness : Completeness (F p) elaborated assumptions := by
   intro i env ⟨ x_var, y_var ⟩ h_env ⟨ x, y ⟩ h_input h_assumptions

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -115,12 +115,15 @@ def mod (x: F p) (c: ℕ+) (lt: c < p) : F p :=
 def floordiv [NeZero p] (x: F p) (c: ℕ+) : F p :=
   FieldUtils.nat_to_field (x.val / c) (by linarith [Nat.div_le_self x.val c, less_than_p x])
 
-theorem mul_val_of_dvd (x c : F p) (c_pos : c.val > 0) (h_dvd: c.val ∣ (c * x).val) :
-    (c * x).val = c.val * x.val := by
-  obtain ⟨x', h_eq⟩ := h_dvd
+theorem mul_val_of_dvd {x c : F p} :
+    c.val ∣ (c * x).val → (c * x).val = c.val * x.val := by
+  by_cases c_pos? : c = 0
+  · subst c_pos?; simp
+  intro ⟨x', h_eq⟩
   have h_lt : c.val * x' < p := by
     rw [←h_eq]
     apply ZMod.val_lt
+  have c_pos : c.val > 0 := ZMod.val_pos.mpr c_pos?
   have x'_lt : x' < p := calc x'
     _ = 1 * x' := by ring
     _ ≤ c.val * x' := by apply Nat.mul_le_mul_right x' (Nat.succ_le_of_lt c_pos)
@@ -134,15 +137,14 @@ theorem mul_val_of_dvd (x c : F p) (c_pos : c.val > 0) (h_dvd: c.val ∣ (c * x)
     exact h_lt
   rw [←cx_val_eq] at h_eq
   obtain h_eq := ext h_eq
-  have c_pos' : c ≠ 0 := ZMod.val_pos.mp c_pos
-  rw [mul_right_inj' c_pos'] at h_eq
+  rw [mul_right_inj' c_pos?] at h_eq
   rw [h_eq, x'_val_eq, cx_val_eq]
 
-theorem mul_nat_val_of_dvd (x: F p) (c: ℕ) (c_pos : c > 0) (c_lt : c < p)
+theorem mul_nat_val_of_dvd (x: F p) (c: ℕ) (c_lt : c < p)
     (h_dvd: ∃ x', (c * x).val = c * x') : (c * x).val = c * x.val := by
   have c_val_eq : c = (c : F p).val := by rw [ZMod.val_cast_of_lt c_lt]
   rw (occs := .pos [2]) [c_val_eq]
-  exact mul_val_of_dvd x (c : F p) (c_val_eq ▸ c_pos) (c_val_eq ▸ h_dvd)
+  exact mul_val_of_dvd (c_val_eq ▸ h_dvd)
 
 end FieldUtils
 

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -115,6 +115,30 @@ def mod (x: F p) (c: ℕ+) (lt: c < p) : F p :=
 def floordiv [NeZero p] (x: F p) (c: ℕ+) : F p :=
   FieldUtils.nat_to_field (x.val / c) (by linarith [Nat.div_le_self x.val c, less_than_p x])
 
+theorem mul_val_of_multiple (x: F p) (c: ℕ) (c_pos : c > 0) (c_lt : c < p) (x' : ℕ)
+    (h_eq: (c * x).val = c * x') (h_lt : c * x' < p) : (c * x).val = c * x.val := by
+  have x'_lt : x' < p := calc x'
+    _ = 1 * x' := by ring
+    _ ≤ c * x' := by apply Nat.mul_le_mul_right x' (Nat.succ_le_of_lt c_pos)
+    _ < p := h_lt
+  let x'_f : F p := nat_to_field x' x'_lt
+  have x'_val_eq : x'_f.val = x' := nat_to_field_eq x'_f rfl
+  have cx_val_eq : (c * x'_f).val = c * x' := by
+    rw [←x'_val_eq]
+    nth_rewrite 2 [←ZMod.val_cast_of_lt c_lt]
+    apply ZMod.val_mul_of_lt
+    rw [x'_val_eq, ZMod.val_cast_of_lt c_lt]
+    exact h_lt
+  rw [←cx_val_eq] at h_eq
+  obtain h_eq := ext h_eq
+  have c_pos_f : (c : F p) ≠ 0 := by
+    intro c_eq_zero
+    have c_val_eq_zero := congrArg ZMod.val c_eq_zero
+    rw [ZMod.val_zero, ZMod.val_cast_of_lt c_lt] at c_val_eq_zero
+    linarith
+  rw [mul_right_inj' c_pos_f] at h_eq
+  rw [h_eq, x'_val_eq, cx_val_eq]
+
 end FieldUtils
 
 -- utils related to bytes, and specifically field elements that are bytes (< 256)

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -140,11 +140,12 @@ theorem mul_val_of_dvd {x c : F p} :
   rw [mul_right_inj' c_pos?] at h_eq
   rw [h_eq, x'_val_eq, cx_val_eq]
 
-theorem mul_nat_val_of_dvd (x: F p) (c: ℕ) (c_lt : c < p)
-    {z} (h_dvd: (c * x).val = c * z) : (c * x).val = c * x.val := by
+theorem mul_nat_val_of_dvd {x: F p} (c: ℕ) (c_lt : c < p) {z : ℕ} :
+    (c * x).val = c * z → (c * x).val = c * x.val := by
   have c_val_eq : c = (c : F p).val := by rw [ZMod.val_cast_of_lt c_lt]
-  rw (occs := .pos [2]) [c_val_eq]
-  exact mul_val_of_dvd (c_val_eq ▸ ⟨ z, h_dvd ⟩)
+  rw (occs := .pos [2, 4]) [c_val_eq]
+  intro h_dvd
+  exact mul_val_of_dvd ⟨ z, h_dvd ⟩
 
 end FieldUtils
 

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -141,10 +141,10 @@ theorem mul_val_of_dvd {x c : F p} :
   rw [h_eq, x'_val_eq, cx_val_eq]
 
 theorem mul_nat_val_of_dvd (x: F p) (c: ℕ) (c_lt : c < p)
-    (h_dvd: ∃ x', (c * x).val = c * x') : (c * x).val = c * x.val := by
+    {z} (h_dvd: (c * x).val = c * z) : (c * x).val = c * x.val := by
   have c_val_eq : c = (c : F p).val := by rw [ZMod.val_cast_of_lt c_lt]
   rw (occs := .pos [2]) [c_val_eq]
-  exact mul_val_of_dvd (c_val_eq ▸ h_dvd)
+  exact mul_val_of_dvd (c_val_eq ▸ ⟨ z, h_dvd ⟩)
 
 end FieldUtils
 

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -138,7 +138,7 @@ theorem mul_val_of_dvd (x c : F p) (c_pos : c.val > 0) (h_dvd: c.val ∣ (c * x)
   rw [mul_right_inj' c_pos'] at h_eq
   rw [h_eq, x'_val_eq, cx_val_eq]
 
-theorem mul_val_nat_of_dvd (x: F p) (c: ℕ) (c_pos : c > 0) (c_lt : c < p)
+theorem mul_nat_val_of_dvd (x: F p) (c: ℕ) (c_pos : c > 0) (c_lt : c < p)
     (h_dvd: ∃ x', (c * x).val = c * x') : (c * x).val = c * x.val := by
   have c_val_eq : c = (c : F p).val := by rw [ZMod.val_cast_of_lt c_lt]
   rw (occs := .pos [2]) [c_val_eq]


### PR DESCRIPTION
adds a non-trivial lifting lemma:

`(c * x).val = c.val * z` for _some_ `z` implies `(c * x).val = c.val * x.val`

the lemma already implicitly existed as part of the AND8 proof, and now we explicitly call it from there.