### PR TITLE
Refactor Byte decomposition and finish proofs

### DIFF
--- a/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
@@ -3,10 +3,10 @@ import Clean.Utils.Field
 import Clean.Gadgets.ByteDecomposition.Theorems
 import Init.Data.Nat.Div.Basic
 
-namespace Gadgets.ByteDecomposition
 variable {p : ℕ} [Fact p.Prime] [p_large_enough: Fact (p > 2^16 + 2^8)]
 instance : Fact (p > 512) := .mk (by linarith [p_large_enough.elim])
 
+namespace Gadgets.ByteDecomposition
 open Gadgets.ByteDecomposition.Theorems (byte_decomposition_lift)
 open FieldUtils (mod floordiv two_lt two_pow_lt two_val two_pow_val)
 
@@ -133,12 +133,6 @@ def circuit (offset : Fin 8) : FormalCircuit (F p) field Outputs := {
 end Gadgets.ByteDecomposition
 
 namespace Gadgets.U64ByteDecomposition
-variable {p : ℕ} [Fact p.Prime]
-variable [p_large_enough: Fact (p > 2^16 + 2^8)]
-
-instance : Fact (p > 512) := by
-  constructor
-  linarith [p_large_enough.elim]
 
 structure Outputs (F : Type) where
   low : U64 F
@@ -215,11 +209,13 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) assumpt
   obtain ⟨ h0, h1, h2, h3, h4, h5, h6, h7 ⟩ := h_holds
   simp_all only [gt_iff_lt, Fin.val_pos_iff, forall_const, and_self]
 
-
 theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) assumptions := by
-  rintro i0 env ⟨x0_var, x1_var, x2_var, x3_var, x4_var, x5_var, x6_var, x7_var⟩ henv ⟨x0, x1, x2, x3, x4, x5, x6, x7⟩ h_eval as
-  simp only [assumptions] at as
-  sorry
+  rintro i0 env ⟨x0_var, x1_var, x2_var, x3_var, x4_var, x5_var, x6_var, x7_var⟩ henv ⟨x0, x1, x2, x3, x4, x5, x6, x7⟩ h_input as
+  simp only [assumptions, U64.is_normalized] at as
+  simp only [circuit_norm, eval, U64.mk.injEq] at h_input
+  dsimp only [circuit_norm, subcircuit_norm, elaborated, u64_byte_decomposition,
+    ByteDecomposition.circuit, ByteDecomposition.elaborated, ByteDecomposition.assumptions, ByteDecomposition.spec] at henv ⊢
+  simp_all only [circuit_norm]
 
 def circuit (offset : Fin 8) : FormalCircuit (F p) U64 Outputs := {
   elaborated offset with

--- a/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
@@ -179,8 +179,6 @@ def spec (offset : Fin 8) (input : U64 (F p)) (out: Outputs (F p)) :=
   x6_l.val = x6.val % (2^offset.val) ∧ x6_h.val = x6.val / (2^offset.val) ∧
   x7_l.val = x7.val % (2^offset.val) ∧ x7_h.val = x7.val / (2^offset.val)
 
--- #eval! (u64_byte_decomposition (p:=p_babybear) 0) default |>.operations.local_length
--- #eval! (u64_byte_decomposition (p:=p_babybear) 0) default |>.output
 def elaborated (offset : Fin 8) : ElaboratedCircuit (F p) U64 Outputs where
   main := u64_byte_decomposition offset
   local_length _ := 16
@@ -228,12 +226,6 @@ def circuit (offset : Fin 8) : FormalCircuit (F p) U64 Outputs := {
 end Gadgets.U64ByteDecomposition
 
 namespace Gadgets.U32ByteDecomposition
-variable {p : ℕ} [Fact p.Prime]
-variable [p_large_enough: Fact (p > 2^16 + 2^8)]
-
-instance : Fact (p > 512) := by
-  constructor
-  linarith [p_large_enough.elim]
 
 structure Outputs (F : Type) where
   low : U32 F
@@ -272,8 +264,6 @@ def spec (offset : Fin 8) (input : U32 (F p)) (out: Outputs (F p)) :=
   x2_l.val = x2.val % (2^offset.val) ∧ x2_h.val = x2.val / (2^offset.val) ∧
   x3_l.val = x3.val % (2^offset.val) ∧ x3_h.val = x3.val / (2^offset.val)
 
--- #eval! (u32_byte_decomposition (p:=p_babybear) 0) default |>.operations.local_length
--- #eval! (u32_byte_decomposition (p:=p_babybear) 0) default |>.output
 def elaborated (offset : Fin 8) : ElaboratedCircuit (F p) U32 Outputs where
   main := u32_byte_decomposition offset
   local_length _ := 8

--- a/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
@@ -303,9 +303,12 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) assumpt
   simp_all only [gt_iff_lt, Fin.val_pos_iff, forall_const, and_self]
 
 theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) assumptions := by
-  rintro i0 env ⟨x0_var, x1_var, x2_var, x3_var⟩ henv ⟨x0, x1, x2, x3⟩ h_eval as
-  simp only [assumptions] at as
-  sorry
+  rintro i0 env ⟨x0_var, x1_var, x2_var, x3_var⟩ henv ⟨x0, x1, x2, x3⟩ h_input as
+  simp only [assumptions, U32.is_normalized] at as
+  simp only [circuit_norm, eval, U32.mk.injEq] at h_input
+  dsimp only [circuit_norm, subcircuit_norm, elaborated, u32_byte_decomposition,
+    ByteDecomposition.circuit, ByteDecomposition.elaborated, ByteDecomposition.assumptions, ByteDecomposition.spec] at henv ⊢
+  simp_all only [circuit_norm]
 
 def circuit (offset : Fin 8) : FormalCircuit (F p) U32 Outputs := {
   elaborated offset with

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -104,6 +104,11 @@ theorem completeness (α : TypeMap) [ProvableType α] (n : ℕ) (env : Environme
     ((circuit α).to_subcircuit n (x, y)).completeness env = (eval env x = eval env y) := by
   simp only [subcircuit_norm, circuit_norm, circuit]
 
+@[circuit_norm]
+theorem uses_local_witnesses (α : TypeMap) [ProvableType α] (n : ℕ) (env : Environment F) (x y : Var α F) :
+    ((circuit α).to_subcircuit n (x, y)).uses_local_witnesses env = True := by
+  simp only [FormalAssertion.to_subcircuit, circuit]
+
 end Equality
 end Gadgets
 

--- a/Clean/Gadgets/Rotation64/Rotation64Bits.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bits.lean
@@ -26,14 +26,14 @@ def rot64_bits (offset : Fin 8) (x : Var U64 (F p)) : Circuit (F p) (Var U64 (F 
 
   let ⟨y0, y1, y2, y3, y4, y5, y6, y7⟩ ← U64.witness fun _env => U64.mk 0 0 0 0 0 0 0 0
 
-  assert_zero (x1_l * base + x0_h - y0)
-  assert_zero (x2_l * base + x1_h - y1)
-  assert_zero (x3_l * base + x2_h - y2)
-  assert_zero (x4_l * base + x3_h - y3)
-  assert_zero (x5_l * base + x4_h - y4)
-  assert_zero (x6_l * base + x5_h - y5)
-  assert_zero (x7_l * base + x6_h - y6)
-  assert_zero (x0_l * base + x7_h - y7)
+  y0.assert_equals (x1_l * base + x0_h)
+  y1.assert_equals (x2_l * base + x1_h)
+  y2.assert_equals (x3_l * base + x2_h)
+  y3.assert_equals (x4_l * base + x3_h)
+  y4.assert_equals (x5_l * base + x4_h)
+  y5.assert_equals (x6_l * base + x5_h)
+  y6.assert_equals (x7_l * base + x6_h)
+  y7.assert_equals (x0_l * base + x7_h)
   return ⟨y0, y1, y2, y3, y4, y5, y6, y7⟩
 
 def assumptions (input : U64 (F p)) := input.is_normalized
@@ -57,15 +57,11 @@ def elaborated (off : Fin 8) : ElaboratedCircuit (F p) U64 U64 where
 theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) assumptions (spec offset) := by
   intro i0 env ⟨x0_var, x1_var, x2_var, x3_var, x4_var, x5_var, x6_var, x7_var ⟩ ⟨x0, x1, x2, x3, x4, x5, x6, x7⟩ h_input x_normalized h_holds
 
-  dsimp only [circuit_norm, elaborated, rot64_bits, U64.witness, var_from_offset] at h_holds
-  simp only [subcircuit_norm, U64.AssertNormalized.assumptions, U64.AssertNormalized.circuit, circuit_norm] at h_holds
-  simp only [U64ByteDecomposition.circuit, U64ByteDecomposition.elaborated, add_zero,
-    ElaboratedCircuit.local_length, ElaboratedCircuit.output, eval, from_elements, size, to_vars,
-    to_elements, Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil,
-    U64ByteDecomposition.assumptions, Expression.eval, U64ByteDecomposition.spec,
-    U64.AssertNormalized.spec, Vector.mapRange_succ, Vector.mapRange_zero, Vector.push_mk,
-    Nat.reduceAdd, List.push_toArray, List.nil_append, List.cons_append, forall_const,
-    Expression.eval.eq_1] at h_holds
+  dsimp only [circuit_norm, elaborated, rot64_bits, U64.witness, U64.AssertNormalized.circuit] at h_holds
+  simp only [circuit_norm, elaborated, U64ByteDecomposition.circuit, U64ByteDecomposition.elaborated, U64.AssertNormalized.circuit] at h_holds
+  dsimp only [circuit_norm, subcircuit_norm, U64.AssertNormalized.assumptions, U64.AssertNormalized.spec,
+    U64ByteDecomposition.assumptions, U64ByteDecomposition.spec] at h_holds
+  simp only [circuit_norm, eval, var_from_offset, Vector.mapRange] at h_holds
 
   simp only [assumptions] at x_normalized
   simp [circuit_norm, spec, rot_right64, eval, elaborated, var_from_offset, Vector.mapRange]

--- a/Clean/Gadgets/Rotation64/Theorems.lean
+++ b/Clean/Gadgets/Rotation64/Theorems.lean
@@ -181,14 +181,14 @@ theorem rotation64_bits_soundness (offset : Fin 8) {
     (h_x6_h : x6_h.val = x6.val / 2 ^ offset.val)
     (h_x7_l : x7_l.val = x7.val % 2 ^ offset.val)
     (h_x7_h : x7_h.val = x7.val / 2 ^ offset.val)
-    (eq0 : x1_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x0_h + -y0 = 0)
-    (eq1 : x2_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x1_h + -y1 = 0)
-    (eq2 : x3_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x2_h + -y2 = 0)
-    (eq3 : x4_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x3_h + -y3 = 0)
-    (eq4 : x5_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x4_h + -y4 = 0)
-    (eq5 : x6_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x5_h + -y5 = 0)
-    (eq6 : x7_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x6_h + -y6 = 0)
-    (eq7 : x0_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x7_h + -y7 = 0):
+    (eq0 : y0 = x1_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x0_h)
+    (eq1 : y1 = x2_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x1_h)
+    (eq2 : y2 = x3_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x2_h)
+    (eq3 : y3 = x4_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x3_h)
+    (eq4 : y4 = x5_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x4_h)
+    (eq5 : y5 = x6_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x5_h)
+    (eq6 : y6 = x7_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x6_h)
+    (eq7 : y7 = x0_l * ↑(2 ^ (8 - offset.val) % 256 : ℕ) + x7_h):
     let x_val := x0.val + x1.val * 256 + x2.val * 256 ^ 2 + x3.val * 256 ^ 3 + x4.val * 256 ^ 4 +
       x5.val * 256 ^ 5 + x6.val * 256 ^ 6 + x7.val * 256 ^ 7
     let y_val := y0.val + y1.val * 256 + y2.val * 256 ^ 2 + y3.val * 256 ^ 3 + y4.val * 256 ^ 4 +

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -261,7 +261,6 @@ def circuit : FormalCircuit (F p) U64 U64 where
     rintro h ⟨x0, x1, x2, x3, x4, x5, x6, x7⟩ h_eval _as
     simp [circuit_norm, u64_copy, spec, h_eval]
     simp [circuit_norm, u64_copy, Gadgets.Equality.elaborated] at h
-    simp [subcircuit_norm, eval] at h
     simp_all [eval, Expression.eval, circuit_norm, h, var_from_offset, Vector.mapRange]
     have h0 := h 0
     have h1 := h 1

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -147,6 +147,21 @@ theorem mul_nat_val_of_dvd {x: F p} (c: ℕ) (c_lt : c < p) {z : ℕ} :
   intro h_dvd
   exact mul_val_of_dvd ⟨ z, h_dvd ⟩
 
+theorem mul_nat_val_eq_iff {x: F p} (c: ℕ) (c_pos : c > 0) (c_lt : c < p) {z : ℕ} :
+    (c * x).val = c * z ↔ (x.val = z ∧ c * x.val < p) := by
+  constructor
+  · intro h_dvd
+    constructor
+    · apply (mul_right_inj' (Nat.ne_zero_iff_zero_lt.mpr c_pos)).mp
+      rw [←h_dvd, mul_nat_val_of_dvd c c_lt h_dvd]
+    · rw [←mul_nat_val_of_dvd c c_lt h_dvd]
+      apply ZMod.val_lt
+  · intro ⟨ h_eq, h_lt ⟩
+    have c_val_eq : c = (c : F p).val := by rw [ZMod.val_cast_of_lt c_lt]
+    rw [←h_eq, ZMod.val_mul_of_lt, ←c_val_eq]
+    rw [←c_val_eq]
+    exact h_lt
+
 -- some helper lemmas about 2, using the common assumption that p > 512
 
 section

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -147,6 +147,29 @@ theorem mul_nat_val_of_dvd {x: F p} (c: ℕ) (c_lt : c < p) {z : ℕ} :
   intro h_dvd
   exact mul_val_of_dvd ⟨ z, h_dvd ⟩
 
+-- some helper lemmas about 2, using the common assumption that p > 512
+
+section
+variable [Fact (p > 512)]
+
+omit p_prime in
+lemma two_lt : 2 < p := by
+  linarith [‹Fact (p > 512)›.elim]
+
+lemma two_val : (2 : F p).val = 2 :=
+  FieldUtils.val_lt_p 2 two_lt
+
+omit p_prime in
+lemma two_pow_lt (n : ℕ) (hn : n ≤ 8) : 2^n < p := by
+  have h : 2^n ≤ 2^8 := Nat.pow_le_pow_of_le (a:=2) Nat.one_lt_ofNat hn
+  linarith [‹Fact (p > 512)›.elim]
+
+lemma two_pow_val (n : ℕ) (hn : n ≤ 8) : (2^n : F p).val = 2^n := by
+  rw [ZMod.val_pow, two_val]
+  rw [two_val]
+  exact two_pow_lt _ hn
+end
+
 end FieldUtils
 
 -- utils related to bytes, and specifically field elements that are bytes (< 256)


### PR DESCRIPTION
This PR refactors the byte decomposition gadget, which splits a byte into a low part (the first `offset < 8` bits) and a high part.

* The new version no longer depends on a custom `TwoPowerLookup` for the specific offset, but only uses `ByteLookup`. This comes at no cost, since two byte lookups are enough to prove soundness.
* Add the missing completeness proofs for `ByteDecomposition`, `U64ByteDecomposition` and `U32ByteDecomposition`
* Simplify proofs in `ByteDecomposition.Theorems`