### PR TITLE
Remove conditionals in `constraints_hold` definition

### DIFF
--- a/Clean.lean
+++ b/Clean.lean
@@ -4,3 +4,4 @@ import Clean.Examples.ToJson
 import Clean.Tables.Fibonacci8
 import Clean.Tables.Fibonacci32
 import Clean.Gadgets.Keccak.KeccakRound
+import Clean.Gadgets.Bits

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -607,7 +607,7 @@ attribute [circuit_norm] pure StateT.pure
 attribute [circuit_norm] StateT.run
 
 -- basic logical simplifcations
-attribute [circuit_norm] true_and and_true true_implies
+attribute [circuit_norm] true_and and_true true_implies forall_const
 
 /-
 when simplifying lookup constraints, `circuit_norm` has to deal with expressions of the form

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -347,15 +347,11 @@ Version of `constraints_hold` that replaces the statement of subcircuits with th
 def constraints_hold.soundness {n : ℕ} (eval : Environment F) : Operations F n → Prop
   | .empty _ => True
   | .witness ops _ _ => constraints_hold.soundness eval ops
-  | .assert ops e =>
-    let constraint := eval e = 0
-    if let .empty m := ops then constraint else (constraints_hold.soundness eval ops ∧ constraint)
+  | .assert ops e => constraints_hold.soundness eval ops ∧ eval e = 0
   | .lookup ops { table, entry, .. } =>
-    let constraint := table.contains (entry.map eval)
-    if let .empty m := ops then constraint else (constraints_hold.soundness eval ops ∧ constraint)
+    constraints_hold.soundness eval ops ∧ table.contains (entry.map eval)
   | .subcircuit ops s =>
-    let constraint := s.soundness eval
-    if let .empty m := ops then constraint else (constraints_hold.soundness eval ops ∧ constraint)
+    constraints_hold.soundness eval ops ∧ s.soundness eval
 
 /--
 Version of `constraints_hold` that replaces the statement of subcircuits with their `completeness`.
@@ -364,16 +360,11 @@ Version of `constraints_hold` that replaces the statement of subcircuits with th
 def constraints_hold.completeness {n : ℕ} (eval : Environment F) : Operations F n → Prop
   | .empty _ => True
   | .witness ops _ _ => constraints_hold.completeness eval ops
-  | .assert ops e =>
-    let constraint := eval e = 0
-    -- avoid a leading `True ∧` if ops is empty
-    if let .empty m := ops then constraint else (constraints_hold.completeness eval ops ∧ constraint)
+  | .assert ops e => constraints_hold.completeness eval ops ∧ eval e = 0
   | .lookup ops { table, entry, .. } =>
-    let constraint := table.contains (entry.map eval)
-    if let .empty m := ops then constraint else (constraints_hold.completeness eval ops ∧ constraint)
+    constraints_hold.completeness eval ops ∧ table.contains (entry.map eval)
   | .subcircuit ops s =>
-    let constraint := s.completeness eval
-    if let .empty m := ops then constraint else (constraints_hold.completeness eval ops ∧ constraint)
+    constraints_hold.completeness eval ops ∧ s.completeness eval
 end Circuit
 
 section
@@ -614,6 +605,9 @@ attribute [circuit_norm] bind StateT.bind
 attribute [circuit_norm] modify modifyGet MonadStateOf.modifyGet StateT.modifyGet
 attribute [circuit_norm] pure StateT.pure
 attribute [circuit_norm] StateT.run
+
+-- basic logical simplifcations
+attribute [circuit_norm] true_and and_true true_implies
 
 /-
 when simplifying lookup constraints, `circuit_norm` has to deal with expressions of the form

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -535,11 +535,6 @@ inductive Operation (F : Type) [Field F] where
   | subcircuit : {n : ℕ} → SubCircuit F n → Operation F
 
 namespace Operation
-def added_witness : Operation F → ℕ
-  | witness m _ => m
-  | subcircuit s => s.local_length
-  | _ => 0
-
 instance [Repr F] : Repr (Operation F) where
   reprPrec op _ := match op with
     | witness m _ => "(Witness " ++ reprStr m ++ ")"

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -755,23 +755,6 @@ lemma forEach.apply_eq :
   congr
   simp only [LawfulCircuit.operations_eq, Subtype.coe_eta, heq_eqRec_iff_heq, heq_eq_eq]
 
--- TODO either prove or get rid of this lemma
-lemma forEach.no_empty :
-  (forEach xs body lawful ops).2.withLength = .empty (forEach xs body lawful ops).2.offset
-    → m = 0 ∨ ∃ (_ : m > 0) (ops : OperationsList F) (n : ℕ), (body xs[m-1] ops).2 = .from_offset n := by
-  rcases ops with ⟨ n, ops ⟩
-  rw [forEach.apply_eq]
-  simp only
-  intro h_empty
-  obtain ⟨ h_eq, _, empty2 ⟩  := Operations.empty_of_append_empty _ _ h_empty
-  let lawful_loop : ConstantLawfulCircuit (forEach xs body lawful) := .from_forM_vector xs lawful
-  rw [Circuit.final_offset, LawfulCircuit.offset_independent, ConstantLawfulCircuit.local_length_eq] at h_eq
-  simp only [ConstantLawfulCircuit.local_length, Nat.add_eq_left, mul_eq_zero, lawful_loop] at h_eq
-  simp only at empty2
-  -- the idea is that `forEach` operations are just concatenated body's operations
-  -- so if `empty2` is true (forEach results in empty operations), then the body (on the final input element) must result in empty operations
-  sorry
-
 end forEach
 
 section foldl

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -22,14 +22,12 @@ theorem can_replace_soundness  {n: ℕ} {ops : Operations F n} {env} :
   intro h
   induction ops with
   | empty => trivial
-  | witness ops _ c ih | assert ops c ih | lookup ops c ih =>
-    cases ops <;> simp_all [constraints_hold.completeness, constraints_hold, circuit_norm]
+  | witness | assert | lookup =>
+    simp_all [constraints_hold.soundness, constraints_hold]
   | subcircuit ops circuit ih =>
     dsimp only [constraints_hold.soundness]
     dsimp only [constraints_hold] at h
-    split
-    · exact circuit.imply_soundness env h.right
-    · exact ⟨ ih h.left, circuit.imply_soundness env h.right ⟩
+    exact ⟨ ih h.left, circuit.imply_soundness env h.right ⟩
 
 /--
 Initial offset + size of local witnesses = final offset of a circuit
@@ -215,8 +213,8 @@ theorem constraints_hold.soundness_iff_forAll {n : ℕ} (env : Environment F) (o
   } := by
   induction ops with
   | empty => trivial
-  | witness ops | assert ops | lookup ops | subcircuit ops =>
-    cases ops <;> simp_all [soundness, Operations.forAll]
+  | witness | assert | lookup | subcircuit =>
+    simp_all [soundness, Operations.forAll]
 
 theorem constraints_hold.completeness_iff_forAll {n : ℕ} (env : Environment F) (ops : Operations F n) :
   completeness env ops ↔ ops.forAll {
@@ -227,8 +225,8 @@ theorem constraints_hold.completeness_iff_forAll {n : ℕ} (env : Environment F)
   } := by
   induction ops with
   | empty => trivial
-  | witness ops | assert ops | lookup ops | subcircuit ops =>
-    cases ops <;> simp_all [completeness, Operations.forAll]
+  | witness | assert | lookup | subcircuit =>
+    simp_all [completeness, Operations.forAll]
 
 /--
 Completeness theorem which proves that we can replace constraints in subcircuits

--- a/Clean/Examples/Add32LawfulCircuit.lean
+++ b/Clean/Examples/Add32LawfulCircuit.lean
@@ -35,7 +35,7 @@ example (input : Var Inputs (F p)) (env) (i0 : ℕ) :
 
   -- first version: using `circuit_norm`
   -- dsimp only [circuit_norm, circuit32, add32_full, add8_full_carry, Boolean.circuit]
-  -- simp only [true_and, and_true, subcircuit_norm, circuit_norm]
+  -- simp only [subcircuit_norm, circuit_norm]
 
   -- second version: using `LawfulCircuit`
   rw [LawfulCircuit.soundness_eq]
@@ -44,5 +44,5 @@ example (input : Var Inputs (F p)) (env) (i0 : ℕ) :
   -- simp constraints hold expression
   simp only [append_empty, empty_append, append_assoc, append_val, Circuit.constraints_hold.append_soundness, Circuit.constraints_hold.soundness]
   -- simp `eval` and boolean subcircuit soundness
-  simp only [true_and, and_true, subcircuit_norm, circuit_norm]
+  simp only [subcircuit_norm, circuit_norm]
   sorry

--- a/Clean/Gadgets/Addition32/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32/Addition32Full.lean
@@ -83,7 +83,7 @@ theorem soundness : Soundness (F p) elaborated assumptions spec := by
 
   -- simplify circuit
   simp only [circuit_norm, subcircuit_norm, add32_full, add8_full_carry, Boolean.circuit, ByteLookup] at h
-  simp only [Boolean.spec, true_and, true_implies, and_assoc, add_zero, h_inputs] at h
+  simp only [Boolean.spec, and_assoc, add_zero, h_inputs] at h
   rw [ByteTable.equiv, ByteTable.equiv, ByteTable.equiv, ByteTable.equiv] at h
   repeat rw [add_neg_eq_zero] at h
   set z0 := env.get i0
@@ -134,12 +134,10 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   -- simplify circuit
   simp only [circuit_norm, subcircuit_norm,
     add32_full, add8_full_carry, Boolean.circuit,
-    h_inputs
+    h_inputs, and_assoc
   ] at henv ⊢
-  simp only [true_and, and_assoc]
 
   -- characterize local witnesses
-  simp only [forall_const, true_and, and_true, and_assoc] at henv
   obtain ⟨ hz0, hc0, hz1, hc1, hz2, hc2, hz3, hc3 ⟩ := henv
 
   set z0 := env.get i0

--- a/Clean/Gadgets/Addition8/Addition8FullCarry.lean
+++ b/Clean/Gadgets/Addition8/Addition8FullCarry.lean
@@ -83,7 +83,7 @@ def circuit : FormalCircuit (F p) Inputs Outputs where
     set z := env.get i0
     set carry_out := env.get (i0 + 1)
     rw [hx, hy, hcarry_in] at h_holds
-    obtain ⟨ ⟨ ⟨ _, h_byte⟩, h_bool_carry⟩, h_add ⟩ := h_holds
+    obtain ⟨ ⟨ h_byte, h_bool_carry⟩, h_add ⟩ := h_holds
 
     rw [(by rfl : outputs = ⟨z, carry_out⟩)]
 
@@ -123,11 +123,11 @@ def circuit : FormalCircuit (F p) Inputs Outputs where
     dsimp [assumptions] at as
 
     -- simplify local witnesses
-    simp only [circuit_norm, subcircuit_norm, add8_full_carry, Boolean.circuit, forall_const] at h_env
-    have ⟨⟨⟨_, hz⟩, hcarry_out⟩, _ ⟩ := h_env
+    simp only [circuit_norm, subcircuit_norm, add8_full_carry, Boolean.circuit] at h_env
+    have ⟨hz, hcarry_out⟩ := h_env
 
     -- unfold goal, (re)introduce names for some of unfolded variables
-    simp only [add8_full_carry, circuit_norm]
+    simp only [add8_full_carry, circuit_norm, Boolean.circuit, subcircuit_norm]
     rw [hx, hy, hcarry_in] at hz hcarry_out ⊢
     set z := env.get i0
     set carry_out := env.get (i0 + 1)
@@ -138,7 +138,7 @@ def circuit : FormalCircuit (F p) Inputs Outputs where
     let goal_byte := ByteTable.contains (#v[z])
     let goal_bool := carry_out = 0 ∨ carry_out = 1
     let goal_add := x + y + carry_in + -z + -(carry_out * 256) = 0
-    show ((True ∧ goal_byte) ∧ True ∧ goal_bool) ∧ goal_add
+    show (goal_byte ∧ goal_bool) ∧ goal_add
     suffices goal_byte ∧ goal_bool ∧ goal_add by tauto
 
     have completeness1 : goal_byte := ByteTable.completeness z (hz ▸ ByteUtils.mod_256_lt _)

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -154,11 +154,10 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (fields n) wher
     bits = to_bits n x
 
   soundness := by
-    intro k eval x_var x h_input h_assumptions h_holds
-    dsimp only [main] at *
-    simp only [main, circuit_norm, Boolean.circuit, true_and] at *
-    simp only [h_input, circuit_norm, subcircuit_norm, true_implies] at h_holds
-    clear h_input
+    intro k eval x_var x h_input _h_assumptions h_holds
+    simp only [main, circuit_norm, Boolean.circuit] at *
+    simp only [h_input, circuit_norm, subcircuit_norm] at h_holds
+    clear h_input _h_assumptions
 
     obtain ⟨ h_bits, h_eq ⟩ := h_holds
 

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -2,12 +2,10 @@ import Clean.Gadgets.Equality
 import Clean.Gadgets.Boolean
 import Clean.Utils.Bits
 
-namespace Gadgets
+namespace Gadgets.ToBits
 open Utils.Bits
 variable {p : ℕ} [prime: Fact p.Prime] [p_large_enough: Fact (p > 2)]
 
-
-namespace ToBits
 def main (n: ℕ) (x : Expression (F p)) := do
   -- witness the bits of `x`
   let bits ← witness_vector n fun env => to_bits n (x.eval env)

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -160,16 +160,6 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (BitVector n) w
     intro k eval x_var x h_input h_assumptions h_holds
     dsimp only [main] at *
     simp only [main, circuit_norm, Boolean.circuit, true_and, eval_vector, var_from_offset_vector] at *
-    -- TODO: simp [circuit_norm] is not able to exclude the case that `forEach` results in empty operations
-    -- which leads to this case split and hard-to-discover proof that dicharges the empty case
-    split at h_holds
-    · rename_i h_eq
-      rcases (Circuit.forEach.no_empty h_eq) with h|h
-      · obtain rfl : n = 0 := h
-        simp [Vector.mapRange_zero]
-      obtain ⟨_, _, h⟩ := h
-      exact Operations.noConfusion h
-    rename_i h_eq; clear h_eq
     simp only [h_input, circuit_norm, subcircuit_norm, true_implies] at h_holds
     clear h_input
 
@@ -193,17 +183,7 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (BitVector n) w
   completeness := by
     intro k eval x_var h_env x h_input h_assumptions
     simp only [main, circuit_norm, Boolean.circuit, eval_vector, var_from_offset_vector] at *
-    -- TODO: simp [circuit_norm] is not able to exclude the case that `forEach` results in empty operations
-    -- which leads to this case split and hard-to-discover proof that dicharges the empty case
-    split
-    · rename_i h_eq
-      rcases (Circuit.forEach.no_empty h_eq) with h|h
-      · obtain rfl : n = 0 := h
-        simp_all [Expression.eval, from_bits_expr]
-      obtain ⟨_, _, h⟩ := h
-      exact Operations.noConfusion h
-    rename_i h_eq; clear h_eq
-    simp only [h_input, circuit_norm, subcircuit_norm, true_implies, true_and, and_true] at h_env ⊢
+    simp only [h_input, circuit_norm, subcircuit_norm] at h_env ⊢
     obtain ⟨ h_bits, right ⟩ := h_env; clear right;
 
     constructor

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -12,14 +12,14 @@ def all_zero {n} (xs : Vector (Expression F) n) : Circuit F Unit := .forEach xs 
 
 theorem all_zero.soundness {offset : ℕ} {env : Environment F} {n} {xs : Vector (Expression F) n} :
     constraints_hold.soundness env ((all_zero xs).operations offset) → ∀ x ∈ xs, x.eval env = 0 := by
-  simp only [all_zero, circuit_norm, true_and]
+  simp only [all_zero, circuit_norm]
   intro h_holds x hx
   obtain ⟨i, hi, rfl⟩ := Vector.getElem_of_mem hx
   exact h_holds ⟨i, hi⟩
 
 theorem all_zero.completeness {offset : ℕ} {env : Environment F} {n} {xs : Vector (Expression F) n} :
     (∀ x ∈ xs, x.eval env = 0) → constraints_hold.completeness env ((all_zero xs).operations offset) := by
-  simp only [all_zero, circuit_norm, true_and]
+  simp only [all_zero, circuit_norm]
   intro h_holds i
   exact h_holds xs[i] (Vector.mem_of_getElem rfl)
 
@@ -97,12 +97,12 @@ lemma elaborated_eq (α : TypeMap) [LawfulProvableType α] : (circuit α (F:=F))
 @[circuit_norm]
 theorem soundness (α : TypeMap) [LawfulProvableType α] (n : ℕ) (env : Environment F) (x y : Var α F) :
     ((circuit α).to_subcircuit n (x, y)).soundness env = (eval env x = eval env y) := by
-  simp only [subcircuit_norm, circuit_norm, circuit, forall_const]
+  simp only [subcircuit_norm, circuit_norm, circuit]
 
 @[circuit_norm]
 theorem completeness (α : TypeMap) [LawfulProvableType α] (n : ℕ) (env : Environment F) (x y : Var α F) :
     ((circuit α).to_subcircuit n (x, y)).completeness env = (eval env x = eval env y) := by
-  simp only [subcircuit_norm, circuit_norm, circuit, true_and]
+  simp only [subcircuit_norm, circuit_norm, circuit]
 
 end Equality
 end Gadgets

--- a/Clean/Gadgets/Keccak/KeccakRound.lean
+++ b/Clean/Gadgets/Keccak/KeccakRound.lean
@@ -45,7 +45,7 @@ theorem soundness (rc : UInt64) : Soundness (F p) (elaborated rc) assumptions (s
     Theta.assumptions, Theta.spec, RhoPi.assumptions, RhoPi.spec,
     Chi.assumptions, Chi.spec, Xor.assumptions, Xor.spec
   ] at h_holds
-  simp only [forall_const, and_assoc, zero_mul, add_zero, and_imp] at h_holds
+  simp only [and_assoc, zero_mul, add_zero, and_imp] at h_holds
 
   obtain ⟨ theta_norm, theta_eq, h_rhopi, h_chi, h_rc ⟩ := h_holds
   have ⟨ rhopi_norm, rhopi_eq ⟩ := h_rhopi theta_norm
@@ -90,7 +90,7 @@ theorem completeness (rc : UInt64) : Completeness (F p) (elaborated rc) assumpti
   ] at h_env ⊢
   simp only [and_assoc] at h_env
   simp_all only [main, h_input, state_norm, circuit_norm,
-    U64.from_u64_normalized, and_true, true_and, true_implies]
+    U64.from_u64_normalized]
 
   -- `simp_all` left one goal to pull out of hypotheses
   obtain ⟨ ⟨theta_norm, _ ⟩, h_rhopi, h_chi, _ ⟩ := h_env

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -76,7 +76,7 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   dsimp only [elaborated, main, assumptions] at h_assumptions h_env ⊢
   simp only [h_input, h_assumptions, circuit_norm, subcircuit_norm, spec,
     KeccakRound.circuit, KeccakRound.elaborated,
-    KeccakRound.spec, KeccakRound.assumptions, zero_add, forall_const, true_and] at h_env ⊢
+    KeccakRound.spec, KeccakRound.assumptions, zero_add] at h_env ⊢
 
   obtain ⟨ ⟨ h_init, _ ⟩, h_succ ⟩ := h_env
   intro i hi

--- a/Clean/Gadgets/Xor/Xor64.lean
+++ b/Clean/Gadgets/Xor/Xor64.lean
@@ -126,7 +126,7 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   obtain ⟨ y0_byte, y1_byte, y2_byte, y3_byte, y4_byte, y5_byte, y6_byte, y7_byte ⟩ := y_bytes
 
   simp only [h_input, circuit_norm, xor_u64, ByteXorLookup,
-    var_from_offset, Vector.mapRange, true_and] at h_env ⊢
+    var_from_offset, Vector.mapRange] at h_env ⊢
   repeat rw [ByteXorTable.equiv]
   have h_env0 := by let h := h_env 0; simp at h; exact h
   have h_env1 := by let h := h_env 1; simp at h; exact h

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -132,7 +132,7 @@ lemma fib_constraints (curr next : Row (F p) RowType) (aux_env : Environment (F 
   set env := recursive_relation.window_env  ⟨<+> +> curr +> next, rfl⟩ aux_env
   simp only [table_norm, circuit_norm, recursive_relation,
     assign_U32, Gadgets.Addition32Full.circuit]
-  rintro ⟨ ⟨_, h_add⟩, h_eq ⟩
+  rintro ⟨ h_add, h_eq ⟩
   simp only [table_norm, circuit_norm, subcircuit_norm, true_implies, Nat.reduceAdd, zero_add] at h_add
   rw [hcurr_x, hcurr_y, hnext_y] at h_add
   rw [hcurr_y, hnext_x] at h_eq
@@ -152,7 +152,7 @@ lemma boundary_constraints (first_row : Row (F p) RowType) (aux_env : Environmen
   := by
   set env := boundary.window_env ⟨<+> +> first_row, rfl⟩ aux_env
   simp only [table_norm, boundary, circuit_norm]
-  simp only [true_and, and_imp]
+  simp only [and_imp]
   have hx : eval env (var_from_offset U32 0) = first_row.x := by rfl
   have hy : eval env (var_from_offset U32 4) = first_row.y := by rfl
   rw [hx, hy]

--- a/Clean/Tables/Fibonacci8.lean
+++ b/Clean/Tables/Fibonacci8.lean
@@ -83,7 +83,7 @@ lemma boundary_step (first_row: Row (F p) RowType) (aux_env : Environment (F p))
   simp only [boundary_fib]
   simp_assign_row
   simp only [circuit_norm, table_norm]
-  simp only [zero_add, neg_eq_zero, true_and, and_imp]
+  simp only [zero_add, neg_eq_zero, and_imp]
   intro boundary1 boundary2
 
   have hx : first_row.x = env.get 0 := by rfl
@@ -131,7 +131,7 @@ def formal_fib_table : FormalTable (F p) RowType := {
 
       simp only [fib_table, fib_relation, circuit_norm, table_norm, table_assignment_norm, copy_to_var,
           Gadgets.Addition8.circuit] at constraints_hold
-      simp only [circuit_norm, subcircuit_norm, eval, var_from_offset, Vector.mapRange, true_and] at constraints_hold
+      simp only [circuit_norm, subcircuit_norm, eval, var_from_offset, Vector.mapRange] at constraints_hold
       dsimp only [Gadgets.Addition8.assumptions, Gadgets.Addition8.spec] at constraints_hold
 
       have hx_curr : env.get 0 = curr.x := by rfl


### PR DESCRIPTION
This PR simplifies the definitions of `constraints_holds`, which had a condition to avoid an extra leading `True` in the statement. It turns out that the condition can be hard to simplify, while the leading `True` is trivial to get rid of by adding `and_true` to the simp set.

* add `and_true` and a few similar lemmas to `circuit_norm`
* remove `and_true` & co from simp invocations where it's no longer needed
* simplify the `Bits` gadget proof
* remove unproved theorem that previously was needed for `Bits`