### PR TITLE
Num2Bits gadget and generalization of loop theorems

### DIFF
--- a/Clean/Circuit/Append.lean
+++ b/Clean/Circuit/Append.lean
@@ -86,6 +86,16 @@ theorem append_lookup (as : Operations F m) (bs : OperationsFrom F m n) (l : Loo
 theorem append_subcircuit (as : Operations F m) (bs : OperationsFrom F m n) (s : SubCircuit F n) :
   as ++ (OperationsFrom.subcircuit bs s) = .subcircuit (as ++ bs) s := by rfl
 
+theorem empty_of_append_empty {m n: ℕ} (as : Operations F m) (bs : OperationsFrom F m n) :
+    as ++ bs = .empty n → n = m ∧ as = .empty m ∧ bs.val = .empty n := by
+  intro h_append_empty
+  induction bs using OperationsFrom.induct with
+  | empty n =>
+    rw [Operations.append_empty] at h_append_empty
+    exact ⟨ rfl, h_append_empty, rfl ⟩
+  | witness bs _ _ ih | assert bs _ ih | lookup bs _ ih | subcircuit bs _ ih =>
+    simp only [append_witness, append_assert, append_lookup, append_subcircuit, reduceCtorEq] at h_append_empty
+
 theorem append_initial_offset {m n: ℕ} (as : Operations F m) (bs : OperationsFrom F m n) :
     (as ++ bs).initial_offset = as.initial_offset := by
   induction bs using OperationsFrom.induct with

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -272,6 +272,11 @@ def witness_vars (n: ℕ) (compute : Environment F → Vector F n) : Circuit F (
     let vars := Vector.mapRange n fun i => ⟨ ops.offset + i ⟩
     ⟨vars, .witness ops n compute⟩
 
+@[circuit_norm]
+def witness_vector (n: ℕ) (compute : Environment F → Vector F n) : Circuit F (Vector (Expression F) n) := do
+  let vars ← witness_vars n compute
+  return vars.map Expression.var
+
 /-- Add a constraint. -/
 @[circuit_norm]
 def assert_zero (e: Expression F) : Circuit F Unit :=
@@ -509,7 +514,7 @@ def subassertion_completeness (circuit: FormalAssertion F β) (b_var : Var β F)
 end Circuit
 end
 
-export Circuit (witness_var witness witness_vars assert_zero lookup)
+export Circuit (witness_var witness witness_vars witness_vector assert_zero lookup)
 
 /-- move from inductive (nested) operations back to flat operations -/
 def to_flat_operations {n: ℕ} : Operations F n → List (FlatOperation F)

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -273,9 +273,10 @@ def witness_vars (n: ℕ) (compute : Environment F → Vector F n) : Circuit F (
     ⟨vars, .witness ops n compute⟩
 
 @[circuit_norm]
-def witness_vector (n: ℕ) (compute : Environment F → Vector F n) : Circuit F (Vector (Expression F) n) := do
-  let vars ← witness_vars n compute
-  return vars.map Expression.var
+def witness_vector (n: ℕ) (compute : Environment F → Vector F n) : Circuit F (Vector (Expression F) n) :=
+  modifyGet fun ops =>
+    let vars := Vector.mapRange n fun i => var ⟨ ops.offset + i ⟩
+    ⟨vars, .witness ops n compute⟩
 
 /-- Add a constraint. -/
 @[circuit_norm]

--- a/Clean/Circuit/Lawful.lean
+++ b/Clean/Circuit/Lawful.lean
@@ -271,12 +271,22 @@ theorem initial_offset_eq (circuit : Circuit F α) [LawfulCircuit circuit] (n : 
   rw [operations_eq circuit n]
   exact (final_offset_eq circuit n ▸ operations n).property
 
+theorem initial_offset_eq' (circuit : Circuit F α) [LawfulCircuit circuit] (ops : OperationsList F) :
+    (circuit ops).2.withLength.initial_offset = ops.withLength.initial_offset := by
+  rw [append_only, Operations.append_initial_offset]
+
 theorem local_length_eq (circuit : Circuit F α) [lawful: ConstantLawfulCircuit circuit] (n : ℕ) :
     circuit.local_length n = lawful.local_length := by
   apply Nat.add_left_cancel (n:=n)
   rw [←lawful.local_length_eq]
   rw (occs := .pos [1]) [←initial_offset_eq circuit n]
   rw [Circuit.total_length_eq, final_offset_eq]
+
+theorem local_length_eq' (circuit : Circuit F α) [lawful: ConstantLawfulCircuit circuit] (ops : OperationsList F) :
+    (circuit ops).2.withLength.local_length = ops.withLength.local_length + lawful.local_length := by
+  apply Nat.add_left_cancel (n:=(circuit ops).2.withLength.initial_offset)
+  rw [←add_assoc, Circuit.total_length_eq, initial_offset_eq', Circuit.total_length_eq,
+    offset_independent, ←lawful.local_length_eq]
 
 theorem bind_local_length (f : Circuit F α) (g : α → Circuit F β)
   (f_lawful: LawfulCircuit f) (g_lawful : ∀ a : α, LawfulCircuit (g a)) (n : ℕ) :

--- a/Clean/Circuit/Lawful.lean
+++ b/Clean/Circuit/Lawful.lean
@@ -347,6 +347,20 @@ theorem bind_forAll {f : Circuit F α} {g : α → Circuit F β} (f_lawful: Lawf
     simp only [fg_lawful, from_bind]
   rw [h_ops, OperationsFrom.append_val, append_forAll]
 
+theorem bind_forAll' {f : Circuit F α} {g : α → Circuit F β} (f_lawful: LawfulCircuit f) (g_lawful : ∀ a, LawfulCircuit (g a))
+  (ops : OperationsList F) :
+  ((f >>= g) ops).2.withLength.forAll prop ↔
+    (f ops).2.withLength.forAll prop ∧
+      ((g (LawfulCircuit.output f ops.offset)).operations (f ops).2.offset).forAll prop := by
+  open LawfulCircuit in
+  let fg_lawful : LawfulCircuit (f >>= g) := .from_bind inferInstance inferInstance
+  rw [append_only, append_only]
+  simp only
+  rw [append_forAll, append_forAll]
+  simp only [←LawfulCircuit.operations_eq' (Operations.forAll prop)]
+  simp only [bind_forAll]
+  simp only [and_assoc, and_assoc]
+
 -- specializations to soundness / completeness
 
 theorem bind_soundness {f : Circuit F α} {g : α → Circuit F β} (f_lawful: LawfulCircuit f) (g_lawful : ∀ a, LawfulCircuit (g a)) :

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -694,17 +694,21 @@ lemma forEach.soundness' :
 
 @[circuit_norm ↓]
 lemma forEach.completeness :
-  constraints_hold.completeness env (forEach xs body lawful |>.operations n) ↔
-    ∀ i : Fin m, constraints_hold.completeness env (body xs[i.val] |>.operations (n + i*(body default).local_length)) := by
-  simp only [forEach, constraints_hold.completeness_iff_forAll, constraints_hold.forM_vector_forAll']
+  constraints_hold.completeness env (forEach xs body lawful ops).2.withLength ↔
+    (constraints_hold.completeness env ops.withLength)
+    ∧ ∀ i : Fin m, constraints_hold.completeness env (body xs[i.val] |>.operations (ops.offset + i*(body default).local_length)) := by
+  simp only [forEach, constraints_hold.completeness_iff_forAll]
+  rw [constraints_hold.forM_vector_forAll_general]
   rw [LawfulCircuit.local_length_eq]
   trivial
 
 @[circuit_norm ↓]
 lemma forEach.uses_local_witnesses :
-  env.uses_local_witnesses_completeness (forEach xs body lawful |>.operations n) ↔
-    ∀ i : Fin m, env.uses_local_witnesses_completeness (body xs[i.val] |>.operations (n + i*(body default).local_length)) := by
-  simp only [forEach, env.uses_local_witnesses_completeness_iff_forAll, constraints_hold.forM_vector_forAll']
+  env.uses_local_witnesses_completeness (forEach xs body lawful ops).2.withLength ↔
+    (env.uses_local_witnesses_completeness ops.withLength)
+    ∧ ∀ i : Fin m, env.uses_local_witnesses_completeness (body xs[i.val] |>.operations (ops.offset + i*(body default).local_length)) := by
+  simp only [forEach, env.uses_local_witnesses_completeness_iff_forAll]
+  rw [constraints_hold.forM_vector_forAll_general]
   rw [LawfulCircuit.local_length_eq]
   trivial
 

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -649,6 +649,13 @@ lemma forEach.uses_local_witnesses :
   rw [LawfulCircuit.local_length_eq]
   trivial
 
+@[circuit_norm]
+lemma forEach.final_offset_eq :
+    (forEach xs body lawful ops).2.offset = ops.offset + m * (body default).local_length := by
+  let lawful_loop : ConstantLawfulCircuit (forEach xs body lawful) := .from_forM_vector xs lawful
+  rw [LawfulCircuit.offset_independent, LawfulCircuit.local_length_eq, mul_comm]
+  rfl
+
 @[circuit_norm ↓]
 lemma forEach.local_length_eq :
     (forEach xs body lawful ops).2.withLength.local_length = ops.withLength.local_length + m * (body default).local_length := by

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -666,7 +666,7 @@ lemma forEach.initial_offset_eq :
 omit [Inhabited α] in
 @[circuit_norm ↓]
 lemma forEach.output_eq :
-  (forEach xs body lawful).output n = () := rfl
+  (forEach xs body lawful ops).1 = () := rfl
 end forEach
 
 section foldl

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -613,7 +613,7 @@ end map
 
 section forEach
 variable {env : Environment F} {m n : ℕ} [Inhabited α] {xs : Vector α m}
-  {body : α → Circuit F Unit} {lawful : ConstantLawfulCircuits body}
+  {body : α → Circuit F Unit} {lawful : ConstantLawfulCircuits body} {ops : OperationsList F}
 
 @[circuit_norm ↓]
 lemma forEach.soundness :
@@ -624,7 +624,7 @@ lemma forEach.soundness :
   trivial
 
 omit [Inhabited α] in
-/-- variant of `forEach.soundness'`, for when the constraints don't depend on the input offset -/
+/-- variant of `forEach.soundness`, for when the constraints don't depend on the input offset -/
 lemma forEach.soundness' :
   constraints_hold.soundness env (forEach xs body lawful |>.operations n) →
     ∀ x ∈ xs, ∃ k : ℕ, constraints_hold.soundness env (body x |>.operations k) := by
@@ -651,17 +651,17 @@ lemma forEach.uses_local_witnesses :
 
 @[circuit_norm ↓]
 lemma forEach.local_length_eq :
-    (forEach xs body lawful).local_length n = m * (body default).local_length := by
+    (forEach xs body lawful ops).2.withLength.local_length = ops.withLength.local_length + m * (body default).local_length := by
   let lawful_loop : ConstantLawfulCircuit (forEach xs body lawful) := .from_forM_vector xs lawful
-  rw [LawfulCircuit.local_length_eq, LawfulCircuit.local_length_eq, mul_comm]
+  rw [LawfulCircuit.local_length_eq', LawfulCircuit.local_length_eq, mul_comm]
   rfl
 
 omit [Inhabited α] in
 @[circuit_norm ↓]
 lemma forEach.initial_offset_eq :
-    (forEach xs body lawful |>.operations n).initial_offset = n := by
+    (forEach xs body lawful ops).2.withLength.initial_offset = ops.withLength.initial_offset := by
   let lawful_loop : ConstantLawfulCircuit (forEach xs body lawful) := .from_forM_vector xs lawful
-  rw [LawfulCircuit.initial_offset_eq]
+  rw [LawfulCircuit.initial_offset_eq']
 
 omit [Inhabited α] in
 @[circuit_norm ↓]

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -254,6 +254,45 @@ theorem forM_forAll {xs : List α} :
     rw [bind_forAll inferInstance inferInstance]
     exact Iff.intro id id
 
+theorem forM_forAll_general {xs : List α} (ops: OperationsList F) :
+  (forM xs circuit ops).2.withLength.forAll prop ↔
+    ops.withLength.forAll prop ∧
+    xs.zipIdx.Forall fun (x, i) => (circuit x |>.operations (ops.offset + i*lawful.local_length)).forAll prop := by
+
+  induction xs generalizing ops with
+  | nil => simp [Operations.forAll, circuit_norm]
+  | cons x xs ih =>
+    rw [List.forM_cons, List.zipIdx_cons, List.forall_cons]
+    simp only at ih ⊢
+    rw [zero_mul, add_zero, zero_add]
+    rw [bind_forAll' inferInstance inferInstance, Circuit.operations, ih]
+
+    have h_zip : xs.zipIdx.Forall (fun (x, i) => ((circuit x).operations (ops.offset + lawful.local_length + i * lawful.local_length)).forAll prop)
+      ↔ (xs.zipIdx 1).Forall (fun (x, i) => ((circuit x).operations (ops.offset + i * lawful.local_length)).forAll prop) := by
+      rw [List.zipIdx_succ, List.forall_map_iff]
+      conv =>
+        rhs
+        change xs.zipIdx.Forall fun (x, i) => ((circuit x).operations (ops.offset + (i + 1) * lawful.local_length)).forAll prop
+        lhs
+        intro t
+        simp only
+        rw [add_mul, one_mul, add_comm _ lawful.local_length, ←add_assoc]
+
+    rw [←h_zip]
+    clear h_zip ih
+    simp only [Operations.forAll_empty, true_and]
+    rw [LawfulCircuit.append_only, append_forAll]
+    simp only
+    rw [and_assoc, LawfulCircuit.operations_eq, iff_iff_eq]
+    have h_offset : LawfulCircuit.final_offset (circuit x) ops.offset = (circuit x).final_offset ops.offset :=
+      by rw [LawfulCircuit.final_offset_eq]
+    congr
+    apply funext_heq (by congr)
+    intro bs
+    congr
+    rw [heq_cast_iff_heq]
+    rw [heq_eqRec_iff_heq]
+
 theorem forM_vector_forAll {xs : Vector α n} :
   (xs.forM circuit |>.operations m).forAll prop ↔
     ∀ x ∈ xs, ∀ (i : ℕ) (_ : (x, i) ∈ xs.zipIdx), (circuit x |>.operations (m + i*lawful.local_length)).forAll prop := by
@@ -280,6 +319,25 @@ theorem forM_vector_forAll' {xs : Vector α n} :
     exact h xs[i] (by simp) i (by simp [Vector.mem_zipIdx_iff_getElem?])
   · intro h x hx i hxi
     simp only [Vector.mem_zipIdx_iff_getElem?, Vector.getElem?_eq_some_iff] at hxi
+    have ⟨ i_lt, x_eq ⟩ := hxi
+    exact x_eq ▸ h ⟨ i, i_lt ⟩
+
+theorem forM_vector_forAll_general {xs : Vector α n} {ops : OperationsList F} :
+  (xs.forM circuit ops).2.withLength.forAll prop ↔
+    ops.withLength.forAll prop ∧
+    ∀ (i : Fin n), (circuit xs[i.val] |>.operations (ops.offset + i*lawful.local_length)).forAll prop := by
+  rw [Vector.forM_toList, forM_forAll_general, and_congr_right_iff, List.forall_iff_forall_mem, Prod.forall]
+  simp only
+  intro _
+  have h_elem_iff {t} :(t ∈ xs.toList.zipIdx ↔ t ∈ xs.zipIdx) := by
+    rw [←Array.toList_zipIdx, ←Vector.mem_toList_iff]
+    trivial
+  constructor
+  · intro h i
+    apply h xs[i]
+    simp [h_elem_iff, Vector.mem_zipIdx_iff_getElem?]
+  · intro h x i hxi
+    simp only [h_elem_iff, Vector.mem_zipIdx_iff_getElem?, Vector.getElem?_eq_some_iff] at hxi
     have ⟨ i_lt, x_eq ⟩ := hxi
     exact x_eq ▸ h ⟨ i, i_lt ⟩
 end
@@ -488,7 +546,7 @@ def map {m : ℕ} [Nonempty β] (xs : Vector α m) (body : α → Circuit F β)
     (_lawful : ConstantLawfulCircuits body := by infer_constant_lawful_circuits) : Circuit F (Vector β m) :=
   xs.mapM body
 
-def forEach {m : ℕ} (xs : Vector α m) (body : α → Circuit F Unit)
+def forEach {m : ℕ} (xs : Vector α m) [Inhabited α]  (body : α → Circuit F Unit)
     (_lawful : ConstantLawfulCircuits body := by infer_constant_lawful_circuits) : Circuit F Unit :=
   xs.forM body
 
@@ -617,13 +675,14 @@ variable {env : Environment F} {m n : ℕ} [Inhabited α] {xs : Vector α m}
 
 @[circuit_norm ↓]
 lemma forEach.soundness :
-  constraints_hold.soundness env (forEach xs body lawful |>.operations n) ↔
-    ∀ i : Fin m, constraints_hold.soundness env (body xs[i.val] |>.operations (n + i*(body default).local_length)) := by
-  simp only [forEach, constraints_hold.soundness_iff_forAll, constraints_hold.forM_vector_forAll']
+  constraints_hold.soundness env (forEach xs body lawful ops).2.withLength ↔
+    (constraints_hold.soundness env ops.withLength)
+    ∧ ∀ i : Fin m, constraints_hold.soundness env (body xs[i.val] |>.operations (ops.offset + i*(body default).local_length)) := by
+  simp only [forEach, constraints_hold.soundness_iff_forAll]
+  rw [constraints_hold.forM_vector_forAll_general]
   rw [LawfulCircuit.local_length_eq]
   trivial
 
-omit [Inhabited α] in
 /-- variant of `forEach.soundness`, for when the constraints don't depend on the input offset -/
 lemma forEach.soundness' :
   constraints_hold.soundness env (forEach xs body lawful |>.operations n) →
@@ -663,14 +722,12 @@ lemma forEach.local_length_eq :
   rw [LawfulCircuit.local_length_eq', LawfulCircuit.local_length_eq, mul_comm]
   rfl
 
-omit [Inhabited α] in
 @[circuit_norm ↓]
 lemma forEach.initial_offset_eq :
     (forEach xs body lawful ops).2.withLength.initial_offset = ops.withLength.initial_offset := by
   let lawful_loop : ConstantLawfulCircuit (forEach xs body lawful) := .from_forM_vector xs lawful
   rw [LawfulCircuit.initial_offset_eq']
 
-omit [Inhabited α] in
 @[circuit_norm ↓]
 lemma forEach.output_eq :
   (forEach xs body lawful ops).1 = () := rfl
@@ -682,6 +739,10 @@ lemma forEach.apply_eq :
     withLength := ops.withLength ++ (⟨(forEach xs body lawful).operations ops.offset, (by simp only [circuit_norm])⟩
       : OperationsFrom F ops.offset ((forEach xs body lawful).final_offset ops.offset))
   }) := by
+  sorry
+
+lemma forEach.no_empty :
+  (forEach xs body lawful ops).2.withLength = .empty (forEach xs body lawful ops).2.offset → m = 0 := by
   sorry
 
 lemma forEach.apply_eq_snd :

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -674,6 +674,23 @@ omit [Inhabited α] in
 @[circuit_norm ↓]
 lemma forEach.output_eq :
   (forEach xs body lawful ops).1 = () := rfl
+
+-- @[circuit_norm ↓]
+lemma forEach.apply_eq :
+  forEach xs body lawful ops = ((), {
+    offset := ((forEach xs body lawful).final_offset ops.offset)
+    withLength := ops.withLength ++ (⟨(forEach xs body lawful).operations ops.offset, (by simp only [circuit_norm])⟩
+      : OperationsFrom F ops.offset ((forEach xs body lawful).final_offset ops.offset))
+  }) := by
+  sorry
+
+lemma forEach.apply_eq_snd :
+  (forEach xs body lawful ops).2 = {
+    offset := ((forEach xs body lawful).final_offset ops.offset)
+    withLength := ops.withLength ++ (⟨(forEach xs body lawful).operations ops.offset, (by simp only [circuit_norm])⟩
+      : OperationsFrom F ops.offset ((forEach xs body lawful).final_offset ops.offset))
+  } := by
+  sorry
 end forEach
 
 section foldl

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -26,7 +26,7 @@ class ProvableType (M : TypeMap) where
   from_elements {F: Type} : Vector F size -> M F
 
 class NonEmptyProvableType (M : TypeMap) extends ProvableType M where
-  nonempty : size > 0 := by norm_num
+  nonempty : size > 0 := by try simp only [size]; try norm_num
 
 export ProvableType (size to_elements from_elements)
 
@@ -116,6 +116,7 @@ instance : LawfulProvableType field where
   size := 1
   to_elements x := #v[x]
   from_elements v := v.get 0
+instance : NonEmptyProvableType field where
 
 @[reducible]
 def ProvablePair (α β : TypeMap) := fun F => α F × β F
@@ -289,6 +290,11 @@ end ProvableStruct
 @[circuit_norm ↓ high]
 theorem eval_field {F : Type} [Field F] (env : Environment F) (x : Var field F) :
   ProvableType.eval env x = Expression.eval env x := by rfl
+
+omit [Field F] in
+@[circuit_norm ↓]
+theorem var_from_offset_field (offset : Nat) :
+  ProvableType.var_from_offset (F:=F) field offset = var ⟨offset⟩ := by rfl
 
 namespace LawfulProvableType
 @[circuit_norm]

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -41,9 +41,8 @@ def circuit (n : ℕ) : FormalCircuit (F p) field (BitVector n) where
   local_length_eq _ _ := by simp only [main, circuit_norm, Boolean.circuit]; ac_rfl
 
   output_eq _ _ := by
-    simp only [main, circuit_norm, Boolean.circuit]
-    sorry
-
+    simp only [main, circuit_norm, Boolean.circuit, var_from_offset_vector]
+    rfl
 
   assumptions (x : F p) := x.val < 2^n
 

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -149,7 +149,7 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (BitVector n) w
   initial_offset_eq _ n := by simp only [main, circuit_norm]
   local_length_eq _ _ := by simp only [main, circuit_norm, Boolean.circuit]; ac_rfl
   output_eq _ _ := by
-    simp only [main, circuit_norm, Boolean.circuit, Circuit.forEach.apply_eq, var_from_offset_vector]
+    simp only [main, circuit_norm, Boolean.circuit, var_from_offset_vector]
 
   assumptions (x : F p) := x.val < 2^n
 
@@ -162,8 +162,11 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (BitVector n) w
     simp only [main, circuit_norm, Boolean.circuit, true_and, eval_vector, var_from_offset_vector] at *
     split at h_holds
     · rename_i h_eq
-      obtain rfl : n = 0 := Circuit.forEach.no_empty h_eq
-      simp [Vector.mapRange_zero]
+      rcases (Circuit.forEach.no_empty h_eq) with h|h
+      · obtain rfl : n = 0 := h
+        simp [Vector.mapRange_zero]
+      obtain ⟨_, _, h⟩ := h
+      exact Operations.noConfusion h
     rename_i h_eq; clear h_eq
     simp only [h_input, circuit_norm, subcircuit_norm, true_implies] at h_holds
     clear h_input
@@ -190,8 +193,11 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (BitVector n) w
     simp only [main, circuit_norm, Boolean.circuit, eval_vector, var_from_offset_vector] at *
     split
     · rename_i h_eq
-      obtain rfl : n = 0 := Circuit.forEach.no_empty h_eq
-      simp_all [Expression.eval, from_bits_expr]
+      rcases (Circuit.forEach.no_empty h_eq) with h|h
+      · obtain rfl : n = 0 := h
+        simp_all [Expression.eval, from_bits_expr]
+      obtain ⟨_, _, h⟩ := h
+      exact Operations.noConfusion h
     rename_i h_eq; clear h_eq
     simp only [h_input, circuit_norm, subcircuit_norm, true_implies, true_and, and_true] at h_env ⊢
     obtain ⟨ h_bits, right ⟩ := h_env; clear right;

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -1,0 +1,68 @@
+import Clean.Circuit.Loops
+import Clean.Gadgets.Equality
+import Clean.Gadgets.Boolean
+
+namespace Gadgets
+variable {p : ℕ} [prime: Fact p.Prime]
+
+def to_bit (x : ZMod p) : Bool := x == 1
+
+def to_bits (n : ℕ) (x : ZMod p) : Vector Bool n :=
+  .ofFn fun i => x.val.testBit i
+
+def from_bits {n : ℕ} (x : Vector Bool n) : ZMod p :=
+  Nat.ofBits fun i => x[i.val]
+
+def from_bits_expr {n: ℕ} (xs : Vector (Expression (F p)) n) : Expression (F p) :=
+  Fin.foldl n (fun acc i => acc + xs[i] * .const (2^i.val)) 0
+
+@[reducible] def BitVector (n : ℕ) := ProvableVector field n
+
+namespace ToBits
+def main {n: ℕ} (x : Expression (F p)) := do
+  let bits ← witness_vector n fun (eval : Environment (F p)) =>
+    .ofFn fun i =>
+      let bit : Bool := (eval x).val.testBit i
+      (if bit then 1 else 0 : F p)
+
+  Circuit.forEach bits fun bit => assertion Boolean.circuit bit
+
+  let x' := Fin.foldl n (fun acc ⟨i, _⟩ => acc + bits[i] * (2^i : F p)) 0
+  x.assert_equals x'
+
+  return bits
+
+def circuit (n : ℕ) : FormalCircuit (F p) field (BitVector n) where
+  main
+  local_length _ := n
+  output _ i := var_from_offset (ProvableVector field n) i
+
+  local_length_eq _ _ := by
+    simp only [main, circuit_norm, Boolean.circuit]
+    sorry
+
+  output_eq _ _ := by
+    simp only [main, circuit_norm, Boolean.circuit]
+    sorry
+
+  initial_offset_eq _ _ := by
+    simp only [main, circuit_norm, Boolean.circuit]
+    sorry
+
+  assumptions (x : F p) := x.val < 2^n
+
+  spec (x : F p) (xs : Vector (F p) n) :=
+    ∀ (i : ℕ) (hi : i < n), xs[i] = if x.val.testBit i then 1 else 0
+
+  soundness := by
+    intro k env x_var x h_input h_assumptions h_holds
+    simp only [main, circuit_norm, eval_vector, var_from_offset_vector] at *
+    intro i hi
+    sorry
+
+  completeness := by
+    intro k env x_var h_env x h_input h_assumptions
+    simp only [main, circuit_norm, eval_vector, var_from_offset_vector] at *
+    sorry
+
+end Gadgets.ToBits

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -5,100 +5,96 @@ import Clean.Gadgets.Boolean
 namespace Gadgets
 variable {p : ℕ} [prime: Fact p.Prime] [p_large_enough: Fact (p > 2)]
 
-def to_bit (x : ZMod p) (_ : x.val = 0 ∨ x.val = 1) : Bool := x == 1
+def to_bits (n : ℕ) (x : F p) : Vector (F p) n :=
+  .mapRange n fun i => if x.val.testBit i then 1 else 0
 
-def from_bits {n : ℕ} (bits : Vector ℕ n) : ℕ :=
+def from_bits {n : ℕ} (bits : Vector (F p) n) : F p :=
   Fin.foldl n (fun acc ⟨i, _⟩ => acc + bits[i] * 2^i) 0
 
 def from_bits_expr {n: ℕ} (bits : Vector (Expression (F p)) n) : Expression (F p) :=
   Fin.foldl n (fun acc ⟨i, _⟩ => acc + bits[i] * (2^i : F p)) 0
 
-theorem from_bits_eval {n: ℕ} (hn : 2^n < p) {env} (bits : Vector (Expression (F p)) n)
-  (h_bits : ∀ (i : ℕ) (hi : i < n), bits[i].eval env = 0 ∨ bits[i].eval env = 1) :
-    ((from_bits_expr bits).eval env).val = from_bits (bits.map (fun b => (b.eval env).val)) := by
+@[reducible] def BitVector (n : ℕ) := ProvableVector field n
 
-  -- strengthen the goal for use in induction
-  suffices h_stronger :
-      ((from_bits_expr bits).eval env).val < 2^n
-      ∧ ((from_bits_expr bits).eval env).val = from_bits (bits.map (fun b => (b.eval env).val))
-    from h_stronger.right
+namespace ToBits
+def main {n: ℕ} (x : Expression (F p)) := do
+  let bits ← witness_vector n fun env => to_bits n (x.eval env)
 
+  Circuit.forEach bits fun bit => assertion Boolean.circuit bit
+
+  x.assert_equals (from_bits_expr bits)
+  return bits
+
+-- theorems about to/from bits that we need
+
+omit p_large_enough in
+theorem from_bits_eval {n: ℕ} {eval : Environment (F p)} (bits : Vector (Expression (F p)) n)
+  (h_bits : ∀ (i : ℕ) (hi : i < n), eval bits[i] = 0 ∨ eval bits[i] = 1) :
+    eval (from_bits_expr bits) = from_bits (bits.map eval) := by
   simp only [from_bits_expr]
-
   induction n with
-  | zero => simp only [Fin.foldl_zero, Expression.eval, ZMod.val_zero, from_bits]; simp
+  | zero => simp only [Fin.foldl_zero, Expression.eval, from_bits]
   | succ n ih =>
     simp only [Fin.foldl_succ_last, Fin.coe_castSucc, Fin.val_last, Expression.eval, from_bits,
       Vector.getElem_map]
     simp only [from_bits, Vector.getElem_map] at ih
 
-    -- instantiate induction hypothesis
-    have : 2*2^n < p := by rw [←Nat.pow_succ']; exact hn
-    have : 2^n < p := by linarith
+    -- now the goal easily follows from the induction hypothesis
     let bits' : Vector (Expression (F p)) n := bits.pop
-    have h_bits' : ∀ j (hj : j < n), bits'[j].eval env = 0 ∨ bits'[j].eval env = 1
+    have h_bits' : ∀ j (hj : j < n), eval bits'[j] = 0 ∨ eval bits'[j] = 1
       | j, hj => by
         simp only [Vector.getElem_pop', bits']
         exact h_bits j (Nat.lt_succ_of_lt hj)
+    obtain ih := ih bits' h_bits'
+    simp only [Vector.getElem_pop', bits'] at ih
+    rw [ih]
 
-    obtain ⟨ ih_lt, ih_eq ⟩ := ih ‹_› bits' h_bits'; clear ih
-    simp only [Vector.getElem_pop', bits'] at ih_eq ih_lt
-
-    -- lift from ZMod to Nat
-    let bitn := bits[n].eval env
-    have : bitn.val < 2 := FieldUtils.boolean_lt_2 (h_bits n (Nat.lt_succ_self _))
-    have : 2 < p := p_large_enough.elim
-    have two_pow_val : ZMod.val (2 ^ n : F p) = 2 ^ n := by
-      have : @ZMod.val p 2 = 2 := ZMod.val_natCast_of_lt (by linarith)
-      rw [ZMod.val_pow, this]
-      rwa [this]
-
-    let xn : F p := Expression.eval env <| Fin.foldl n (fun acc ⟨i, _⟩ => acc + bits[i] * (2 ^ i : F p)) 0
-    have h_lt : xn.val + bitn.val * 2^n < 2^(n + 1) := by
-      have : bitn.val * 2^n ≤ 1 * 2^n := Nat.mul_le_mul_right (2 ^ n) (by linarith)
-      rw [Nat.pow_succ']
-      linarith
-
-    have h_to_nat : ZMod.val (xn + bitn * 2 ^ n) = xn.val + bitn.val * ZMod.val (2 ^ n : F p) := by
-      field_to_nat
-      rw [two_pow_val]
-      linarith
-
-    -- now we have everything in place
-    rw [h_to_nat, two_pow_val, ←ih_eq]
-    exact ⟨ h_lt, rfl ⟩
-
-theorem from_bits_testBit {n: ℕ} (bits : Vector ℕ n)
+lemma to_bits_from_bits_aux {n: ℕ} (hn : 2^n < p) (bits : Vector (F p) n)
   (h_bits : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1) :
-    ∀ (i : ℕ) (hi : i < n), (from_bits bits).testBit i = (bits[i] == 1) := by
-
-  -- strengthen the goal for use in induction
-  suffices h_stronger :
-      from_bits bits < 2^n
-      ∧ ∀ (i : ℕ) (hi : i < n), (from_bits bits).testBit i = (bits[i] == 1)
-    from h_stronger.right
-
-  simp only [from_bits]
+    (from_bits bits).val < 2^n ∧ to_bits n (from_bits bits) = bits := by
+  rw [Vector.ext_iff]
+  simp only [from_bits, to_bits, Vector.getElem_mapRange]
   induction n with
   | zero => simp_all
   | succ n ih =>
     simp only [Fin.foldl_succ_last, Fin.coe_castSucc, Fin.val_last]
 
-    let bits' : Vector ℕ n := bits.pop
+    -- instantiate induction hypothesis
+    have : 2*2^n < p := by rw [←Nat.pow_succ']; exact hn
+    have : 2^n < p := by linarith
+    let bits' : Vector (F p) n := bits.pop
     have h_bits' : ∀ j (hj : j < n), bits'[j] = 0 ∨ bits'[j] = 1
       | j, hj => by
         simp only [Vector.getElem_pop', bits']
         exact h_bits j (Nat.lt_succ_of_lt hj)
 
     have h_bits_n : bits[n] = 0 ∨ bits[n] = 1 := h_bits n (Nat.lt_succ_self _)
-    obtain ⟨ ih_lt, ih_eq ⟩ := ih bits' h_bits'; clear h_bits' h_bits ih
+    obtain ⟨ ih_lt, ih_eq ⟩ := ih ‹_› bits' h_bits'; clear h_bits' h_bits ih
     simp only [Vector.getElem_pop', bits'] at ih_eq ih_lt
 
-    have : bits[n] * 2 ^ n ≤ 2^n := by
-      simp only [Nat.ofNat_pos, pow_pos, mul_le_iff_le_one_left, bits']
-      rcases h_bits_n <;> simp [*, ZMod.val_one]
+    -- lift from ZMod to Nat
+    have : 2 < p := p_large_enough.elim
+    have two_pow_val : ZMod.val (2 ^ n : F p) = 2 ^ n := by
+      have : @ZMod.val p 2 = 2 := ZMod.val_natCast_of_lt (by linarith)
+      rw [ZMod.val_pow, this]
+      rwa [this]
+
+    let xn : F p := Fin.foldl n (fun acc ⟨i, _⟩ => acc + bits[i] * (2 ^ i : F p)) 0
+    have : bits[n].val ≤ 1 := by rcases h_bits_n <;> simp [*, ZMod.val_one]
+    have h_lt : xn.val + bits[n].val * 2^n < 2^(n + 1) := by
+      have : bits[n].val * 2^n ≤ 1 * 2^n := Nat.mul_le_mul_right (2 ^ n) (by linarith)
+      rw [Nat.pow_succ']
+      linarith
+
+    have h_to_nat : ZMod.val (xn + bits[n] * 2 ^ n) = xn.val + bits[n].val * 2 ^ n := by
+      field_to_nat
+      · rw [two_pow_val]
+      · rw [two_pow_val]; linarith
+
+    -- now everything is in place to finish the proof
+    rw [h_to_nat]
     constructor
-    · rw [Nat.pow_succ']; linarith
+    · exact h_lt
 
     intro i hi
     rw [mul_comm _ (2^n), add_comm _ (2^n * _), Nat.testBit_two_pow_mul_add _ ih_lt]
@@ -108,21 +104,43 @@ theorem from_bits_testBit {n: ℕ} (bits : Vector ℕ n)
     subst this
     rcases h_bits_n <;> simp [*, ZMod.val_one]
 
-@[reducible] def BitVector (n : ℕ) := ProvableVector field n
+theorem from_bits_lt {n: ℕ} (hn : 2^n < p) (bits : Vector (F p) n)
+  (h_bits : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1) :
+    (from_bits bits).val < 2^n := (to_bits_from_bits_aux hn bits h_bits).left
 
-namespace ToBits
-def main {n: ℕ} (x : Expression (F p)) := do
-  let bits ← witness_vector n fun (eval : Environment (F p)) =>
-    .ofFn fun i =>
-      let bit : Bool := (eval x).val.testBit i
-      (if bit then 1 else 0 : F p)
+theorem to_bits_from_bits {n: ℕ} (hn : 2^n < p) (bits : Vector (F p) n)
+  (h_bits : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1) :
+    to_bits n (from_bits bits) = bits := (to_bits_from_bits_aux hn bits h_bits).right
 
-  Circuit.forEach bits fun bit => assertion Boolean.circuit bit
+omit p_large_enough in
+/-- on numbers less than `2^n`, `to_bits n` is injective -/
+theorem to_bits_injective (n: ℕ) {x y : F p} : x.val < 2^n → y.val < 2^n →
+    to_bits n x = to_bits n y → x = y := by
+  intro hx hy h_eq
+  rw [Vector.ext_iff] at h_eq
+  simp only [to_bits, Vector.getElem_mapRange] at h_eq
+  have h_eq' : ∀ i (hi : i < n), x.val.testBit i = y.val.testBit i := by
+    intro i hi
+    specialize h_eq i hi
+    by_cases hx_i : x.val.testBit i <;> by_cases hy_i : y.val.testBit i <;>
+      simp_all
+  apply FieldUtils.ext
+  apply Nat.eq_of_testBit_eq
+  intro i
+  by_cases hi : i < n
+  · exact h_eq' i hi
+  have : n ≤ i := by linarith
+  have : 2^n ≤ 2^i := Nat.pow_le_pow_of_le (a:=2) (by norm_num) this
+  replace hx : x.val < 2^i := by linarith
+  replace hy : y.val < 2^i := by linarith
+  rw [Nat.testBit_lt_two_pow hx, Nat.testBit_lt_two_pow hy]
 
-  let x' := from_bits_expr bits
-  x.assert_equals x'
-
-  return bits
+theorem from_bits_to_bits {n: ℕ} (hn : 2^n < p) {x : F p} (hx : x.val < 2^n) :
+    from_bits (to_bits n x) = x := by
+  have h_bits : ∀ i (hi : i < n), (to_bits n x)[i] = 0 ∨ (to_bits n x)[i] = 1 := by
+    intro i hi; simp [to_bits]
+  apply to_bits_injective n (from_bits_lt hn _ h_bits) hx
+  rw [to_bits_from_bits hn _ h_bits]
 
 def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (BitVector n) where
   main
@@ -136,17 +154,17 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (BitVector n) w
 
   assumptions (x : F p) := x.val < 2^n
 
-  spec (x : F p) (xs : Vector (F p) n) :=
-    ∀ (i : ℕ) (hi : i < n), xs[i] = if x.val.testBit i then 1 else 0
+  spec (x : F p) (bits : Vector (F p) n) :=
+    bits = to_bits n x
 
   soundness := by
-    intro k env x_var x h_input h_assumptions h_holds
+    intro k eval x_var x h_input h_assumptions h_holds
     dsimp only [main] at *
     simp only [main, circuit_norm, Boolean.circuit, true_and, eval_vector, var_from_offset_vector] at *
     split at h_holds
     · rename_i h_eq
       obtain rfl : n = 0 := Circuit.forEach.no_empty h_eq
-      simp
+      simp [Vector.mapRange_zero]
     rename_i h_eq; clear h_eq
     simp only [h_input, circuit_norm, subcircuit_norm, true_implies] at h_holds
     clear h_input
@@ -154,9 +172,9 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (BitVector n) w
     obtain ⟨ h_bits, h_eq ⟩ := h_holds
 
     let bit_vars : Vector (Expression (F p)) n := .mapRange n fun i => var ⟨k + i⟩
-    let bits : Vector ℕ n := bit_vars.map (fun b => (b.eval env).val)
+    let bits : Vector (F p) n := bit_vars.map eval
 
-    have h_bit_vars : ∀ (i : ℕ) (hi : i < n), bit_vars[i].eval env = 0 ∨ bit_vars[i].eval env = 1
+    have h_bit_vars : ∀ (i : ℕ) (hi : i < n), eval bit_vars[i] = 0 ∨ eval bit_vars[i] = 1
       | i, hi => by
         simp only [Vector.getElem_mapRange, bit_vars]
         exact h_bits ⟨ i, hi ⟩
@@ -164,32 +182,49 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (BitVector n) w
     replace h_bits : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1
       | i, hi => by
         simp only [Vector.getElem_map, bits]
-        rcases h_bit_vars i hi with h|h
-        · left; rw [h, ZMod.val_zero]
-        · right; rw [h, ZMod.val_one]
+        exact h_bit_vars i hi
 
-    change x = (from_bits_expr bit_vars).eval env at h_eq
-    rw [h_eq, from_bits_eval hn bit_vars h_bit_vars]
-    intro i hi
+    change x = eval (from_bits_expr bit_vars) at h_eq
+    rw [h_eq, from_bits_eval bit_vars h_bit_vars]
 
-    show env.get (k + i) = if (from_bits bits).testBit i then 1 else 0
-
-    have h_bit_i : (env.get (k + i)).val = bits[i] := by
-      simp [Vector.getElem_map, bits, bit_vars, Expression.eval]
-    apply FieldUtils.ext
-    rw [h_bit_i, from_bits_testBit bits h_bits i hi]
-    specialize h_bits i hi
-    rcases h_bits <;> simp [*, bits, ZMod.val_one]
+    show _ = to_bits n (from_bits bits)
+    rw [to_bits_from_bits hn bits h_bits]
+    simp [bits, bit_vars, eval_field]
 
   completeness := by
-    intro k env x_var h_env x h_input h_assumptions
-    simp only [main, circuit_norm, Boolean.circuit, eval_vector, var_from_offset_vector, from_bits_expr] at *
+    intro k eval x_var h_env x h_input h_assumptions
+    simp only [main, circuit_norm, Boolean.circuit, eval_vector, var_from_offset_vector] at *
     split
     · rename_i h_eq
       obtain rfl : n = 0 := Circuit.forEach.no_empty h_eq
-      simp_all [Expression.eval]
+      simp_all [Expression.eval, from_bits_expr]
     rename_i h_eq; clear h_eq
     simp only [h_input, circuit_norm, subcircuit_norm, true_implies, true_and, and_true] at h_env ⊢
-    sorry
+    obtain ⟨ h_bits, right ⟩ := h_env; clear right;
+
+    let bit_vars : Vector (Expression (F p)) n := .mapRange n fun i => var ⟨k + i⟩
+    let bits := to_bits n x
+
+    have h_bits_eq : bit_vars.map eval = bits := by
+      rw [Vector.ext_iff]
+      intro i hi
+      simp only [Vector.getElem_map, Vector.getElem_mapRange, Expression.eval, bit_vars]
+      exact h_bits ⟨ i, hi ⟩
+
+    have h_bit_vars' : (∀ (i : Fin n), eval.get (k + i) = 0 ∨ eval.get (k + i) = 1)
+      | ⟨i, hi⟩ => by
+        rw [h_bits ⟨ i, hi ⟩]
+        simp [to_bits]
+    use h_bit_vars'
+
+    have h_bit_vars : ∀ (i : ℕ) (hi : i < n), eval bit_vars[i] = 0 ∨ eval bit_vars[i] = 1
+      | i, hi => by
+        simp only [Vector.getElem_mapRange, bit_vars, Expression.eval]
+        exact h_bit_vars' ⟨i, hi⟩
+
+    show x = eval (from_bits_expr bit_vars)
+    rw [from_bits_eval bit_vars h_bit_vars, h_bits_eq]
+    show x = from_bits (to_bits n x)
+    rw [from_bits_to_bits hn h_assumptions]
 
 end Gadgets.ToBits

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -3,7 +3,7 @@ import Clean.Gadgets.Equality
 import Clean.Gadgets.Boolean
 
 namespace Gadgets
-variable {p : ℕ} [prime: Fact p.Prime]
+variable {p : ℕ} [prime: Fact p.Prime] [p_large_enough: Fact (p > 2)]
 
 def to_bit (x : ZMod p) : Bool := x == 1
 
@@ -13,8 +13,8 @@ def to_bits (n : ℕ) (x : ZMod p) : Vector Bool n :=
 def from_bits {n : ℕ} (x : Vector Bool n) : ZMod p :=
   Nat.ofBits fun i => x[i.val]
 
-def from_bits_expr {n: ℕ} (xs : Vector (Expression (F p)) n) : Expression (F p) :=
-  Fin.foldl n (fun acc i => acc + xs[i] * .const (2^i.val)) 0
+def from_bits_expr {n: ℕ} (bits : Vector (Expression (F p)) n) : Expression (F p) :=
+  Fin.foldl n (fun acc ⟨i, _⟩ => acc + bits[i] * (2^i : F p)) 0
 
 @[reducible] def BitVector (n : ℕ) := ProvableVector field n
 
@@ -32,7 +32,7 @@ def main {n: ℕ} (x : Expression (F p)) := do
 
   return bits
 
-def circuit (n : ℕ) : FormalCircuit (F p) field (BitVector n) where
+def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (BitVector n) where
   main
   local_length _ := n
   output _ i := var_from_offset (BitVector n) i
@@ -61,40 +61,80 @@ def circuit (n : ℕ) : FormalCircuit (F p) field (BitVector n) where
     clear h_input
 
     obtain ⟨ h_bits, h_eq ⟩ := h_holds
-    replace h_eq := congrArg ZMod.val h_eq
-    -- generalize x.val = x
-    -- set x := x.val
-    stop
-    have h_eq' x : x = Fin.foldl n (fun acc ⟨i, _⟩ => acc + (env.get (k + i)).val * 2^i) 0 := by
+    let bits i := env.get (k + i)
+    replace h_bits : ∀ (i : ℕ) (hi : i < n), bits i = 0 ∨ bits i = 1
+      | i, hi => h_bits ⟨ i, hi ⟩
+
+    have ⟨_, h_eq'⟩ : x.val < 2^n ∧ x.val = Fin.foldl n (fun acc ⟨i, _⟩ => acc + (bits i).val * 2^i) 0 := by
+      rw [congrArg ZMod.val h_eq]
+      clear h_assumptions h_eq
       induction n with
-      | zero => simp only [Fin.foldl_zero]; linarith
+      | zero => simp only [Fin.foldl_zero, Expression.eval, ZMod.val_zero]; trivial
       | succ n ih =>
-        have h_split : x = (x % 2^n) + (x / 2^n) * 2^n := Eq.symm (Nat.mod_add_div' x (2 ^ n))
-        set x' := x % 2^n
-        have x'_lt : x' < 2^n := Nat.mod_lt x (by norm_num)
-        rw [h_split]
-        simp only [Fin.foldl_succ_last]
+        simp only [Fin.foldl_succ_last, Fin.coe_castSucc, Fin.val_last, Expression.eval]
 
-        have h_bits' : ∀ (j : Fin n), env.get (k + j.val) = 0 ∨ env.get (k + j.val) = 1 := by
-          intro j
-          specialize h_bits j
-          simp only [Fin.coe_eq_castSucc, Fin.coe_castSucc] at h_bits
-          exact h_bits
+        -- instantiate induction hypothesis
+        have : 2*2^n < p := by rw [←Nat.pow_succ']; exact hn
+        have : 2^n < p := by linarith
+        have h_bits' : ∀ j (hj : j < n), bits j = 0 ∨ bits j = 1
+          | j, hj => h_bits j (Nat.lt_succ_of_lt hj)
+        obtain ⟨ ih_lt, ih_eq ⟩ := ih ‹2^n < p› h_bits'; clear ih
 
-        specialize ih x' x'_lt h_bits'
-        simp only [eval_vector, var_from_offset_vector] at h_eq
-        exact h_eq
-    have h_testbit i : x.val.testBit i = ((env.get (k + i)).val == 1) := by
-      sorry
+        -- lift from ZMod to Nat
+        have : (bits n).val < 2 := FieldUtils.boolean_lt_2 (h_bits n (Nat.lt_succ_self _))
+        have two_pow_val : ZMod.val (2 ^ n : F p) = 2 ^ n := by
+          have : @ZMod.val p 2 = 2 := ZMod.val_natCast_of_lt (by linarith [p_large_enough.elim])
+          rw [ZMod.val_pow, this]
+          rwa [this]
+        let xn : F p := Expression.eval env <| Fin.foldl n (fun acc ⟨i, _⟩ => acc + var (F:=F p) ⟨ k + i ⟩ * (2 ^ i : F p)) 0
+        have h_lt : xn.val + (bits n).val * 2^n < 2^(n + 1) := by
+          have : (env.get (k + n)).val * 2^n ≤ 1 * 2^n := Nat.mul_le_mul_right (2 ^ n) (by linarith)
+          rw [Nat.pow_succ']
+          linarith
+        have h_to_nat : ZMod.val (xn + (bits n) * 2 ^ n) = xn.val + (bits n).val * ZMod.val (2 ^ n : F p) := by
+          field_to_nat
+          rw [two_pow_val]
+          linarith
+
+        -- now we have everything in place
+        rw [h_to_nat, two_pow_val, ←ih_eq]
+        exact ⟨ h_lt, rfl ⟩
+
+    have ⟨_, h_testbit⟩ : x.val < 2^n ∧ ∀ {i : ℕ} (hi : i < n), x.val.testBit i = ((bits i).val == 1) := by
+      rw [h_eq']
+      clear h_assumptions h_eq h_eq' ‹ZMod.val x < 2 ^ n› hn
+      simp only
+      induction n with
+      | zero =>
+        simp only [Fin.foldl_zero]
+        exact ⟨ by trivial, fun i => by trivial ⟩
+      | succ n ih =>
+        simp only [Fin.foldl_succ_last, Fin.coe_castSucc, Fin.val_last]
+        have h_bits_prev : ∀ j (hj : j < n), bits j = 0 ∨ bits j = 1
+          | j, hj => h_bits j (Nat.lt_succ_of_lt hj)
+        have h_bits_n : bits n = 0 ∨ bits n = 1 := h_bits n (Nat.lt_succ_self _)
+        obtain ⟨ ih_lt, ih_eq ⟩ := ih h_bits_prev; clear h_bits_prev h_bits ih
+        have : 2 ^ n * ZMod.val (bits n) ≤ 2^n := by
+          simp only [Nat.ofNat_pos, pow_pos, mul_le_iff_le_one_right]
+          rcases h_bits_n <;> simp [*, ZMod.val_one]
+        constructor
+        · rw [Nat.pow_succ']; linarith
+        intro i hi
+        rw [mul_comm _ (2^n), add_comm _ (2^n * _), Nat.testBit_two_pow_mul_add _ ih_lt]
+        by_cases hin : i < n <;> simp only [hin, reduceIte]
+        · exact ih_eq hin
+        have : n = i := by linarith
+        subst this
+        rcases h_bits_n <;> simp [*, ZMod.val_one]
+
     intro i hi
-    specialize h_bits ⟨ i, hi ⟩ trivial
+    specialize h_bits i hi
     simp only at h_bits
-    rw [h_testbit]
+    rw [h_testbit hi]
     simp only [beq_iff_eq]
-    set bi := env.get (k + i)
     rcases h_bits with h|h
-    · simp [h]
-    · simp [h, ZMod.val_one]
+    · simp [h, bits]
+    · simp [h, bits, ZMod.val_one]
 
   completeness := by
     intro k env x_var h_env x h_input h_assumptions

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -37,17 +37,13 @@ def circuit (n : ℕ) : FormalCircuit (F p) field (BitVector n) where
   local_length _ := n
   output _ i := var_from_offset (ProvableVector field n) i
 
-  local_length_eq _ _ := by
-    simp only [main, circuit_norm, Boolean.circuit]
-    sorry
+  initial_offset_eq _ _ := by simp only [main, circuit_norm]
+  local_length_eq _ _ := by simp only [main, circuit_norm, Boolean.circuit]; ac_rfl
 
   output_eq _ _ := by
     simp only [main, circuit_norm, Boolean.circuit]
     sorry
 
-  initial_offset_eq _ _ := by
-    simp only [main, circuit_norm, Boolean.circuit]
-    sorry
 
   assumptions (x : F p) := x.val < 2^n
 

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -39,7 +39,6 @@ def circuit (n : ℕ) : FormalCircuit (F p) field (BitVector n) where
 
   initial_offset_eq _ _ := by simp only [main, circuit_norm]
   local_length_eq _ _ := by simp only [main, circuit_norm, Boolean.circuit]; ac_rfl
-
   output_eq _ _ := by
     simp only [main, circuit_norm, Boolean.circuit, var_from_offset_vector]
     rfl
@@ -51,8 +50,10 @@ def circuit (n : ℕ) : FormalCircuit (F p) field (BitVector n) where
 
   soundness := by
     intro k env x_var x h_input h_assumptions h_holds
+    dsimp only [main] at *
     simp only [main, circuit_norm, eval_vector, var_from_offset_vector] at *
-    intro i hi
+    -- rw [Circuit.forEach.final_offset_eq] at h_holds
+    -- intro i hi
     sorry
 
   completeness := by

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -37,11 +37,11 @@ def circuit (n : ℕ) : FormalCircuit (F p) field (BitVector n) where
   local_length _ := n
   output _ i := var_from_offset (ProvableVector field n) i
 
-  initial_offset_eq _ _ := by simp only [main, circuit_norm]
+  initial_offset_eq _ n := by simp only [main, circuit_norm]
   local_length_eq _ _ := by simp only [main, circuit_norm, Boolean.circuit]; ac_rfl
   output_eq _ _ := by
-    simp only [main, circuit_norm, Boolean.circuit, var_from_offset_vector]
-    rfl
+    simp only [main, circuit_norm, Boolean.circuit, Circuit.forEach.apply_eq, var_from_offset_vector]
+    -- rfl
 
   assumptions (x : F p) := x.val < 2^n
 
@@ -51,7 +51,7 @@ def circuit (n : ℕ) : FormalCircuit (F p) field (BitVector n) where
   soundness := by
     intro k env x_var x h_input h_assumptions h_holds
     dsimp only [main] at *
-    simp only [main, circuit_norm, eval_vector, var_from_offset_vector] at *
+    simp only [main, circuit_norm, eval_vector, var_from_offset_vector, Circuit.forEach.apply_eq, Circuit.forEach.apply_eq_snd] at *
     -- rw [Circuit.forEach.final_offset_eq] at h_holds
     -- intro i hi
     sorry

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -5,16 +5,108 @@ import Clean.Gadgets.Boolean
 namespace Gadgets
 variable {p : ℕ} [prime: Fact p.Prime] [p_large_enough: Fact (p > 2)]
 
-def to_bit (x : ZMod p) : Bool := x == 1
+def to_bit (x : ZMod p) (_ : x.val = 0 ∨ x.val = 1) : Bool := x == 1
 
-def to_bits (n : ℕ) (x : ZMod p) : Vector Bool n :=
-  .ofFn fun i => x.val.testBit i
-
-def from_bits {n : ℕ} (x : Vector Bool n) : ZMod p :=
-  Nat.ofBits fun i => x[i.val]
+def from_bits {n : ℕ} (bits : Vector ℕ n) : ℕ :=
+  Fin.foldl n (fun acc ⟨i, _⟩ => acc + bits[i] * 2^i) 0
 
 def from_bits_expr {n: ℕ} (bits : Vector (Expression (F p)) n) : Expression (F p) :=
   Fin.foldl n (fun acc ⟨i, _⟩ => acc + bits[i] * (2^i : F p)) 0
+
+theorem from_bits_eval {n: ℕ} (hn : 2^n < p) {env} (bits : Vector (Expression (F p)) n)
+  (h_bits : ∀ (i : ℕ) (hi : i < n), bits[i].eval env = 0 ∨ bits[i].eval env = 1) :
+    ((from_bits_expr bits).eval env).val = from_bits (bits.map (fun b => (b.eval env).val)) := by
+
+  -- strengthen the goal for use in induction
+  suffices h_stronger :
+      ((from_bits_expr bits).eval env).val < 2^n
+      ∧ ((from_bits_expr bits).eval env).val = from_bits (bits.map (fun b => (b.eval env).val))
+    from h_stronger.right
+
+  simp only [from_bits_expr]
+
+  induction n with
+  | zero => simp only [Fin.foldl_zero, Expression.eval, ZMod.val_zero, from_bits]; simp
+  | succ n ih =>
+    simp only [Fin.foldl_succ_last, Fin.coe_castSucc, Fin.val_last, Expression.eval, from_bits,
+      Vector.getElem_map]
+    simp only [from_bits, Vector.getElem_map] at ih
+
+    -- instantiate induction hypothesis
+    have : 2*2^n < p := by rw [←Nat.pow_succ']; exact hn
+    have : 2^n < p := by linarith
+    let bits' : Vector (Expression (F p)) n := bits.pop
+    have h_bits' : ∀ j (hj : j < n), bits'[j].eval env = 0 ∨ bits'[j].eval env = 1
+      | j, hj => by
+        simp only [Vector.getElem_pop', bits']
+        exact h_bits j (Nat.lt_succ_of_lt hj)
+
+    obtain ⟨ ih_lt, ih_eq ⟩ := ih ‹_› bits' h_bits'; clear ih
+    simp only [Vector.getElem_pop', bits'] at ih_eq ih_lt
+
+    -- lift from ZMod to Nat
+    let bitn := bits[n].eval env
+    have : bitn.val < 2 := FieldUtils.boolean_lt_2 (h_bits n (Nat.lt_succ_self _))
+    have : 2 < p := p_large_enough.elim
+    have two_pow_val : ZMod.val (2 ^ n : F p) = 2 ^ n := by
+      have : @ZMod.val p 2 = 2 := ZMod.val_natCast_of_lt (by linarith)
+      rw [ZMod.val_pow, this]
+      rwa [this]
+
+    let xn : F p := Expression.eval env <| Fin.foldl n (fun acc ⟨i, _⟩ => acc + bits[i] * (2 ^ i : F p)) 0
+    have h_lt : xn.val + bitn.val * 2^n < 2^(n + 1) := by
+      have : bitn.val * 2^n ≤ 1 * 2^n := Nat.mul_le_mul_right (2 ^ n) (by linarith)
+      rw [Nat.pow_succ']
+      linarith
+
+    have h_to_nat : ZMod.val (xn + bitn * 2 ^ n) = xn.val + bitn.val * ZMod.val (2 ^ n : F p) := by
+      field_to_nat
+      rw [two_pow_val]
+      linarith
+
+    -- now we have everything in place
+    rw [h_to_nat, two_pow_val, ←ih_eq]
+    exact ⟨ h_lt, rfl ⟩
+
+theorem from_bits_testBit {n: ℕ} (bits : Vector ℕ n)
+  (h_bits : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1) :
+    ∀ (i : ℕ) (hi : i < n), (from_bits bits).testBit i = (bits[i] == 1) := by
+
+  -- strengthen the goal for use in induction
+  suffices h_stronger :
+      from_bits bits < 2^n
+      ∧ ∀ (i : ℕ) (hi : i < n), (from_bits bits).testBit i = (bits[i] == 1)
+    from h_stronger.right
+
+  simp only [from_bits]
+  induction n with
+  | zero => simp_all
+  | succ n ih =>
+    simp only [Fin.foldl_succ_last, Fin.coe_castSucc, Fin.val_last]
+
+    let bits' : Vector ℕ n := bits.pop
+    have h_bits' : ∀ j (hj : j < n), bits'[j] = 0 ∨ bits'[j] = 1
+      | j, hj => by
+        simp only [Vector.getElem_pop', bits']
+        exact h_bits j (Nat.lt_succ_of_lt hj)
+
+    have h_bits_n : bits[n] = 0 ∨ bits[n] = 1 := h_bits n (Nat.lt_succ_self _)
+    obtain ⟨ ih_lt, ih_eq ⟩ := ih bits' h_bits'; clear h_bits' h_bits ih
+    simp only [Vector.getElem_pop', bits'] at ih_eq ih_lt
+
+    have : bits[n] * 2 ^ n ≤ 2^n := by
+      simp only [Nat.ofNat_pos, pow_pos, mul_le_iff_le_one_left, bits']
+      rcases h_bits_n <;> simp [*, ZMod.val_one]
+    constructor
+    · rw [Nat.pow_succ']; linarith
+
+    intro i hi
+    rw [mul_comm _ (2^n), add_comm _ (2^n * _), Nat.testBit_two_pow_mul_add _ ih_lt]
+    by_cases hin : i < n <;> simp only [hin, reduceIte]
+    · exact ih_eq i hin
+    have : n = i := by linarith
+    subst this
+    rcases h_bits_n <;> simp [*, ZMod.val_one]
 
 @[reducible] def BitVector (n : ℕ) := ProvableVector field n
 
@@ -27,7 +119,7 @@ def main {n: ℕ} (x : Expression (F p)) := do
 
   Circuit.forEach bits fun bit => assertion Boolean.circuit bit
 
-  let x' := Fin.foldl n (fun acc ⟨i, _⟩ => acc + bits[i] * (2^i : F p)) 0
+  let x' := from_bits_expr bits
   x.assert_equals x'
 
   return bits
@@ -41,7 +133,6 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (BitVector n) w
   local_length_eq _ _ := by simp only [main, circuit_norm, Boolean.circuit]; ac_rfl
   output_eq _ _ := by
     simp only [main, circuit_norm, Boolean.circuit, Circuit.forEach.apply_eq, var_from_offset_vector]
-    -- rfl
 
   assumptions (x : F p) := x.val < 2^n
 
@@ -61,84 +152,44 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (BitVector n) w
     clear h_input
 
     obtain ⟨ h_bits, h_eq ⟩ := h_holds
-    let bits i := env.get (k + i)
-    replace h_bits : ∀ (i : ℕ) (hi : i < n), bits i = 0 ∨ bits i = 1
-      | i, hi => h_bits ⟨ i, hi ⟩
 
-    have ⟨_, h_eq'⟩ : x.val < 2^n ∧ x.val = Fin.foldl n (fun acc ⟨i, _⟩ => acc + (bits i).val * 2^i) 0 := by
-      rw [congrArg ZMod.val h_eq]
-      clear h_assumptions h_eq
-      induction n with
-      | zero => simp only [Fin.foldl_zero, Expression.eval, ZMod.val_zero]; trivial
-      | succ n ih =>
-        simp only [Fin.foldl_succ_last, Fin.coe_castSucc, Fin.val_last, Expression.eval]
+    let bit_vars : Vector (Expression (F p)) n := .mapRange n fun i => var ⟨k + i⟩
+    let bits : Vector ℕ n := bit_vars.map (fun b => (b.eval env).val)
 
-        -- instantiate induction hypothesis
-        have : 2*2^n < p := by rw [←Nat.pow_succ']; exact hn
-        have : 2^n < p := by linarith
-        have h_bits' : ∀ j (hj : j < n), bits j = 0 ∨ bits j = 1
-          | j, hj => h_bits j (Nat.lt_succ_of_lt hj)
-        obtain ⟨ ih_lt, ih_eq ⟩ := ih ‹2^n < p› h_bits'; clear ih
+    have h_bit_vars : ∀ (i : ℕ) (hi : i < n), bit_vars[i].eval env = 0 ∨ bit_vars[i].eval env = 1
+      | i, hi => by
+        simp only [Vector.getElem_mapRange, bit_vars]
+        exact h_bits ⟨ i, hi ⟩
 
-        -- lift from ZMod to Nat
-        have : (bits n).val < 2 := FieldUtils.boolean_lt_2 (h_bits n (Nat.lt_succ_self _))
-        have two_pow_val : ZMod.val (2 ^ n : F p) = 2 ^ n := by
-          have : @ZMod.val p 2 = 2 := ZMod.val_natCast_of_lt (by linarith [p_large_enough.elim])
-          rw [ZMod.val_pow, this]
-          rwa [this]
-        let xn : F p := Expression.eval env <| Fin.foldl n (fun acc ⟨i, _⟩ => acc + var (F:=F p) ⟨ k + i ⟩ * (2 ^ i : F p)) 0
-        have h_lt : xn.val + (bits n).val * 2^n < 2^(n + 1) := by
-          have : (env.get (k + n)).val * 2^n ≤ 1 * 2^n := Nat.mul_le_mul_right (2 ^ n) (by linarith)
-          rw [Nat.pow_succ']
-          linarith
-        have h_to_nat : ZMod.val (xn + (bits n) * 2 ^ n) = xn.val + (bits n).val * ZMod.val (2 ^ n : F p) := by
-          field_to_nat
-          rw [two_pow_val]
-          linarith
+    replace h_bits : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1
+      | i, hi => by
+        simp only [Vector.getElem_map, bits]
+        rcases h_bit_vars i hi with h|h
+        · left; rw [h, ZMod.val_zero]
+        · right; rw [h, ZMod.val_one]
 
-        -- now we have everything in place
-        rw [h_to_nat, two_pow_val, ←ih_eq]
-        exact ⟨ h_lt, rfl ⟩
-
-    have ⟨_, h_testbit⟩ : x.val < 2^n ∧ ∀ {i : ℕ} (hi : i < n), x.val.testBit i = ((bits i).val == 1) := by
-      rw [h_eq']
-      clear h_assumptions h_eq h_eq' ‹ZMod.val x < 2 ^ n› hn
-      simp only
-      induction n with
-      | zero =>
-        simp only [Fin.foldl_zero]
-        exact ⟨ by trivial, fun i => by trivial ⟩
-      | succ n ih =>
-        simp only [Fin.foldl_succ_last, Fin.coe_castSucc, Fin.val_last]
-        have h_bits_prev : ∀ j (hj : j < n), bits j = 0 ∨ bits j = 1
-          | j, hj => h_bits j (Nat.lt_succ_of_lt hj)
-        have h_bits_n : bits n = 0 ∨ bits n = 1 := h_bits n (Nat.lt_succ_self _)
-        obtain ⟨ ih_lt, ih_eq ⟩ := ih h_bits_prev; clear h_bits_prev h_bits ih
-        have : 2 ^ n * ZMod.val (bits n) ≤ 2^n := by
-          simp only [Nat.ofNat_pos, pow_pos, mul_le_iff_le_one_right]
-          rcases h_bits_n <;> simp [*, ZMod.val_one]
-        constructor
-        · rw [Nat.pow_succ']; linarith
-        intro i hi
-        rw [mul_comm _ (2^n), add_comm _ (2^n * _), Nat.testBit_two_pow_mul_add _ ih_lt]
-        by_cases hin : i < n <;> simp only [hin, reduceIte]
-        · exact ih_eq hin
-        have : n = i := by linarith
-        subst this
-        rcases h_bits_n <;> simp [*, ZMod.val_one]
-
+    change x = (from_bits_expr bit_vars).eval env at h_eq
+    rw [h_eq, from_bits_eval hn bit_vars h_bit_vars]
     intro i hi
+
+    show env.get (k + i) = if (from_bits bits).testBit i then 1 else 0
+
+    have h_bit_i : (env.get (k + i)).val = bits[i] := by
+      simp [Vector.getElem_map, bits, bit_vars, Expression.eval]
+    apply FieldUtils.ext
+    rw [h_bit_i, from_bits_testBit bits h_bits i hi]
     specialize h_bits i hi
-    simp only at h_bits
-    rw [h_testbit hi]
-    simp only [beq_iff_eq]
-    rcases h_bits with h|h
-    · simp [h, bits]
-    · simp [h, bits, ZMod.val_one]
+    rcases h_bits <;> simp [*, bits, ZMod.val_one]
 
   completeness := by
     intro k env x_var h_env x h_input h_assumptions
-    simp only [main, circuit_norm, eval_vector, var_from_offset_vector] at *
+    simp only [main, circuit_norm, Boolean.circuit, eval_vector, var_from_offset_vector, from_bits_expr] at *
+    split
+    · rename_i h_eq
+      obtain rfl : n = 0 := Circuit.forEach.no_empty h_eq
+      simp_all [Expression.eval]
+    rename_i h_eq; clear h_eq
+    simp only [h_input, circuit_norm, subcircuit_norm, true_implies, true_and, and_true] at h_env ⊢
     sorry
 
 end Gadgets.ToBits

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -35,7 +35,7 @@ def main {n: ℕ} (x : Expression (F p)) := do
 def circuit (n : ℕ) : FormalCircuit (F p) field (BitVector n) where
   main
   local_length _ := n
-  output _ i := var_from_offset (ProvableVector field n) i
+  output _ i := var_from_offset (BitVector n) i
 
   initial_offset_eq _ n := by simp only [main, circuit_norm]
   local_length_eq _ _ := by simp only [main, circuit_norm, Boolean.circuit]; ac_rfl
@@ -51,10 +51,50 @@ def circuit (n : ℕ) : FormalCircuit (F p) field (BitVector n) where
   soundness := by
     intro k env x_var x h_input h_assumptions h_holds
     dsimp only [main] at *
-    simp only [main, circuit_norm, eval_vector, var_from_offset_vector, Circuit.forEach.apply_eq, Circuit.forEach.apply_eq_snd] at *
-    -- rw [Circuit.forEach.final_offset_eq] at h_holds
-    -- intro i hi
-    sorry
+    simp only [main, circuit_norm, Boolean.circuit, true_and, eval_vector, var_from_offset_vector] at *
+    split at h_holds
+    · rename_i h_eq
+      obtain rfl : n = 0 := Circuit.forEach.no_empty h_eq
+      simp
+    rename_i h_eq; clear h_eq
+    simp only [h_input, circuit_norm, subcircuit_norm, true_implies] at h_holds
+    clear h_input
+
+    obtain ⟨ h_bits, h_eq ⟩ := h_holds
+    replace h_eq := congrArg ZMod.val h_eq
+    -- generalize x.val = x
+    -- set x := x.val
+    stop
+    have h_eq' x : x = Fin.foldl n (fun acc ⟨i, _⟩ => acc + (env.get (k + i)).val * 2^i) 0 := by
+      induction n with
+      | zero => simp only [Fin.foldl_zero]; linarith
+      | succ n ih =>
+        have h_split : x = (x % 2^n) + (x / 2^n) * 2^n := Eq.symm (Nat.mod_add_div' x (2 ^ n))
+        set x' := x % 2^n
+        have x'_lt : x' < 2^n := Nat.mod_lt x (by norm_num)
+        rw [h_split]
+        simp only [Fin.foldl_succ_last]
+
+        have h_bits' : ∀ (j : Fin n), env.get (k + j.val) = 0 ∨ env.get (k + j.val) = 1 := by
+          intro j
+          specialize h_bits j
+          simp only [Fin.coe_eq_castSucc, Fin.coe_castSucc] at h_bits
+          exact h_bits
+
+        specialize ih x' x'_lt h_bits'
+        simp only [eval_vector, var_from_offset_vector] at h_eq
+        exact h_eq
+    have h_testbit i : x.val.testBit i = ((env.get (k + i)).val == 1) := by
+      sorry
+    intro i hi
+    specialize h_bits ⟨ i, hi ⟩ trivial
+    simp only at h_bits
+    rw [h_testbit]
+    simp only [beq_iff_eq]
+    set bi := env.get (k + i)
+    rcases h_bits with h|h
+    · simp [h]
+    · simp [h, ZMod.val_one]
 
   completeness := by
     intro k env x_var h_env x h_input h_assumptions

--- a/Clean/Gadgets/BitsAux.lean
+++ b/Clean/Gadgets/BitsAux.lean
@@ -1,0 +1,34 @@
+import Clean.Circuit.Loops
+import Clean.Gadgets.Boolean
+import Batteries.Data.Nat.Lemmas
+
+variable {p : ℕ} [prime: Fact p.Prime]
+
+def to_bits (n : ℕ) (x : ZMod p) : Vector Bool n :=
+  .ofFn fun i => x.val.testBit i
+
+def from_bits {n : ℕ} (x : Vector Bool n) : ZMod p :=
+  Nat.ofBits fun i => x[i.val]
+
+theorem to_bits_from_bits {n} {x : ZMod p} (hx : x.val < 2^n) :
+    from_bits (to_bits n x) = x := by
+  apply ZMod.val_injective
+  simp only [to_bits, from_bits, Vector.getElem_ofFn, ZMod.val_natCast]
+
+  have : .ofBits (fun (i : Fin n) => x.val.testBit i) = x.val % 2^n := by
+    apply Nat.eq_of_testBit_eq
+    simp [Nat.testBit_ofBits, Nat.testBit_mod_two_pow]
+
+  rw [this, Nat.mod_eq_of_lt hx, Nat.mod_eq_of_lt (ZMod.val_lt x)]
+
+theorem from_bits_to_bits {n} {x : Vector Bool n} (hp : p > 2^n) :
+    to_bits n (from_bits (p:=p) x) = x := by
+  apply Vector.ext
+  intro j (hj : j < n)
+  simp only [to_bits, from_bits, Vector.getElem_ofFn, ZMod.val_natCast]
+  let x' := Nat.ofBits fun (i : Fin n) => x[i.val]
+  show (x' % p).testBit j = x[j]
+
+  have lt_pow : x' < 2^n := Nat.ofBits_lt_two_pow _
+  have lt_p : x' < p := by linarith
+  rw [Nat.mod_eq_of_lt lt_p, Nat.testBit_ofBits_lt _ _ hj]

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -12,7 +12,7 @@ def all_zero {n} (xs : Vector (Expression F) n) : Circuit F Unit := .forEach xs 
 
 theorem all_zero.soundness {offset : ℕ} {env : Environment F} {n} {xs : Vector (Expression F) n} :
     constraints_hold.soundness env ((all_zero xs).operations offset) → ∀ x ∈ xs, x.eval env = 0 := by
-  simp only [all_zero, circuit_norm]
+  simp only [all_zero, circuit_norm, true_and]
   intro h_holds x hx
   obtain ⟨i, hi, rfl⟩ := Vector.getElem_of_mem hx
   exact h_holds ⟨i, hi⟩

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -19,7 +19,7 @@ theorem all_zero.soundness {offset : ℕ} {env : Environment F} {n} {xs : Vector
 
 theorem all_zero.completeness {offset : ℕ} {env : Environment F} {n} {xs : Vector (Expression F) n} :
     (∀ x ∈ xs, x.eval env = 0) → constraints_hold.completeness env ((all_zero xs).operations offset) := by
-  simp only [all_zero, circuit_norm]
+  simp only [all_zero, circuit_norm, true_and]
   intro h_holds i
   exact h_holds xs[i] (Vector.mem_of_getElem rfl)
 

--- a/Clean/Utils/Misc.lean
+++ b/Clean/Utils/Misc.lean
@@ -4,6 +4,18 @@ Miscellaneous utility lemmas/methods that don't fit anywhere else.
 import Mathlib.Tactic
 variable {α : Type}
 
+theorem funext_heq {α α' β : Type} (h : α = α') {f : α → β} {g : α' → β} :
+    (∀ x : α, f x = g (cast h x)) → HEq f g := by
+  subst h
+  intro h
+  apply heq_of_eq
+  funext x
+  exact h x
+
+theorem fun_cast_heq {α α' β : Type} (h : α' = α) (f : α → β) : HEq (fun x => f (cast h x)) f := by
+  subst h
+  exact heq_of_eq rfl
+
 theorem Fin.foldl_const_succ (n : ℕ) (f : Fin (n + 1) → α) (init : α) :
     Fin.foldl (n + 1) (fun _ i => f i) init = f n := by
   induction n generalizing init with


### PR DESCRIPTION
- **(potentially) auxiliary file with to/from bits methods and consistency theorems**
- **add witness_vector**
- **missing theorems and better auto tactic in Provable**
- **add to bits gadget, it doesn't neatly simplify**
- **generalize forEach lemmas. we'll have to do this everywhere**
- **progress on output**
- **problem: offset doesn't simplify**
- **this solves output simp**
- **more general foreach soundness**
- **good progress on to_bits soundness**
- **full soundness proof**
- **general forEach completeness theorems**
- **extract most of toBits proof into lemmas**
- **finish to_bits theorems**
- **add range check version to tobits**
- **simplify proofs and add comments**
- **get fairly close to a sorry-free proof**
