### PR TITLE
Keccak table

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -119,7 +119,13 @@ def ProvableType.witness {α: TypeMap} [ProvableType α] (compute : Environment 
     let var := var_from_offset α offset
     (var, [.witness (size α) (fun env => compute env |> to_elements)])
 
+@[circuit_norm]
+def ProvableVector.witness {α: TypeMap} [NonEmptyProvableType α] (m: ℕ)
+    (compute : Environment F → Vector (α F) m) : Circuit F (Vector (α (Expression F)) m) :=
+  ProvableType.witness (α := ProvableVector α m) compute
+
 namespace Circuit
+
 -- formal concepts of soundness and completeness of a circuit
 
 /--

--- a/Clean/Circuit/Extensions.lean
+++ b/Clean/Circuit/Extensions.lean
@@ -29,6 +29,5 @@ def ProvableType.witnessAny (α: TypeMap) [ProvableType α] : Circuit F (Var α 
   ProvableType.witness compute
 
 @[circuit_norm]
-def ProvableVector.witnessAny (α: TypeMap) [NonEmptyProvableType α] (m : ℕ) : Circuit F (Vector (Var α F) m) := do
-  let compute ← undetermined (ProvableVector α m)
-  ProvableVector.witness m compute
+def ProvableVector.witnessAny (α: TypeMap) [NonEmptyProvableType α] (m : ℕ) : Circuit F (Vector (Var α F) m) :=
+  ProvableType.witnessAny (ProvableVector α m)

--- a/Clean/Circuit/Extensions.lean
+++ b/Clean/Circuit/Extensions.lean
@@ -1,4 +1,4 @@
-/- This file contains possible additions to the Circuit DSL that aren't currently used -/
+/- This file contains experimental additions to the Circuit DSL -/
 import Clean.Circuit.Constant
 
 variable {F : Type} [Field F]
@@ -14,3 +14,21 @@ def copy_to_var (x: Expression F) : Circuit F (Variable F) := do
 def to_var : Expression F → Circuit F (Variable F)
   | var v => pure v
   | x => copy_to_var x
+
+@[circuit_norm]
+def getOffset : Circuit F ℕ := fun n => (n, [])
+
+@[circuit_norm]
+def undetermined (α: TypeMap) [ProvableType α] : Circuit F ((Environment F) → α F) := do
+  let offset ← getOffset
+  return fun env => from_elements <| .mapRange _ fun i => env.get (offset + i)
+
+@[circuit_norm]
+def ProvableType.witnessAny (α: TypeMap) [ProvableType α] : Circuit F (Var α F) := do
+  let compute ← undetermined α
+  ProvableType.witness compute
+
+@[circuit_norm]
+def ProvableVector.witnessAny (α: TypeMap) [NonEmptyProvableType α] (m : ℕ) : Circuit F (Vector (Var α F) m) := do
+  let compute ← undetermined (ProvableVector α m)
+  ProvableVector.witness m compute

--- a/Clean/Circuit/Extensions.lean
+++ b/Clean/Circuit/Extensions.lean
@@ -15,23 +15,19 @@ def to_var : Expression F → Circuit F (Variable F)
   | var v => pure v
   | x => copy_to_var x
 
-@[circuit_norm]
+-- these could be used if you want to witness _any_ value and don't care which
+-- (typically useless, because in completeness proofs you will often have to prove some assumption about the value)
+
 def getOffset : Circuit F ℕ := fun n => (n, [])
 
 def compute_value_from_offset (α : TypeMap) [ProvableType α] (offset : ℕ) (env : Environment F) : α F :=
   from_elements <| .mapRange _ fun i => env.get (offset + i)
 
--- @[circuit_norm]
 def ProvableType.witnessAny (α: TypeMap) [ProvableType α] : Circuit F (Var α F) := do
   let offset ← getOffset
   ProvableType.witness (compute_value_from_offset α offset)
 
-@[circuit_norm]
-def ProvableVector.witnessAny (α: TypeMap) [NonEmptyProvableType α] (m : ℕ) : Circuit F (Vector (Var α F) m) :=
-  ProvableType.witnessAny (ProvableVector α m)
-
-@[circuit_norm]
-theorem ProvableType.witnessAny_local_witnesses (offset : ℕ) (env : Environment F) :
-  env.uses_local_witnesses_completeness offset (ProvableType.witnessAny α offset).2 ↔ True := by
-  simp only [circuit_norm, ProvableType.witnessAny, compute_value_from_offset,
+theorem ProvableType.witnessAny.local_witnesses (n : ℕ) (env : Environment F) :
+    env.uses_local_witnesses_completeness n (ProvableType.witnessAny α |>.operations n) ↔ True := by
+  simp only [circuit_norm, getOffset, ProvableType.witnessAny, compute_value_from_offset,
     ProvableType.to_elements_from_elements]

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -462,3 +462,12 @@ theorem eval_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (env : En
     eval (α:=ProvablePair α β) env (a, b) = (eval env a, eval env b) := by
   simp only [eval, to_vars, to_elements, from_elements, Vector.map_append]
   rw [Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
+
+omit [Field F] in
+@[circuit_norm ↓ high]
+theorem var_from_offset_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (offset : ℕ) :
+    var_from_offset (F:=F) (ProvablePair α β) offset
+    = (var_from_offset α offset, var_from_offset β (offset + size α)) := by
+  simp only [var_from_offset, from_vars, ProvablePair.instance]
+  rw [Vector.mapRange_add_eq_append, Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
+  ac_rfl

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -390,12 +390,14 @@ end ProvableType
 -- more concrete ProvableType instances
 
 -- `ProvableVector`
+section
+variable {n: ℕ} {α: TypeMap} [NonEmptyProvableType α]
 
 @[reducible]
 def psize (α : TypeMap) [NonEmptyProvableType α] : ℕ+ :=
   ⟨ size α, NonEmptyProvableType.nonempty⟩
 
-instance ProvableVector.instance {α: TypeMap} [NonEmptyProvableType α] : ProvableType (ProvableVector α n) where
+instance ProvableVector.instance : ProvableType (ProvableVector α n) where
   size := n * size α
   to_elements x := x.map to_elements |>.flatten
   from_elements v := v.toChunks (psize α) |>.map from_elements
@@ -404,13 +406,21 @@ instance ProvableVector.instance {α: TypeMap} [NonEmptyProvableType α] : Prova
   to_elements_from_elements v := by
     rw [Vector.map_map, ProvableType.comp_to_elements_from_elements, Vector.map_id, Vector.toChunks_flatten]
 
-theorem eval_vector {F : Type} [Field F] {α: TypeMap} [NonEmptyProvableType α] (env : Environment F)
+theorem eval_vector (env : Environment F)
   (x : Var (ProvableVector α n) F) :
     eval env x = x.map (eval env) := by
   simp only [eval, to_vars, to_elements, from_elements]
   simp only [Vector.map_flatten, Vector.map_map]
   rw [Vector.flatten_toChunks]
   simp [from_elements, eval, to_vars]
+
+theorem getElem_eval_vector (env : Environment F) (x : Var (ProvableVector α n) F) (i : ℕ) (h : i < n) :
+    (eval env x[i]) = (eval env x)[i] := by
+  rw [eval_vector, Vector.getElem_map]
+
+theorem getElemFin_eval_vector (env : Environment F) (x : Var (ProvableVector α n) F) (i : Fin n) :
+    (eval env x[i.val]) = (eval env x)[i.val] := by
+  rw [eval_vector, Vector.getElem_map]
 
 theorem var_from_offset_vector {F : Type} [Field F] {α: TypeMap} [NonEmptyProvableType α] (offset : ℕ) :
     var_from_offset (F:=F) (ProvableVector α n) offset
@@ -428,6 +438,7 @@ theorem var_from_offset_vector {F : Type} [Field F] {α: TypeMap} [NonEmptyProva
     rw [h_create, ←Vector.mapRange_add_eq_append]
     have h_size_succ : (n + 1) * size α = n * size α + size α := by rw [add_mul]; ac_rfl
     rw [←Vector.cast_mapRange h_size_succ]
+end
 
 -- `ProvablePair`
 

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -418,10 +418,6 @@ theorem getElem_eval_vector (env : Environment F) (x : Var (ProvableVector α n)
     (eval env x[i]) = (eval env x)[i] := by
   rw [eval_vector, Vector.getElem_map]
 
-theorem getElemFin_eval_vector (env : Environment F) (x : Var (ProvableVector α n) F) (i : Fin n) :
-    (eval env x[i.val]) = (eval env x)[i.val] := by
-  rw [eval_vector, Vector.getElem_map]
-
 theorem var_from_offset_vector {F : Type} [Field F] {α: TypeMap} [NonEmptyProvableType α] (offset : ℕ) :
     var_from_offset (F:=F) (ProvableVector α n) offset
     = .mapRange n fun i => var_from_offset α (offset + (size α)*i) := by

--- a/Clean/Gadgets/Keccak/AbsorbBlock.lean
+++ b/Clean/Gadgets/Keccak/AbsorbBlock.lean
@@ -6,8 +6,6 @@ namespace Gadgets.Keccak256.AbsorbBlock
 variable {p : ℕ} [Fact p.Prime] [Fact (p > 2^16 + 2^8)]
 open Specs.Keccak256
 
-@[reducible] def KeccakBlock := ProvableVector U64 RATE
-
 structure Input (F : Type) where
   state : KeccakState F
   block : KeccakBlock F
@@ -20,10 +18,10 @@ instance : ProvableStruct Input where
 def main (input : Var Input (F p)) : Circuit (F p) (Var KeccakState (F p)) := do
   let { state, block } := input
   -- absorb the block into the state by XORing with the first RATE elements
-  let state_rate ← Circuit.mapFinRange RATE fun i => subcircuit Xor.circuit ⟨state[i], block[i]⟩
+  let state_rate ← Circuit.mapFinRange RATE fun i => subcircuit Xor.circuit ⟨state[i.val], block[i.val]⟩
 
   -- the remaining elements of the state are unchanged
-  let state_capacity := Vector.mapFinRange (25 - RATE) fun i => state[RATE + i]
+  let state_capacity := Vector.mapFinRange (25 - RATE) fun i => state[RATE + i.val]
   let state' : Vector _ 25 := state_rate ++ state_capacity
 
   -- apply the permutation
@@ -40,5 +38,21 @@ instance elaborated : ElaboratedCircuit (F p) Input KeccakState where
   output_eq input i0 := by simp only [main, circuit_norm, Xor.circuit, Permutation.circuit, RATE]
   subcircuits_consistent _ _ := by simp +arith only [main, circuit_norm, Xor.circuit, Permutation.circuit, RATE]
 
+@[reducible] def assumptions (input : Input (F p)) :=
+  input.state.is_normalized ∧ input.block.is_normalized
+
+@[reducible] def spec (input : Input (F p)) (out_state : KeccakState (F p)) :=
+  out_state.is_normalized ∧
+  out_state.value = absorb_block input.state.value input.block.value
+
+theorem soundness : Soundness (F p) elaborated assumptions spec := by
+  intro i0 env ⟨ state_var, block_var ⟩ ⟨ state, block ⟩ h_input h_assumptions h_holds
+
+  -- simplify goal and constraints
+  apply KeccakState.normalized_value_ext
+  simp only [circuit_norm, Input.mk.injEq] at h_input
+  simp only [assumptions] at h_assumptions
+  simp only [circuit_norm, RATE, main, h_input, Xor.circuit, Permutation.circuit, subcircuit_norm,
+    Xor.assumptions, Xor.spec, Permutation.assumptions, Permutation.spec] at h_holds ⊢
 
 end Gadgets.Keccak256.AbsorbBlock

--- a/Clean/Gadgets/Keccak/AbsorbBlock.lean
+++ b/Clean/Gadgets/Keccak/AbsorbBlock.lean
@@ -1,0 +1,44 @@
+import Clean.Gadgets.Keccak.Permutation
+import Clean.Circuit.Explicit
+import Clean.Specs.Keccak256
+
+namespace Gadgets.Keccak256.AbsorbBlock
+variable {p : ℕ} [Fact p.Prime] [Fact (p > 2^16 + 2^8)]
+open Specs.Keccak256
+
+@[reducible] def KeccakBlock := ProvableVector U64 RATE
+
+structure Input (F : Type) where
+  state : KeccakState F
+  block : KeccakBlock F
+
+instance : ProvableStruct Input where
+  components := [KeccakState, KeccakBlock]
+  to_components := fun { state, block } => .cons state (.cons block .nil)
+  from_components := fun (.cons state (.cons block .nil)) => { state, block }
+
+def main (input : Var Input (F p)) : Circuit (F p) (Var KeccakState (F p)) := do
+  let { state, block } := input
+  -- absorb the block into the state by XORing with the first RATE elements
+  let state_rate ← Circuit.mapFinRange RATE fun i => subcircuit Xor.circuit ⟨state[i], block[i]⟩
+
+  -- the remaining elements of the state are unchanged
+  let state_capacity := Vector.mapFinRange (25 - RATE) fun i => state[RATE + i]
+  let state' : Vector _ 25 := state_rate ++ state_capacity
+
+  -- apply the permutation
+  subcircuit Permutation.circuit state'
+
+set_option linter.constructorNameAsVariable false
+
+instance elaborated : ElaboratedCircuit (F p) Input KeccakState where
+  main
+  local_length _ := 36808
+  output _ i0 := Permutation.state_var (i0 + 136) 23
+
+  local_length_eq _ _ := by simp only [main, circuit_norm, Xor.circuit, Permutation.circuit, RATE]
+  output_eq input i0 := by simp only [main, circuit_norm, Xor.circuit, Permutation.circuit, RATE]
+  subcircuits_consistent _ _ := by simp +arith only [main, circuit_norm, Xor.circuit, Permutation.circuit, RATE]
+
+
+end Gadgets.Keccak256.AbsorbBlock

--- a/Clean/Gadgets/Keccak/KeccakState.lean
+++ b/Clean/Gadgets/Keccak/KeccakState.lean
@@ -28,7 +28,7 @@ def KeccakRow.value (row : KeccakRow (F p)) := row.map U64.value
 @[reducible] def KeccakBlock := ProvableVector U64 RATE
 
 def KeccakBlock.is_normalized (block : KeccakBlock (F p)) :=
-  ∀ i : Fin 8, block[i.val].is_normalized
+  ∀ i : Fin RATE, block[i.val].is_normalized
 
 def KeccakBlock.value (block : KeccakBlock (F p)) := block.map U64.value
 

--- a/Clean/Gadgets/Keccak/KeccakState.lean
+++ b/Clean/Gadgets/Keccak/KeccakState.lean
@@ -68,4 +68,20 @@ lemma KeccakRow.normalized_value_ext (row : KeccakRow (F p)) (rhs : Vector ℕ 5
   intro i hi
   exact (h ⟨ i, hi ⟩).right
 
+-- circuits
+
+def KeccakBlock.normalized : FormalAssertion (F p) KeccakBlock where
+  main block := .forEach block (assertion U64.AssertNormalized.circuit)
+  assumptions _ := True
+  spec block := block.is_normalized
+  local_length_eq _ _ := by simp +arith only [circuit_norm, U64.AssertNormalized.circuit]
+  soundness := by
+    simp only [circuit_norm, U64.AssertNormalized.circuit]
+    dsimp only [subcircuit_norm, U64.AssertNormalized.assumptions, U64.AssertNormalized.spec]
+    simp [getElem_eval_vector, KeccakBlock.is_normalized]
+  completeness := by
+    simp only [circuit_norm, U64.AssertNormalized.circuit]
+    dsimp only [subcircuit_norm, U64.AssertNormalized.assumptions, U64.AssertNormalized.spec]
+    simp [getElem_eval_vector, KeccakBlock.is_normalized]
+
 end Gadgets.Keccak256

--- a/Clean/Gadgets/Keccak/KeccakState.lean
+++ b/Clean/Gadgets/Keccak/KeccakState.lean
@@ -1,11 +1,15 @@
 import Clean.Types.U64
 import Clean.Circuit.Provable
 import Clean.Utils.Field
+import Clean.Specs.Keccak256
 
 namespace Gadgets.Keccak256
+open Specs.Keccak256
 
 variable {p : ℕ} [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
+
+-- definitions
 
 @[reducible] def KeccakState := ProvableVector U64 25
 
@@ -20,6 +24,15 @@ def KeccakRow.is_normalized (row : KeccakRow (F p)) :=
   ∀ i : Fin 5, row[i.val].is_normalized
 
 def KeccakRow.value (row : KeccakRow (F p)) := row.map U64.value
+
+@[reducible] def KeccakBlock := ProvableVector U64 RATE
+
+def KeccakBlock.is_normalized (block : KeccakBlock (F p)) :=
+  ∀ i : Fin 8, block[i.val].is_normalized
+
+def KeccakBlock.value (block : KeccakBlock (F p)) := block.map U64.value
+
+-- lemmas
 
 def KeccakRow.is_normalized_iff (row : KeccakRow (F p)) :
     row.is_normalized ↔

--- a/Clean/Specs/Keccak256.lean
+++ b/Clean/Specs/Keccak256.lean
@@ -153,7 +153,7 @@ def initial_state : Vector ℕ 25 := .fill 25 0
 
 def absorb_block (state : Vector ℕ 25) (block : Vector ℕ RATE) : Vector ℕ 25 :=
   -- absorb the block into the state by XORing with the first RATE elements
-  let state' := Vector.mapFinRange 25 fun i => state[i] ^^^ (if _ : i < RATE then block[i] else 0)
+  let state' := Vector.mapFinRange 25 fun i => state[i] ^^^ (if _ : i.val < RATE then block[i] else 0)
   -- apply the permutation
   keccak_f state'
 

--- a/Clean/Specs/Keccak256.lean
+++ b/Clean/Specs/Keccak256.lean
@@ -142,8 +142,8 @@ def keccak_round (state : Vector ℕ 25) (rc : UInt64) : Vector ℕ 25 :=
   let chi_state := chi rho_pi_state
   iota chi_state rc
 
-def keccak_f (state : Vector ℕ 25): Vector ℕ 25 :=
-  Fin.foldl 24 (fun state i => keccak_round state roundConstants[i.val]) state
+def keccak_permutation (state : Vector ℕ 25): Vector ℕ 25 :=
+  roundConstants.foldl keccak_round state
 
 @[reducible] def CAPACITY := 8
 @[reducible] def RATE := 17
@@ -155,7 +155,10 @@ def absorb_block (state : Vector ℕ 25) (block : Vector ℕ RATE) : Vector ℕ 
   -- absorb the block into the state by XORing with the first RATE elements
   let state' := Vector.mapFinRange 25 fun i => state[i] ^^^ (if _ : i.val < RATE then block[i] else 0)
   -- apply the permutation
-  keccak_f state'
+  keccak_permutation state'
+
+def absorb_blocks (blocks : List (Vector ℕ RATE)) : Vector ℕ 25 :=
+  blocks.foldl absorb_block initial_state
 
 end Specs.Keccak256
 
@@ -195,7 +198,7 @@ def state' := state.map U64.value_nat
 
 def rc : U64 ℕ := ⟨235, 226, 178, 113, 2, 17, 87, 249⟩
 #eval theta state' |> rho_pi |> chi
-#eval keccak_f state' |>.map U64.decompose_nat_nat
+#eval keccak_permutation state' |>.map U64.decompose_nat_nat
 -- [[158, 112, 239, 65, 247, 184, 42, 29],[18, 33, 104, 153, 4, 113, 230, 164], [203, 128, 138, 52, 66, 249, 134, 137], [204, 130, 87, 203, 75, 229, 26, 49], [101, 124, 134, 181, 193, 247, 248, 194], [170, 160, 115, 17, 65, 59, 26, 242], [211, 14, 202, 60, 11, 138, 72, 44], [21, 90, 64, 58, 127, 167, 131, 94], [242, 160, 171, 170, 232, 135, 11, 166], [172, 234, 194, 74, 41, 176, 182, 229], [174, 35, 251, 95, 139, 151, 128, 196], [140, 76, 0, 166, 43, 181, 26, 214], [15, 95, 132, 163, 192, 11, 248, 213], [99, 110, 8, 73, 127, 107, 70, 240], [208, 251, 207, 18, 172, 113, 72, 220], [166, 119, 55, 190, 184, 224, 76, 193], [132, 182, 193, 105, 46, 92, 159, 3], [161, 219, 100, 118, 249, 82, 69, 168], [3, 191, 204, 13, 134, 22, 134, 93], [250, 46, 70, 133, 112, 75, 14, 27], [230, 133, 192, 229, 9, 245, 148, 47], [41, 51, 79, 61, 157, 210, 157, 201], [81, 88, 205, 113, 250, 141, 5, 116], [137, 227, 13, 73, 228, 151, 175, 151], [62, 184, 103, 254, 5, 201, 102, 121]]
 
 end Specs.Keccak256.Tests

--- a/Clean/Specs/Keccak256.lean
+++ b/Clean/Specs/Keccak256.lean
@@ -145,6 +145,18 @@ def keccak_round (state : Vector ℕ 25) (rc : UInt64) : Vector ℕ 25 :=
 def keccak_f (state : Vector ℕ 25): Vector ℕ 25 :=
   Fin.foldl 24 (fun state i => keccak_round state roundConstants[i.val]) state
 
+@[reducible] def CAPACITY := 8
+@[reducible] def RATE := 17
+example : RATE + CAPACITY = 25 := rfl
+
+def initial_state : Vector ℕ 25 := .fill 25 0
+
+def absorb_block (state : Vector ℕ 25) (block : Vector ℕ RATE) : Vector ℕ 25 :=
+  -- absorb the block into the state by XORing with the first RATE elements
+  let state' := Vector.mapFinRange 25 fun i => state[i] ^^^ (if _ : i < RATE then block[i] else 0)
+  -- apply the permutation
+  keccak_f state'
+
 end Specs.Keccak256
 
 namespace Specs.Keccak256.Tests

--- a/Clean/Table/Inductive.lean
+++ b/Clean/Table/Inductive.lean
@@ -164,34 +164,39 @@ lemma tableSoundnessAux (table : InductiveTable F State Input) (input output: St
     simp only [zero_add, Nat.add_zero, Fin.isValue, PNat.val_ofNat, Nat.reduceAdd, Nat.add_one_sub_one,
       CellAssignment.assignment_from_circuit_offset, CellAssignment.assignment_from_circuit_vars] at h_env'
     set curr_var : Var State F × Var Input F := var_from_offset (ProvablePair State Input) 0
-    set main_ops : Operations F := (table.step (var_from_offset State 0) (var_from_offset Input (size State)) (size State + size Input)).2
     set s := size State
     set x := size Input
-    set t := Operations.local_length main_ops
+    set main_ops : Operations F := (table.step (var_from_offset State 0) (var_from_offset Input s) (s + x)).2
+    set t := main_ops.local_length
 
     have h_env_input_1 i (hi : i < s) : (to_elements curr.1)[i] = env'.get i := by
-      have hi' : i < s + x + t + s := by linarith
+      have hi' : i < s + x + t + (s + x) := by linarith
       have hi'' : i < 0 + (s + x) := by linarith
       have hi''' : i < 0 + (s + x) + t := by linarith
       rw [h_env']
-      simp only [main_ops, s, t, hi', hi'', hi''', table_assignment_norm, inductiveConstraint, circuit_norm, reduceDIte,
+      simp +arith only [main_ops, s, t, x, hi, hi', hi'', hi''', table_assignment_norm, inductiveConstraint, circuit_norm, reduceDIte,
         CellAssignment.assignment_from_circuit_offset,
         Vector.mapRange_zero, Vector.empty_append, Vector.append_empty, Vector.getElem_append]
-      sorry
 
     have h_env_input_2 i (hi : i < x) : (to_elements curr.2)[i] = env'.get (i + s) := by
-      sorry
-
-    have h_env_output i (hi : i < s) : (to_elements next.1)[i] = env'.get (i + (s + x) + t) := by
-      have hi' : i + s + t < s + t + s := by linarith
-      have hi'' : ¬(i + s + t < 0 + s) := by linarith
-      have hi''' : ¬(i + s + t < 0 + s + t) := by linarith
+      have hi' : i + s < s + x + t + (s + x) := by linarith
+      have hi'' : i + s < 0 + (s + x) := by linarith
+      have hi''' : i + s < 0 + (s + x) + t := by linarith
       rw [h_env']
-      simp only [main_ops, hi', hi'', hi''', s, t, table_assignment_norm, inductiveConstraint, circuit_norm, reduceDIte,
+      simp +arith only [main_ops, s, t, x, hi, hi', hi'', hi''', table_assignment_norm, inductiveConstraint, circuit_norm, reduceDIte,
         CellAssignment.assignment_from_circuit_offset,
         Vector.mapRange_zero, Vector.empty_append, Vector.append_empty, Vector.getElem_append]
-      simp +arith [add_assoc]
-      sorry
+      congr; omega
+
+    have h_env_output i (hi : i < s) : (to_elements next.1)[i] = env'.get (i + (s + x) + t) := by
+      have hi' : i + (s + x) + t < s + x + t + (s + x) := by linarith
+      have hi'' : ¬(i + (s + x) + t < 0 + (s + x)) := by linarith
+      have hi''' : ¬(i + (s + x) + t < 0 + (s + x) + t) := by linarith
+      rw [h_env']
+      simp +arith only [main_ops, hi, hi', hi'', hi''', s, t, x, table_assignment_norm, inductiveConstraint, circuit_norm, reduceDIte,
+        CellAssignment.assignment_from_circuit_offset,
+        Vector.mapRange_zero, Vector.empty_append, Vector.append_empty, Vector.getElem_append]
+      simp +arith [hi, s, add_assoc]
     clear h_env'
 
     have input_eq_1 : eval env' curr_var.1 = curr.1 := by

--- a/Clean/Table/Inductive.lean
+++ b/Clean/Table/Inductive.lean
@@ -19,7 +19,7 @@ In the case of two-row windows, an `InductiveTable` is basically a `FormalCircui
 structure InductiveTable (F : Type) [Field F] (State Input : Type → Type) [ProvableType State] [ProvableType Input] where
   step : Var State F → Var Input F → Circuit F (Var State F)
   spec : ℕ → State F → Prop
-  input_spec : ℕ → Input F → Prop := fun _ _ => True
+  honest_input_assumptions : ℕ → Input F → Prop := fun _ _ => True
 
   soundness : ∀ (row_index : ℕ) (env : Environment F),
     -- for all rows and inputs
@@ -41,7 +41,7 @@ structure InductiveTable (F : Type) [Field F] (State Input : Type → Type) [Pro
     -- when using honest-prover witnesses
     env.uses_local_witnesses_completeness ((size State) + (size Input)) (step acc_var x_var |>.operations ((size State) + (size Input))) →
     -- assuming the spec on the current row, and the input_spec on the input
-    spec row_index acc ∧ input_spec row_index x →
+    spec row_index acc ∧ honest_input_assumptions row_index x →
     -- the constraints hold
     Circuit.constraints_hold.completeness env (step acc_var x_var |>.operations ((size State) + (size Input)))
 

--- a/Clean/Table/Theorems.lean
+++ b/Clean/Table/Theorems.lean
@@ -114,8 +114,8 @@ def twoRowInduction {prop : Row F S → ℕ → Prop}
     have h3 : prop next (rest +> curr).len := succ _ _ _ ih2.left
     exact ⟨ h3, ih2.left, ih2.right ⟩
 
-def lastRow_of_forAll {N: ℕ+} {prop : Row F S → ℕ → Prop}
-    (trace : TraceOfLength F S N) (h : forAllRowsOfTraceWithIndex trace prop) :
+theorem lastRow_of_forAllWithIndex {N: ℕ+} {prop : Row F S → ℕ → Prop}
+  (trace : TraceOfLength F S N) (h : forAllRowsOfTraceWithIndex trace prop) :
     prop trace.lastRow (N - 1) := by
   induction N, trace using everyRowTwoRowsInduction' with
   | one row =>
@@ -124,6 +124,20 @@ def lastRow_of_forAll {N: ℕ+} {prop : Row F S → ℕ → Prop}
   | more N curr next rest ih =>
     simp only [table_norm, and_true] at h ⊢
     rw [rest.property] at h
+    exact h.left
+
+theorem lastRow_of_forAllWithPrevious {N: ℕ+} {prop : Row F S → (i: ℕ) → TraceOfLength F S i → Prop}
+  (trace : TraceOfLength F S N) (h : forAllRowsWithPrevious trace prop) :
+    prop trace.lastRow (N - 1) trace.tail := by
+  induction N, trace using everyRowTwoRowsInduction' with
+  | one row =>
+    simp only [forAllRowsWithPrevious, Trace.forAllRowsWithPrevious, and_true] at h
+    exact h
+  | more N curr next rest ih =>
+    rcases rest with ⟨ rest, hN ⟩
+    subst hN
+    simp only [forAllRowsWithPrevious, Trace.forAllRowsWithPrevious, table_norm, and_true] at h ⊢
+    simp only [PNat.mk_coe, Nat.add_one_sub_one, tail, Trace.tail]
     exact h.left
 
 end TraceOfLength

--- a/Clean/Tables/Fibonacci32Inductive.lean
+++ b/Clean/Tables/Fibonacci32Inductive.lean
@@ -27,7 +27,7 @@ def table : InductiveTable (F p) Row unit where
     }
     return { x := row.y, y := z }
 
-  spec i row : Prop :=
+  spec i row _ _ : Prop :=
     row.x.value = fib32 i ∧
     row.y.value = fib32 (i + 1) ∧
     row.x.is_normalized ∧ row.y.is_normalized

--- a/Clean/Tables/Fibonacci32Inductive.lean
+++ b/Clean/Tables/Fibonacci32Inductive.lean
@@ -20,8 +20,8 @@ instance : ProvableStruct Row where
   to_components := fun { x, y } => .cons x (.cons y .nil)
   from_components := fun (.cons x (.cons y .nil)) => { x, y }
 
-def table : InductiveTable (F p) Row where
-  step row := do
+def table : InductiveTable (F p) Row unit where
+  step row _ := do
     let { z, .. } ← subcircuit Gadgets.Addition32Full.circuit {
       x := row.x, y := row.y, carry_in := 0
     }

--- a/Clean/Tables/Fibonacci32Inductive.lean
+++ b/Clean/Tables/Fibonacci32Inductive.lean
@@ -4,9 +4,9 @@ import Clean.Gadgets.Addition32.Addition32Full
 
 namespace Tables.Fibonacci32Inductive
 open Gadgets
-variable {p : ℕ} [Fact p.Prime] [p_large_enough: Fact (p > 512)]
+variable {p : ℕ} [Fact p.Prime] [Fact (p > 512)]
 
-def fib32 : ℕ -> ℕ
+def fib32 : ℕ → ℕ
   | 0 => 0
   | 1 => 1
   | n + 2 => (fib32 n + fib32 (n + 1)) % 2^32
@@ -39,7 +39,7 @@ def table : InductiveTable (F p) Row unit where
     Addition32Full.circuit, Addition32Full.assumptions, Addition32Full.spec]
 
 -- the input is hard-coded to (0, 1)
-def formalTable (output : Row (F p)) := table.toFormal { x:= U32.from_byte 0, y:= U32.from_byte 1 } output
+def formalTable (output : Row (F p)) := table.toFormal { x := U32.from_byte 0, y := U32.from_byte 1 } output
 
 -- The table's statement implies that the output row contains the nth Fibonacci number
 theorem tableStatement (output : Row (F p)) : ∀ n > 0, ∀ trace,

--- a/Clean/Tables/Fibonacci32Inductive.lean
+++ b/Clean/Tables/Fibonacci32Inductive.lean
@@ -1,7 +1,6 @@
 /- Simple Fibonacci example using `InductiveTable` -/
 import Clean.Table.Inductive
 import Clean.Gadgets.Addition32.Addition32Full
-import Clean.Gadgets.Equality
 
 namespace Tables.Fibonacci32Inductive
 open Gadgets

--- a/Clean/Tables/KeccakInductive.lean
+++ b/Clean/Tables/KeccakInductive.lean
@@ -6,18 +6,6 @@ import Clean.Specs.Keccak256
 open Specs.Keccak256
 variable {p : ℕ} [Fact p.Prime] [Fact (p > 2 ^ 16 + 2 ^ 8)]
 
-namespace Gadgets.Keccak256
-def KeccakBlock.normalized : FormalAssertion (F p) KeccakBlock where
-  main block := .forEach block (assertion U64.AssertNormalized.circuit)
-  assumptions _ := True
-  spec block := block.is_normalized
-  local_length_eq _ _ := by simp +arith only [circuit_norm, U64.AssertNormalized.circuit]
-  soundness := by
-    sorry
-  completeness := by
-    sorry
-end Gadgets.Keccak256
-
 namespace Tables.KeccakInductive
 open Gadgets.Keccak256
 

--- a/Clean/Tables/KeccakInductive.lean
+++ b/Clean/Tables/KeccakInductive.lean
@@ -18,7 +18,7 @@ def table : InductiveTable (F p) KeccakState KeccakBlock where
     state.is_normalized
     ∧ state.value = absorb_blocks (blocks.map KeccakBlock.value)
 
-  honest_input_assumptions i block := block.is_normalized
+  input_assumptions i block := block.is_normalized
 
   soundness := by
     intro i env state_var block_var state block blocks _ h_input h_holds spec_previous

--- a/Clean/Tables/KeccakInductive.lean
+++ b/Clean/Tables/KeccakInductive.lean
@@ -19,7 +19,7 @@ def table : InductiveTable (F p) KeccakState KeccakBlock where
     ∧ ∃ blocks : List (KeccakBlock (F p)), blocks.length = i
       ∧ state.value = absorb_blocks (blocks.map KeccakBlock.value)
 
-  input_spec i block := block.is_normalized
+  honest_input_assumptions i block := block.is_normalized
 
   soundness := by
     intro i env state_var block_var state block h_input h_holds spec_previous

--- a/Clean/Tables/KeccakInductive.lean
+++ b/Clean/Tables/KeccakInductive.lean
@@ -46,8 +46,6 @@ lemma initialState_normalized : (initialState (p:=p)).is_normalized := by
 
 def formalTable (output : KeccakState (F p)) := table.toFormal initialState output
 
-def domain {p q : Sort*} (_ : p → q) := p
-
 -- The table's statement implies that the output state is the result of keccak-hashing some list of input blocks
 theorem tableStatement (output : KeccakState (F p)) : ∀ n > 0, ∀ trace, ∃ blocks, blocks.length = n - 1 ∧
   (formalTable output).statement n trace →

--- a/Clean/Tables/KeccakInductive.lean
+++ b/Clean/Tables/KeccakInductive.lean
@@ -4,14 +4,27 @@ import Clean.Circuit.Extensions
 import Clean.Gadgets.Keccak.AbsorbBlock
 import Clean.Specs.Keccak256
 open Specs.Keccak256
+variable {p : ℕ} [Fact p.Prime] [Fact (p > 2 ^ 16 + 2 ^ 8)]
+
+namespace Gadgets.Keccak256
+def KeccakBlock.normalized : FormalAssertion (F p) KeccakBlock where
+  main block := .forEach block (assertion U64.AssertNormalized.circuit)
+  assumptions _ := True
+  spec block := block.is_normalized
+  local_length_eq _ _ := by simp +arith only [circuit_norm, U64.AssertNormalized.circuit]
+  soundness := by
+    sorry
+  completeness := by
+    sorry
+end Gadgets.Keccak256
 
 namespace Tables.KeccakInductive
 open Gadgets.Keccak256
-variable {p : ℕ} [Fact p.Prime] [Fact (p > 2 ^ 16 + 2 ^ 8)]
 
 def table : InductiveTable (F p) KeccakState where
   step state := do
-    let block ← ProvableVector.witnessAny U64 RATE
+    let block : KeccakBlock (Expression (F p)) ← ProvableType.witnessAny KeccakBlock
+    assertion KeccakBlock.normalized block
     subcircuit AbsorbBlock.circuit { state, block }
 
   spec i state : Prop :=
@@ -19,7 +32,20 @@ def table : InductiveTable (F p) KeccakState where
     ∧ ∃ blocks : List (Vector ℕ RATE), blocks.length = i
       ∧ state.value = absorb_blocks blocks
 
-  soundness := by sorry
+  soundness := by
+    intro i env state_var state h_input h_holds spec_previous
+    simp_all only [circuit_norm, subcircuit_norm,
+      AbsorbBlock.circuit, AbsorbBlock.assumptions, AbsorbBlock.spec,
+      KeccakBlock.normalized]
+    replace h_holds := h_holds.right h_holds.left
+    set block := (eval env (var_from_offset KeccakBlock (25 * 8))).value
+    obtain ⟨ blocks, blocks_length, state_value ⟩ := spec_previous.right
+    use blocks.concat block
+    constructor
+    · rw [List.length_concat, blocks_length]
+    rw [state_value]
+    simp only [absorb_blocks]
+    rw [List.concat_eq_append, List.foldl_concat]
 
   completeness := by sorry
 

--- a/Clean/Tables/KeccakInductive.lean
+++ b/Clean/Tables/KeccakInductive.lean
@@ -24,8 +24,7 @@ def table : InductiveTable (F p) KeccakState KeccakBlock where
     intro i env state_var block_var state block blocks _ h_input h_holds spec_previous
     simp_all only [circuit_norm, subcircuit_norm,
       AbsorbBlock.circuit, AbsorbBlock.assumptions, AbsorbBlock.spec,
-      KeccakBlock.normalized]
-    simp only [absorb_blocks]
+      KeccakBlock.normalized, absorb_blocks]
     rw [List.concat_eq_append, List.map_append, List.map_cons, List.map_nil, List.foldl_concat]
 
   completeness := by

--- a/Clean/Tables/KeccakInductive.lean
+++ b/Clean/Tables/KeccakInductive.lean
@@ -1,0 +1,26 @@
+/- Simple Keccak example using `InductiveTable` -/
+import Clean.Table.Inductive
+import Clean.Circuit.Extensions
+import Clean.Gadgets.Keccak.AbsorbBlock
+import Clean.Specs.Keccak256
+open Specs.Keccak256
+
+namespace Tables.KeccakInductive
+open Gadgets.Keccak256
+variable {p : ℕ} [Fact p.Prime] [Fact (p > 2 ^ 16 + 2 ^ 8)]
+
+def table : InductiveTable (F p) KeccakState where
+  step state := do
+    let block ← ProvableVector.witnessAny U64 RATE
+    subcircuit AbsorbBlock.circuit { state, block }
+
+  spec i state : Prop :=
+    state.is_normalized
+    ∧ ∃ blocks : List (Vector ℕ RATE), blocks.length = i
+      ∧ state.value = absorb_blocks blocks
+
+  soundness := by sorry
+
+  completeness := by sorry
+
+end Tables.KeccakInductive

--- a/Clean/Tables/KeccakInductive.lean
+++ b/Clean/Tables/KeccakInductive.lean
@@ -9,45 +9,34 @@ variable {p : ℕ} [Fact p.Prime] [Fact (p > 2 ^ 16 + 2 ^ 8)]
 namespace Tables.KeccakInductive
 open Gadgets.Keccak256
 
--- set_option trace.Meta.Tactic.simp true
--- set_option maxHeartbeats 200000
--- set_option diagnostics true
-
-def table : InductiveTable (F p) KeccakState where
-  step state := do
-    let block : KeccakBlock (Expression (F p)) ← ProvableType.witnessAny KeccakBlock
+def table : InductiveTable (F p) KeccakState KeccakBlock where
+  step state block := do
     assertion KeccakBlock.normalized block
     subcircuit AbsorbBlock.circuit { state, block }
 
   spec i state : Prop :=
     state.is_normalized
-    ∧ ∃ blocks : List (Vector ℕ RATE), blocks.length = i
-      ∧ state.value = absorb_blocks blocks
+    ∧ ∃ blocks : List (KeccakBlock (F p)), blocks.length = i
+      ∧ state.value = absorb_blocks (blocks.map KeccakBlock.value)
+
+  input_spec i block := block.is_normalized
 
   soundness := by
-    intro i env state_var state h_input h_holds spec_previous
+    intro i env state_var block_var state block h_input h_holds spec_previous
     simp_all only [circuit_norm, subcircuit_norm,
       AbsorbBlock.circuit, AbsorbBlock.assumptions, AbsorbBlock.spec,
-      KeccakBlock.normalized, ProvableType.witnessAny]
+      KeccakBlock.normalized]
     replace h_holds := h_holds.right h_holds.left
-    set block := (eval env (var_from_offset KeccakBlock (25 * 8))).value
     obtain ⟨ blocks, blocks_length, state_value ⟩ := spec_previous.right
     use blocks.concat block
     constructor
     · rw [List.length_concat, blocks_length]
     rw [state_value]
     simp only [absorb_blocks]
-    rw [List.concat_eq_append, List.foldl_concat]
+    rw [List.concat_eq_append, List.map_append, List.map_cons, List.map_nil, List.foldl_concat]
 
   completeness := by
-    intro i env state_var state h_input h_env spec_previous
-    simp_all only [circuit_norm, AbsorbBlock.circuit, KeccakBlock.normalized]
-    simp only [circuit_norm, subcircuit_norm, AbsorbBlock.assumptions, AbsorbBlock.spec] at h_env ⊢
-    simp only [ProvableType.witnessAny, circuit_norm, h_input] at h_env ⊢
-    set block := var_from_offset KeccakBlock (25 * 8)
-    suffices goal : (eval env block).is_normalized by simp_all
-    -- TODO this is impossble to prove because we deliberately assumed nothing about `block`
-    sorry
-
+    simp_all only [circuit_norm, AbsorbBlock.circuit, KeccakBlock.normalized,
+      subcircuit_norm, AbsorbBlock.assumptions, AbsorbBlock.spec]
 
 end Tables.KeccakInductive

--- a/Clean/Tables/KeccakInductive.lean
+++ b/Clean/Tables/KeccakInductive.lean
@@ -9,6 +9,8 @@ variable {p : ℕ} [Fact p.Prime] [Fact (p > 2 ^ 16 + 2 ^ 8)]
 namespace Tables.KeccakInductive
 open Gadgets.Keccak256
 
+set_option trace.Meta.Tactic.simp true
+
 def table : InductiveTable (F p) KeccakState where
   step state := do
     let block : KeccakBlock (Expression (F p)) ← ProvableType.witnessAny KeccakBlock
@@ -35,6 +37,14 @@ def table : InductiveTable (F p) KeccakState where
     simp only [absorb_blocks]
     rw [List.concat_eq_append, List.foldl_concat]
 
-  completeness := by sorry
+  completeness := by
+    intro i env state_var state h_input h_env spec_previous
+    set block' := ProvableType.witnessAny (F:=F p) KeccakBlock
+    simp_all only [circuit_norm, subcircuit_norm,
+      AbsorbBlock.circuit, AbsorbBlock.assumptions, AbsorbBlock.spec,
+      KeccakBlock.normalized]
+    set block := (block' (25 * 8)).1
+    simp only [block'] at h_env ⊢
+    simp only [circuit_norm] at h_env ⊢
 
 end Tables.KeccakInductive

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -292,4 +292,18 @@ end U64.Copy
 def U64.copy (x : Var U64 (F p)) : Circuit (F p) (Var U64 (F p)) := do
   subcircuit U64.Copy.circuit x
 
+namespace U64
+def from_byte (x: Fin 256) : U64 (F p) :=
+  ⟨ x.val, 0, 0, 0, 0, 0, 0, 0 ⟩
+
+lemma from_byte_value {x : Fin 256} : (from_byte x).value (p:=p) = x := by
+  simp [value, from_byte]
+  apply FieldUtils.val_lt_p x
+  linarith [x.is_lt, p_large_enough.elim]
+
+lemma from_byte_is_normalized {x : Fin 256} : (from_byte x).is_normalized (p:=p) := by
+  simp [is_normalized, from_byte]
+  rw [FieldUtils.val_lt_p x]
+  repeat linarith [x.is_lt, p_large_enough.elim]
+end U64
 end

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -217,6 +217,12 @@ def fill (n : ℕ) (a: α) : Vector α n :=
   | 0 => #v[]
   | k + 1 => (fill k a).push a
 
+theorem getElem_fill {n} {a: α} {i : ℕ} {hi : i < n} :
+    (fill n a)[i] = a := by
+  induction n with
+  | zero => nomatch hi
+  | succ => simp_all [fill, getElem_push]
+
 instance [Inhabited α] {n: ℕ} : Inhabited (Vector α n) where
   default := fill n default
 


### PR DESCRIPTION
* change `InductiveTable` to allow for an extra user input on every row. this essentially makes the table behave like a `foldl` loop, where the circuit defines how you map `(state, input) => state'`
* adds keccak gadget `AbsorbBlock` which XORs an input block with the state, and applies the permutation
* define an `InductiveTable` for keccak, that uses `AbsorbBlock` on every row to map the state + input block on the current row to the new state on the next row