### PR TITLE
forEach loop

### DIFF
--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -1,9 +1,13 @@
+/-
+This file proves some properties about `forM`, `mapM`, and `foldlM` monad loops when used in a `Circuit`,
+typically leveraging a `ConstantLawfulCircuits` assumption on the loop body.
+
+The end result are loop methods `Circuit.{mapFinRange, map, for, foldl}` that simplify
+under `circuit_norm` in every way we need them to.
+-/
 import Clean.Circuit.Lawful
 import Clean.Utils.Misc
 variable {n m : ℕ} {F : Type} [Field F] {α β : Type}
-
--- we prove a few properties about the circuit `forM xs circuit`, where `circuit : α → Circuit F Unit`
--- TODO handle more general loops
 
 instance LawfulCircuit.from_forM {circuit : α → Circuit F Unit} [∀ x : α, LawfulCircuit (circuit x)] (xs : List α) :
     LawfulCircuit (forM xs circuit) := by

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -282,17 +282,6 @@ theorem forM_vector_forAll' {xs : Vector α n} :
     simp only [Vector.mem_zipIdx_iff_getElem?, Vector.getElem?_eq_some_iff] at hxi
     have ⟨ i_lt, x_eq ⟩ := hxi
     exact x_eq ▸ h ⟨ i, i_lt ⟩
-
--- specialization to soundness / completeness
-theorem forM_soundness {xs : List α} :
-  soundness env (forM xs circuit |>.operations n) ↔
-    xs.zipIdx.Forall fun (x, i) => soundness env (circuit x |>.operations (n + i*lawful.local_length)) := by
-  simp only [soundness_iff_forAll, forM_forAll]
-
-theorem forM_completeness {xs : List α} :
-  completeness env (forM xs circuit |>.operations n) ↔
-    xs.zipIdx.Forall fun (x, i) => completeness env (circuit x |>.operations (n + i*lawful.local_length)) := by
-  simp only [completeness_iff_forAll, forM_forAll]
 end
 
 end Circuit.constraints_hold
@@ -371,18 +360,6 @@ theorem mapM_vector_forAll {xs : Vector α n} :
   rw [mapM_forAll_vector_iff_list, mapM_forAll_iff_forM, ←Vector.forM_toList, forM_vector_forAll']
   simp only [operations_ignore]
   trivial
-
--- specialization to soundness / completeness
-
-theorem mapM_soundness {xs : List α} :
-  soundness env (xs.mapM circuit |>.operations n) ↔
-    xs.zipIdx.Forall fun (x, i) => soundness env (circuit x |>.operations (n + i*lawful.local_length)) := by
-  simp only [soundness_iff_forAll, mapM_forAll]
-
-theorem mapM_completeness {xs : List α} :
-  completeness env (xs.mapM circuit |>.operations n) ↔
-    xs.zipIdx.Forall fun (x, i) => completeness env (circuit x |>.operations (n + i*lawful.local_length)) := by
-  simp only [completeness_iff_forAll, mapM_forAll]
 end
 
 -- specialization to mapFinRangeM

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -70,8 +70,6 @@ def fib32_table : List (TableOperation RowType (F p)) := [
   EveryRowExceptLast recursive_relation,
 ]
 
-#eval fib32_table (p:=p_babybear)
-
 /--
   Specification for fibonacci32: for each row with index i
   - the first U32 value is the i-th fibonacci number


### PR DESCRIPTION
This finishes a line of work on loops in clean, by adding `Circuit.forEach` which is just `Vector.forM` but simplifies well under `circuit_norm`.

* Refactor the generic equality gadget to use `Circuit.forEach`, mainly to test that everything works as expected
* Remove several theorems in `Loops.lean` that aren't needed for our collection of `Circuit` loops