### PR TITLE
Lighter Mathlib dependency

### DIFF
--- a/Clean/Specs/Keccak256.lean
+++ b/Clean/Specs/Keccak256.lean
@@ -1,6 +1,4 @@
-import Mathlib.Tactic.Linarith.Frontend
 import Clean.Types.U64
-import Clean.Gadgets.Rotation64.Theorems
 namespace Specs.Keccak256
 
 open Bitwise (not64 rot_left64)

--- a/Clean/Utils/Bitwise.lean
+++ b/Clean/Utils/Bitwise.lean
@@ -1,5 +1,4 @@
-import Mathlib.Tactic
-import Mathlib.Algebra.Field.ZMod
+import Mathlib.Analysis.Normed.Ring.Lemmas
 import Clean.Utils.Field
 
 namespace Bitwise

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -1,5 +1,6 @@
-import Mathlib.Tactic
 import Mathlib.Algebra.Field.ZMod
+import Mathlib.Algebra.Order.Star.Basic
+import Mathlib.Analysis.Normed.Ring.Lemmas
 
 -- main field definition
 def F p := ZMod p

--- a/Clean/Utils/Misc.lean
+++ b/Clean/Utils/Misc.lean
@@ -1,7 +1,7 @@
 /-
 Miscellaneous utility lemmas/methods that don't fit anywhere else.
 -/
-import Mathlib.Tactic
+import Mathlib.Data.Fin.Basic
 variable {α : Type}
 
 theorem funext_heq {α α' β : Type} (h : α = α') {f : α → β} {g : α' → β} :

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -1,4 +1,5 @@
-import Mathlib.Tactic
+import Mathlib.Analysis.Normed.Ring.Lemmas
+import Mathlib.Combinatorics.Enumerative.Composition
 import Init.Data.List.Find
 
 variable {α β : Type} {n m : ℕ}


### PR DESCRIPTION
I followed outputs of the min_imports command. The changes aim at importing only those Mathlib files that are needed.

I don't know whether we want to optimize imports this way. Caches work well enough?