### PR TITLE
Change Circuit monad to be consistent by definition

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -43,10 +43,14 @@ reason about (because it avoids the duplicated `f n` term).
  -/
 @[circuit_norm]
 theorem Circuit.bind_def {α β} (f : Circuit F α) (g : α → Circuit F β) :
-  Circuit.bind f g = fun n =>
+  f >>= g = fun n =>
     let ((a, ops), n') := f n
     let ((b, ops'), n'') := g a n'
     ((b, ops ++ ops'), n'') := rfl
+
+-- normalize `bind` to `>>=`
+@[circuit_norm]
+theorem Circuit.bind_normal {α β} (f : Circuit F α) (g : α → Circuit F β) : f.bind g = f >>= g := rfl
 
 instance : Monoid (List α) := inferInstanceAs (Monoid (FreeMonoid _))
 instance : LawfulMonad (Circuit F) := inferInstanceAs (LawfulMonad (WriterT (List _) (StateM ℕ)))
@@ -357,7 +361,7 @@ def Circuit.witnesses (circuit: Circuit F α) (offset := 0) : Array F :=
 -- `circuit_norm` attributes
 
 -- `circuit_norm` has to expand monad operations, so we need to add them to the simp set
-attribute [circuit_norm] bind StateT.bind
+-- attribute [circuit_norm] bind StateT.bind
 attribute [circuit_norm] modify modifyGet MonadStateOf.modifyGet StateT.modifyGet
 attribute [circuit_norm] pure StateT.pure
 attribute [circuit_norm] StateT.run

--- a/Clean/Circuit/Lawful.lean
+++ b/Clean/Circuit/Lawful.lean
@@ -2,140 +2,84 @@
 import Clean.Circuit.SubCircuit
 variable {n m o : ℕ} {F : Type} [Field F] {α β : Type}
 
--- there are two different definitions of the offset resulting from running a `Circuit`:
--- 1. the output of the state monad
--- 2. the offset computed from the operations list: initial_offset + local_length
--- a lawful circuit is one where these two definitions agree.
-
-class LawfulCircuit (circuit : Circuit F α) where
-  /-- the offset derived from operations is the same as the state offset -/
-  offset_consistent : ∀ n : ℕ, circuit.final_offset n = n + circuit.local_length n := by intro _; rfl
+/-- the offset derived from operations is the same as the state offset -/
+lemma offset_consistent (circuit : Circuit F α) :
+  ∀ n : ℕ, circuit.final_offset n = n + circuit.local_length n := by intro _; rfl
 
 -- a constant circuit is one where the local length is constant for all inputs
 class ConstantCircuit (circuit : Circuit F α) where
   local_length : ℕ
   local_length_eq : ∀ n : ℕ, circuit.local_length n = local_length := by intro _; rfl
 
--- combination
-class ConstantLawfulCircuit (circuit : Circuit F α)
-  extends LawfulCircuit circuit, ConstantCircuit circuit
-
 -- even stronger (and still the typical case): an indexed family of lawful circuits that all share the same local length
-class ConstantLawfulCircuits (circuit : α → Circuit F β) where
+class ConstantCircuits (circuit : α → Circuit F β) where
   local_length : ℕ
-  offset_consistent : ∀ (a : α) (n: ℕ), (circuit a).final_offset n = n + local_length := by intro _ _; rfl
   local_length_eq : ∀ (a : α) (n : ℕ), (circuit a).local_length n = local_length := by intro _ _; rfl
 
--- `pure` is a (constant) lawful circuit
-instance LawfulCircuit.from_pure {a : α} : ConstantLawfulCircuit (pure a : Circuit F α) where
+-- `pure` is a constant circuit
+instance LawfulCircuit.from_pure {a : α} : ConstantCircuit (pure a : Circuit F α) where
   local_length := 0
 
-instance ConstantLawfulCircuits.from_pure {f : α → β} : ConstantLawfulCircuits (fun a => pure (f a) : α → Circuit F β) where
+instance ConstantLawfulCircuits.from_pure {f : α → β} : ConstantCircuits (fun a => pure (f a) : α → Circuit F β) where
   local_length := 0
 
--- `bind` and `map` of two lawful circuits yields a lawful circuit
+-- basic operations are constant circuits
 
-instance LawfulCircuit.from_bind {f: Circuit F α} {g : α → Circuit F β}
-    (f_lawful : LawfulCircuit f) (g_lawful : ∀ a : α, LawfulCircuit (g a)) : LawfulCircuit (f >>= g) where
-  offset_consistent n := by
-    show (g _).final_offset (f.final_offset _) = n + (f >>= g).local_length n
-    rw [Circuit.bind_local_length, offset_consistent, offset_consistent, add_assoc]
-
-instance LawfulCircuit.from_map {f : α → β} {g : Circuit F α}
-    (g_lawful : LawfulCircuit g) : LawfulCircuit (f <$> g) where
-  offset_consistent n := by
-    show g.final_offset n = n + g.local_length n
-    rw [offset_consistent]
-
--- basic operations are (constant) lawful circuits
-
-instance : ConstantLawfulCircuits (F:=F) witness_var where
+instance : ConstantCircuits (F:=F) witness_var where
   local_length := 1
 
-instance {k : ℕ} {c : Environment F → Vector F k} : ConstantLawfulCircuit (witness_vars k c) where
+instance {k : ℕ} {c : Environment F → Vector F k} : ConstantCircuit (witness_vars k c) where
   local_length := k
 
-instance {α: TypeMap} [ProvableType α] : ConstantLawfulCircuits (ProvableType.witness (α:=α) (F:=F)) where
+instance {α: TypeMap} [ProvableType α] : ConstantCircuits (ProvableType.witness (α:=α) (F:=F)) where
   local_length := size α
 
-instance : ConstantLawfulCircuits (F:=F) assert_zero where
+instance : ConstantCircuits (F:=F) assert_zero where
   local_length := 0
 
-instance : ConstantLawfulCircuits (F:=F) lookup where
+instance : ConstantCircuits (F:=F) lookup where
   local_length := 0
 
 instance {β α: TypeMap} [ProvableType α] [ProvableType β] {circuit : FormalCircuit F β α} {input} :
-    ConstantLawfulCircuit (subcircuit circuit input) where
+    ConstantCircuit (subcircuit circuit input) where
   local_length := circuit.local_length input
 
 instance {β: TypeMap} [ProvableType β] {circuit : FormalAssertion F β} {input} :
-    ConstantLawfulCircuit (assertion circuit input) where
+    ConstantCircuit (assertion circuit input) where
   local_length := circuit.local_length input
 
--- lower `ConstantLawfulCircuits` to `ConstantLawfulCircuit`
-instance ConstantLawfulCircuits.to_single (circuit : α → Circuit F β) (a : α) [lawful : ConstantLawfulCircuits circuit] : ConstantLawfulCircuit (circuit a) where
+-- lower `ConstantCircuits` to `ConstantCircuit`
+instance ConstantCircuits.to_single (circuit : α → Circuit F β) (a : α) [lawful : ConstantCircuits circuit] :
+    ConstantCircuit (circuit a) where
   local_length := local_length circuit
-  offset_consistent n := lawful.local_length_eq a n ▸ offset_consistent a n
   local_length_eq n := local_length_eq a n
 
-instance LawfulCircuit.from_constants {circuit : α → Circuit F β} (lawful : ConstantLawfulCircuits circuit) (a : α) :
-    LawfulCircuit (circuit a) := ConstantLawfulCircuits.to_single circuit a |>.toLawfulCircuit
+instance ConstantCircuit.from_constants {circuit : α → Circuit F β} (lawful : ConstantCircuits circuit) (a : α) :
+  ConstantCircuit (circuit a) := ConstantCircuits.to_single circuit a
 
-syntax "infer_lawful_circuit" : tactic
-
-macro_rules
-  | `(tactic|infer_lawful_circuit) => `(tactic|(
-    try intros
-    try repeat infer_instance
-    repeat (
-      try intros
-      first
-        | apply LawfulCircuit.from_bind
-        | apply LawfulCircuit.from_map
-      repeat infer_instance
-    )))
-
--- this tactic is pretty good at inferring lawful circuits!
-section
-example : LawfulCircuit (witness (fun _ => (0 : F)))
-  := by infer_lawful_circuit
-
-example :
-  let add := do
-    let x : Expression F ← witness (fun _ => 0)
-    let y ← witness (fun _ => 1)
-    let z ← witness (fun eval => eval (x + y))
-    assert_zero (x + y - z)
-    pure z
-
-  LawfulCircuit add := by infer_lawful_circuit
-end
-
--- `ConstantLawfulCircuit(s)` can be proved from `LawfulCircuit` by adding the requirement that the local length is constant.
+-- `ConstantCircuit(s)` can be proved from `Circuit` by adding the requirement that the local length is constant.
 -- the latter can usually be proved by rfl!
-def ConstantLawfulCircuit.from_constant_length {circuit : Circuit F α} (lawful : LawfulCircuit circuit)
-    (h_length : ∀ n, circuit.local_length n = circuit.local_length 0) : ConstantLawfulCircuit circuit where
+def ConstantCircuit.from_constant_length {circuit : Circuit F α}
+    (h_length : ∀ n, circuit.local_length n = circuit.local_length 0) : ConstantCircuit circuit where
   local_length := circuit.local_length 0
   local_length_eq := h_length
 
-def ConstantLawfulCircuits.from_constant_length {circuit : α → Circuit F β} [Inhabited α] (lawful : ∀ a, LawfulCircuit (circuit a))
-    (h_length : ∀ a n, (circuit a).local_length n = (circuit default).local_length 0) : ConstantLawfulCircuits circuit where
+def ConstantCircuits.from_constant_length {circuit : α → Circuit F β} [Inhabited α]
+    (h_length : ∀ a n, (circuit a).local_length n = (circuit default).local_length 0) : ConstantCircuits circuit where
   local_length := (circuit default).local_length 0
-  offset_consistent a n := by rw [(lawful a).offset_consistent, h_length]
   local_length_eq a n := by rw [h_length]
 
-syntax "infer_constant_lawful_circuits" : tactic
+syntax "infer_constant_circuits" : tactic
 
 macro_rules
-  | `(tactic|infer_constant_lawful_circuits) => `(tactic|(
-    apply ConstantLawfulCircuits.from_constant_length (by infer_lawful_circuit)
+  | `(tactic|infer_constant_circuits) => `(tactic|(
+    apply ConstantCircuits.from_constant_length
     try intros
-    try simp only [LawfulCircuit.final_offset]
     try ac_rfl))
 
 section
-example : ConstantLawfulCircuits (witness (F:=F))
-  := by infer_constant_lawful_circuits
+example : ConstantCircuits (witness (F:=F))
+  := by infer_constant_circuits
 
 example :
   let add (x : Expression F) := do
@@ -144,7 +88,7 @@ example :
     assert_zero (x + y - z)
     pure z
 
-  ConstantLawfulCircuits add := by infer_constant_lawful_circuits
+  ConstantCircuits add := by infer_constant_circuits
 end
 
 def Circuit.constant_output (circuit : α → Circuit F β) [Inhabited α] :=
@@ -164,14 +108,10 @@ lemma forAll_def {circuit : Circuit F α} {n : ℕ} :
 
 theorem bind_forAll {f : Circuit F α} {g : α → Circuit F β} :
   (f >>= g).forAll prop n ↔
-    f.forAll prop n ∧ ((g (f.output n)).operations (f.final_offset n)).forAll (n + f.local_length n) prop := by
+    f.forAll prop n ∧ ((g (f.output n)).forAll prop (n + f.local_length n)) := by
   have h_ops : (f >>= g).operations n = f.operations n ++ (g (f.output n)).operations (f.final_offset n) := rfl
   simp only [forAll]
-  rw [h_ops, Operations.forAll_append, add_comm n]
-
-theorem bind_forAll_lawful {f : Circuit F α} {g : α → Circuit F β} (f_lawful: LawfulCircuit f) :
-  (f >>= g).forAll prop n ↔ f.forAll prop n ∧ (g (f.output n)).forAll prop (n + f.local_length n) := by
-  rw [bind_forAll, ←f_lawful.offset_consistent]
+  rw [h_ops, Operations.forAll_append, offset_consistent, add_comm n]
 
 theorem constraints_hold.soundness_iff_forAll' {env : Environment F} {circuit : Circuit F α} {n : ℕ} :
   constraints_hold.soundness env (circuit.operations n) ↔ circuit.forAll {

--- a/Clean/Circuit/LoopsForAll.lean
+++ b/Clean/Circuit/LoopsForAll.lean
@@ -111,10 +111,8 @@ lemma forEach.uses_local_witnesses :
 
 @[circuit_norm ↓]
 lemma forEach.forAll :
-  Operations.forAll n prop (forEach xs body lawful n).2 ↔
-    ∀ i : Fin m, (body xs[i.val]
-      |>.operations (n + i*(body default).local_length)
-      |>.forAll (n + i*(body default).local_length)) prop := by
+  Operations.forAll n prop ((forEach xs body lawful).operations n) ↔
+    ∀ i : Fin m, (body xs[i.val] |>.forAll prop (n + i*(body default).local_length)) := by
   simp only [forEach, ←forAll_def]
   rw [ForM.forAll_iff, ConstantCircuits.local_length_eq]
 
@@ -123,23 +121,8 @@ lemma forEach.local_length_eq :
     (forEach xs body lawful).local_length n = m * (body default).local_length := by
   rw [forEach, ForM.local_length_eq, mul_comm, lawful.local_length_eq]
 
-@[circuit_norm]
-lemma forEach.final_offset_eq :
-    (forEach xs body lawful).final_offset n = n + m * (body default).local_length := by
-  rw [offset_consistent, local_length_eq]
-
 @[circuit_norm ↓]
 lemma forEach.output_eq :
   (forEach xs body lawful).output n = () := rfl
-
--- def opaqueOperations (circuit : Circuit F α) (n : ℕ) : Operations F :=
---   circuit.operations n
-
--- @[circuit_norm ↓]
--- lemma forEach.apply_eq :
---   forEach xs body lawful n = (((), (forEach xs body lawful).opaqueOperations n), n + m *(body default).local_length) := by
---   apply Prod.ext
---   · rfl
---   apply final_offset_eq
 
 end forEach

--- a/Clean/Circuit/LoopsForAll.lean
+++ b/Clean/Circuit/LoopsForAll.lean
@@ -111,7 +111,7 @@ lemma forEach.uses_local_witnesses :
 
 @[circuit_norm ↓]
 lemma forEach.forAll :
-  ((forEach xs body lawful).operations n).forAll n prop ↔
+  Operations.forAll n prop (forEach xs body lawful n).2 ↔
     ∀ i : Fin m, (body xs[i.val]
       |>.operations (n + i*(body default).local_length)
       |>.forAll (n + i*(body default).local_length)) prop := by

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -115,7 +115,7 @@ def field : TypeMap := id
 instance : LawfulProvableType field where
   size := 1
   to_elements x := #v[x]
-  from_elements v := v.get 0
+  from_elements v := let ⟨ .mk [x], _ ⟩ := v; x
 instance : NonEmptyProvableType field where
 
 @[reducible]

--- a/Clean/Circuit/SubCircuit.lean
+++ b/Clean/Circuit/SubCircuit.lean
@@ -196,14 +196,14 @@ def subcircuit (circuit: FormalCircuit F β α) (b: Var β F) : Circuit F (Var �
   fun offset =>
     let a := circuit.output b offset
     let subcircuit := circuit.to_subcircuit offset b
-    ((a, [.subcircuit subcircuit]), offset + subcircuit.local_length)
+    (a, [.subcircuit subcircuit])
 
 /-- Include an assertion subcircuit. -/
 @[circuit_norm]
 def assertion (circuit: FormalAssertion F β) (b: Var β F) : Circuit F Unit :=
   fun offset =>
     let subcircuit := circuit.to_subcircuit offset b
-    (((), [.subcircuit subcircuit]), offset + subcircuit.local_length)
+    ((), [.subcircuit subcircuit])
 
 namespace Circuit
 variable {α β: TypeMap} [ProvableType α] [ProvableType β]

--- a/Clean/Gadgets/Addition32/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32/Addition32Full.lean
@@ -87,7 +87,8 @@ theorem soundness : Soundness (F p) elaborated assumptions spec := by
   obtain ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm
 
   -- simplify circuit
-  simp only [circuit_norm, subcircuit_norm, add32_full, add8_full_carry, Boolean.circuit, ByteLookup] at h
+  dsimp only [circuit_norm, subcircuit_norm, add32_full, add8_full_carry, Boolean.circuit, ByteLookup] at h
+  simp only [circuit_norm, subcircuit_norm] at h
   simp only [h_inputs] at h
   rw [ByteTable.equiv, ByteTable.equiv, ByteTable.equiv, ByteTable.equiv] at h
   repeat rw [add_neg_eq_zero] at h
@@ -137,8 +138,8 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   have ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm
 
   -- simplify circuit
-  simp only [h_inputs, circuit_norm, subcircuit_norm,
-    add32_full, add8_full_carry, Boolean.circuit] at henv ⊢
+  dsimp only [circuit_norm, subcircuit_norm, add32_full, add8_full_carry, Boolean.circuit] at henv ⊢
+  simp only [h_inputs, circuit_norm, subcircuit_norm] at henv ⊢
 
   -- characterize local witnesses
   obtain ⟨ hz0, hc0, hz1, hc1, hz2, hc2, hz3, hc3 ⟩ := henv

--- a/Clean/Gadgets/Addition32/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32/Addition32Full.lean
@@ -64,12 +64,13 @@ instance elaborated : ElaboratedCircuit (F p) Inputs Outputs where
     z := { x0 := var ⟨i0⟩, x1 := var ⟨i0 + 2⟩, x2 := var ⟨i0 + 4⟩, x3 := var ⟨i0 + 6⟩ },
     carry_out := var ⟨i0 + 7⟩
   }
+  -- unfortunately, `rfl` in default tactic times out here
   local_length_eq _ i0 := by
     simp only [circuit_norm, add32_full, add8_full_carry, Boolean.circuit]
-  output_eq _ i0 := by
-    simp only [circuit_norm, add32_full, add8_full_carry, Boolean.circuit]
-  subcircuits_consistent _ i0 := by
-    simp +arith only [circuit_norm, add32_full, add8_full_carry, Boolean.circuit]
+  -- output_eq _ i0 := by
+  --   simp only [circuit_norm, add32_full, add8_full_carry, Boolean.circuit]
+  -- subcircuits_consistent _ i0 := by
+  --   simp +arith only [circuit_norm, add32_full, add8_full_carry, Boolean.circuit]
 
 theorem soundness : Soundness (F p) elaborated assumptions spec := by
   rintro i0 env ⟨ x_var, y_var, carry_in_var ⟩ ⟨ x, y, carry_in ⟩ h_inputs as h


### PR DESCRIPTION
- **tweak bind unfolding to go directly from >>= to the intended definition**
- **avoid vector.get which got unfolded in an annoying way**
- **experiment: redefine circuit to derive next offset from operations**
- **simplification is slowed down a bit**
- **we no longer need lawful, just constant circuit**
- **fix foreach loop**
- **some progress on to_bits**
- **clean up forall loop, I think it has everything we need**
