### PR TITLE
Get rid of copy constraint in bit rotation gadget

### DIFF
--- a/Clean/Gadgets/BLAKE3/BLAKE3G.lean
+++ b/Clean/Gadgets/BLAKE3/BLAKE3G.lean
@@ -56,8 +56,6 @@ def main (a b c d : Fin 16) (input : Var Inputs (F p)) : Circuit (F p) (Var BLAK
                     |>.set d state_d
   return state
 
--- #eval (main (p:=p_babybear) 0 1 2 3 default).local_length
--- set_option profiler true in
 instance elaborated (a b c d : Fin 16): ElaboratedCircuit (F p) Inputs BLAKE3State where
   main := main a b c d
   local_length _ := 96

--- a/Clean/Gadgets/BLAKE3/BLAKE3G.lean
+++ b/Clean/Gadgets/BLAKE3/BLAKE3G.lean
@@ -61,15 +61,17 @@ instance elaborated (a b c d : Fin 16): ElaboratedCircuit (F p) Inputs BLAKE3Sta
   local_length _ := 96
   output inputs i0 := (inputs.state : Vector (U32 (Expression (F p))) 16)
     |>.set a (⟨var ⟨i0 + 56⟩, var ⟨i0 + 58⟩, var ⟨i0 + 60⟩, var ⟨i0 + 62⟩⟩) a.is_lt
-    |>.set b (Rotation32Bits.output 7 (i0 + 88)) b.is_lt
+    |>.set b (Rotation32.output 7 (i0 + 88)) b.is_lt
     |>.set c (⟨var ⟨i0 + 76⟩, var ⟨i0 + 78⟩, var ⟨i0 + 80⟩, var ⟨i0 + 82⟩⟩) c.is_lt
-    |>.set d (Rotation32Bits.output 0 (i0 + 68)) d.is_lt
+    |>.set d (Rotation32.output 8 (i0 + 68)) d.is_lt
 
   local_length_eq _ n := by
     dsimp only [main, circuit_norm, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated]
   output_eq _ _ := by
     dsimp only [main, circuit_norm, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated]
-    simp only [circuit_norm, seval]
+  subcircuits_consistent _ _ := by
+    simp only [main, circuit_norm, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated]
+    ring_nf; trivial
 
 def assumptions (input : Inputs (F p)) :=
   let { state, x, y } := input
@@ -85,7 +87,7 @@ theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) assu
   dsimp only [assumptions, BLAKE3State.is_normalized] at h_normalized
 
   dsimp only [main, circuit_norm, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated] at h_holds
-  simp only [circuit_norm, subcircuit_norm, seval, and_imp,
+  simp only [circuit_norm, subcircuit_norm, and_imp,
     Addition32.assumptions, Addition32.spec, Rotation32.assumptions, Rotation32.spec,
     Xor32.assumptions, Xor32.spec, getElem_eval_vector, h_input] at h_holds
 
@@ -106,7 +108,7 @@ theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) assu
   constructor
   · ext i hi
     simp only [BLAKE3State.value, eval_vector, Vector.map_set, Vector.map_map, ↓Vector.getElem_set,
-      Vector.getElem_map, g, Fin.getElem_fin, Bitwise.add32, Nat.reducePow]
+      Vector.getElem_map, g, Fin.getElem_fin, Bitwise.add32]
     repeat' split
     · rw [c11.left]
     · rw [c12.left]
@@ -124,46 +126,18 @@ theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) assu
     · simp only [Vector.getElem_map, getElem_eval_vector, h_input, h_normalized]
 
 theorem completeness (a b c d : Fin 16) : Completeness (F p) (elaborated a b c d) assumptions := by
-  rintro i0 env ⟨state_var, x_var, y_var⟩ henv ⟨state, x, y⟩ h_inputs h_normalized
-  dsimp only [elaborated, ElaboratedCircuit.main, main, Addition32.circuit, Addition32.elaborated,
-    ↓Fin.getElem_fin, Xor32.circuit, Xor32.elaborated, Fin.isValue, Rotation32.circuit,
-    Rotation32.elaborated, pure, Circuit.bind_def, subcircuit.eq_1, ElaboratedCircuit.output,
-    FormalCircuit.to_subcircuit.eq_1, Circuit.operations, ElaboratedCircuit.local_length,
-    List.cons_append, List.nil_append, Operations.local_length.eq_5, Operations.local_length.eq_1,
-    Nat.add_zero, Environment.uses_local_witnesses_completeness.eq_5, Circuit.subcircuit_soundness,
-    Addition32.assumptions, Addition32.spec, Nat.reducePow, Xor32.assumptions, Xor32.spec,
-    Rotation32.assumptions, Rotation32.spec, Fin.coe_ofNat_eq_mod, Nat.reduceMod,
-    Environment.uses_local_witnesses_completeness.eq_1, Circuit.constraints_hold.completeness.eq_5,
-    Circuit.subcircuit_completeness, Circuit.constraints_hold.completeness.eq_1] at henv ⊢
-
+  rintro i0 env ⟨state_var, x_var, y_var⟩ henv ⟨state, x, y⟩ h_input h_normalized
   simp only [↓ProvableStruct.eval_eq_eval_struct, ProvableStruct.eval, from_components,
-    ProvableStruct.eval.go, Inputs.mk.injEq] at h_inputs
-  obtain ⟨h_state_var, h_x_var, h_y_var⟩ := h_inputs
+    ProvableStruct.eval.go, Inputs.mk.injEq] at h_input
+  dsimp only [assumptions, BLAKE3State.is_normalized] at h_normalized
 
-  dsimp only [assumptions] at h_normalized
-  obtain ⟨h_state, h_x, h_y⟩ := h_normalized
-  simp only [BLAKE3State.is_normalized] at h_state
-
-  have h_state_var_getElem (i : Fin 16) : eval env state_var[i.val] = state[i.val] := by
-    rw [←h_state_var]
-    simp only [Fin.getElem_fin, getElem_eval_vector]
-
-  ring_nf at henv
-  simp only [↓ProvableStruct.eval_eq_eval_struct, ProvableStruct.eval, from_components,
-    ProvableStruct.eval.go, h_state_var_getElem, h_x_var, and_imp, h_y_var, and_true] at henv
-  obtain ⟨c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14⟩ := henv
+  dsimp only [main, circuit_norm, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated] at henv ⊢
+  simp only [h_input, circuit_norm, subcircuit_norm, and_imp,
+    Addition32.assumptions, Addition32.spec, Rotation32.assumptions, Rotation32.spec,
+    Xor32.assumptions, Xor32.spec, getElem_eval_vector] at henv ⊢
 
   -- resolve all chains of assumptions
-  simp_all only [implies_true, forall_const]
-
-  simp only [↓ProvableStruct.eval_eq_eval_struct, ProvableStruct.eval, from_components,
-    ProvableStruct.eval.go, and_true]
-
-  -- normalize offsets
-  ring_nf
-
-  -- now, all the conclusions are somewhere in the hypotheses
-  simp_all only [gt_iff_lt, Nat.add_mod_mod, Nat.mod_add_mod, and_self]
+  simp_all only [implies_true, forall_const, and_true]
 
 def circuit (a b c d : Fin 16) : FormalCircuit (F p) Inputs BLAKE3State := {
   elaborated a b c d with

--- a/Clean/Gadgets/BLAKE3/BLAKE3G.lean
+++ b/Clean/Gadgets/BLAKE3/BLAKE3G.lean
@@ -56,18 +56,22 @@ def main (a b c d : Fin 16) (input : Var Inputs (F p)) : Circuit (F p) (Var BLAK
                     |>.set d state_d
   return state
 
+-- #eval (main (p:=p_babybear) 0 1 2 3 default).local_length
+-- set_option profiler true in
 instance elaborated (a b c d : Fin 16): ElaboratedCircuit (F p) Inputs BLAKE3State where
   main := main a b c d
-  local_length _ := 112
-  output inputs i0 := inputs.state
-      |>.set a (⟨var ⟨i0 + 64⟩, var ⟨i0 + 66⟩, var ⟨i0 + 68⟩, var ⟨i0 + 70⟩⟩)
-      |>.set b (var_from_offset U32 (i0 + 108))
-      |>.set c (⟨var ⟨i0 + 88⟩, var ⟨i0 + 90⟩, var ⟨i0 + 92⟩, var ⟨i0 + 94⟩⟩)
-      |>.set d (var_from_offset U32 (i0 + 84))
+  local_length _ := 96
+  output inputs i0 := (inputs.state : Vector (U32 (Expression (F p))) 16)
+    |>.set a (⟨var ⟨i0 + 56⟩, var ⟨i0 + 58⟩, var ⟨i0 + 60⟩, var ⟨i0 + 62⟩⟩) a.is_lt
+    |>.set b (Rotation32Bits.output 7 (i0 + 88)) b.is_lt
+    |>.set c (⟨var ⟨i0 + 76⟩, var ⟨i0 + 78⟩, var ⟨i0 + 80⟩, var ⟨i0 + 82⟩⟩) c.is_lt
+    |>.set d (Rotation32Bits.output 0 (i0 + 68)) d.is_lt
 
   local_length_eq _ n := by
-    simp [main, circuit_norm, Xor32.circuit, Addition32.circuit, Rotation32.circuit,
-      Xor32.elaborated, Addition32.elaborated, Rotation32.elaborated]
+    dsimp only [main, circuit_norm, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated]
+  output_eq _ _ := by
+    dsimp only [main, circuit_norm, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated]
+    simp only [circuit_norm, seval]
 
 def assumptions (input : Inputs (F p)) :=
   let { state, x, y } := input
@@ -79,39 +83,18 @@ def spec (a b c d : Fin 16) (input : Inputs (F p)) (out: BLAKE3State (F p)) :=
 
 theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) assumptions (spec a b c d) := by
   intro i0 env ⟨state_var, x_var, y_var⟩ ⟨state, x, y⟩ h_input h_normalized h_holds
-  dsimp only [elaborated, ElaboratedCircuit.main, main, Addition32.circuit, Addition32.elaborated,
-    ↓Fin.getElem_fin, Xor32.circuit, Xor32.elaborated, Fin.isValue, Rotation32.circuit,
-    Rotation32.elaborated, pure, Circuit.bind_def, subcircuit.eq_1, ElaboratedCircuit.output,
-    FormalCircuit.to_subcircuit.eq_1, Circuit.operations, ElaboratedCircuit.local_length,
-    List.cons_append, List.nil_append, Operations.local_length.eq_5, Operations.local_length.eq_1,
-    Nat.add_zero, Circuit.constraints_hold.soundness.eq_5, Circuit.subcircuit_soundness,
-    Addition32.assumptions, Addition32.spec, Nat.reducePow, Xor32.assumptions, Xor32.spec,
-    Rotation32.assumptions, Rotation32.spec, Fin.coe_ofNat_eq_mod, Nat.reduceMod,
-    Circuit.constraints_hold.soundness.eq_1] at h_holds
-  dsimp only [assumptions] at h_normalized
+  simp only [circuit_norm, Inputs.mk.injEq] at h_input
+  dsimp only [assumptions, BLAKE3State.is_normalized] at h_normalized
 
-  obtain ⟨h_state, h_x, h_y⟩ := h_normalized
-  simp only [↓ProvableStruct.eval_eq_eval_struct, ProvableStruct.eval, from_components,
-    ProvableStruct.eval.go, Inputs.mk.injEq] at h_input
-  obtain ⟨h_state_var, h_x_var, h_y_var⟩ := h_input
+  dsimp only [main, circuit_norm, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated] at h_holds
+  simp only [circuit_norm, subcircuit_norm, seval, and_imp,
+    Addition32.assumptions, Addition32.spec, Rotation32.assumptions, Rotation32.spec,
+    Xor32.assumptions, Xor32.spec, getElem_eval_vector, h_input] at h_holds
 
-  simp only [BLAKE3State.is_normalized] at h_state
-
-  have h_state_var_getElem (i : Fin 16) : eval env state_var[i.val] = state[i.val] := by
-    rw [←h_state_var]
-    simp only [Fin.getElem_fin, getElem_eval_vector]
-
-  have h_state_normalized_getElem (i : Fin 16) : state[i.val].is_normalized := by
-    simp only [h_state]
-
-  -- normalize offsets
-  ring_nf at h_holds ⊢
-  simp only [↓ProvableStruct.eval_eq_eval_struct, ProvableStruct.eval, from_components,
-    ProvableStruct.eval.go, h_state_var_getElem, h_x_var, and_imp, h_y_var, and_true] at h_holds
   obtain ⟨c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14⟩ := h_holds
 
   -- resolve all chains of assumptions, fortunately this is easy
-  simp_all only [implies_true, forall_const]
+  simp_all only [forall_const]
 
   -- In c9, c11, c12, and c14, we now have the correct hypotheses regarding the
   -- updated values in the output state.
@@ -124,32 +107,23 @@ theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) assu
   simp only [spec, ElaboratedCircuit.output]
   constructor
   · ext i hi
-    ring_nf
     simp only [BLAKE3State.value, eval_vector, Vector.map_set, Vector.map_map, ↓Vector.getElem_set,
-      Vector.getElem_map, g, Fin.getElem_fin, Bitwise.add32]
-    (repeat' split) <;> first
-      | rw [c11.left]
-        simp only [Nat.add_mod_mod, Nat.mod_add_mod, Nat.reducePow]
-      | rw [c12.left]
-        simp only [Nat.add_mod_mod, Nat.mod_add_mod, Nat.reducePow]
-      | rw [c14.left]
-        simp only [Nat.add_mod_mod, Nat.mod_add_mod, Nat.reducePow]
-      | rw [c9.left]
-        simp only [Nat.add_mod_mod, Nat.mod_add_mod, Nat.reducePow]
-      | rw [Function.comp_apply, ←h_state_var]
-        simp only [Fin.getElem_fin, getElem_eval_vector]
+      Vector.getElem_map, g, Fin.getElem_fin, Bitwise.add32, Nat.reducePow]
+    repeat' split
+    · rw [c11.left]
+    · rw [c12.left]
+    · rw [c14.left]
+    · rw [c9.left]
+    · rw [Function.comp_apply, ←h_input.left, getElem_eval_vector]
 
   · intro i
-    ring_nf
-    simp only [eval_vector, Vector.map_set, ↓Vector.getElem_set, ↓reduceIte]
-    (repeat' split) <;> first
-      | exact c11.right
-      | exact c12.right
-      | exact c14.right
-      | exact c9.right
-      | simp only [Vector.getElem_map]
-        rw [h_state_var_getElem]
-        exact h_state_normalized_getElem i
+    simp only [eval_vector, Vector.map_set, ↓Vector.getElem_set]
+    repeat' split
+    · exact c11.right
+    · exact c12.right
+    · exact c14.right
+    · exact c9.right
+    · simp only [Vector.getElem_map, getElem_eval_vector, h_input, h_normalized]
 
 theorem completeness (a b c d : Fin 16) : Completeness (F p) (elaborated a b c d) assumptions := by
   rintro i0 env ⟨state_var, x_var, y_var⟩ henv ⟨state, x, y⟩ h_inputs h_normalized

--- a/Clean/Gadgets/Keccak/AbsorbBlock.lean
+++ b/Clean/Gadgets/Keccak/AbsorbBlock.lean
@@ -29,7 +29,7 @@ def main (input : Var Input (F p)) : Circuit (F p) (Var KeccakState (F p)) := do
 
 instance elaborated : ElaboratedCircuit (F p) Input KeccakState where
   main
-  local_length _ := 36808
+  local_length _ := 31048
   output _ i0 := Permutation.state_var (i0 + 136) 23
 
   local_length_eq _ _ := by simp only [main, circuit_norm, Xor.circuit, Permutation.circuit, RATE]

--- a/Clean/Gadgets/Keccak/KeccakRound.lean
+++ b/Clean/Gadgets/Keccak/KeccakRound.lean
@@ -25,8 +25,8 @@ def spec (rc : UInt64) (state : KeccakState (F p)) (out_state : KeccakState (F p
 
 instance elaborated (rc : UInt64) : ElaboratedCircuit (F p) KeccakState KeccakState where
   main := main rc
-  local_length _ := 1528
-  output _ i0 := (Vector.mapRange 25 fun i => var_from_offset U64 (i0 + i*16 + 1128) ).set 0 (var_from_offset U64 (i0 + 1520))
+  local_length _ := 1288
+  output _ i0 := (Vector.mapRange 25 fun i => var_from_offset U64 (i0 + i*16 + 888) ).set 0 (var_from_offset U64 (i0 + 1280))
 
   local_length_eq _ _ := by simp only [main, circuit_norm, Theta.circuit, RhoPi.circuit, Chi.circuit, Xor.circuit]
   output_eq state i0 := by
@@ -55,7 +55,7 @@ theorem soundness (rc : UInt64) : Soundness (F p) (elaborated rc) assumptions (s
   clear theta_norm theta_eq h_rhopi rhopi_eq rhopi_norm h_chi state_norm h_input
 
   -- simplify round constant constraint
-  set state0_before_rc := eval env (var_from_offset U64 (i0 + 1128))
+  set state0_before_rc := eval env (var_from_offset U64 (i0 + 888))
   have h_rc_norm : state0_before_rc.is_normalized := by
     simp only [KeccakState.is_normalized, eval_vector, circuit_norm] at chi_norm
     exact chi_norm 0

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -17,15 +17,15 @@ def spec (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
 
 /-- state in the ith round, starting from offset n -/
 def state_var (n : ℕ) (i : ℕ) : Var KeccakState (F p) :=
-  Vector.mapRange 25 (fun j => var_from_offset U64 (n + i * 1528 + j * 16 + 1128))
-  |>.set 0 (var_from_offset U64 (n + i * 1528 + 1520))
+  Vector.mapRange 25 (fun j => var_from_offset U64 (n + i * 1288 + j * 16 + 888))
+  |>.set 0 (var_from_offset U64 (n + i * 1288 + 1280))
 
 -- NOTE: this linter times out and blows up memory usage
 set_option linter.constructorNameAsVariable false
 
 instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where
   main
-  local_length _ := 36672
+  local_length _ := 30912
   output _ i0 := state_var i0 23
 
   local_length_eq state i0 := by simp only [main, circuit_norm, KeccakRound.circuit]

--- a/Clean/Gadgets/Keccak/RhoPi.lean
+++ b/Clean/Gadgets/Keccak/RhoPi.lean
@@ -27,7 +27,7 @@ def spec (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
   ∧ out_state.value = Specs.Keccak256.rho_pi state.value
 
 def output (i0 : ℕ) : Var KeccakState (F p) :=
-  rhoPiShifts.mapIdx fun i s => Rotation64Bits.output ((-s) % 8).val (i0 + i*16)
+  rhoPiShifts.mapIdx fun i s => Rotation64.output (-s) (i0 + i*16)
 
 instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where
   main
@@ -72,7 +72,7 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   simp only [assumptions, KeccakState.is_normalized] at state_norm
 
   -- simplify constraints (goal + environment) and apply assumptions
-  simp_all [state_norm, h_input, main, circuit_norm, subcircuit_norm,
+  simp_all [main, circuit_norm, subcircuit_norm,
     Rotation64.circuit, Rotation64.assumptions, Rotation64.spec]
 
 def circuit : FormalCircuit (F p) KeccakState KeccakState := {

--- a/Clean/Gadgets/Keccak/Theta.lean
+++ b/Clean/Gadgets/Keccak/Theta.lean
@@ -15,8 +15,8 @@ def theta (state : Var KeccakState (F p)) : Circuit (F p) (Var KeccakState (F p)
 
 instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where
   main := theta
-  local_length _ := 520
-  output _ i0 := var_from_offset KeccakState (i0 + 320)
+  local_length _ := 480
+  output _ i0 := var_from_offset KeccakState (i0 + 280)
 
 def assumptions (state : KeccakState (F p)) := state.is_normalized
 

--- a/Clean/Gadgets/Keccak/ThetaD.lean
+++ b/Clean/Gadgets/Keccak/ThetaD.lean
@@ -28,13 +28,13 @@ def theta_d (row : Var KeccakRow (F p)) : Circuit (F p) (Var KeccakRow (F p)) :=
 
 instance elaborated : ElaboratedCircuit (F p) KeccakRow KeccakRow where
   main := theta_d
-  local_length _ := 160
+  local_length _ := 120
   output _ i0 := #v[
-    var_from_offset U64 (i0 + 24),
-    var_from_offset U64 (i0 + 56),
+    var_from_offset U64 (i0 + 16),
+    var_from_offset U64 (i0 + 40),
+    var_from_offset U64 (i0 + 64),
     var_from_offset U64 (i0 + 88),
-    var_from_offset U64 (i0 + 120),
-    var_from_offset U64 (i0 + 152)
+    var_from_offset U64 (i0 + 112)
   ]
 
 def assumptions (state : KeccakRow (F p)) := state.is_normalized

--- a/Clean/Gadgets/Rotation32/Rotation32.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32.lean
@@ -33,12 +33,15 @@ def spec (offset : Fin 32) (x : U32 (F p)) (y: U32 (F p)) :=
   y.value = rot_right32 x.value offset.val
   ∧ y.is_normalized
 
+def output (offset : Fin 32) (i0 : Nat) : U32 (Expression (F p)) :=
+  Rotation32Bits.output (offset % 8).val i0
+
 -- #eval! (rot32 (p:=p_babybear) 0) default |>.operations.local_length
 -- #eval! (rot32 (p:=p_babybear) 0) default |>.output
 def elaborated (off : Fin 32) : ElaboratedCircuit (F p) U32 U32 where
   main := rot32 off
   local_length _ := 8
-  output _inputs i0 := Rotation32Bits.output (off % 8).val i0
+  output _inputs i0 := output off i0
 
 theorem soundness (offset : Fin 32) : Soundness (F p) (circuit := elaborated offset) assumptions (spec offset) := by
   intro i0 env x_var x h_input x_normalized h_holds
@@ -55,7 +58,7 @@ theorem soundness (offset : Fin 32) : Soundness (F p) (circuit := elaborated off
     Rotation32Bits.circuit, Rotation32Bits.elaborated, Rotation32Bits.spec, Rotation32Bits.assumptions,
     Vector.finRange] at h_holds
 
-  simp [circuit_norm, spec, h_holds, elaborated]
+  simp [circuit_norm, spec, output, h_holds, elaborated]
   set y := eval env (Rotation32Bits.output (offset.val % 8 : ℕ) i0)
 
   simp [assumptions] at x_normalized

--- a/Clean/Gadgets/Rotation32/Rotation32.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32.lean
@@ -37,8 +37,8 @@ def spec (offset : Fin 32) (x : U32 (F p)) (y: U32 (F p)) :=
 -- #eval! (rot32 (p:=p_babybear) 0) default |>.output
 def elaborated (off : Fin 32) : ElaboratedCircuit (F p) U32 U32 where
   main := rot32 off
-  local_length _ := 12
-  output _inputs i0 := var_from_offset U32 (i0 + 8)
+  local_length _ := 8
+  output _inputs i0 := Rotation32Bits.output (off % 8).val i0
 
 theorem soundness (offset : Fin 32) : Soundness (F p) (circuit := elaborated offset) assumptions (spec offset) := by
   intro i0 env x_var x h_input x_normalized h_holds
@@ -56,7 +56,7 @@ theorem soundness (offset : Fin 32) : Soundness (F p) (circuit := elaborated off
     Vector.finRange] at h_holds
 
   simp [circuit_norm, spec, h_holds, elaborated]
-  set y := eval env (var_from_offset U32 (i0 + 8))
+  set y := eval env (Rotation32Bits.output (offset.val % 8 : ℕ) i0)
 
   simp [assumptions] at x_normalized
   rw [←h_input] at x_normalized

--- a/Clean/Gadgets/Rotation32/Rotation32Bits.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32Bits.lean
@@ -29,7 +29,7 @@ def rot32_bits (offset : Fin 8) (x : U32 (Expression (F p))) : Circuit (F p) (Va
   let rotated := highs.zip (lows.rotate 1) |>.map fun (high, low) =>
     high + low * ((2^(8 - offset.val) : ℕ) : F p)
 
-  U32.from_limbs rotated |>.copy -- copy for convenience of addressing the output, TODO code smell
+  return U32.from_limbs rotated
 
 def assumptions (input : U32 (F p)) := input.is_normalized
 
@@ -37,45 +37,45 @@ def spec (offset : Fin 8) (x : U32 (F p)) (y: U32 (F p)) :=
   y.value = rot_right32 x.value offset.val
   ∧ y.is_normalized
 
+def output (offset : Fin 8) (i0 : Nat) : U32 (Expression (F p)) :=
+  U32.from_limbs (.ofFn fun ⟨i,_⟩ =>
+    (var ⟨i0 + i*2 + 1⟩) + var ⟨i0 + (i + 1) % 4 * 2⟩ * .const ((2^(8 - offset.val) : ℕ) : F p))
+
 -- #eval rot32_bits (p:=p_babybear) 1 default |>.output
 def elaborated (off : Fin 8) : ElaboratedCircuit (F p) U32 U32 where
   main := rot32_bits off
-  local_length _ := 12
-  output _inputs i0 := var_from_offset U32 (i0 + 8)
+  local_length _ := 8
+  output _inputs i0 := output off i0
   local_length_eq _ i0 := by
-    simp only [circuit_norm, rot32_bits, U32.Copy.circuit,
-      ByteDecomposition.circuit, ByteDecomposition.elaborated]
+    simp only [circuit_norm, rot32_bits, ByteDecomposition.circuit, ByteDecomposition.elaborated]
   output_eq _ _ := by
-    simp only [circuit_norm, rot32_bits, U32.Copy.circuit,
-      ByteDecomposition.circuit, ByteDecomposition.elaborated]
+    simp only [circuit_norm, rot32_bits, output, ByteDecomposition.circuit, ByteDecomposition.elaborated]
+    apply congrArg U32.from_limbs
+    simp [Vector.ext_iff, Vector.getElem_rotate]
   subcircuits_consistent _ _ := by
-    simp +arith only [circuit_norm, rot32_bits, U32.Copy.circuit,
+    simp +arith only [circuit_norm, rot32_bits,
       ByteDecomposition.circuit, ByteDecomposition.elaborated]
 
 theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) assumptions (spec offset) := by
   intro i0 env x_var x h_input x_normalized h_holds
 
   -- simplify statements
-  dsimp only [circuit_norm, elaborated, rot32_bits, U32.copy, U32.Copy.circuit,
+  dsimp only [circuit_norm, elaborated, rot32_bits,
     ByteDecomposition.circuit, ByteDecomposition.elaborated] at h_holds
-  simp only [spec, circuit_norm, elaborated, subcircuit_norm, U32.Copy.assumptions, U32.Copy.spec,
+  simp only [spec, circuit_norm, elaborated, subcircuit_norm,
     ByteDecomposition.assumptions, ByteDecomposition.spec] at h_holds ⊢
-  set y := eval env (var_from_offset U32 (i0 + 8))
-  obtain ⟨ h_decomposition, h_concatenation ⟩ := h_holds
 
   -- targeted rewriting of the assumptions
-  simp only [size, U32.ByteVector.ext_iff, U32.ByteVector.eval_from_limbs,
-    U32.ByteVector.to_limbs_from_limbs, Vector.getElem_map, Vector.getElem_zip,
-    Vector.getElem_mapIdx, Vector.getElem_rotate, Expression.eval] at h_concatenation
-
   rw [assumptions, U32.ByteVector.is_normalized_iff] at x_normalized
-  simp only [size, Fin.forall_iff, U32.ByteVector.getElem_eval_to_limbs, h_input, x_normalized, true_implies] at h_decomposition
+  simp only [U32.ByteVector.getElem_eval_to_limbs, h_input, x_normalized, true_implies,
+    Fin.forall_iff] at h_holds
 
   set base := ((2^(8 - offset.val) : ℕ) : F p)
   have neg_offset_le : 8 - offset.val ≤ 8 := by
     rw [tsub_le_iff_right, le_add_iff_nonneg_right]; apply zero_le
 
   -- capture the rotation relation in terms of byte vectors
+  set y := eval env (output offset i0)
   set xs := x.to_limbs
   set ys := y.to_limbs
   set o := offset.val
@@ -83,11 +83,12 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) assumpt
   have h_rot_vector (i : ℕ) (hi : i < 4) :
       ys[i].val < 2^8 ∧
       ys[i].val = xs[i].val / 2^o + (xs[(i + 1) % 4].val % 2^o) * 2^(8-o) := by
-    rw [←h_concatenation i hi]
+    simp only [ys, y, output, U32.ByteVector.eval_from_limbs, U32.ByteVector.to_limbs_from_limbs,
+      Vector.getElem_map, Vector.getElem_ofFn, Expression.eval]
     set high := env.get (i0 + i * 2 + 1)
     set next_low := env.get (i0 + (i + 1) % 4 * 2)
-    have ⟨⟨_, high_eq⟩, ⟨_, high_lt⟩⟩ := h_decomposition i hi
-    have ⟨⟨next_low_eq, _⟩, ⟨next_low_lt, _⟩⟩ := h_decomposition ((i + 1) % 4) (Nat.mod_lt _ (by norm_num))
+    have ⟨⟨_, high_eq⟩, ⟨_, high_lt⟩⟩ := h_holds i hi
+    have ⟨⟨next_low_eq, _⟩, ⟨next_low_lt, _⟩⟩ := h_holds ((i + 1) % 4) (Nat.mod_lt _ (by norm_num))
     have next_low_lt' : next_low.val < 2^(8 - (8 - o)) := by rw [Nat.sub_sub_self offset.is_le']; exact next_low_lt
     have ⟨lt, eq⟩ := byte_decomposition_lt (8-o) neg_offset_le high_lt next_low_lt'
     use lt
@@ -114,7 +115,6 @@ theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) a
 
   -- simplify goal
   simp only [rot32_bits, elaborated, circuit_norm, subcircuit_norm,
-    U32.copy, U32.Copy.circuit, U32.Copy.assumptions,
     ByteDecomposition.circuit, ByteDecomposition.assumptions]
 
   -- we only have to prove the byte decomposition assumptions

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -38,12 +38,8 @@ def spec (offset : Fin 64) (x : U64 (F p)) (y: U64 (F p)) :=
 -- #eval! (rot64 (p:=p_babybear) 0) default |>.output
 def elaborated (off : Fin 64) : ElaboratedCircuit (F p) U64 U64 where
   main := rot64 off
-  local_length _ := 24
-  output _inputs i0 := var_from_offset U64 (i0 + 16)
-  local_length_eq := by
-    intros
-    simp only [rot64]
-    rfl
+  local_length _ := 16
+  output _ i0 := Rotation64Bits.output (off % 8).val i0
 
 theorem soundness (offset : Fin 64) : Soundness (F p) (circuit := elaborated offset) assumptions (spec offset) := by
   intro i0 env x_var x h_input x_normalized h_holds

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -57,7 +57,7 @@ theorem soundness (offset : Fin 64) : Soundness (F p) (circuit := elaborated off
     Vector.finRange] at h_holds
 
   simp [circuit_norm, spec, h_holds, elaborated]
-  set y := eval env (var_from_offset U64 (i0 + 16))
+  set y := eval env (Rotation64Bits.output (offset.val % 8 : ℕ) i0)
 
   simp [assumptions] at x_normalized
   rw [←h_input] at x_normalized

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -34,12 +34,15 @@ def spec (offset : Fin 64) (x : U64 (F p)) (y: U64 (F p)) :=
   y.value = rot_right64 x.value offset.val
   ∧ y.is_normalized
 
+def output (offset : Fin 64) (i0 : Nat) : U64 (Expression (F p)) :=
+  Rotation64Bits.output (offset % 8).val i0
+
 -- #eval! (rot64 (p:=p_babybear) 0) default |>.operations.local_length
 -- #eval! (rot64 (p:=p_babybear) 0) default |>.output
 def elaborated (off : Fin 64) : ElaboratedCircuit (F p) U64 U64 where
   main := rot64 off
   local_length _ := 16
-  output _ i0 := Rotation64Bits.output (off % 8).val i0
+  output _ i0 := output off i0
 
 theorem soundness (offset : Fin 64) : Soundness (F p) (circuit := elaborated offset) assumptions (spec offset) := by
   intro i0 env x_var x h_input x_normalized h_holds
@@ -56,7 +59,7 @@ theorem soundness (offset : Fin 64) : Soundness (F p) (circuit := elaborated off
     Rotation64Bits.circuit, Rotation64Bits.elaborated, Rotation64Bits.spec, Rotation64Bits.assumptions,
     Vector.finRange] at h_holds
 
-  simp [circuit_norm, spec, h_holds, elaborated]
+  simp [circuit_norm, spec, output, h_holds, elaborated]
   set y := eval env (Rotation64Bits.output (offset.val % 8 : ℕ) i0)
 
   simp [assumptions] at x_normalized

--- a/Clean/Gadgets/Rotation64/Rotation64Bits.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bits.lean
@@ -44,23 +44,22 @@ def elaborated (off : Fin 8) : ElaboratedCircuit (F p) U64 U64 where
   local_length _ := 16
   output _ i0 := output off i0
   local_length_eq _ i0 := by
-    simp only [circuit_norm, rot64_bits, U64.Copy.circuit,
-      ByteDecomposition.circuit, ByteDecomposition.elaborated]
+    simp only [circuit_norm, rot64_bits, ByteDecomposition.circuit, ByteDecomposition.elaborated]
   output_eq _ _ := by
     simp only [circuit_norm, rot64_bits, output, ByteDecomposition.circuit, ByteDecomposition.elaborated]
     apply congrArg U64.from_limbs
     simp [Vector.ext_iff, Vector.getElem_rotate]
   subcircuits_consistent _ _ := by
-    simp +arith only [circuit_norm, rot64_bits, U64.Copy.circuit,
+    simp +arith only [circuit_norm, rot64_bits,
       ByteDecomposition.circuit, ByteDecomposition.elaborated]
 
 theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) assumptions (spec offset) := by
   intro i0 env x_var x h_input x_normalized h_holds
 
   -- simplify statements
-  dsimp only [circuit_norm, elaborated, rot64_bits, U64.copy, U64.Copy.circuit,
+  dsimp only [circuit_norm, elaborated, rot64_bits,
     ByteDecomposition.circuit, ByteDecomposition.elaborated] at h_holds
-  simp only [spec, circuit_norm, elaborated, subcircuit_norm, U64.Copy.assumptions, U64.Copy.spec,
+  simp only [spec, circuit_norm, elaborated, subcircuit_norm,
     ByteDecomposition.assumptions, ByteDecomposition.spec] at h_holds ⊢
 
   -- targeted rewriting of the assumptions
@@ -113,7 +112,6 @@ theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) a
 
   -- simplify goal
   simp only [rot64_bits, elaborated, circuit_norm, subcircuit_norm,
-    U64.copy, U64.Copy.circuit, U64.Copy.assumptions,
     ByteDecomposition.circuit, ByteDecomposition.assumptions]
 
   -- we only have to prove the byte decomposition assumptions


### PR DESCRIPTION
As the title says -- I didn't like that we copied variables just to make the output of bit rotation gadgets easier to deal with. In fact, the concrete value of a circuit's output rarely matters in parent circuits, and a reasonable strategy to reduce complexity is to wrap the output in a method that parent circuits never have to unfold.

* Abstract away output of bit rotation and general rotation gadgets
* Adapt many hard-coded offsets in Keccak elaborated circuits, since we reduced the number of variables
* Adapt and simplify Blake3 G proof