### PR TITLE
[Codex] follow naming conventions

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -19,7 +19,7 @@ def circuit : Circuit F Unit := do
   let x ← witness (fun _ => 1)
 
   -- add a constraint
-  assert_zero (x - 1) * x
+  assertZero (x - 1) * x
 
   -- or add a lookup
   lookup { table := MyTable, entry := [x], ... }
@@ -75,7 +75,7 @@ def local_length (circuit: Circuit F α) (offset := 0) : ℕ :=
 
 /-- Create a new variable. -/
 @[circuit_norm]
-def witness_var (compute : Environment F → F) : Circuit F (Variable F) :=
+def witnessVar (compute : Environment F → F) : Circuit F (Variable F) :=
   fun (offset : ℕ) =>
     let var : Variable F := ⟨ offset ⟩
     (var, [.witness 1 fun env => #v[compute env]])
@@ -83,26 +83,26 @@ def witness_var (compute : Environment F → F) : Circuit F (Variable F) :=
 /-- Create a new variable, as an `Expression`. -/
 @[circuit_norm]
 def witness (compute : Environment F → F) := do
-  let v ← witness_var compute
+  let v ← witnessVar compute
   return var v
 
 /-- Create a vector of variables. -/
 @[circuit_norm]
-def witness_vars (m: ℕ) (compute : Environment F → Vector F m) : Circuit F (Vector (Variable F) m) :=
+def witnessVars (m: ℕ) (compute : Environment F → Vector F m) : Circuit F (Vector (Variable F) m) :=
   fun (offset : ℕ) =>
     let vars := .mapRange m fun i => ⟨offset + i⟩
     (vars, [.witness m compute])
 
 /-- Create a vector of expressions. -/
 @[circuit_norm]
-def witness_vector (m: ℕ) (compute : Environment F → Vector F m) : Circuit F (Vector (Expression F) m) :=
+def witnessVector (m: ℕ) (compute : Environment F → Vector F m) : Circuit F (Vector (Expression F) m) :=
   fun (offset : ℕ) =>
     let vars := var_from_offset (fields m) offset
     (vars, [.witness m compute])
 
 /-- Add a constraint. -/
 @[circuit_norm]
-def assert_zero (e: Expression F) : Circuit F Unit := fun _ =>
+def assertZero (e: Expression F) : Circuit F Unit := fun _ =>
   ((), [.assert e])
 
 /-- Add a lookup. -/
@@ -346,7 +346,7 @@ def subassertion_completeness (circuit: FormalAssertion F β) (b_var : Var β F)
 end Circuit
 end
 
-export Circuit (witness_var witness witness_vars witness_vector assert_zero lookup)
+export Circuit (witnessVar witness witnessVars witnessVector assertZero lookup)
 
 -- witness generation
 

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -142,7 +142,7 @@ def constraints_hold (eval : Environment F) : List (Operation F) → Prop
   | .lookup { table, entry, .. } :: ops =>
     table.contains (entry.map eval) ∧ constraints_hold eval ops
   | .subcircuit s :: ops =>
-    constraints_hold_flat eval s.ops ∧ constraints_hold eval ops
+    ConstraintsHoldFlat eval s.ops ∧ constraints_hold eval ops
 
 /--
 Version of `constraints_hold` that replaces the statement of subcircuits with their `soundness`.
@@ -178,8 +178,8 @@ for all variables declared locally within the circuit.
 
 This is the condition needed to prove completeness of a circuit.
 -/
-def Environment.UsesLocalWitnesses (env: Environment F) (offset : ℕ) (ops : Operations F) : Prop :=
-  ops.forAllFlat offset { witness n _ compute := env.extends_vector (compute env) n }
+def Environment.UsesLocalWitnesses (env : Environment F) (offset : ℕ) (ops : Operations F) : Prop :=
+  ops.forAllFlat offset { witness n _ compute := env.ExtendsVector (compute env) n }
 
 /--
 Modification of `UsesLocalWitnesses` where subcircuits replace the condition with a custom statement.
@@ -187,14 +187,14 @@ Modification of `UsesLocalWitnesses` where subcircuits replace the condition wit
 @[circuit_norm]
 def Environment.UsesLocalWitnessesCompleteness (env : Environment F) (offset : ℕ) : List (Operation F) → Prop
   | [] => True
-  | .witness m c :: ops => env.extends_vector (c env) offset ∧ env.UsesLocalWitnessesCompleteness (offset + m) ops
+  | .witness m c :: ops => env.ExtendsVector (c env) offset ∧ env.UsesLocalWitnessesCompleteness (offset + m) ops
   | .assert _ :: ops => env.UsesLocalWitnessesCompleteness offset ops
   | .lookup _ :: ops => env.UsesLocalWitnessesCompleteness offset ops
   | .subcircuit s :: ops => s.UsesLocalWitnesses env ∧ env.UsesLocalWitnessesCompleteness (offset + s.local_length) ops
 
 /-- Same as `UsesLocalWitnesses`, but on flat operations -/
 def Environment.UsesLocalWitnessesFlat (env : Environment F) (n : ℕ) (ops : List (FlatOperation F)) : Prop :=
-  FlatOperation.forAll n { witness n _ compute := env.extends_vector (compute env) n } ops
+  FlatOperation.forAll n { witness n _ compute := env.ExtendsVector (compute env) n } ops
 
 section
 open Circuit (constraints_hold)
@@ -224,7 +224,7 @@ class ElaboratedCircuit (F: Type) [Field F] (β α: TypeMap) [ProvableType β] [
     := by intros; rfl
 
   /-- technical condition: all subcircuits must be consistent with the current offset -/
-  subcircuits_consistent : ∀ input offset, ((main input).operations offset).subcircuits_consistent offset
+  subcircuits_consistent : ∀ input offset, ((main input).operations offset).SubcircuitsConsistent offset
     := by intros; and_intros <;> (
       try simp only [circuit_norm]
       try first | ac_rfl | trivial

--- a/Clean/Circuit/Constant.lean
+++ b/Clean/Circuit/Constant.lean
@@ -33,16 +33,16 @@ instance Constantircuits.from_pure {f : α → β} : ConstantCircuits (fun a => 
 
 -- basic operations are constant circuits
 
-instance : ConstantCircuits (F:=F) witness_var where
+instance : ConstantCircuits (F:=F) witnessVar where
   local_length := 1
 
-instance {k : ℕ} {c : Environment F → Vector F k} : ConstantCircuit (witness_vars k c) where
+instance {k : ℕ} {c : Environment F → Vector F k} : ConstantCircuit (witnessVars k c) where
   local_length := k
 
 instance {α: TypeMap} [ProvableType α] : ConstantCircuits (ProvableType.witness (α:=α) (F:=F)) where
   local_length := size α
 
-instance : ConstantCircuits (F:=F) assert_zero where
+instance : ConstantCircuits (F:=F) assertZero where
   local_length := 0
 
 instance {α: TypeMap} [ProvableType α] {table : Table F α} : ConstantCircuits (F:=F) (lookup table) where
@@ -94,7 +94,7 @@ example :
   let add (x : Expression F) := do
     let y ← witness (fun _ => (1 : F))
     let z ← witness (fun eval => eval (x + y))
-    assert_zero (x + y - z)
+    assertZero (x + y - z)
     pure z
 
   ConstantCircuits add := by infer_constant_circuits

--- a/Clean/Circuit/Explicit.lean
+++ b/Clean/Circuit/Explicit.lean
@@ -105,12 +105,12 @@ instance ExplicitCircuit.from_map {f : α → β} {g : Circuit F α}
 
 -- basic operations are explicit circuits
 
-instance : ExplicitCircuits (F:=F) witness_var where
+instance : ExplicitCircuits (F:=F) witnessVar where
   output _ n := ⟨ n ⟩
   local_length _ _ := 1
   operations c n := [.witness 1 fun env => #v[c env]]
 
-instance {k : ℕ} {c : Environment F → Vector F k} : ExplicitCircuit (witness_vars k c) where
+instance {k : ℕ} {c : Environment F → Vector F k} : ExplicitCircuit (witnessVars k c) where
   output n := .mapRange k fun i => ⟨n + i⟩
   local_length _ := k
   operations n := [.witness k c]
@@ -120,7 +120,7 @@ instance {α: TypeMap} [ProvableType α] : ExplicitCircuits (ProvableType.witnes
   local_length _ _ := size α
   operations c n := [.witness (size α) (to_elements ∘ c)]
 
-instance : ExplicitCircuits (F:=F) assert_zero where
+instance : ExplicitCircuits (F:=F) assertZero where
   output _ _ := ()
   local_length _ _ := 0
   operations e n := [.assert e]
@@ -173,7 +173,7 @@ example :
     let x : Expression F ← witness (fun _ => 0)
     let y ← witness (fun _ => 1)
     let z ← witness (fun eval => eval (x + y))
-    assert_zero (x + y - z)
+    assertZero (x + y - z)
     pure z
 
   ExplicitCircuit add := by infer_explicit_circuit
@@ -185,7 +185,7 @@ example :
   let add (x : Expression F) := do
     let y ← witness (fun _ => (1 : F))
     let z ← witness (fun eval => eval (x + y))
-    assert_zero (x + y - z)
+    assertZero (x + y - z)
     pure z
 
   ExplicitCircuits add := by infer_explicit_circuits

--- a/Clean/Circuit/Explicit.lean
+++ b/Clean/Circuit/Explicit.lean
@@ -20,7 +20,7 @@ class ExplicitCircuit (circuit : Circuit F α) where
   operations_eq : ∀ n : ℕ, circuit.operations n = operations n := by intro _; rfl
 
   /-- same condition as in `ElaboratedCircuit`: subcircuits must be consistent with the current offset -/
-  subcircuits_consistent : ∀ n : ℕ, (circuit.operations n).subcircuits_consistent n := by
+  subcircuits_consistent : ∀ n : ℕ, (circuit.operations n).SubcircuitsConsistent n := by
     intro _; and_intros <;> try first | ac_rfl | trivial
 
 /-- family of explicit circuits -/
@@ -31,7 +31,7 @@ class ExplicitCircuits (circuit : α → Circuit F β) where
   output_eq : ∀ (a : α) (n: ℕ), (circuit a).output n = output a n := by intro _ _; rfl
   local_length_eq : ∀ (a : α) (n: ℕ), (circuit a).local_length n = local_length a n := by intro _ _; rfl
   operations_eq : ∀ (a : α) (n: ℕ), (circuit a).operations n = operations a n := by intro _ _; rfl
-  subcircuits_consistent : ∀ (a : α) (n: ℕ), ((circuit a).operations n).subcircuits_consistent n := by
+  subcircuits_consistent : ∀ (a : α) (n: ℕ), ((circuit a).operations n).SubcircuitsConsistent n := by
     intro _ _; and_intros <;> try first | ac_rfl | trivial
 
 -- move between family and single explicit circuit
@@ -86,7 +86,7 @@ instance ExplicitCircuit.from_bind {f: Circuit F α} {g : α → Circuit F β}
   local_length_eq n := by rw [Circuit.bind_local_length_eq, local_length_eq, output_eq, local_length_eq]
   operations_eq n := by rw [Circuit.bind_operations_eq, operations_eq, output_eq, local_length_eq, operations_eq]
   subcircuits_consistent n := by
-    rw [Operations.subcircuits_consistent, Circuit.bind_forAll]
+    rw [Operations.SubcircuitsConsistent, Circuit.bind_forAll]
     exact ⟨ f_explicit.subcircuits_consistent .., (g_explicit _).subcircuits_consistent .. ⟩
 
 -- `map` of an explicit circuit yields an explicit circuit

--- a/Clean/Circuit/Extensions.lean
+++ b/Clean/Circuit/Extensions.lean
@@ -7,8 +7,8 @@ instance {α: TypeMap} [ProvableType α] : Inhabited (Circuit F (Var α F)) wher
   default := ProvableType.witness default
 
 def copy_to_var (x: Expression F) : Circuit F (Variable F) := do
-  let x' ← witness_var x.eval
-  assert_zero (x - (var x'))
+  let x' ← witnessVar x.eval
+  assertZero (x - (var x'))
   return x'
 
 def to_var : Expression F → Circuit F (Variable F)

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -229,9 +229,9 @@ what follows are relationships between different versions of `Environment.UsesLo
 -/
 
 lemma env_extends_witness {F} {n: ℕ} {ops: List (FlatOperation F)} {env: Environment F} {m c} :
-    env.extends_vector (local_witnesses env (.witness m c :: ops)) n ↔
-      (env.extends_vector (c env) n ∧ env.extends_vector (local_witnesses env ops) (m + n)) := by
-  simp_all only [extends_vector, local_length, local_witnesses, Vector.getElem_append]
+    env.ExtendsVector (local_witnesses env (.witness m c :: ops)) n ↔
+      (env.ExtendsVector (c env) n ∧ env.ExtendsVector (local_witnesses env ops) (m + n)) := by
+  simp_all only [ExtendsVector, local_length, local_witnesses, Vector.getElem_append]
   constructor
   · intro h
     constructor
@@ -250,10 +250,10 @@ lemma env_extends_witness {F} {n: ℕ} {ops: List (FlatOperation F)} {env: Envir
       congr 1
       omega
 
-theorem usesLocalWitnessesFlat_iff_extends {env: Environment F} (n: ℕ) {ops: List (FlatOperation F)}  :
-    env.UsesLocalWitnessesFlat n ops ↔ env.extends_vector (local_witnesses env ops) n := by
+theorem usesLocalWitnessesFlat_iff_extends {env: Environment F} (n : ℕ) {ops : List (FlatOperation F)}  :
+    env.UsesLocalWitnessesFlat n ops ↔ env.ExtendsVector (local_witnesses env ops) n := by
   induction ops using FlatOperation.induct generalizing n with
-  | empty => simp [UsesLocalWitnessesFlat, FlatOperation.forAll_empty, extends_vector, local_length]
+  | empty => simp [UsesLocalWitnessesFlat, FlatOperation.forAll_empty, ExtendsVector, local_length]
   | witness m _ _ ih =>
     rw [UsesLocalWitnessesFlat, FlatOperation.forAll, env_extends_witness,←ih (m + n)]
     trivial
@@ -261,7 +261,7 @@ theorem usesLocalWitnessesFlat_iff_extends {env: Environment F} (n: ℕ) {ops: L
     simp_all [UsesLocalWitnessesFlat, circuit_norm,
       FlatOperation.forAll_cons, Condition.applyFlat, FlatOperation.single_local_length]
 
-theorem can_replace_usesLocalWitnessesCompleteness {env : Environment F} {ops : Operations F} {n : ℕ} (h : ops.subcircuits_consistent n) :
+theorem can_replace_usesLocalWitnessesCompleteness {env : Environment F} {ops : Operations F} {n : ℕ} (h : ops.SubcircuitsConsistent n) :
   env.UsesLocalWitnesses n ops → env.UsesLocalWitnessesCompleteness n ops := by
   induction ops, n, h using Operations.induct_consistent with
   | empty => intros; trivial
@@ -278,7 +278,7 @@ theorem can_replace_usesLocalWitnessesCompleteness {env : Environment F} {ops : 
 
 theorem usesLocalWitnessesCompleteness_iff_forAll (n : ℕ) {env : Environment F} {ops : Operations F} :
   env.UsesLocalWitnessesCompleteness n ops ↔ ops.forAll n {
-    witness m _ c := env.extends_vector (c env) m,
+    witness m _ c := env.ExtendsVector (c env) m,
     subcircuit _ _ s := s.UsesLocalWitnesses env
   } := by
   induction ops using Operations.induct generalizing n with
@@ -288,8 +288,8 @@ theorem usesLocalWitnessesCompleteness_iff_forAll (n : ℕ) {env : Environment F
 
 theorem usesLocalWitnesses_iff_forAll (n: ℕ) {env: Environment F} {ops: Operations F} :
   env.UsesLocalWitnesses n ops ↔ ops.forAll n {
-    witness n _ c := env.extends_vector (c env) n,
-    subcircuit n _ s := FlatOperation.forAll n { witness n _ c := env.extends_vector (c env) n} s.ops
+    witness n _ c := env.ExtendsVector (c env) n,
+    subcircuit n _ s := FlatOperation.forAll n { witness n _ c := env.ExtendsVector (c env) n} s.ops
   } := by
   simp only [UsesLocalWitnesses, Operations.forAllFlat]
 end Environment
@@ -330,7 +330,7 @@ Together with `Circuit.SubCircuit.can_replace_subcircuits`, it justifies only pr
 `constraints_hold.completeness` when defining formal circuits,
 because it already implies the flat version.
 -/
-theorem can_replace_completeness {env} {ops : Operations F} {n : ℕ} (h : ops.subcircuits_consistent n) : env.UsesLocalWitnesses n ops →
+theorem can_replace_completeness {env} {ops : Operations F} {n : ℕ} (h : ops.SubcircuitsConsistent n) : env.UsesLocalWitnesses n ops →
     constraints_hold.completeness env ops → constraints_hold env ops := by
   induction ops, n, h using Operations.induct_consistent with
   | empty => intros; exact trivial
@@ -504,7 +504,7 @@ theorem proverEnvironment_usesLocalWitnesses {ops : List (FlatOperation F)} (ini
   (∀ (env env' : Environment F),
     forAll init.length { witness n _ c := env.agreesBelow n env' → c env = c env' } ops) →
     (proverEnvironment ops init).UsesLocalWitnessesFlat init.length ops := by
-  simp only [proverEnvironment, Environment.UsesLocalWitnessesFlat, Environment.extends_vector]
+  simp only [proverEnvironment, Environment.UsesLocalWitnessesFlat, Environment.ExtendsVector]
   intro h_computable
   induction ops generalizing init with
   | nil => trivial

--- a/Clean/Examples/Add32Explicit.lean
+++ b/Clean/Examples/Add32Explicit.lean
@@ -21,7 +21,7 @@ example : ExplicitCircuit.output (circuit32 default) 0
   -- rfl -- also works
   dsimp only [explicit_circuit_norm, explicit, Boolean.circuit]
 
-example : ((circuit32 default).operations 0).subcircuits_consistent 0 :=
+example : ((circuit32 default).operations 0).SubcircuitsConsistent 0 :=
   ExplicitCircuits.subcircuits_consistent ..
 
 example (x0 x1 x2 x3 y0 y1 y2 y3 carry_in : Var field (F p)) env (i0 : ℕ) :

--- a/Clean/Gadgets/Addition8/Addition8FullCarry.lean
+++ b/Clean/Gadgets/Addition8/Addition8FullCarry.lean
@@ -38,7 +38,7 @@ def add8_full_carry (input : Var Inputs (F p)) : Circuit (F p) (Var Outputs (F p
   let carry_out ← witness (fun eval => floordiv_256 (eval (x + y + carry_in)))
   assertion Boolean.circuit carry_out
 
-  assert_zero (x + y + carry_in - z - carry_out * 256)
+  assertZero (x + y + carry_in - z - carry_out * 256)
 
   return { z, carry_out }
 

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -8,7 +8,7 @@ variable {p : ℕ} [prime: Fact p.Prime] [p_large_enough: Fact (p > 2)]
 
 def main (n: ℕ) (x : Expression (F p)) := do
   -- witness the bits of `x`
-  let bits ← witness_vector n fun env => field_to_bits n (x.eval env)
+  let bits ← witnessVector n fun env => field_to_bits n (x.eval env)
 
   -- add boolean constraints on all bits
   Circuit.forEach bits (assertion Boolean.circuit)

--- a/Clean/Gadgets/Boolean.lean
+++ b/Clean/Gadgets/Boolean.lean
@@ -5,7 +5,7 @@ section
 variable {p : ℕ} [Fact p.Prime]
 
 def assert_bool (x: Expression (F p)) := do
-  assert_zero (x * (x - 1))
+  assertZero (x * (x - 1))
 
 inductive Boolean (F: Type) where
   | private mk : Variable F → Boolean F
@@ -14,7 +14,7 @@ namespace Boolean
 def var (b: Boolean (F p)) := Expression.var b.1
 
 def witness (compute : Environment (F p) → F p) := do
-  let x ← witness_var compute
+  let x ← witnessVar compute
   assert_bool (Expression.var x)
   return Boolean.mk x
 
@@ -31,7 +31,7 @@ theorem equiv : ∀ {x: F p},
 Asserts that x = 0 ∨ x = 1 by adding the constraint x * (x - 1) = 0
 -/
 def circuit : FormalAssertion (F p) field where
-  main (x : Expression (F p)) := assert_zero (x * (x - 1))
+  main (x : Expression (F p)) := assertZero (x * (x - 1))
   assumptions _ := True
   spec (x : F p) := x = 0 ∨ x = 1
 

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -8,7 +8,7 @@ variable {F : Type} [Field F]
 open Circuit (constraints_hold)
 
 namespace Gadgets
-def all_zero {n} (xs : Vector (Expression F) n) : Circuit F Unit := .forEach xs assert_zero
+def all_zero {n} (xs : Vector (Expression F) n) : Circuit F Unit := .forEach xs assertZero
 
 theorem all_zero.soundness {offset : ℕ} {env : Environment F} {n} {xs : Vector (Expression F) n} :
     constraints_hold.soundness env ((all_zero xs).operations offset) → ∀ x ∈ xs, x.eval env = 0 := by
@@ -27,7 +27,7 @@ namespace Equality
 def main {α : TypeMap} [ProvableType α] (input : Var α F × Var α F) : Circuit F Unit := do
   let (x, y) := input
   let diffs := (to_vars x).zip (to_vars y) |>.map (fun (xi, yi) => xi - yi)
-  .forEach diffs assert_zero
+  .forEach diffs assertZero
 
 @[reducible]
 instance elaborated (α : TypeMap) [ProvableType α] : ElaboratedCircuit F (ProvablePair α α) unit where

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -423,8 +423,8 @@ def assign (off : CellOffset W S) : Expression F → TableConstraint W S F Unit
   | .var v => assign_var off v
   -- a composed expression or constant is first stored in a new variable, which is assigned
   | x => do
-    let new_var ← witness_var x.eval
-    assert_zero (x - var new_var)
+    let new_var ← witnessVar x.eval
+    assertZero (x - var new_var)
     assign_var off new_var
 
 @[table_norm, table_assignment_norm]

--- a/Clean/Table/Inductive.lean
+++ b/Clean/Table/Inductive.lean
@@ -55,7 +55,7 @@ structure InductiveTable (F : Type) [Field F] (State Input : Type → Type) [Pro
     -- the constraints hold
     Circuit.constraints_hold.completeness env (step acc_var x_var |>.operations ((size State) + (size Input)))
 
-  subcircuits_consistent : ∀ acc x, ((step acc x).operations ((size State) + (size Input))).subcircuits_consistent ((size State) + (size Input))
+  subcircuits_consistent : ∀ acc x, ((step acc x).operations ((size State) + (size Input))).SubcircuitsConsistent ((size State) + (size Input))
     := by intros; and_intros <;> (
       try simp only [circuit_norm]
       try first | ac_rfl | trivial

--- a/Clean/Types/Byte.lean
+++ b/Clean/Types/Byte.lean
@@ -11,7 +11,7 @@ namespace Byte
 def var (b: Byte (F p)) := Expression.var b.1
 
 def witness (compute : Environment (F p) → F p) := do
-  let x ← witness_var compute
+  let x ← witnessVar compute
   lookup (ByteLookup x)
   return Byte.mk x
 


### PR DESCRIPTION
## Summary
- rename witness_var to witnessVar
- rename witness_vars to witnessVars
- rename witness_vector to witnessVector
- rename assert_zero to assertZero
- propagate name changes through the code

## Testing
- `lake build`

------
https://chatgpt.com/codex/tasks/task_e_685ab1e4081483238fa68fa9cff11b34