### PR TITLE
 Add a new `assert_equals` notation of the form `===`

### DIFF
--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -14,7 +14,7 @@ def main (n: ℕ) (x : Expression (F p)) := do
   Circuit.forEach bits (assertion Boolean.circuit)
 
   -- check that the bits correctly sum to `x`
-  x.assert_equals (field_from_bits_expr bits)
+  x === (field_from_bits_expr bits)
   return bits
 
 -- formal circuit that implements `to_bits` like a function, assuming `x.val < 2^n`

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -107,16 +107,63 @@ theorem completeness (α : TypeMap) [ProvableType α] (n : ℕ) (env : Environme
 end Equality
 end Gadgets
 
--- this is exported at the top level because it is a core builtin gadget
+/-
+Provides a unified `===` notation for asserting equality in circuits:
+- Core `assert_equals` for `α (Expression F)` and `Expression F`.
+- `HasAssertEq` / `HasAssertEqM` dispatch so `assert_equals_generic x y`
+  and `x === y` pick the right gadget and lift via `MonadLift`.
+- Marked `@[circuit_norm]`/`@[reducible]` so `dsimp only [circuit_norm]`
+  unfolds `===` to the original `assert_equals`.
+-/
 @[circuit_norm]
-def assert_equals {α : TypeMap} [ProvableType α] (x y : α (Expression F)) : Circuit F Unit :=
+def assert_equals {F : Type} [Field F] {α : TypeMap} [ProvableType α]
+  (x y : α (Expression F)) : Circuit F Unit :=
   assertion (Gadgets.Equality.circuit α) (x, y)
 
--- TODO unfortunately, if the inputs to `assert_equals` are just `Expression F`,
--- Lean doesn't come up with `α = id` -- even though `ProvableType` is inferred when `(α:=id)` is passed explicitly.
--- this definition is a somehwat natural alternative that can be used on `Expression F` directly
-@[reducible]
-def Expression.assert_equals (x y : Expression F) : Circuit F Unit :=
+@[circuit_norm, reducible]
+def Expression.assert_equals {F : Type} [Field F]
+  (x y : Expression F) : Circuit F Unit :=
   assertion (Gadgets.Equality.circuit id) (x, y)
 
--- TODO define a custom syntax e.g. `===` that figures out whether to use `assert_equals` or `Expression.assert_equals`
+class HasAssertEq (β : Type) (F : outParam Type) [Field F] where
+  assert_eq : β → β → Circuit F Unit
+
+@[circuit_norm, reducible]
+instance {F : Type} [Field F] : HasAssertEq (Expression F) F where
+  assert_eq := Expression.assert_equals
+
+@[circuit_norm, reducible]
+instance {F : Type} [Field F] {α : TypeMap} [ProvableType α] :
+  HasAssertEq (α (Expression F)) F where
+  assert_eq := @assert_equals F _ α _
+
+@[circuit_norm, reducible]
+def assert_equals_generic {β : Type} {F : Type} [Field F] [HasAssertEq β F]
+  (x y : β) : Circuit F Unit :=
+  HasAssertEq.assert_eq x y
+
+class HasAssertEqM (β : Type) (m : Type → Type) (F : outParam Type) [Field F] where
+  assert_eqM : β → β → m Unit
+
+@[circuit_norm, reducible]
+instance hasAssertEqM_Circuit {β : Type} {F : Type} [Field F] [HasAssertEq β F] :
+  HasAssertEqM β (Circuit F) F where
+  assert_eqM x y := assert_equals_generic x y
+
+@[circuit_norm, reducible]
+instance hasAssertEqM_lift {β : Type} {F : Type} [Field F] [HasAssertEq β F]
+  {m : Type → Type} [MonadLift (Circuit F) m] :
+  HasAssertEqM β m F where
+  assert_eqM x y := MonadLift.monadLift (assert_equals_generic x y)
+
+@[circuit_norm, reducible, simp]
+def assert_eqM' {β : Type} {m : Type → Type} {F : Type} [Field F] [HasAssertEqM β m F]
+  (x y : β) : m Unit :=
+  HasAssertEqM.assert_eqM x y
+
+infix:50 " === " => assert_eqM'
+
+@[circuit_norm]
+lemma HasAssertEq.assert_eq_eq {β : Type} {F : Type} [Field F] [inst : HasAssertEq β F]
+  (x y : β) :
+  inst.assert_eq x y = assert_equals_generic x y := rfl

--- a/Clean/Table/Inductive.lean
+++ b/Clean/Table/Inductive.lean
@@ -78,11 +78,11 @@ def inductiveConstraint (table : InductiveTable F State Input) : TableConstraint
   let output ← table.step acc x
   let (output', _) ← get_next_row
   -- TODO make this more efficient by assigning variables as long as they don't come from the input
-  assert_equals output' output
+  output' === output
 
 def equalityConstraint (Input : TypeMap) [ProvableType Input] (target : State F) : SingleRowConstraint (ProvablePair State Input) F := do
   let (actual, _) ← get_curr_row
-  assert_equals actual (const target)
+  actual === (const target)
 
 def tableConstraints (table : InductiveTable F State Input) (input_state output_state: State F) :
   List (TableOperation (ProvablePair State Input) F) := [

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -52,15 +52,15 @@ def recursive_relation : TwoRowsConstraint RowType (F p) := do
   }
 
   assign_U32 next_row_off.y z
-  assert_equals curr.y next.x
+  curr.y === next.x
 
 /--
   Boundary constraints that are applied at the beginning of the trace.
 -/
 def boundary : SingleRowConstraint RowType (F p) := do
   let row ← TableConstraint.get_curr_row
-  assert_equals row.x (const (U32.from_byte 0))
-  assert_equals row.y (const (U32.from_byte 1))
+  row.x === (const (U32.from_byte 0))
+  row.y === (const (U32.from_byte 1))
 
 /--
   The fib32 table is composed of the boundary and recursive relation constraints.

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -221,7 +221,7 @@ namespace U32.Copy
 def u32_copy (x : Var U32 (F p)) : Circuit (F p) (Var U32 (F p))  := do
   let y ← ProvableType.witness fun env =>
     U32.mk (env x.x0) (env x.x1) (env x.x2) (env x.x3)
-  assert_equals x y
+  x === y
   return y
 
 def assumptions (_input : U32 (F p)) := True

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -235,7 +235,7 @@ namespace U64.Copy
 def u64_copy (x : Var U64 (F p)) : Circuit (F p) (Var U64 (F p))  := do
   let y ← ProvableType.witness fun env =>
     U64.mk (env x.x0) (env x.x1) (env x.x2) (env x.x3) (env x.x4) (env x.x5) (env x.x6) (env x.x7)
-  assert_equals x y
+  x === y
   return y
 
 def assumptions (_input : U64 (F p)) := True


### PR DESCRIPTION
Introduce a unified `===` notation for equality assertions in circuits. Under the hood, we keep the original `assert_equals` gadget and add:

- A `HasAssertEq` class and instances for `Expression F` and `α (Expression F)`.
- A `HasAssertEqM` class and MonadLift-based instance so `x === y` works in any monad built over `Circuit F`.
- Notation `infix:50 " === " => assert_eqM'`.
- `@[circuit_norm]/@[reducible]` on the defs/instances and a small lemma so that `dsimp only [circuit_norm]` (or `simp`) unfolds `===` back to the core `assert_equals` call.

It was tricky to make inference and normalization line up everywhere, so the added boilerplate is larger than expected, happy to refine further if requested.