### PR TITLE
[Codex] Rename var_from_offset to varFromOffset

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -97,7 +97,7 @@ def witness_vars (m: ℕ) (compute : Environment F → Vector F m) : Circuit F (
 @[circuit_norm]
 def witness_vector (m: ℕ) (compute : Environment F → Vector F m) : Circuit F (Vector (Expression F) m) :=
   fun (offset : ℕ) =>
-    let vars := var_from_offset (fields m) offset
+    let vars := varFromOffset (fields m) offset
     (vars, [.witness m compute])
 
 /-- Add a constraint. -/
@@ -116,7 +116,7 @@ end Circuit
 @[circuit_norm]
 def ProvableType.witness {α: TypeMap} [ProvableType α] (compute : Environment F → α F) : Circuit F (α (Expression F)) :=
   fun (offset : ℕ) =>
-    let var := var_from_offset α offset
+    let var := varFromOffset α offset
     (var, [.witness (size α) (fun env => compute env |> to_elements)])
 
 @[circuit_norm]

--- a/Clean/Circuit/Explicit.lean
+++ b/Clean/Circuit/Explicit.lean
@@ -116,7 +116,7 @@ instance {k : ℕ} {c : Environment F → Vector F k} : ExplicitCircuit (witness
   operations n := [.witness k c]
 
 instance {α: TypeMap} [ProvableType α] : ExplicitCircuits (ProvableType.witness (α:=α) (F:=F)) where
-  output _ n := var_from_offset α n
+  output _ n := varFromOffset α n
   local_length _ _ := size α
   operations c n := [.witness (size α) (to_elements ∘ c)]
 

--- a/Clean/Circuit/LookupCircuit.lean
+++ b/Clean/Circuit/LookupCircuit.lean
@@ -70,7 +70,7 @@ def lookupCircuit (circuit : LookupCircuit F α β) : FormalCircuit F α β wher
     return output
 
   local_length n := size β
-  output _ n := var_from_offset β n
+  output _ n := varFromOffset β n
 
   assumptions := circuit.assumptions
   spec := circuit.spec
@@ -84,7 +84,7 @@ def lookupCircuit (circuit : LookupCircuit F α β) : FormalCircuit F α β wher
     simp_all only [circuit_norm, toTable]
     rw [ProvableType.ext_iff]
     intro i hi
-    rw [←h_env ⟨ i, hi ⟩, ProvableType.eval_var_from_offset, ProvableType.to_elements_from_elements, Vector.getElem_mapRange]
+    rw [←h_env ⟨ i, hi ⟩, ProvableType.eval_varFromOffset, ProvableType.to_elements_from_elements, Vector.getElem_mapRange]
 
 @[circuit_norm]
 def lookup (circuit : LookupCircuit F α β) (input : Var α F) : Circuit F (Var β F) :=

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -100,7 +100,7 @@ instance [Field F] : Inhabited (Var α F) where
   default := synthesize_const_var
 
 @[explicit_provable_type]
-def var_from_offset (α : TypeMap) [ProvableType α] (offset : ℕ) : Var α F :=
+def varFromOffset (α : TypeMap) [ProvableType α] (offset : ℕ) : Var α F :=
   let vars := Vector.mapRange (size α) fun i => var ⟨offset + i⟩
   from_vars vars
 
@@ -108,7 +108,7 @@ def var_from_offset (α : TypeMap) [ProvableType α] (offset : ℕ) : Var α F :
 attribute [explicit_provable_type] Vector.mapRange_succ Vector.mapRange_zero
 end ProvableType
 
-export ProvableType (eval const var_from_offset)
+export ProvableType (eval const varFromOffset)
 
 @[reducible]
 def unit (_: Type) := Unit
@@ -305,36 +305,36 @@ where
     apply eval_eq_eval_struct_aux
 
 /--
-Alternative `var_from_offset` which creates each component separately.
+Alternative `varFromOffset` which creates each component separately.
 -/
 @[circuit_norm]
-def var_from_offset (α : TypeMap) [ProvableStruct α] (offset : ℕ) : Var α F :=
+def varFromOffset (α : TypeMap) [ProvableStruct α] (offset : ℕ) : Var α F :=
   go (components α) offset |> from_components (F:=Expression F)
 where
   @[circuit_norm]
   go : (cs : List WithProvableType) → ℕ → ProvableTypeList (Expression F) cs
     | [], _ => .nil
-    | c :: cs, offset => .cons (ProvableType.var_from_offset c.type offset) (go cs (offset + c.provable_type.size))
+    | c :: cs, offset => .cons (ProvableType.varFromOffset c.type offset) (go cs (offset + c.provable_type.size))
 
 omit [Field F] in
 /--
-  `var_from_offset` === `ProvableStruct.var_from_offset`
+  `varFromOffset` === `ProvableStruct.varFromOffset`
 -/
 @[circuit_norm ↓ high]
 theorem from_offset_eq_from_offset_struct {α: TypeMap} [ProvableStruct α] (offset : ℕ) :
-    ProvableType.var_from_offset (F:=F) α offset = ProvableStruct.var_from_offset α offset := by
+    ProvableType.varFromOffset (F:=F) α offset = ProvableStruct.varFromOffset α offset := by
   symm
-  simp only [var_from_offset, ProvableType.var_from_offset, from_vars, size, from_elements]
+  simp only [varFromOffset, ProvableType.varFromOffset, from_vars, size, from_elements]
   congr
   rw [←Vector.cast_mapRange combined_size_eq.symm]
   apply from_offset_eq_from_offset_struct_aux (components α) offset
 where
   from_offset_eq_from_offset_struct_aux : (cs : List WithProvableType) → (offset: ℕ) →
-    var_from_offset.go cs offset = (
+    varFromOffset.go cs offset = (
       Vector.mapRange (combined_size' cs) (fun i => var (F:=F) ⟨offset + i⟩) |> components_from_elements cs)
     | [], _ => rfl
     | c :: cs, offset => by
-      simp only [var_from_offset.go, components_from_elements, ProvableType.var_from_offset, from_vars]
+      simp only [varFromOffset.go, components_from_elements, ProvableType.varFromOffset, from_vars]
       have h_size : combined_size' (c :: cs) = size c.type + combined_size' cs := rfl
       rw [Vector.cast_mapRange h_size, Vector.mapRange_add_eq_append, Vector.cast_rfl,
         Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
@@ -347,23 +347,23 @@ end ProvableStruct
 namespace ProvableType
 variable {α: TypeMap} [ProvableType α]
 
--- resolve `eval` and `var_from_offset` for a few basic types
+-- resolve `eval` and `varFromOffset` for a few basic types
 
 @[circuit_norm ↓ high]
 theorem eval_field {F : Type} [Field F] (env : Environment F) (x : Var field F) :
   ProvableType.eval env x = Expression.eval env x := by rfl
 
 @[circuit_norm ↓]
-theorem var_from_offset_field {F} (offset : ℕ) :
-  var_from_offset (F:=F) field offset = var ⟨offset⟩ := by rfl
+theorem varFromOffset_field {F} (offset : ℕ) :
+  varFromOffset (F:=F) field offset = var ⟨offset⟩ := by rfl
 
 @[circuit_norm ↓]
 theorem eval_fields {F : Type} [Field F] (env : Environment F) (x : Var (fields n) F) :
   ProvableType.eval env x = x.map (Expression.eval env) := rfl
 
 @[circuit_norm ↓]
-theorem var_from_offset_fields {F} (offset : ℕ) :
-  var_from_offset (F:=F) (fields n) offset = .mapRange n fun i => var ⟨offset + i⟩ := rfl
+theorem varFromOffset_fields {F} (offset : ℕ) :
+  varFromOffset (F:=F) (fields n) offset = .mapRange n fun i => var ⟨offset + i⟩ := rfl
 
 @[circuit_norm ↓]
 theorem eval_fieldPair {F : Type} [Field F] (env : Environment F) (t : Var fieldPair F) :
@@ -375,12 +375,12 @@ theorem eval_fieldTriple {F : Type} [Field F] (env : Environment F) (t : Var fie
     | (x, y, z) => (Expression.eval env x, Expression.eval env y, Expression.eval env z)) := rfl
 
 @[circuit_norm ↓]
-theorem var_from_offset_fieldPair {F} (offset : ℕ) :
-  var_from_offset (F:=F) fieldPair offset = (var ⟨offset⟩, var ⟨offset + 1⟩) := rfl
+theorem varFromOffset_fieldPair {F} (offset : ℕ) :
+  varFromOffset (F:=F) fieldPair offset = (var ⟨offset⟩, var ⟨offset + 1⟩) := rfl
 
 @[circuit_norm ↓]
-theorem var_from_offset_fieldTriple {F} (offset : ℕ) :
-  var_from_offset (F:=F) fieldTriple offset = (var ⟨offset⟩, var ⟨offset + 1⟩, var ⟨offset + 2⟩) := rfl
+theorem varFromOffset_fieldTriple {F} (offset : ℕ) :
+  varFromOffset (F:=F) fieldTriple offset = (var ⟨offset⟩, var ⟨offset + 1⟩, var ⟨offset + 2⟩) := rfl
 
 -- a few general lemmas about provable types
 
@@ -404,9 +404,9 @@ theorem eval_const {F : Type} [Field F] {α: TypeMap} [ProvableType α] {env : E
     simp only [Function.comp_apply, Expression.eval, id_eq]
   rw [this, Vector.map_id_fun, id_eq, from_elements_to_elements]
 
-theorem eval_var_from_offset {α: TypeMap} [ProvableType α] (env : Environment F) (offset : ℕ) :
-    eval env (var_from_offset α offset) = from_elements (.mapRange (size α) fun i => env.get (offset + i)) := by
-  simp only [eval, var_from_offset, to_vars, from_vars, to_elements, from_elements]
+theorem eval_varFromOffset {α: TypeMap} [ProvableType α] (env : Environment F) (offset : ℕ) :
+    eval env (varFromOffset α offset) = from_elements (.mapRange (size α) fun i => env.get (offset + i)) := by
+  simp only [eval, varFromOffset, to_vars, from_vars, to_elements, from_elements]
   rw [to_elements_from_elements]
   congr
   rw [Vector.ext_iff]
@@ -473,14 +473,14 @@ theorem getElem_eval_vector (env : Environment F) (x : Var (ProvableVector α n)
     (eval env x[i]) = (eval env x)[i] := by
   rw [eval_vector, Vector.getElem_map]
 
-theorem var_from_offset_vector {F : Type} [Field F] {α: TypeMap} [NonEmptyProvableType α] (offset : ℕ) :
-    var_from_offset (F:=F) (ProvableVector α n) offset
-    = .mapRange n fun i => var_from_offset α (offset + (size α)*i) := by
+theorem varFromOffset_vector {F : Type} [Field F] {α: TypeMap} [NonEmptyProvableType α] (offset : ℕ) :
+    varFromOffset (F:=F) (ProvableVector α n) offset
+    = .mapRange n fun i => varFromOffset α (offset + (size α)*i) := by
   induction n with
   | zero => rfl
   | succ n ih =>
     rw [Vector.mapRange_succ, ←ih]
-    simp only [var_from_offset, from_vars, from_elements, size]
+    simp only [varFromOffset, from_vars, from_elements, size]
     rw [←Vector.map_push, Vector.toChunks_push]
     congr
     conv => rhs; congr; rhs; congr; intro i; rw [mul_comm, add_assoc]
@@ -522,9 +522,9 @@ theorem eval_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (env : En
 
 omit [Field F] in
 @[circuit_norm ↓ high]
-theorem var_from_offset_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (offset : ℕ) :
-    var_from_offset (F:=F) (ProvablePair α β) offset
-    = (var_from_offset α offset, var_from_offset β (offset + size α)) := by
-  simp only [var_from_offset, from_vars, ProvablePair.instance]
+theorem varFromOffset_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (offset : ℕ) :
+    varFromOffset (F:=F) (ProvablePair α β) offset
+    = (varFromOffset α offset, varFromOffset β (offset + size α)) := by
+  simp only [varFromOffset, from_vars, ProvablePair.instance]
   rw [Vector.mapRange_add_eq_append, Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
   ac_rfl

--- a/Clean/Gadgets/And/And64.lean
+++ b/Clean/Gadgets/And/And64.lean
@@ -39,7 +39,7 @@ def spec (input: Inputs (F p)) (z : U64 (F p)) :=
 instance elaborated : ElaboratedCircuit (F p) Inputs U64 where
   main
   local_length _ := 8
-  output _ i := var_from_offset U64 i
+  output _ i := varFromOffset U64 i
 
 omit [Fact (Nat.Prime p)] p_large_enough in
 theorem soundness_to_u64 {x y z : U64 (F p)}

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -22,7 +22,7 @@ def main (n: ℕ) (x : Expression (F p)) := do
 def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (fields n) where
   main := main n
   local_length _ := n
-  output _ i := var_from_offset (fields n) i
+  output _ i := varFromOffset (fields n) i
 
   local_length_eq _ _ := by simp only [main, circuit_norm, Boolean.circuit]; ac_rfl
   subcircuits_consistent x i0 := by simp +arith only [main, circuit_norm]

--- a/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
@@ -44,7 +44,7 @@ def spec (offset : Fin 8) (x : F p) (out: Outputs (F p)) :=
 def elaborated (offset : Fin 8) : ElaboratedCircuit (F p) field Outputs where
   main := byte_decomposition offset
   local_length _ := 2
-  output _ i0 := var_from_offset Outputs i0
+  output _ i0 := varFromOffset Outputs i0
 
 theorem soundness (offset : Fin 8) : Soundness (F p) (circuit := elaborated offset) assumptions (spec offset) := by
   intro i0 env x_var (x : F p) h_input (x_byte : x.val < 256) h_holds

--- a/Clean/Gadgets/Keccak/AbsorbBlock.lean
+++ b/Clean/Gadgets/Keccak/AbsorbBlock.lean
@@ -54,7 +54,7 @@ theorem soundness : Soundness (F p) elaborated assumptions spec := by
 
   -- reduce goal to characterizing absorb step
   set state_after_absorb : Var KeccakState (F p) :=
-    (Vector.mapFinRange 17 fun i => var_from_offset (F:=F p) U64 (i0 + i.val * 8)) ++
+    (Vector.mapFinRange 17 fun i => varFromOffset (F:=F p) U64 (i0 + i.val * 8)) ++
     (Vector.mapFinRange 8 fun i => state_var[17 + i.val])
 
   suffices goal : (eval env state_after_absorb).is_normalized
@@ -94,7 +94,7 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
 
   -- reduce goal to characterizing absorb step
   set state_after_absorb : Var KeccakState (F p) :=
-    (Vector.mapFinRange 17 fun i => var_from_offset (F:=F p) U64 (i0 + i.val * 8)) ++
+    (Vector.mapFinRange 17 fun i => varFromOffset (F:=F p) U64 (i0 + i.val * 8)) ++
     (Vector.mapFinRange 8 fun i => state_var[17 + i.val])
 
   suffices goal : (eval env state_after_absorb).is_normalized

--- a/Clean/Gadgets/Keccak/Chi.lean
+++ b/Clean/Gadgets/Keccak/Chi.lean
@@ -28,7 +28,7 @@ def spec (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
 instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where
   main
   local_length _ := 400
-  output _ i0 := Vector.mapRange 25 fun i => var_from_offset U64 (i0 + i*16 + 8)
+  output _ i0 := Vector.mapRange 25 fun i => varFromOffset U64 (i0 + i*16 + 8)
 
   local_length_eq state i0 := by simp only [main, circuit_norm, Xor64.circuit, And.And64.circuit, Not.circuit]
   subcircuits_consistent state i0 := by

--- a/Clean/Gadgets/Keccak/KeccakRound.lean
+++ b/Clean/Gadgets/Keccak/KeccakRound.lean
@@ -26,7 +26,7 @@ def spec (rc : UInt64) (state : KeccakState (F p)) (out_state : KeccakState (F p
 instance elaborated (rc : UInt64) : ElaboratedCircuit (F p) KeccakState KeccakState where
   main := main rc
   local_length _ := 1288
-  output _ i0 := (Vector.mapRange 25 fun i => var_from_offset U64 (i0 + i*16 + 888) ).set 0 (var_from_offset U64 (i0 + 1280))
+  output _ i0 := (Vector.mapRange 25 fun i => varFromOffset U64 (i0 + i*16 + 888) ).set 0 (varFromOffset U64 (i0 + 1280))
 
   local_length_eq _ _ := by simp only [main, circuit_norm, Theta.circuit, RhoPi.circuit, Chi.circuit, Xor64.circuit]
   output_eq state i0 := by
@@ -55,7 +55,7 @@ theorem soundness (rc : UInt64) : Soundness (F p) (elaborated rc) assumptions (s
   clear theta_norm theta_eq h_rhopi rhopi_eq rhopi_norm h_chi state_norm h_input
 
   -- simplify round constant constraint
-  set state0_before_rc := eval env (var_from_offset U64 (i0 + 888))
+  set state0_before_rc := eval env (varFromOffset U64 (i0 + 888))
   have h_rc_norm : state0_before_rc.is_normalized := by
     simp only [KeccakState.is_normalized, eval_vector, circuit_norm] at chi_norm
     exact chi_norm 0

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -17,8 +17,8 @@ def spec (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
 
 /-- state in the ith round, starting from offset n -/
 def state_var (n : ℕ) (i : ℕ) : Var KeccakState (F p) :=
-  Vector.mapRange 25 (fun j => var_from_offset U64 (n + i * 1288 + j * 16 + 888))
-  |>.set 0 (var_from_offset U64 (n + i * 1288 + 1280))
+  Vector.mapRange 25 (fun j => varFromOffset U64 (n + i * 1288 + j * 16 + 888))
+  |>.set 0 (varFromOffset U64 (n + i * 1288 + 1280))
 
 -- NOTE: this linter times out and blows up memory usage
 set_option linter.constructorNameAsVariable false

--- a/Clean/Gadgets/Keccak/ThetaXor.lean
+++ b/Clean/Gadgets/Keccak/ThetaXor.lean
@@ -45,7 +45,7 @@ theorem soundness : Soundness (F p) elaborated assumptions spec := by
 
   -- rewrite goal
   apply KeccakState.normalized_value_ext
-  simp only [main, circuit_norm, theta_xor_loop, Xor64.circuit, var_from_offset_vector, eval_vector,
+  simp only [main, circuit_norm, theta_xor_loop, Xor64.circuit, varFromOffset_vector, eval_vector,
     mul_comm, KeccakState.value, KeccakRow.value]
 
   -- simplify constraints

--- a/Clean/Gadgets/Xor/Xor32.lean
+++ b/Clean/Gadgets/Xor/Xor32.lean
@@ -50,7 +50,7 @@ def spec (input: Inputs (F p)) (z : U32 (F p)) :=
 instance elaborated : ElaboratedCircuit (F p) Inputs U32 where
   main := main
   local_length _ := 4
-  output _ i0 := var_from_offset U32 i0
+  output _ i0 := varFromOffset U32 i0
 
 omit [Fact (Nat.Prime p)] p_large_enough in
 theorem soundness_to_u32 {x y z : U32 (F p)}
@@ -87,7 +87,7 @@ theorem soundness : Soundness (F p) elaborated assumptions spec := by
   obtain ⟨ x_norm, y_norm ⟩ := h_as
 
   simp only [h_input, circuit_norm, main, ByteXorTable,
-    var_from_offset, Vector.mapRange] at h_holds
+    varFromOffset, Vector.mapRange] at h_holds
 
   apply soundness_to_u32 x_norm y_norm
   simp only [circuit_norm, explicit_provable_type]

--- a/Clean/Gadgets/Xor/Xor64.lean
+++ b/Clean/Gadgets/Xor/Xor64.lean
@@ -58,7 +58,7 @@ def spec (input: Inputs (F p)) (z : U64 (F p)) :=
 instance elaborated : ElaboratedCircuit (F p) Inputs U64 where
   main := main
   local_length _ := 8
-  output _ i0 := var_from_offset U64 i0
+  output _ i0 := varFromOffset U64 i0
 
 omit [Fact (Nat.Prime p)] p_large_enough in
 theorem soundness_to_u64 {x y z : U64 (F p)}
@@ -101,7 +101,7 @@ theorem soundness : Soundness (F p) elaborated assumptions spec := by
   obtain ⟨ x_norm, y_norm ⟩ := h_as
 
   simp only [h_input, circuit_norm, main, ByteXorTable,
-    var_from_offset, Vector.mapRange] at h_holds
+    varFromOffset, Vector.mapRange] at h_holds
 
   apply soundness_to_u64 x_norm y_norm
   simp only [circuit_norm, explicit_provable_type]

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -397,7 +397,7 @@ def get_row (row : Fin W) : TableConstraint W S F (Var S F) :=
       circuit := ctx.circuit ++ [.witness (size S) fun env => .mapRange _ fun i => env.get (ctx.offset + i)],
       assignment := ctx.assignment.push_row row
     }
-    (var_from_offset S ctx.offset, ctx')
+    (varFromOffset S ctx.offset, ctx')
 
 /--
   Get a fresh variable for each cell in the current row

--- a/Clean/Table/Inductive.lean
+++ b/Clean/Table/Inductive.lean
@@ -105,10 +105,10 @@ theorem equalityConstraint.soundness {row : State F × Input F} {input_state : S
     simp [h_env', hi, hi', Vector.getElem_mapFinRange, Trace.getLeFromBottom, _root_.Row.get, Vector.get_eq,
       Vector.mapRange_zero, Vector.append_empty, ProvablePair.instance]
 
-  have h_env : eval env' (var_from_offset State 0) = row.1 := by
+  have h_env : eval env' (varFromOffset State 0) = row.1 := by
     rw [ProvableType.ext_iff]
     intro i hi
-    rw [h_env_in i hi, ProvableType.eval_var_from_offset,
+    rw [h_env_in i hi, ProvableType.eval_varFromOffset,
       ProvableType.to_elements_from_elements, Vector.getElem_mapRange, zero_add]
   rw [h_env]
 
@@ -183,10 +183,10 @@ lemma tableSoundnessAux (table : InductiveTable F State Input) (input output: St
     simp only [window_env, table_assignment_norm, inductiveConstraint, circuit_norm] at h_env'
     simp only [zero_add, Nat.add_zero, Fin.isValue, PNat.val_ofNat, Nat.reduceAdd, Nat.add_one_sub_one,
       CellAssignment.assignment_from_circuit_offset, CellAssignment.assignment_from_circuit_vars] at h_env'
-    set curr_var : Var State F × Var Input F := var_from_offset (ProvablePair State Input) 0
+    set curr_var : Var State F × Var Input F := varFromOffset (ProvablePair State Input) 0
     set s := size State
     set x := size Input
-    set main_ops : Operations F := (table.step (var_from_offset State 0) (var_from_offset Input s) (s + x)).2
+    set main_ops : Operations F := (table.step (varFromOffset State 0) (varFromOffset Input s) (s + x)).2
     set t := main_ops.local_length
 
     have h_env_input_1 i (hi : i < s) : (to_elements curr.1)[i] = env'.get i := by
@@ -222,24 +222,24 @@ lemma tableSoundnessAux (table : InductiveTable F State Input) (input output: St
     have input_eq_1 : eval env' curr_var.1 = curr.1 := by
       rw [ProvableType.ext_iff]
       intro i hi
-      simp only [curr_var, var_from_offset_pair]
+      simp only [curr_var, varFromOffset_pair]
       rw [h_env_input_1 i hi]
-      simp only [ProvableType.eval_var_from_offset,
+      simp only [ProvableType.eval_varFromOffset,
         ProvableType.to_elements_from_elements, Vector.getElem_mapRange, zero_add]
 
     have input_eq_2 : eval env' curr_var.2 = curr.2 := by
       rw [ProvableType.ext_iff]
       intro i hi
-      simp only [curr_var, var_from_offset_pair]
+      simp only [curr_var, varFromOffset_pair]
       rw [h_env_input_2 i hi]
-      simp only [s, ProvableType.eval_var_from_offset,
+      simp only [s, ProvableType.eval_varFromOffset,
         ProvableType.to_elements_from_elements, Vector.getElem_mapRange, zero_add]
       ac_rfl
 
-    have next_eq : eval env' (var_from_offset State (size State + size Input + main_ops.local_length)) = next.1 := by
+    have next_eq : eval env' (varFromOffset State (size State + size Input + main_ops.local_length)) = next.1 := by
       rw [ProvableType.ext_iff]
       intro i hi
-      rw [h_env_output i hi, ProvableType.eval_var_from_offset,
+      rw [h_env_output i hi, ProvableType.eval_varFromOffset,
         ProvableType.to_elements_from_elements, Vector.getElem_mapRange]
       simp only [t, s, x]
       ac_rfl
@@ -247,7 +247,7 @@ lemma tableSoundnessAux (table : InductiveTable F State Input) (input output: St
     simp only [t, x] at main_constraints
     have constraints : Circuit.constraints_hold.soundness
         env' ((table.step curr_var.1 curr_var.2).operations (size State + size Input)) := by
-      simp only [curr_var, var_from_offset_pair]
+      simp only [curr_var, varFromOffset_pair]
       exact main_constraints
 
     let xs := traceInputs ⟨ rest, rfl ⟩
@@ -257,7 +257,7 @@ lemma tableSoundnessAux (table : InductiveTable F State Input) (input output: St
 
     have h_soundness := table.soundness rest.len env' curr_var.1 curr_var.2 curr.1 curr.2 xs xs_len
       ⟨ input_eq_1, input_eq_2 ⟩ constraints spec_previous
-    simp only [curr_var, var_from_offset_pair] at h_soundness
+    simp only [curr_var, varFromOffset_pair] at h_soundness
     simp only [s, x, t, main_ops] at *
     simp +arith only at return_eq h_soundness
     rw [←return_eq, next_eq] at h_soundness

--- a/Clean/Tables/Addition8.lean
+++ b/Clean/Tables/Addition8.lean
@@ -56,7 +56,7 @@ def formal_add8_table : FormalTable (F p) RowType := {
         change Circuit.constraints_hold.soundness env _ at h_holds
 
         -- this is the slowest step, but still ok
-        simp [table_norm, circuit_norm, subcircuit_norm, var_from_offset, Vector.mapRange,
+        simp [table_norm, circuit_norm, subcircuit_norm, varFromOffset, Vector.mapRange,
           add8_inline, Gadgets.Addition8.circuit, ByteLookup
         ] at h_holds
 

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -99,9 +99,9 @@ lemma fib_assignment : (recursive_relation (p:=p)).final_assignment.vars =
 
 lemma fib_vars (curr next : Row (F p) RowType) (aux_env : Environment (F p)) :
     let env := recursive_relation.window_env ⟨<+> +> curr +> next, rfl⟩ aux_env;
-    eval env (var_from_offset U32 0) = curr.x ∧
-    eval env (var_from_offset U32 4) = curr.y ∧
-    eval env (var_from_offset U32 8) = next.x ∧
+    eval env (varFromOffset U32 0) = curr.x ∧
+    eval env (varFromOffset U32 4) = curr.y ∧
+    eval env (varFromOffset U32 8) = next.x ∧
     eval env (U32.mk (var ⟨16⟩) (var ⟨18⟩) (var ⟨20⟩) (var ⟨22⟩)) = next.y
   := by
   intro env
@@ -150,8 +150,8 @@ lemma boundary_constraints (first_row : Row (F p) RowType) (aux_env : Environmen
   set env := boundary.window_env ⟨<+> +> first_row, rfl⟩ aux_env
   simp only [table_norm, boundary, circuit_norm]
   simp only [and_imp]
-  have hx : eval env (var_from_offset U32 0) = first_row.x := by rfl
-  have hy : eval env (var_from_offset U32 4) = first_row.y := by rfl
+  have hx : eval env (varFromOffset U32 0) = first_row.x := by rfl
+  have hy : eval env (varFromOffset U32 4) = first_row.y := by rfl
   rw [hx, hy]
   clear hx hy
   intro x_zero y_one

--- a/Clean/Tables/Fibonacci8.lean
+++ b/Clean/Tables/Fibonacci8.lean
@@ -131,7 +131,7 @@ def formal_fib_table : FormalTable (F p) RowType := {
 
       simp only [fib_table, fib_relation, circuit_norm, table_norm, table_assignment_norm, copy_to_var,
           Gadgets.Addition8.circuit] at constraints_hold
-      simp only [circuit_norm, subcircuit_norm, eval, var_from_offset, Vector.mapRange] at constraints_hold
+      simp only [circuit_norm, subcircuit_norm, eval, varFromOffset, Vector.mapRange] at constraints_hold
 
       have hx_curr : env.get 0 = curr.x := by rfl
       have hy_curr : env.get 1 = curr.y := by rfl

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -238,7 +238,7 @@ def circuit : FormalCircuit (F p) U32 U32 where
   assumptions := assumptions
   spec := spec
   local_length _ := 4
-  output inputs i0 := var_from_offset U32 i0
+  output inputs i0 := varFromOffset U32 i0
   soundness := by
     rintro i0 env x_var
     rintro ⟨ x0, x1, x2, x3 ⟩ h_eval _as

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -251,7 +251,7 @@ def circuit : FormalCircuit (F p) U64 U64 where
   assumptions := assumptions
   spec := spec
   local_length _ := 8
-  output inputs i0 := var_from_offset U64 i0
+  output inputs i0 := varFromOffset U64 i0
   soundness := by
     rintro i0 env x_var
     rintro ⟨x0, x1, x2, x3, x4, x5, x6, x7⟩ h_eval _as


### PR DESCRIPTION
## Summary
- change `var_from_offset` to `varFromOffset`
- update all usages

## Testing
- `lake build`

------
https://chatgpt.com/codex/tasks/task_e_685afc6aaa9483239fad1917cf0d8701