### PR TITLE
[Codex] rename utilities to mathlib style

### DIFF
--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -95,7 +95,7 @@ variable {circuit : α → Circuit F β} {xs : Vector α m} [constant: ConstantC
   {prop : Condition F}
 
 theorem localLength_eq : (xs.mapM circuit).localLength n = m * constant.localLength := by
-  induction xs using Vector.induct_push
+  induction xs using Vector.inductPush
   case nil =>
     rw [Vector.mapM_mk_empty, pure_localLength_eq, zero_mul]
   case push xs x ih =>
@@ -104,7 +104,7 @@ theorem localLength_eq : (xs.mapM circuit).localLength n = m * constant.localLen
 
 theorem output_eq : (xs.mapM circuit).output n =
     xs.mapIdx fun i x => (circuit x).output (n + i * constant.localLength) := by
-  induction xs using Vector.induct_push
+  induction xs using Vector.inductPush
   case nil => simp
   case push xs x ih =>
     rw [Vector.mapM_push, bind_output_eq, bind_output_eq, pure_output_eq, ih, localLength_eq]

--- a/Clean/Examples/ToJson.lean
+++ b/Clean/Examples/ToJson.lean
@@ -4,11 +4,11 @@ import Clean.Tables.Fibonacci32Inductive
 import Clean.Table.Json
 
 -- serialize constraints of the Fibonacci8 table to JSON
-def fib8json := Lean.toJson (Tables.Fibonacci8Table.fib_table (p:= p_babybear))
+def fib8json := Lean.toJson (Tables.Fibonacci8Table.fib_table (p:= pBabybear))
 -- #eval fib8json
 
 -- serialize constraints of the Fibonacci32 table to JSON
-def fib32json := Lean.toJson ((Tables.Fibonacci32Inductive.table (p:= p_babybear)).tableConstraints
+def fib32json := Lean.toJson ((Tables.Fibonacci32Inductive.table (p:= pBabybear)).tableConstraints
   { x := U32.from_byte 0, y:= U32.from_byte 1 }
   { x := U32.from_byte 0, y:= U32.from_byte 0 })
 -- #eval fib32json

--- a/Clean/Gadgets/Addition32/Addition32.lean
+++ b/Clean/Gadgets/Addition32/Addition32.lean
@@ -6,7 +6,7 @@ import Clean.Utils.Primes
 namespace Gadgets.Addition32
 variable {p : ℕ} [Fact p.Prime] [Fact (p > 512)]
 
-open ByteUtils (mod_256 floordiv_256)
+open ByteUtils (mod256 floorDiv256)
 
 structure Inputs (F : Type) where
   x: U32 F

--- a/Clean/Gadgets/Addition32/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32/Addition32Full.lean
@@ -6,7 +6,7 @@ import Clean.Utils.Primes
 namespace Gadgets.Addition32Full
 variable {p : ℕ} [Fact p.Prime] [Fact (p > 512)]
 
-open ByteUtils (mod_256 floordiv_256)
+open ByteUtils (mod256 floorDiv256)
 
 structure Inputs (F : Type) where
   x: U32 F
@@ -136,18 +136,18 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
 
   -- the add8 completeness proof, four times
   have add8_completeness {x y c_in z c_out : F p}
-    (hz: z = mod_256 (x + y + c_in)) (hc_out: c_out = floordiv_256 (x + y + c_in)) :
+    (hz: z = mod256 (x + y + c_in)) (hc_out: c_out = floorDiv256 (x + y + c_in)) :
     x.val < 256 → y.val < 256 → c_in = 0 ∨ c_in = 1 →
     z.val < 256 ∧ (c_out = 0 ∨ c_out = 1) ∧ x + y + c_in + -z + -(c_out * 256) = 0
   := by
     intro x_byte y_byte hc
-    have : z.val < 256 := hz ▸ ByteUtils.mod_256_lt (x + y + c_in)
+    have : z.val < 256 := hz ▸ ByteUtils.mod256_lt (x + y + c_in)
     use this
     have carry_lt_2 : c_in.val < 2 := FieldUtils.boolean_lt_2 hc
     have : (x + y + c_in).val < 512 :=
       ByteUtils.byte_sum_and_bit_lt_512 x y c_in x_byte y_byte carry_lt_2
-    use (hc_out ▸ ByteUtils.floordiv_256_bool this)
-    rw [ByteUtils.mod_add_div_256 (x + y + c_in), hz, hc_out]
+    use (hc_out ▸ ByteUtils.floorDiv256_bool this)
+    rw [ByteUtils.mod_add_div256 (x + y + c_in), hz, hc_out]
     ring
 
   have ⟨ z0_byte, c0_bool, h0 ⟩ := add8_completeness hz0 hc0 x0_byte y0_byte carry_in_bool

--- a/Clean/Gadgets/Addition8/Addition8FullCarry.lean
+++ b/Clean/Gadgets/Addition8/Addition8FullCarry.lean
@@ -6,7 +6,7 @@ import Clean.Gadgets.Addition8.Theorems
 namespace Gadgets.Addition8FullCarry
 variable {p : ℕ} [Fact p.Prime] [Fact (p > 512)]
 
-open ByteUtils (mod_256 floordiv_256)
+open ByteUtils (mod256 floorDiv256)
 
 structure Inputs (F : Type) where
   x: F
@@ -31,11 +31,11 @@ def add8_full_carry (input : Var Inputs (F p)) : Circuit (F p) (Var Outputs (F p
   let ⟨x, y, carry_in⟩ := input
 
   -- witness the result
-  let z ← witness (fun eval => mod_256 (eval (x + y + carry_in)))
+  let z ← witness (fun eval => mod256 (eval (x + y + carry_in)))
   lookup ByteTable z
 
   -- witness the output carry
-  let carry_out ← witness (fun eval => floordiv_256 (eval (x + y + carry_in)))
+  let carry_out ← witness (fun eval => floorDiv256 (eval (x + y + carry_in)))
   assertion Boolean.circuit carry_out
 
   assertZero (x + y + carry_in - z - carry_out * 256)
@@ -114,7 +114,7 @@ def circuit : FormalCircuit (F p) Inputs Outputs where
 
     have completeness1 : z.val < 256 := by
       rw [hz]
-      apply ByteUtils.mod_256_lt
+      apply ByteUtils.mod256_lt
 
     have ⟨as_x, as_y, as_carry_in⟩ := h_assumptions
     have carry_in_bound := FieldUtils.boolean_lt_2 as_carry_in

--- a/Clean/Gadgets/Addition8/Theorems.lean
+++ b/Clean/Gadgets/Addition8/Theorems.lean
@@ -143,20 +143,20 @@ theorem completeness_add [p_neq_zero : NeZero p] (x y carry_in: F p) :
     x.val < 256 ->
     y.val < 256 ->
     carry_in.val < 2 ->
-    let carry_out := FieldUtils.floordiv (x + y + carry_in) 256
-    let z := ByteUtils.mod_256 (x + y + carry_in)
+    let carry_out := FieldUtils.floorDiv (x + y + carry_in) 256
+    let z := ByteUtils.mod256 (x + y + carry_in)
     x + y + carry_in + -z + -(carry_out * 256) = 0 := by
   intro as_x as_y carry_in_bound
   simp
   rw [←sub_eq_add_neg, sub_eq_zero, add_eq_of_eq_sub]
   ring_nf
-  dsimp only [ByteUtils.mod_256, FieldUtils.mod, PNat.val_ofNat]
+  dsimp only [ByteUtils.mod256, FieldUtils.mod, PNat.val_ofNat]
 
   -- lift everything to the naturals
   apply_fun ZMod.val
-  · simp only [ZMod.val_add (FieldUtils.floordiv (x + y + carry_in) 256 * 256)]
-    dsimp only [FieldUtils.floordiv, PNat.val_ofNat]
-    rw [ZMod.val_mul, FieldUtils.val_of_nat_to_field_eq, FieldUtils.val_of_nat_to_field_eq]
+  · simp only [ZMod.val_add (FieldUtils.floorDiv (x + y + carry_in) 256 * 256)]
+    dsimp only [FieldUtils.floorDiv, PNat.val_ofNat]
+    rw [ZMod.val_mul, FieldUtils.val_of_natToField_eq, FieldUtils.val_of_natToField_eq]
     repeat rw [ZMod.val_add]
     simp
 
@@ -196,10 +196,10 @@ theorem completeness_bool [p_neq_zero : NeZero p] (x y carry_in: F p) :
     x.val < 256 ->
     y.val < 256 ->
     carry_in.val < 2 ->
-    let carry_out := FieldUtils.floordiv (x + y + carry_in) 256
+    let carry_out := FieldUtils.floorDiv (x + y + carry_in) 256
     carry_out = 0 ∨ carry_out = 1 := by
   intro as_x as_y carry_in_bound
-  dsimp only [FieldUtils.floordiv, PNat.val_ofNat]
+  dsimp only [FieldUtils.floorDiv, PNat.val_ofNat]
 
   -- we show that the carry_out is either 0 or 1 by explicitly
   -- constructing the two cases
@@ -208,7 +208,7 @@ theorem completeness_bool [p_neq_zero : NeZero p] (x y carry_in: F p) :
   · -- we want to show that the carry is 0
     apply Or.inl
     apply_fun ZMod.val
-    · rw [FieldUtils.val_of_nat_to_field_eq]
+    · rw [FieldUtils.val_of_natToField_eq]
       have h : (x + y + carry_in).val = x.val + y.val + carry_in.val := by
         rw [ZMod.val_add, ZMod.val_add x]
         simp
@@ -231,7 +231,7 @@ theorem completeness_bool [p_neq_zero : NeZero p] (x y carry_in: F p) :
     -- we want to show that the carry is 1
     apply Or.inr
     apply_fun ZMod.val
-    · rw [FieldUtils.val_of_nat_to_field_eq]
+    · rw [FieldUtils.val_of_natToField_eq]
       have div_one : (x.val + y.val + carry_in.val) / 256 = 1 := by
         apply Nat.div_eq_of_lt_le
         · simp; apply sum_ge_256

--- a/Clean/Gadgets/And/And8.lean
+++ b/Clean/Gadgets/And/And8.lean
@@ -122,8 +122,8 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   have and_byte : x.val &&& y.val < 256 := Nat.and_lt_two_pow (n:=8) x.val hy_byte
   have p_large := p_large_enough.elim
   have and_lt : x.val &&& y.val < p := by linarith
-  rw [nat_to_field_eq_natcast and_lt] at hw
-  have h_and : w.val = x.val &&& y.val := nat_to_field_eq w hw
+  rw [natToField_eq_natCast and_lt] at hw
+  have h_and : w.val = x.val &&& y.val := natToField_eq w hw
 
   have two_and_val : (2 * w).val = 2 * (x.val &&& y.val) := by
     rw [ZMod.val_mul_of_lt, val_two, h_and]

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -8,16 +8,16 @@ variable {p : ℕ} [prime: Fact p.Prime] [p_large_enough: Fact (p > 2)]
 
 def main (n: ℕ) (x : Expression (F p)) := do
   -- witness the bits of `x`
-  let bits ← witnessVector n fun env => field_to_bits n (x.eval env)
+  let bits ← witnessVector n fun env => fieldToBits n (x.eval env)
 
   -- add boolean constraints on all bits
   Circuit.forEach bits (assertion Boolean.circuit)
 
   -- check that the bits correctly sum to `x`
-  x === (field_from_bits_expr bits)
+  x === (fieldFromBitsExpr bits)
   return bits
 
--- formal circuit that implements `to_bits` like a function, assuming `x.val < 2^n`
+-- formal circuit that implements `toBits` like a function, assuming `x.val < 2^n`
 
 def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (fields n) where
   main := main n
@@ -31,7 +31,7 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (fields n) wher
   assumptions (x : F p) := x.val < 2^n
 
   spec (x : F p) (bits : Vector (F p) n) :=
-    bits = field_to_bits n x
+    bits = fieldToBits n x
 
   soundness := by
     intro k eval x_var x h_input _h_assumptions h_holds
@@ -48,8 +48,8 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (fields n) wher
       simp only [circuit_norm, bits, bit_vars]
       exact h_bits ⟨ i, hi ⟩
 
-    change x = eval (field_from_bits_expr bit_vars) at h_eq
-    rw [h_eq, field_from_bits_eval bit_vars, field_to_bits_field_from_bits hn bits h_bits]
+    change x = eval (fieldFromBitsExpr bit_vars) at h_eq
+    rw [h_eq, fieldFromBits_eval bit_vars, fieldToBits_fieldFromBits hn bits h_bits]
 
   completeness := by
     intro k eval x_var h_env x h_input h_assumptions
@@ -59,18 +59,18 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (fields n) wher
     constructor
     · intro i
       rw [h_env i]
-      simp [field_to_bits, to_bits]
+      simp [fieldToBits, toBits]
 
     let bit_vars : Vector (Expression (F p)) n := .mapRange n (var ⟨k + ·⟩)
 
-    have h_bits_eq : bit_vars.map eval = field_to_bits n x := by
+    have h_bits_eq : bit_vars.map eval = fieldToBits n x := by
       rw [Vector.ext_iff]
       intro i hi
       simp only [circuit_norm, bit_vars]
       exact h_env ⟨ i, hi ⟩
 
-    show x = eval (field_from_bits_expr bit_vars)
-    rw [field_from_bits_eval bit_vars, h_bits_eq, field_from_bits_field_to_bits hn h_assumptions]
+    show x = eval (fieldFromBitsExpr bit_vars)
+    rw [fieldFromBits_eval bit_vars, h_bits_eq, fieldFromBits_fieldToBits hn h_assumptions]
 
 -- formal assertion that uses the same circuit to implement a range check. without input assumption
 
@@ -90,8 +90,8 @@ def range_check (n : ℕ) (hn : 2^n < p) : FormalAssertion (F p) field where
     intro k eval x_var x h_input ⟨ h_bits, h_eq ⟩
     rw [h_input] at h_eq
     change x = eval _ at h_eq
-    rw [h_eq, field_from_bits_eval]
-    apply field_from_bits_lt hn
+    rw [h_eq, fieldFromBits_eval]
+    apply fieldFromBits_lt hn
     intro i hi
     simp only [circuit_norm, h_bits ⟨ i, hi ⟩]
 
@@ -104,17 +104,17 @@ def range_check (n : ℕ) (hn : 2^n < p) : FormalAssertion (F p) field where
     constructor
     · intro i
       rw [h_env i]
-      simp [field_to_bits, to_bits]
+      simp [fieldToBits, toBits]
 
     let bit_vars : Vector (Expression (F p)) n := .mapRange n (var ⟨k + ·⟩)
 
-    have h_bits_eq : bit_vars.map eval = field_to_bits n x := by
+    have h_bits_eq : bit_vars.map eval = fieldToBits n x := by
       rw [Vector.ext_iff]
       intro i hi
       simp only [circuit_norm, bit_vars]
       exact h_env ⟨ i, hi ⟩
 
     show _ = eval _
-    rw [field_from_bits_eval, h_bits_eq, field_from_bits_field_to_bits hn h_assumptions]
+    rw [fieldFromBits_eval, h_bits_eq, fieldFromBits_fieldToBits hn h_assumptions]
 
 end Gadgets.ToBits

--- a/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
@@ -7,7 +7,7 @@ variable {p : ℕ} [Fact p.Prime] [p_large_enough: Fact (p > 2^16 + 2^8)]
 instance : Fact (p > 512) := .mk (by linarith [p_large_enough.elim])
 
 namespace Gadgets.ByteDecomposition
-open FieldUtils (mod floordiv two_lt two_pow_lt two_val two_pow_val)
+open FieldUtils (mod floorDiv two_lt two_pow_lt two_val two_pow_val)
 
 structure Outputs (F : Type) where
   low : F
@@ -25,7 +25,7 @@ instance : ProvableStruct Outputs where
 -/
 def byte_decomposition (offset : Fin 8) (x :  Expression (F p)) : Circuit (F p) (Var Outputs (F p)) := do
   let low ← witness fun env => mod (env x) (2^offset.val) (by simp [two_pow_lt])
-  let high ← witness fun env => floordiv (env x) (2^offset.val)
+  let high ← witness fun env => floorDiv (env x) (2^offset.val)
 
   lookup ByteTable ((2^(8 - offset.val) : F p) * low)
   lookup ByteTable high
@@ -113,15 +113,15 @@ theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) a
     rw [two_pow_val _ (by omega), pow_8_nat]
     exact Nat.mul_lt_mul_of_pos_left FieldUtils.mod_lt (Nat.pow_pos (by norm_num))
 
-  · show (floordiv x (2^offset.val)).val < 2^8
-    apply FieldUtils.floordiv_lt
+  · show (floorDiv x (2^offset.val)).val < 2^8
+    apply FieldUtils.floorDiv_lt
     rw [PNat.pow_coe, PNat.val_ofNat]
     suffices 1 * 2^8 ≤ 2^offset.val * 2^8 by linarith
     apply Nat.mul_le_mul_right
     exact Nat.succ_le_of_lt (by norm_num)
 
   · have : (2^offset.val : F p) = ((2^offset.val : ℕ+) : F p) := by simp
-    rw [this, mul_comm, FieldUtils.mod_add_floordiv]
+    rw [this, mul_comm, FieldUtils.mod_add_floorDiv]
 
 def circuit (offset : Fin 8) : FormalCircuit (F p) field Outputs := {
   elaborated offset with

--- a/Clean/Gadgets/ByteLookup.lean
+++ b/Clean/Gadgets/ByteLookup.lean
@@ -6,7 +6,7 @@ variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
 def from_byte (x: Fin 256) : F p :=
-  FieldUtils.nat_to_field x.val (by linarith [x.is_lt, p_large_enough.elim])
+  FieldUtils.natToField x.val (by linarith [x.is_lt, p_large_enough.elim])
 
 def ByteTable : Table (F p) field := .fromStatic {
   name := "Bytes"
@@ -21,7 +21,7 @@ def ByteTable : Table (F p) field := .fromStatic {
     intro x
     constructor
     · intro ⟨ i, h ⟩
-      have h'' : x.val = i.val := FieldUtils.nat_to_field_eq x h
+      have h'' : x.val = i.val := FieldUtils.natToField_eq x h
       rw [h'']
       exact i.is_lt
     · intro h
@@ -30,6 +30,6 @@ def ByteTable : Table (F p) field := .fromStatic {
       have h' : (x.val) % 256 = x.val := by
         rw [Nat.mod_eq_iff_lt]; assumption; norm_num
       simp only [h', List.cons.injEq]
-      simp [FieldUtils.nat_to_field_of_val_eq_iff]
+      simp [FieldUtils.natToField_of_val_eq_iff]
 }
 end Gadgets

--- a/Clean/Gadgets/Keccak/RhoPi.lean
+++ b/Clean/Gadgets/Keccak/RhoPi.lean
@@ -6,7 +6,7 @@ import Clean.Specs.Keccak256
 namespace Gadgets.Keccak256.RhoPi
 variable {p : ℕ} [Fact p.Prime] [Fact (p > 2^16 + 2^8)]
 instance : Fact (p > 512) := .mk (by linarith [‹Fact (p > _)›.elim])
-open Bitwise (rot_left64)
+open Bitwise (rotLeft64)
 
 def rhoPiIndices : Vector (Fin 25) 25 := #v[
   0, 15, 5, 20, 10, 6, 21, 11, 1, 16, 12, 2, 17, 7, 22, 18, 8, 23, 13, 3, 24, 14, 4, 19, 9
@@ -34,7 +34,7 @@ instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where
 
 -- recharacterize rho_phi as a loop
 lemma rho_pi_loop (state : Vector ℕ 25) :
-    Specs.Keccak256.rho_pi state = rhoPiConstants.map fun (i, s) => rot_left64 state[i.val] s := by
+    Specs.Keccak256.rho_pi state = rhoPiConstants.map fun (i, s) => rotLeft64 state[i.val] s := by
   simp only [Specs.Keccak256.rho_pi, circuit_norm]
   rw [Vector.map_mk]
   simp only

--- a/Clean/Gadgets/Keccak/ThetaD.lean
+++ b/Clean/Gadgets/Keccak/ThetaD.lean
@@ -71,7 +71,7 @@ theorem soundness : Soundness (F p) elaborated assumptions spec := by
   specialize h_xor4 (row_norm 3) h_rot4.right
   rw [h_rot4.left] at h_xor4
 
-  simp [Specs.Keccak256.theta_d, h_xor0, h_xor1, h_xor2, h_xor3, h_xor4, Bitwise.rot_left64]
+  simp [Specs.Keccak256.theta_d, h_xor0, h_xor1, h_xor2, h_xor3, h_xor4, Bitwise.rotLeft64]
 
 theorem completeness : Completeness (F p) elaborated assumptions := by
   intro i0 env row_var h_env row h_input h_assumptions

--- a/Clean/Gadgets/Rotation32/Rotation32.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32.lean
@@ -13,8 +13,8 @@ instance : Fact (p > 512) := by
   constructor
   linarith [p_large_enough.elim]
 
-open Bitwise (rot_right32)
-open Utils.Rotation (rot_right32_composition)
+open Bitwise (rotRight32)
+open Utils.Rotation (rotRight32_composition)
 
 /--
   Rotate the 32-bit integer by `offset` bits
@@ -30,7 +30,7 @@ def rot32 (offset : Fin 32) (x : Var U32 (F p)) : Circuit (F p) (Var U32 (F p)) 
 def assumptions (input : U32 (F p)) := input.is_normalized
 
 def spec (offset : Fin 32) (x : U32 (F p)) (y: U32 (F p)) :=
-  y.value = rot_right32 x.value offset.val
+  y.value = rotRight32 x.value offset.val
   ∧ y.is_normalized
 
 def output (offset : Fin 32) (i0 : Nat) : U32 (Expression (F p)) :=
@@ -73,7 +73,7 @@ theorem soundness (offset : Fin 32) : Soundness (F p) (circuit := elaborated off
   rw [h_input] at hy x_normalized
 
   -- reason about rotation
-  rw [rot_right32_composition _ _ _ (U32.value_lt_of_normalized x_normalized)] at hy
+  rw [rotRight32_composition _ _ _ (U32.value_lt_of_normalized x_normalized)] at hy
   rw [hy]
   rw [show(offset.val / 8) % 4 = offset.val / 8 by
     apply Nat.mod_eq_of_lt

--- a/Clean/Gadgets/Rotation32/Rotation32Bits.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32Bits.lean
@@ -13,7 +13,7 @@ instance : Fact (p > 512) := by
   constructor
   linarith [p_large_enough.elim]
 
-open Bitwise (rot_right32)
+open Bitwise (rotRight32)
 open Gadgets.Rotation32.Theorems
 open ByteDecomposition (Outputs)
 open ByteDecomposition.Theorems (byte_decomposition_lt)
@@ -34,7 +34,7 @@ def rot32_bits (offset : Fin 8) (x : U32 (Expression (F p))) : Circuit (F p) (Va
 def assumptions (input : U32 (F p)) := input.is_normalized
 
 def spec (offset : Fin 8) (x : U32 (F p)) (y: U32 (F p)) :=
-  y.value = rot_right32 x.value offset.val
+  y.value = rotRight32 x.value offset.val
   ∧ y.is_normalized
 
 def output (offset : Fin 8) (i0 : Nat) : U32 (Expression (F p)) :=
@@ -101,10 +101,10 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) assumpt
     exact (h_rot_vector i hi).left
 
   -- finish the proof using our characerization of rotation on byte vectors
-  have h_rot_vector' : y.vals = rot_right32_u32 x.vals o := by
-    rw [U32.ByteVector.ext_iff, ←rot_right32_bytes_u32_eq]
+  have h_rot_vector' : y.vals = rotRight32_u32 x.vals o := by
+    rw [U32.ByteVector.ext_iff, ←rotRight32_bytes_u32_eq]
     intro i hi
-    simp only [U32.vals, U32.ByteVector.to_limbs_map, Vector.getElem_map, rot_right32_bytes, size, Vector.getElem_ofFn]
+    simp only [U32.vals, U32.ByteVector.to_limbs_map, Vector.getElem_map, rotRight32_bytes, size, Vector.getElem_ofFn]
     exact (h_rot_vector i hi).right
 
   rw [←U32.vals_value, ←U32.vals_value, h_rot_vector']

--- a/Clean/Gadgets/Rotation32/Rotation32Bytes.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32Bytes.lean
@@ -5,7 +5,7 @@ import Clean.Utils.Primes
 namespace Gadgets.Rotation32Bytes
 variable {p : ℕ} [Fact p.Prime]
 
-open Bitwise (rot_right32)
+open Bitwise (rotRight32)
 /--
   Rotate the 32-bit integer by increments of 8 positions
   This gadget does not introduce constraints
@@ -25,7 +25,7 @@ def rot32_bytes (offset : Fin 4) (input : Var U32 (F p)) : Circuit (F p) (Var U3
 def assumptions (input : U32 (F p)) := input.is_normalized
 
 def spec (offset : Fin 4) (x : U32 (F p)) (y: U32 (F p)) :=
-  y.value = rot_right32 x.value (offset.val * 8) ∧ y.is_normalized
+  y.value = rotRight32 x.value (offset.val * 8) ∧ y.is_normalized
 
 instance elaborated (off : Fin 4): ElaboratedCircuit (F p) U32 U32 where
   main := rot32_bytes off
@@ -66,7 +66,7 @@ theorem soundness (off : Fin 4) : Soundness (F p) (elaborated off) assumptions (
 
   simp [circuit_norm, spec, U32.value, -Nat.reducePow]
   constructor
-  · fin_cases off <;> (simp_all [explicit_provable_type, rot_right32, circuit_norm, -Nat.reducePow]; omega)
+  · fin_cases off <;> (simp_all [explicit_provable_type, rotRight32, circuit_norm, -Nat.reducePow]; omega)
   · fin_cases off <;> simp_all [circuit_norm, U32.is_normalized, explicit_provable_type]
 
 theorem completeness (off : Fin 4) : Completeness (F p) (elaborated off) assumptions := by

--- a/Clean/Gadgets/Rotation32/Theorems.lean
+++ b/Clean/Gadgets/Rotation32/Theorems.lean
@@ -8,7 +8,7 @@ variable {p : ℕ} [Fact p.Prime]
 variable [p_large_enough: Fact (p > 2^16 + 2^8)]
 
 namespace Gadgets.Rotation32.Theorems
-open Bitwise (rot_right32)
+open Bitwise (rotRight32)
 open Gadgets.ByteDecomposition.Theorems (byte_decomposition_lift)
 open Utils.Rotation
 
@@ -17,13 +17,13 @@ We define a bit rotation on byte vectors like U32 by splitting each byte
 into low and high bits, and moving the lowest low bits to the top and concatenating
 each resulting (high, low) pair again.
 
-The ultimate goal is to prove that this is equivalent to `rot_right32`.
+The ultimate goal is to prove that this is equivalent to `rotRight32`.
 -/
-def rot_right32_bytes (xs : Vector ℕ 4) (o : ℕ) : Vector ℕ 4 :=
+def rotRight32_bytes (xs : Vector ℕ 4) (o : ℕ) : Vector ℕ 4 :=
   .ofFn fun ⟨ i, hi ⟩ => xs[i] / 2^o + (xs[(i + 1) % 4] % 2^o) * 2^(8-o)
 
--- unfold what rot_right32_bytes does on a U32
-def rot_right32_u32 : U32 ℕ → ℕ → U32 ℕ
+-- unfold what rotRight32_bytes does on a U32
+def rotRight32_u32 : U32 ℕ → ℕ → U32 ℕ
   | ⟨ x0, x1, x2, x3 ⟩, o => ⟨
     (x0 / 2^o) + (x1 % 2^o) * 2^(8-o),
     (x1 / 2^o) + (x2 % 2^o) * 2^(8-o),
@@ -32,13 +32,13 @@ def rot_right32_u32 : U32 ℕ → ℕ → U32 ℕ
   ⟩
 
 -- these two are definitionally equal
-lemma rot_right32_bytes_u32_eq (o : ℕ) (x : U32 ℕ) :
-  rot_right32_bytes x.to_limbs o = (rot_right32_u32 x o).to_limbs := rfl
+lemma rotRight32_bytes_u32_eq (o : ℕ) (x : U32 ℕ) :
+  rotRight32_bytes x.to_limbs o = (rotRight32_u32 x o).to_limbs := rfl
 
 lemma h_mod32 {o : ℕ} (ho : o < 8) {x0 x1 x2 x3 : ℕ} :
     (x0 + x1 * 256 + x2 * 256^2 + x3 * 256^3) % 2^o = x0 % 2^o := by
   nth_rw 1 [←Nat.pow_one 256]
-  repeat rw [Nat.add_mod, mul_mod_256_off ho _ _ (by trivial), add_zero, Nat.mod_mod]
+  repeat rw [Nat.add_mod, mul_mod256_off ho _ _ (by trivial), add_zero, Nat.mod_mod]
 
 lemma h_div32 {o : ℕ} (ho : o < 8) {x0 x1 x2 x3: ℕ} :
     (x0 + x1 * 256 + x2 * 256^2 + x3 * 256^3) / 2^o
@@ -58,9 +58,9 @@ lemma h_x0_const32 {o : ℕ} (ho : o < 8) :
   omega
 
 theorem rotation32_bits_soundness {o : ℕ} (ho : o < 8) {x : U32 ℕ} :
-    (rot_right32_u32 x o).value_nat = rot_right32 x.value_nat o := by
+    (rotRight32_u32 x o).value_nat = rotRight32 x.value_nat o := by
   -- simplify the goal
-  simp only [rot_right32, rot_right32_u32, U32.value_nat]
+  simp only [rotRight32, rotRight32_u32, U32.value_nat]
 
   have offset_mod_32 : o % 32 = o := Nat.mod_eq_of_lt (by linarith)
   simp only [offset_mod_32]

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -14,8 +14,8 @@ instance : Fact (p > 512) := by
   constructor
   linarith [p_large_enough.elim]
 
-open Bitwise (rot_right64)
-open Utils.Rotation (rot_right64_composition)
+open Bitwise (rotRight64)
+open Utils.Rotation (rotRight64_composition)
 
 /--
   Rotate the 64-bit integer by `offset` bits
@@ -31,7 +31,7 @@ def rot64 (offset : Fin 64) (x : Var U64 (F p)) : Circuit (F p) (Var U64 (F p)) 
 def assumptions (input : U64 (F p)) := input.is_normalized
 
 def spec (offset : Fin 64) (x : U64 (F p)) (y: U64 (F p)) :=
-  y.value = rot_right64 x.value offset.val
+  y.value = rotRight64 x.value offset.val
   ∧ y.is_normalized
 
 def output (offset : Fin 64) (i0 : Nat) : U64 (Expression (F p)) :=
@@ -74,7 +74,7 @@ theorem soundness (offset : Fin 64) : Soundness (F p) (circuit := elaborated off
   rw [h_input] at hy x_normalized
 
   -- reason about rotation
-  rw [rot_right64_composition _ _ _ (U64.value_lt_of_normalized x_normalized)] at hy
+  rw [rotRight64_composition _ _ _ (U64.value_lt_of_normalized x_normalized)] at hy
   rw [hy]
   rw [show(offset.val / 8) % 8 = offset.val / 8 by
     apply Nat.mod_eq_of_lt

--- a/Clean/Gadgets/Rotation64/Rotation64Bits.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bits.lean
@@ -12,7 +12,7 @@ instance : Fact (p > 512) := by
   constructor
   linarith [p_large_enough.elim]
 
-open Bitwise (rot_right64)
+open Bitwise (rotRight64)
 open Rotation64.Theorems
 open ByteDecomposition (Outputs)
 open ByteDecomposition.Theorems (byte_decomposition_lt)
@@ -32,7 +32,7 @@ def rot64_bits (offset : Fin 8) (x : Var U64 (F p)) : Circuit (F p) (Var U64 (F 
 def assumptions (input : U64 (F p)) := input.is_normalized
 
 def spec (offset : Fin 8) (x : U64 (F p)) (y: U64 (F p)) :=
-  y.value = rot_right64 x.value offset.val
+  y.value = rotRight64 x.value offset.val
   ∧ y.is_normalized
 
 def output (offset : Fin 8) (i0 : Nat) : U64 (Expression (F p)) :=
@@ -98,10 +98,10 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) assumpt
     exact (h_rot_vector i hi).left
 
   -- finish the proof using our characerization of rotation on byte vectors
-  have h_rot_vector' : y.vals = rot_right64_u64 x.vals o := by
-    rw [U64.ByteVector.ext_iff, ←rot_right64_bytes_u64_eq]
+  have h_rot_vector' : y.vals = rotRight64_u64 x.vals o := by
+    rw [U64.ByteVector.ext_iff, ←rotRight64_bytes_u64_eq]
     intro i hi
-    simp only [U64.vals, U64.ByteVector.to_limbs_map, Vector.getElem_map, rot_right64_bytes, size, Vector.getElem_ofFn]
+    simp only [U64.vals, U64.ByteVector.to_limbs_map, Vector.getElem_map, rotRight64_bytes, size, Vector.getElem_ofFn]
     exact (h_rot_vector i hi).right
 
   rw [←U64.vals_value, ←U64.vals_value, h_rot_vector']

--- a/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
@@ -5,7 +5,7 @@ import Clean.Utils.Primes
 namespace Gadgets.Rotation64Bytes
 variable {p : ℕ} [Fact p.Prime]
 
-open Bitwise (rot_right64)
+open Bitwise (rotRight64)
 
 /--
   Rotate the 64-bit integer by increments of 8 positions
@@ -34,7 +34,7 @@ def rot64_bytes (offset : Fin 8) (input : Var U64 (F p)) : Circuit (F p) (Var U6
 def assumptions (input : U64 (F p)) := input.is_normalized
 
 def spec (offset : Fin 8) (x : U64 (F p)) (y: U64 (F p)) :=
-  y.value = rot_right64 x.value (offset.val * 8) ∧ y.is_normalized
+  y.value = rotRight64 x.value (offset.val * 8) ∧ y.is_normalized
 
 instance elaborated (off : Fin 8): ElaboratedCircuit (F p) U64 U64 where
   main := rot64_bytes off
@@ -82,7 +82,7 @@ theorem soundness (off : Fin 8) : Soundness (F p) (elaborated off) assumptions (
 
   simp [circuit_norm, spec, U64.value, -Nat.reducePow]
   constructor
-  · fin_cases off <;> (simp_all [explicit_provable_type, rot_right64, circuit_norm, -Nat.reducePow]; omega)
+  · fin_cases off <;> (simp_all [explicit_provable_type, rotRight64, circuit_norm, -Nat.reducePow]; omega)
   · fin_cases off <;> simp_all [circuit_norm, U64.is_normalized, explicit_provable_type]
 
 theorem completeness (off : Fin 8) : Completeness (F p) (elaborated off) assumptions := by

--- a/Clean/Gadgets/Rotation64/Theorems.lean
+++ b/Clean/Gadgets/Rotation64/Theorems.lean
@@ -7,7 +7,7 @@ variable {p : ℕ} [Fact p.Prime]
 variable [p_large_enough: Fact (p > 2^16 + 2^8)]
 
 namespace Gadgets.Rotation64.Theorems
-open Bitwise (rot_right64)
+open Bitwise (rotRight64)
 open Utils.Rotation
 
 /--
@@ -15,13 +15,13 @@ We define a bit rotation on "byte vectors" like u64 by splitting each byte
 into low and high bits, and moving the lowest low bits to the top and concatenating
 each resulting (high, low) pair again.
 
-The ultimate goal is to prove that this is equivalent to `rot_right64`.
+The ultimate goal is to prove that this is equivalent to `rotRight64`.
 -/
-def rot_right64_bytes (xs : Vector ℕ 8) (o : ℕ) : Vector ℕ 8 :=
+def rotRight64_bytes (xs : Vector ℕ 8) (o : ℕ) : Vector ℕ 8 :=
   .ofFn fun ⟨ i, hi ⟩ => xs[i] / 2^o + (xs[(i + 1) % 8] % 2^o) * 2^(8-o)
 
--- unfold what rot_right64_bytes does on a U64
-def rot_right64_u64 : U64 ℕ → ℕ → U64 ℕ
+-- unfold what rotRight64_bytes does on a U64
+def rotRight64_u64 : U64 ℕ → ℕ → U64 ℕ
   | ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩, o => ⟨
     (x0 / 2^o) + (x1 % 2^o) * 2^(8-o),
     (x1 / 2^o) + (x2 % 2^o) * 2^(8-o),
@@ -34,14 +34,14 @@ def rot_right64_u64 : U64 ℕ → ℕ → U64 ℕ
   ⟩
 
 -- these two are definitionally equal
-lemma rot_right64_bytes_u64_eq (o : ℕ) (x : U64 ℕ) :
-  rot_right64_bytes x.to_limbs o = (rot_right64_u64 x o).to_limbs := rfl
+lemma rotRight64_bytes_u64_eq (o : ℕ) (x : U64 ℕ) :
+  rotRight64_bytes x.to_limbs o = (rotRight64_u64 x o).to_limbs := rfl
 
 lemma h_mod {o : ℕ} (ho : o < 8) {x0 x1 x2 x3 x4 x5 x6 x7 : ℕ} :
     (x0 + x1 * 256 + x2 * 256 ^ 2 + x3 * 256 ^ 3 + x4 * 256 ^ 4 + x5 * 256 ^ 5 + x6 * 256 ^ 6 + x7 * 256 ^ 7) %
       2^o = x0 % 2^o := by
   nth_rw 1 [←Nat.pow_one 256]
-  repeat rw [Nat.add_mod, mul_mod_256_off ho _ _ (by trivial), add_zero, Nat.mod_mod]
+  repeat rw [Nat.add_mod, mul_mod256_off ho _ _ (by trivial), add_zero, Nat.mod_mod]
 
 lemma h_div {o : ℕ} (ho : o < 8) {x0 x1 x2 x3 x4 x5 x6 x7 : ℕ} :
     (x0 + x1 * 256 + x2 * 256^2 + x3 * 256^3 + x4 * 256^4 + x5 * 256^5 + x6 * 256^6 + x7 * 256^7) / 2 ^ o
@@ -65,9 +65,9 @@ lemma h_x0_const {o : ℕ} (ho : o < 8) :
   omega
 
 theorem rotation64_bits_soundness {o : ℕ} (ho : o < 8) {x : U64 ℕ} :
-    (rot_right64_u64 x o).value_nat = rot_right64 x.value_nat o := by
+    (rotRight64_u64 x o).value_nat = rotRight64 x.value_nat o := by
   -- simplify the goal
-  simp only [rot_right64, rot_right64_u64, U64.value_nat]
+  simp only [rotRight64, rotRight64_u64, U64.value_nat]
 
   have offset_mod_64 : o % 64 = o := Nat.mod_eq_of_lt (by linarith)
   simp only [offset_mod_64]

--- a/Clean/Gadgets/TwoPowerLookup.lean
+++ b/Clean/Gadgets/TwoPowerLookup.lean
@@ -6,7 +6,7 @@ variable {p : ℕ} [Fact (p ≠ 0)] [Fact p.Prime]
 variable [p_large_enough: Fact (p > 512)]
 
 def from_byte_limb {two_exponent : Fin 9} (x: Fin (2 ^ two_exponent.val)) : F p :=
-  FieldUtils.nat_to_field x.val (by
+  FieldUtils.natToField x.val (by
     have two_exponent_small : 2^two_exponent.val < 2 ^ 9 := by
       apply Nat.pow_lt_pow_of_lt
       · simp only [Nat.one_lt_ofNat]
@@ -31,7 +31,7 @@ def ByteLessThanTwoPower (two_exponent : Fin 9) : Table (F p) field := .fromStat
     constructor
     · dsimp only
       rintro ⟨ i, h ⟩
-      rw [FieldUtils.nat_to_field_eq x h]
+      rw [FieldUtils.natToField_eq x h]
       exact i.is_lt
     · dsimp only
       rintro h
@@ -40,6 +40,6 @@ def ByteLessThanTwoPower (two_exponent : Fin 9) : Table (F p) field := .fromStat
       have h' : (x.val) % 2^two_exponent.val = x.val := by
         rw [Nat.mod_eq_iff_lt]; assumption; norm_num
       simp only [h', List.cons.injEq, and_true]
-      simp [FieldUtils.nat_to_field_of_val_eq_iff]
+      simp [FieldUtils.natToField_of_val_eq_iff]
 }
 end Gadgets.TwoPowerLookup

--- a/Clean/Gadgets/Xor/ByteXorTable.lean
+++ b/Clean/Gadgets/Xor/ByteXorTable.lean
@@ -10,7 +10,7 @@ def ByteXorTable : Table (F p) fieldTriple := .fromStatic {
   length := 256*256
 
   row i :=
-    let (x, y) := split_two_bytes i
+    let (x, y) := splitTwoBytes i
     (from_byte x, from_byte y, from_byte (x ^^^ y))
 
   index := fun (x, y, _) => x.val * 256 + y.val
@@ -31,18 +31,18 @@ def ByteXorTable : Table (F p) fieldTriple := .fromStatic {
       · rw [hy]
         apply from_byte_lt
       rw [hx, hy, hz]
-      repeat rw [from_byte, FieldUtils.val_of_nat_to_field_eq]
+      repeat rw [from_byte, FieldUtils.val_of_natToField_eq]
       simp only [HXor.hXor, Xor.xor, Fin.xor]
       rw [Nat.mod_eq_iff_lt (by norm_num)]
       apply Nat.xor_lt_two_pow (n:=8)
-      exact (split_two_bytes i).1.is_lt
-      exact (split_two_bytes i).2.is_lt
+      exact (splitTwoBytes i).1.is_lt
+      exact (splitTwoBytes i).2.is_lt
     intro ⟨ hx, hy, h ⟩
-    · use concat_two_bytes ⟨ x.val, hx ⟩ ⟨ y.val, hy ⟩
-      rw [concat_split]
-      simp only [from_byte, FieldUtils.nat_to_field_of_val_eq_iff, Fin.xor_val_of_uInt8Size,
+    · use concatTwoBytes ⟨ x.val, hx ⟩ ⟨ y.val, hy ⟩
+      rw [splitTwoBytes_concatTwoBytes]
+      simp only [from_byte, FieldUtils.natToField_of_val_eq_iff, Fin.xor_val_of_uInt8Size,
         Prod.mk.injEq, true_and]
       apply FieldUtils.ext
-      simp [h, FieldUtils.val_of_nat_to_field_eq]
+      simp [h, FieldUtils.val_of_natToField_eq]
 }
 end Gadgets.Xor

--- a/Clean/Specs/BLAKE3.lean
+++ b/Clean/Specs/BLAKE3.lean
@@ -1,7 +1,7 @@
 import Clean.Utils.Bitwise
 
 namespace Specs.BLAKE3
-open Bitwise (add32 rot_right32)
+open Bitwise (add32 rotRight32)
 
 ------------
 -- CONSTANTS
@@ -75,14 +75,14 @@ def msgPermutation : Vector (Fin 16) 16 :=
 -- The mixing function, G, which mixes either a column or a diagonal.
 def g (state: Vector Nat 16) (a b c d : Fin 16) (mx my : Nat) : Vector Nat 16 :=
   let state_a := add32 (state[a]) (add32 state[b] mx)
-  let state_d := rot_right32 (state[d] ^^^ state_a) 16
+  let state_d := rotRight32 (state[d] ^^^ state_a) 16
   let state_c := add32 (state[c]) state_d
-  let state_b := rot_right32 (state[b] ^^^ state_c) 12
+  let state_b := rotRight32 (state[b] ^^^ state_c) 12
 
   let state_a := add32 state_a (add32 state_b my)
-  let state_d := rot_right32 (state_d ^^^ state_a) 8
+  let state_d := rotRight32 (state_d ^^^ state_a) 8
   let state_c := add32 state_c state_d
-  let state_b := rot_right32 (state_b ^^^ state_c) 7
+  let state_b := rotRight32 (state_b ^^^ state_c) 7
 
   state.set a state_a
         |>.set b state_b

--- a/Clean/Specs/Keccak256.lean
+++ b/Clean/Specs/Keccak256.lean
@@ -1,7 +1,7 @@
 import Clean.Types.U64
 namespace Specs.Keccak256
 
-open Bitwise (not64 rot_left64)
+open Bitwise (not64 rotLeft64)
 
 def roundConstants : Vector UInt64 24 := #v[
   0x0000000000000001, 0x0000000000008082,
@@ -32,11 +32,11 @@ def theta_c (state : Vector ℕ 25) : Vector ℕ 5 :=
 
 def theta_d (c : Vector ℕ 5) : Vector ℕ 5 :=
   #v[
-    c[4] ^^^ (rot_left64 c[1] 1),
-    c[0] ^^^ (rot_left64 c[2] 1),
-    c[1] ^^^ (rot_left64 c[3] 1),
-    c[2] ^^^ (rot_left64 c[4] 1),
-    c[3] ^^^ (rot_left64 c[0] 1)
+    c[4] ^^^ (rotLeft64 c[1] 1),
+    c[0] ^^^ (rotLeft64 c[2] 1),
+    c[1] ^^^ (rotLeft64 c[3] 1),
+    c[2] ^^^ (rotLeft64 c[4] 1),
+    c[3] ^^^ (rotLeft64 c[0] 1)
   ]
 
 def theta_xor (state : Vector ℕ 25) (d : Vector ℕ 5) : Vector ℕ 25 :=
@@ -75,31 +75,31 @@ def theta (state : Vector ℕ 25) : Vector ℕ 25 :=
 
 def rho_pi (state : Vector ℕ 25) : Vector ℕ 25 :=
   #v[
-    rot_left64 state[0] 0,
-    rot_left64 state[15] 28,
-    rot_left64 state[5] 1,
-    rot_left64 state[20] 27,
-    rot_left64 state[10] 62,
-    rot_left64 state[6] 44,
-    rot_left64 state[21] 20,
-    rot_left64 state[11] 6,
-    rot_left64 state[1] 36,
-    rot_left64 state[16] 55,
-    rot_left64 state[12] 43,
-    rot_left64 state[2] 3,
-    rot_left64 state[17] 25,
-    rot_left64 state[7] 10,
-    rot_left64 state[22] 39,
-    rot_left64 state[18] 21,
-    rot_left64 state[8] 45,
-    rot_left64 state[23] 8,
-    rot_left64 state[13] 15,
-    rot_left64 state[3] 41,
-    rot_left64 state[24] 14,
-    rot_left64 state[14] 61,
-    rot_left64 state[4] 18,
-    rot_left64 state[19] 56,
-    rot_left64 state[9] 2
+    rotLeft64 state[0] 0,
+    rotLeft64 state[15] 28,
+    rotLeft64 state[5] 1,
+    rotLeft64 state[20] 27,
+    rotLeft64 state[10] 62,
+    rotLeft64 state[6] 44,
+    rotLeft64 state[21] 20,
+    rotLeft64 state[11] 6,
+    rotLeft64 state[1] 36,
+    rotLeft64 state[16] 55,
+    rotLeft64 state[12] 43,
+    rotLeft64 state[2] 3,
+    rotLeft64 state[17] 25,
+    rotLeft64 state[7] 10,
+    rotLeft64 state[22] 39,
+    rotLeft64 state[18] 21,
+    rotLeft64 state[8] 45,
+    rotLeft64 state[23] 8,
+    rotLeft64 state[13] 15,
+    rotLeft64 state[3] 41,
+    rotLeft64 state[24] 14,
+    rotLeft64 state[14] 61,
+    rotLeft64 state[4] 18,
+    rotLeft64 state[19] 56,
+    rotLeft64 state[9] 2
   ]
 
 def chi (b : Vector ℕ 25) : Vector ℕ 25 :=

--- a/Clean/Utils/Bits.lean
+++ b/Clean/Utils/Bits.lean
@@ -10,24 +10,24 @@ namespace Utils.Bits
 /--
   Convert a natural number to a vector of bits.
 -/
-def to_bits (n : ℕ) (x : ℕ) : Vector ℕ n :=
+def toBits (n : ℕ) (x : ℕ) : Vector ℕ n :=
   .mapRange n fun i => if x.testBit i then 1 else 0
 
 /--
   Convert a vector of bits to a natural number.
 -/
-def from_bits {n : ℕ} (bits : Vector ℕ n) : ℕ :=
+def fromBits {n : ℕ} (bits : Vector ℕ n) : ℕ :=
   Fin.foldl n (fun acc ⟨i, _⟩ => acc + bits[i] * 2^i) 0
 
 /--
-  Main lemma which establishes the behaviour of `from_bits`
-  and `to_bits` by induction
+  Main lemma which establishes the behaviour of `fromBits`
+  and `toBits` by induction
 -/
-lemma to_bits_from_bits_aux {n: ℕ} (bits : Vector ℕ n)
+lemma toBits_fromBits_aux {n: ℕ} (bits : Vector ℕ n)
   (h_bits : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1) :
-    (from_bits bits) < 2^n ∧ to_bits n (from_bits bits) = bits := by
+    (fromBits bits) < 2^n ∧ toBits n (fromBits bits) = bits := by
   rw [Vector.ext_iff]
-  simp only [from_bits, to_bits, Vector.getElem_mapRange]
+  simp only [fromBits, toBits, Vector.getElem_mapRange]
   induction n with
   | zero => simp_all
   | succ n ih =>
@@ -60,22 +60,22 @@ lemma to_bits_from_bits_aux {n: ℕ} (bits : Vector ℕ n)
         subst this
         rcases h_bits_n <;> simp [*, ZMod.val_one]
 
-/-- `to_bits` is a left-inverse of `from_bits` -/
-theorem to_bits_from_bits {n: ℕ} (bits : Vector ℕ n)
+/-- `toBits` is a left-inverse of `fromBits` -/
+theorem toBits_fromBits {n: ℕ} (bits : Vector ℕ n)
   (h_bits : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1) :
-    to_bits n (from_bits bits) = bits := (to_bits_from_bits_aux bits h_bits).right
+    toBits n (fromBits bits) = bits := (toBits_fromBits_aux bits h_bits).right
 
-/-- The result of `from_bits` is less than 2^n -/
-theorem from_bits_lt {n: ℕ} (bits : Vector ℕ n)
+/-- The result of `fromBits` is less than 2^n -/
+theorem fromBits_lt {n: ℕ} (bits : Vector ℕ n)
   (h_bits : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1) :
-    (from_bits bits) < 2^n := (to_bits_from_bits_aux bits h_bits).left
+    (fromBits bits) < 2^n := (toBits_fromBits_aux bits h_bits).left
 
-/-- On numbers less than `2^n`, `to_bits n` is injective -/
-theorem to_bits_injective (n: ℕ) {x y : ℕ} : x < 2^n → y < 2^n →
-    to_bits n x = to_bits n y → x = y := by
+/-- On numbers less than `2^n`, `toBits n` is injective -/
+theorem toBits_injective (n: ℕ) {x y : ℕ} : x < 2^n → y < 2^n →
+    toBits n x = toBits n y → x = y := by
   intro hx hy h_eq
   rw [Vector.ext_iff] at h_eq
-  simp only [to_bits, Vector.getElem_mapRange] at h_eq
+  simp only [toBits, Vector.getElem_mapRange] at h_eq
   have h_eq' : ∀ i (hi : i < n), x.testBit i = y.testBit i := by
     intro i hi
     specialize h_eq i hi
@@ -92,37 +92,37 @@ theorem to_bits_injective (n: ℕ) {x y : ℕ} : x < 2^n → y < 2^n →
     replace hy : y < 2^i := by linarith
     rw [Nat.testBit_lt_two_pow hx, Nat.testBit_lt_two_pow hy]
 
-/-- On numbers less than `2^n`, `to_bits` is a right-inverse of `from_bits` -/
-theorem from_bits_to_bits {n: ℕ} {x : ℕ} (hx : x < 2^n) :
-    from_bits (to_bits n x) = x := by
-  have h_bits : ∀ i (hi : i < n), (to_bits n x)[i] = 0 ∨ (to_bits n x)[i] = 1 := by
-    intro i hi; simp [to_bits]
-  apply to_bits_injective n (from_bits_lt _ h_bits) hx
-  rw [to_bits_from_bits _ h_bits]
+/-- On numbers less than `2^n`, `toBits` is a right-inverse of `fromBits` -/
+theorem fromBits_toBits {n: ℕ} {x : ℕ} (hx : x < 2^n) :
+    fromBits (toBits n x) = x := by
+  have h_bits : ∀ i (hi : i < n), (toBits n x)[i] = 0 ∨ (toBits n x)[i] = 1 := by
+    intro i hi; simp [toBits]
+  apply toBits_injective n (fromBits_lt _ h_bits) hx
+  rw [toBits_fromBits _ h_bits]
 
 
--- field variant of `to_bits` and `from_bits`
+-- field variant of `toBits` and `fromBits`
 variable {p : ℕ} [prime: Fact p.Prime]
 
 /--
   Convert a field element to a vector of bits, which are themselves field elements.
 -/
-def field_to_bits (n : ℕ) (x : F p) : Vector (F p) n :=
-  .map (↑) (to_bits n x.val)
+def fieldToBits (n : ℕ) (x : F p) : Vector (F p) n :=
+  .map (↑) (toBits n x.val)
 
 /--
   Convert a vector of bits to a field element.
 -/
-def field_from_bits {n : ℕ} (bits : Vector (F p) n) : F p :=
-  from_bits <| bits.map ZMod.val
+def fieldFromBits {n : ℕ} (bits : Vector (F p) n) : F p :=
+  fromBits <| bits.map ZMod.val
 
-def field_from_bits_expr {n: ℕ} (bits : Vector (Expression (F p)) n) : Expression (F p) :=
+def fieldFromBitsExpr {n: ℕ} (bits : Vector (Expression (F p)) n) : Expression (F p) :=
   Fin.foldl n (fun acc ⟨i, _⟩ => acc + bits[i] * (2^i : F p)) 0
 
 /-- Evaluation commutes with bits accumulation -/
-theorem field_from_bits_eval {n: ℕ} {eval : Environment (F p)} (bits : Vector (Expression (F p)) n) :
-    eval (field_from_bits_expr bits) = field_from_bits (bits.map eval) := by
-  simp only [field_from_bits_expr, field_from_bits, from_bits]
+theorem fieldFromBits_eval {n: ℕ} {eval : Environment (F p)} (bits : Vector (Expression (F p)) n) :
+    eval (fieldFromBitsExpr bits) = fieldFromBits (bits.map eval) := by
+  simp only [fieldFromBitsExpr, fieldFromBits, fromBits]
   induction n with
   | zero => simp only [Fin.foldl_zero, Expression.eval, Vector.map_map, Vector.getElem_map,
     Function.comp_apply, Nat.cast_zero]
@@ -135,14 +135,14 @@ theorem field_from_bits_eval {n: ℕ} {eval : Environment (F p)} (bits : Vector 
     rw [ZMod.cast_id]
 
 /--
-  Define the behaviour of `field_from_bits` and `field_to_bits` by
-  lifting `to_bits_from_bits_aux`
+  Define the behaviour of `fieldFromBits` and `fieldToBits` by
+  lifting `toBits_fromBits_aux`
 -/
-lemma field_to_bits_field_from_bits_aux {n: ℕ} (hn : 2^n < p) (bits : Vector (F p) n)
+lemma fieldToBits_fieldFromBits_aux {n: ℕ} (hn : 2^n < p) (bits : Vector (F p) n)
   (h_bits : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1) :
-    (field_from_bits bits).val < 2^n ∧ field_to_bits n (field_from_bits bits) = bits := by
+    (fieldFromBits bits).val < 2^n ∧ fieldToBits n (fieldFromBits bits) = bits := by
   rw [Vector.ext_iff]
-  simp only [field_from_bits, field_to_bits, Vector.getElem_mapRange]
+  simp only [fieldFromBits, fieldToBits, Vector.getElem_mapRange]
 
   have h_bool : ∀ i (hi : i < n), (bits.map ZMod.val)[i] = 0 ∨ (bits.map ZMod.val)[i] = 1 := by
     intro i hi
@@ -154,37 +154,37 @@ lemma field_to_bits_field_from_bits_aux {n: ℕ} (hn : 2^n < p) (bits : Vector (
       simp only [ZMod.val_zero, ZMod.val_one] at h
       exact h
 
-  obtain ⟨thm_lt, thm_val⟩ := to_bits_from_bits_aux (bits.map ZMod.val) h_bool
+  obtain ⟨thm_lt, thm_val⟩ := toBits_fromBits_aux (bits.map ZMod.val) h_bool
   constructor
   · rw [ZMod.val_natCast_of_lt (by linarith)]
     exact thm_lt
   · intro i hi
     simp
-    have h := ZMod.val_natCast p ((from_bits (Vector.map ZMod.val bits)))
+    have h := ZMod.val_natCast p ((fromBits (Vector.map ZMod.val bits)))
     simp_rw [h]
-    have h_lt : from_bits (Vector.map ZMod.val bits) < p := by linarith
+    have h_lt : fromBits (Vector.map ZMod.val bits) < p := by linarith
     simp_rw [Nat.mod_eq_of_lt h_lt, thm_val]
     simp
     rw [ZMod.cast_id]
     rfl
 
-/-- The result of `field_from_bits` is less than 2^n -/
-theorem field_from_bits_lt {n: ℕ} (hn : 2^n < p) (bits : Vector (F p) n)
+/-- The result of `fieldFromBits` is less than 2^n -/
+theorem fieldFromBits_lt {n: ℕ} (hn : 2^n < p) (bits : Vector (F p) n)
   (h_bits : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1) :
-    (field_from_bits bits).val < 2^n := (field_to_bits_field_from_bits_aux hn bits h_bits).left
+    (fieldFromBits bits).val < 2^n := (fieldToBits_fieldFromBits_aux hn bits h_bits).left
 
-/-- `field_to_bits` is a left-inverse of `field_from_bits` -/
-theorem field_to_bits_field_from_bits {n: ℕ} (hn : 2^n < p) (bits : Vector (F p) n)
+/-- `fieldToBits` is a left-inverse of `fieldFromBits` -/
+theorem fieldToBits_fieldFromBits {n: ℕ} (hn : 2^n < p) (bits : Vector (F p) n)
   (h_bits : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1) :
-    field_to_bits n (field_from_bits bits) = bits := (field_to_bits_field_from_bits_aux hn bits h_bits).right
+    fieldToBits n (fieldFromBits bits) = bits := (fieldToBits_fieldFromBits_aux hn bits h_bits).right
 
-/-- On field elements less than `2^n`, `field_to_bits n` is injective -/
-theorem field_to_bits_injective (n: ℕ) {x y : F p} : x.val < 2^n → y.val < 2^n →
-    field_to_bits n x = field_to_bits n y → x = y := by
+/-- On field elements less than `2^n`, `fieldToBits n` is injective -/
+theorem fieldToBits_injective (n: ℕ) {x y : F p} : x.val < 2^n → y.val < 2^n →
+    fieldToBits n x = fieldToBits n y → x = y := by
   intro hx hy h_eq
-  simp only [field_to_bits] at h_eq
+  simp only [fieldToBits] at h_eq
   rw [Vector.ext_iff] at h_eq
-  simp only [to_bits, Vector.getElem_map, Vector.getElem_mapRange, Nat.cast_ite, Nat.cast_one,
+  simp only [toBits, Vector.getElem_map, Vector.getElem_mapRange, Nat.cast_ite, Nat.cast_one,
     Nat.cast_zero] at h_eq
 
   have h_eq' : ∀ i (hi : i < n), x.val.testBit i = y.val.testBit i := by
@@ -203,14 +203,14 @@ theorem field_to_bits_injective (n: ℕ) {x y : F p} : x.val < 2^n → y.val < 2
   replace hy : y.val < 2^i := by linarith
   rw [Nat.testBit_lt_two_pow hx, Nat.testBit_lt_two_pow hy]
 
-/-- On field elements less than `2^n`, `field_to_bits` is a right-inverse of `field_from_bits` -/
-theorem field_from_bits_field_to_bits {n: ℕ} (hn : 2^n < p) {x : F p} (hx : x.val < 2^n) :
-    field_from_bits (field_to_bits n x) = x := by
-  have h_bits : ∀ i (hi : i < n), (field_to_bits n x)[i] = 0 ∨ (field_to_bits n x)[i] = 1 := by
+/-- On field elements less than `2^n`, `fieldToBits` is a right-inverse of `fieldFromBits` -/
+theorem fieldFromBits_fieldToBits {n: ℕ} (hn : 2^n < p) {x : F p} (hx : x.val < 2^n) :
+    fieldFromBits (fieldToBits n x) = x := by
+  have h_bits : ∀ i (hi : i < n), (fieldToBits n x)[i] = 0 ∨ (fieldToBits n x)[i] = 1 := by
     intro i hi
-    simp [field_to_bits, to_bits]
+    simp [fieldToBits, toBits]
 
-  apply field_to_bits_injective n (field_from_bits_lt hn _ h_bits) hx
-  rw [field_to_bits_field_from_bits hn _ h_bits]
+  apply fieldToBits_injective n (fieldFromBits_lt hn _ h_bits) hx
+  rw [fieldToBits_fieldFromBits hn _ h_bits]
 
 end Utils.Bits

--- a/Clean/Utils/Bitwise.lean
+++ b/Clean/Utils/Bitwise.lean
@@ -6,35 +6,35 @@ def not64 (a : ℕ) : ℕ := a ^^^ 0xffffffffffffffff
 
 def add32 (a b : ℕ) : ℕ := (a + b) % 2^32
 
-def rot_right8 (x : Fin 256) (offset : Fin 8) : Fin 256 :=
+def rotRight8 (x : Fin 256) (offset : Fin 8) : Fin 256 :=
   let low := x % (2^offset.val)
   let high := x / (2^offset.val)
   low * (2^(8 - offset.val)) + high
 
-def rot_left8 (x : Fin 256) (offset : Fin 8) : Fin 256 :=
+def rotLeft8 (x : Fin 256) (offset : Fin 8) : Fin 256 :=
   let low := x % (2^(8 - offset.val))
   let high := x / (2^(8 - offset.val))
   low * (2^offset.val) + high
 
-def rot_right64 (x : ℕ) (offset : ℕ) : ℕ :=
+def rotRight64 (x : ℕ) (offset : ℕ) : ℕ :=
   let offset := offset % 64
   let low := x % (2^offset)
   let high := x / (2^offset)
   low * (2^(64 - offset)) + high
 
-def rot_right32 (x : ℕ) (offset : ℕ) : ℕ :=
+def rotRight32 (x : ℕ) (offset : ℕ) : ℕ :=
   let offset := offset % 32
   let low := x % (2^offset)
   let high := x / (2^offset)
   low * (2^(32 - offset)) + high
 
-def rot_left64 (value : ℕ) (left : Fin 64) : ℕ:=
+def rotLeft64 (value : ℕ) (left : Fin 64) : ℕ:=
   let right := (64 - left) % 64
-  rot_right64 value right
+  rotRight64 value right
 
-lemma rot_left_eq_rot_right (x : ℕ) (offset : Fin 64) :
-    rot_left64 x offset = rot_right64 x (-offset).val := by
-  simp [rot_left64]
+lemma rotLeft64_eq_rotRight64 (x : ℕ) (offset : Fin 64) :
+    rotLeft64 x offset = rotRight64 x (-offset).val := by
+  simp [rotLeft64]
 
 theorem eq_of_mod_eq_and_div_eq (m : ℕ) {x y : ℕ} (mod : x % m = y % m) (div : x / m = y / m) : x = y := by
   rw [←Nat.mod_add_div x m, ←Nat.mod_add_div y m, mod, div]
@@ -61,7 +61,7 @@ theorem xor_mul_two_pow {x y n : Nat} : 2 ^ n * (x ^^^ y) =  2 ^ n * x ^^^  2 ^ 
   simp only [mul_comm]
   exact Nat.bitwise_mul_two_pow
 
-lemma and_mul_pow_two_lt {n : ℕ} {x : ℕ} (hx : x < 2^n) (y : ℕ) : x &&& 2^n * y = 0 := by
+lemma and_mul_two_pow_lt {n : ℕ} {x : ℕ} (hx : x < 2^n) (y : ℕ) : x &&& 2^n * y = 0 := by
   apply Nat.eq_of_testBit_eq
   intro i
   rw [Nat.testBit_and, Nat.zero_testBit, Nat.testBit_two_pow_mul]
@@ -77,8 +77,8 @@ lemma and_mul_pow_two_lt {n : ℕ} {x : ℕ} (hx : x < 2^n) (y : ℕ) : x &&& 2^
 lemma and_xor_sum (x0 x1 y0 y1 : ℕ) (hx0 : x0 < 2^8) (hy0 : y0 < 2^8) :
   (x0 ^^^ (2^8 * x1)) &&& (y0 ^^^ (2^8 * y1)) = (x0 &&& y0) ^^^ 2^8 * (x1 &&& y1) := by
   simp only [Nat.and_xor_distrib_left, Nat.and_xor_distrib_right]
-  have zero0 : 2 ^ 8 * x1 &&& y0 = 0 := by rw [Nat.and_comm]; apply and_mul_pow_two_lt hy0
-  have zero1 : x0 &&& 2 ^ 8 * y1 = 0 := and_mul_pow_two_lt hx0 _
+  have zero0 : 2 ^ 8 * x1 &&& y0 = 0 := by rw [Nat.and_comm]; apply and_mul_two_pow_lt hy0
+  have zero1 : x0 &&& 2 ^ 8 * y1 = 0 := and_mul_two_pow_lt hx0 _
   rw [zero0, zero1, Nat.xor_zero, Nat.zero_xor]
   congr; symm
   exact and_mul_two_pow

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -14,16 +14,16 @@ variable {p : ℕ} [p_prime: Fact p.Prime]
 
 instance : NeZero p := ⟨p_prime.elim.ne_zero⟩
 
-theorem p_neq_zero : p ≠ 0 := p_prime.elim.ne_zero
+theorem p_ne_zero : p ≠ 0 := p_prime.elim.ne_zero
 
 theorem ext {x y : F p} (h : x.val = y.val) : x = y := by
-  cases p; cases p_neq_zero rfl
+  cases p; cases p_ne_zero rfl
   exact Fin.ext h
 
 theorem val_lt_p {p : ℕ} (x: ℕ) : (x < p) → (x : F p).val = x := by
   intro x_lt_p
-  have p_neq_zero : p ≠ 0 := Nat.ne_zero_of_lt x_lt_p
-  have x_mod_is_x : x % p = x := (Nat.mod_eq_iff_lt p_neq_zero).mpr x_lt_p
+  have p_ne_zero : p ≠ 0 := Nat.ne_zero_of_lt x_lt_p
+  have x_mod_is_x : x % p = x := (Nat.mod_eq_iff_lt p_ne_zero).mpr x_lt_p
   rw [ZMod.val_natCast, x_mod_is_x]
 
 lemma val_eq_256 [p_large_enough: Fact (p > 512)] : (256 : F p).val = 256 := val_lt_p 256 (by linarith [p_large_enough.elim])
@@ -67,32 +67,32 @@ theorem boolean_lt_2 {b : F p} (hb : b = 0 ∨ b = 1) : b.val < 2 := by
   · rw [h0]; simp
   · rw [h1]; simp only [ZMod.val_one, Nat.one_lt_ofNat]
 
-def nat_to_field (n: ℕ) (lt: n < p) : F p :=
+def natToField (n: ℕ) (lt: n < p) : F p :=
   match p with
   | 0 => False.elim (Nat.not_lt_zero n lt)
   | _ + 1 => ⟨ n, lt ⟩
 
-theorem nat_to_field_zero : nat_to_field 0 (p_prime.elim.pos) = 0 := by
-  dsimp [nat_to_field]
+theorem natToField_zero : natToField 0 (p_prime.elim.pos) = 0 := by
+  dsimp [natToField]
   cases p
   · exact False.elim (Nat.not_lt_zero 0 p_prime.elim.pos)
   · simp only
 
-theorem nat_to_field_eq {n: ℕ} {lt: n < p} (x : F p) (hx: x = nat_to_field n lt) : x.val = n := by
+theorem natToField_eq {n: ℕ} {lt: n < p} (x : F p) (hx: x = natToField n lt) : x.val = n := by
   cases p
   · exact False.elim (Nat.not_lt_zero n lt)
   · rw [hx]; rfl
 
-theorem nat_to_field_of_val_eq_iff {x : F p} {lt: x.val < p} : nat_to_field (x.val) lt = x := by
+theorem natToField_of_val_eq_iff {x : F p} {lt: x.val < p} : natToField (x.val) lt = x := by
   cases p
   · exact False.elim (Nat.not_lt_zero x.val lt)
-  · dsimp only [nat_to_field]; rfl
+  · dsimp only [natToField]; rfl
 
-theorem nat_to_field_eq_natcast {n: ℕ} (lt: n < p) : ↑n = FieldUtils.nat_to_field n lt := by
+theorem natToField_eq_natCast {n: ℕ} (lt: n < p) : ↑n = FieldUtils.natToField n lt := by
   cases p with
   | zero => exact False.elim (Nat.not_lt_zero n lt)
   | succ n' => {
-    simp only [FieldUtils.nat_to_field]
+    simp only [FieldUtils.natToField]
     rw [Fin.natCast_def]
     apply_fun Fin.val
     · simp only [Nat.mod_succ_eq_iff_lt, Nat.succ_eq_add_one]
@@ -100,47 +100,47 @@ theorem nat_to_field_eq_natcast {n: ℕ} (lt: n < p) : ↑n = FieldUtils.nat_to_
     · apply Fin.val_injective
   }
 
-theorem val_of_nat_to_field_eq {n: ℕ} (lt: n < p) : (nat_to_field n lt).val = n := by
+theorem val_of_natToField_eq {n: ℕ} (lt: n < p) : (natToField n lt).val = n := by
   cases p
   · exact False.elim (Nat.not_lt_zero n lt)
   · rfl
 
 def less_than_p (x: F p) : x.val < p := by
-  rcases p with _ | n; cases p_neq_zero rfl
+  rcases p with _ | n; cases p_ne_zero rfl
   exact x.is_lt
 
 def mod (x: F p) (c: ℕ+) (lt: c < p) : F p :=
-  FieldUtils.nat_to_field (x.val % c) (by linarith [Nat.mod_lt x.val c.pos, lt])
+  FieldUtils.natToField (x.val % c) (by linarith [Nat.mod_lt x.val c.pos, lt])
 
-def floordiv (x: F p) (c: ℕ+) : F p :=
-  FieldUtils.nat_to_field (x.val / c) (by linarith [Nat.div_le_self x.val c, less_than_p x])
+def floorDiv (x: F p) (c: ℕ+) : F p :=
+  FieldUtils.natToField (x.val / c) (by linarith [Nat.div_le_self x.val c, less_than_p x])
 
 theorem mod_lt {x : F p} {c: ℕ+} {lt : c < p} : (mod x c lt).val < c := by
-  rcases p with _ | p; cases p_neq_zero rfl
+  rcases p with _ | p; cases p_ne_zero rfl
   show (x.val % c) < c
   exact Nat.mod_lt x.val (by norm_num)
 
-theorem floordiv_lt {x : F p} {c: ℕ+} {d : ℕ} (h : x.val < c * d) : (floordiv x c).val < d := by
-  rcases p with _ | n; cases p_neq_zero rfl
+theorem floorDiv_lt {x : F p} {c: ℕ+} {d : ℕ} (h : x.val < c * d) : (floorDiv x c).val < d := by
+  rcases p with _ | n; cases p_ne_zero rfl
   exact Nat.div_lt_of_lt_mul h
 
-lemma val_mul_floordiv_self {x : F p} {c: ℕ+} (lt : c < p) : (c * (floordiv x c)).val = c * (x.val / c) := by
-  rcases p with _ | n; cases p_neq_zero rfl
+lemma val_mul_floorDiv_self {x : F p} {c: ℕ+} (lt : c < p) : (c * (floorDiv x c)).val = c * (x.val / c) := by
+  rcases p with _ | n; cases p_ne_zero rfl
   have : c * (x.val / c) ≤ x.val := Nat.mul_div_le (ZMod.val x) ↑c
   have h : x.val < n + 1 := x.is_lt
   rw [ZMod.val_mul, ZMod.val_cast_of_lt lt,
-    show ZMod.val (floordiv x c) = x.val / c by rfl, Nat.mod_eq_of_lt (by linarith)]
+    show ZMod.val (floorDiv x c) = x.val / c by rfl, Nat.mod_eq_of_lt (by linarith)]
 
-theorem mod_add_floordiv {x : F p} {c: ℕ+} (lt : c < p) :
-    mod x c lt + c * (floordiv x c) = x := by
-  rcases p with _ | n; cases p_neq_zero rfl
+theorem mod_add_floorDiv {x : F p} {c: ℕ+} (lt : c < p) :
+    mod x c lt + c * (floorDiv x c) = x := by
+  rcases p with _ | n; cases p_ne_zero rfl
   have h : x.val < n + 1 := x.is_lt
   apply ext
-  suffices x.val % c + (c * (floordiv x c)).val = x.val by
+  suffices x.val % c + (c * (floorDiv x c)).val = x.val by
     change (mod x c lt).val + _ = _ at this
     rwa [ZMod.val_add_of_lt]
     rwa [this]
-  rw [val_mul_floordiv_self lt, Nat.mod_add_div x.val c]
+  rw [val_mul_floorDiv_self lt, Nat.mod_add_div x.val c]
 
 theorem mul_val_of_dvd {x c : F p} :
     c.val ∣ (c * x).val → (c * x).val = c.val * x.val := by
@@ -155,8 +155,8 @@ theorem mul_val_of_dvd {x c : F p} :
     _ = 1 * x' := by ring
     _ ≤ c.val * x' := by apply Nat.mul_le_mul_right x' (Nat.succ_le_of_lt c_pos)
     _ < p := h_lt
-  let x'_f : F p := nat_to_field x' x'_lt
-  have x'_val_eq : x'_f.val = x' := nat_to_field_eq x'_f rfl
+  let x'_f : F p := natToField x' x'_lt
+  have x'_val_eq : x'_f.val = x' := natToField_eq x'_f rfl
   have cx_val_eq : (c * x'_f).val = c.val * x' := by
     rw [←x'_val_eq]
     apply ZMod.val_mul_of_lt
@@ -219,16 +219,16 @@ namespace ByteUtils
 open FieldUtils
 variable {p : ℕ} [p_prime: Fact p.Prime]
 
-def mod_256 (x: F p) [p_large_enough: Fact (p > 512)] : F p :=
+def mod256 (x: F p) [p_large_enough: Fact (p > 512)] : F p :=
   mod x 256 (by linarith [p_large_enough.elim])
 
-def floordiv_256 (x: F p) : F p := floordiv x 256
+def floorDiv256 (x: F p) : F p := floorDiv x 256
 
-theorem mod_256_lt [Fact (p > 512)] (x : F p) : (mod_256 x).val < 256 := mod_lt
+theorem mod256_lt [Fact (p > 512)] (x : F p) : (mod256 x).val < 256 := mod_lt
 
-theorem floordiv_256_bool [Fact (p > 512)] {x: F p} (h : x.val < 512) :
-  floordiv_256 x = 0 ∨ floordiv_256 x = 1 := by
-  rcases p with _ | n; cases p_neq_zero rfl
+theorem floorDiv256_bool [Fact (p > 512)] {x: F p} (h : x.val < 512) :
+  floorDiv256 x = 0 ∨ floorDiv256 x = 1 := by
+  rcases p with _ | n; cases p_ne_zero rfl
   let z := x.val / 256
   have : z < 2 := Nat.div_lt_of_lt_mul h
   -- show z = 0 ∨ z = 1
@@ -237,8 +237,8 @@ theorem floordiv_256_bool [Fact (p > 512)] {x: F p} (h : x.val < 512) :
   · right; apply ext; show z = ZMod.val 1; rw [h1, ZMod.val_one]
   · linarith -- contradiction
 
-theorem mod_add_div_256 [Fact (p > 512)] (x : F p) : x = mod_256 x + 256 * (floordiv_256 x) := by
-  rcases p with _ | n; cases p_neq_zero rfl
+theorem mod_add_div256 [Fact (p > 512)] (x : F p) : x = mod256 x + 256 * (floorDiv256 x) := by
+  rcases p with _ | n; cases p_ne_zero rfl
   let p := n + 1
   apply ext
   rw [ZMod.val_add, ZMod.val_mul]
@@ -247,22 +247,22 @@ theorem mod_add_div_256 [Fact (p > 512)] (x : F p) : x = mod_256 x + 256 * (floo
   show x.val = (x.val % 256 + 256 * (x.val / 256)) % p
   rw [Nat.mod_add_div, (Nat.mod_eq_of_lt x.is_lt : x.val % p = x.val)]
 
-def split_two_bytes (i : Fin (256 * 256)) : Fin 256 × Fin 256 :=
+def splitTwoBytes (i : Fin (256 * 256)) : Fin 256 × Fin 256 :=
   let x := i.val / 256
   let y := i.val % 256
   have x_lt : x < 256 := by simp [x, Nat.div_lt_iff_lt_mul]
   have y_lt : y < 256 := Nat.mod_lt i.val (by norm_num)
   (⟨ x, x_lt ⟩, ⟨ y, y_lt ⟩)
 
-def concat_two_bytes (x y : Fin 256) : Fin (256 * 256) :=
+def concatTwoBytes (x y : Fin 256) : Fin (256 * 256) :=
   let i := x.val * 256 + y.val
   have i_lt : i < 256 * 256 := by
     unfold i
     linarith [x.is_lt, y.is_lt]
   ⟨ i, i_lt ⟩
 
-theorem concat_split (x y : Fin 256) : split_two_bytes (concat_two_bytes x y) = (x, y) := by
-  dsimp [split_two_bytes, concat_two_bytes]
+theorem splitTwoBytes_concatTwoBytes (x y : Fin 256) : splitTwoBytes (concatTwoBytes x y) = (x, y) := by
+  dsimp [splitTwoBytes, concatTwoBytes]
   ext
   simp only
   rw [mul_comm]
@@ -292,23 +292,23 @@ theorem byte_plus_256_do_not_wrap (x: F p) [Fact (p > 512)]:
 section
 variable [p_large_enough: Fact (p > 512)]
 
-def from_byte (x: Fin 256) : F p :=
-  FieldUtils.nat_to_field x.val (by linarith [x.is_lt, p_large_enough.elim])
+def fromByte (x: Fin 256) : F p :=
+  FieldUtils.natToField x.val (by linarith [x.is_lt, p_large_enough.elim])
 
-lemma from_byte_lt (x: Fin 256) : (from_byte (p:=p) x).val < 256 := by
-  dsimp [from_byte]
-  rw [FieldUtils.val_of_nat_to_field_eq]
+lemma fromByte_lt (x: Fin 256) : (fromByte (p:=p) x).val < 256 := by
+  dsimp [fromByte]
+  rw [FieldUtils.val_of_natToField_eq]
   exact x.is_lt
 
-lemma from_byte_eq (x : F p) (x_lt : x.val < 256) : from_byte ⟨ x.val, x_lt ⟩ = x := by
-  dsimp [from_byte]
-  apply FieldUtils.nat_to_field_of_val_eq_iff
+lemma fromByte_eq (x : F p) (x_lt : x.val < 256) : fromByte ⟨ x.val, x_lt ⟩ = x := by
+  dsimp [fromByte]
+  apply FieldUtils.natToField_of_val_eq_iff
 
-lemma from_byte_cast_eq {z: F p} (z_lt : z.val < 256) : from_byte z.cast = z := by
-  simp only [from_byte]
+lemma fromByte_cast_eq {z: F p} (z_lt : z.val < 256) : fromByte z.cast = z := by
+  simp only [fromByte]
   have : (z.cast : Fin 256).val = z.val := ZMod.val_cast_eq_val_of_lt z_lt
   simp only [this]
-  apply FieldUtils.nat_to_field_of_val_eq_iff
+  apply FieldUtils.natToField_of_val_eq_iff
 
 end
 end ByteUtils

--- a/Clean/Utils/Primes.lean
+++ b/Clean/Utils/Primes.lean
@@ -1,16 +1,16 @@
 import Mathlib.Data.ZMod.Basic
 
-def p_1009 := 1009
-def p_babybear := 15 * 2^27 + 1
-def p_mersenne := 2^31 - 1
+def p1009 := 1009
+def pBabybear := 15 * 2^27 + 1
+def pMersenne := 2^31 - 1
 
-instance prime_1009 : Fact (p_1009.Prime) := by native_decide
-instance prime_babybear : Fact (p_babybear.Prime) := by native_decide
-instance prime_mersenne : Fact (p_mersenne.Prime) := by native_decide
+instance prime1009 : Fact (p1009.Prime) := by native_decide
+instance primeBabybear : Fact (pBabybear.Prime) := by native_decide
+instance primeMersenne : Fact (pMersenne.Prime) := by native_decide
 
-instance : Fact (p_babybear > 512) := by native_decide
-instance : Fact (p_babybear > 2^16 + 2^8) := by native_decide
-instance : Fact (p_mersenne > 512) := by native_decide
+instance : Fact (pBabybear > 512) := by native_decide
+instance : Fact (pBabybear > 2^16 + 2^8) := by native_decide
+instance : Fact (pMersenne > 512) := by native_decide
 
-instance : Fact (p_babybear > 2^16 + 2^8) := by native_decide
-instance : Fact (p_mersenne > 2^16 + 2^8) := by native_decide
+instance : Fact (pBabybear > 2^16 + 2^8) := by native_decide
+instance : Fact (pMersenne > 2^16 + 2^8) := by native_decide

--- a/Clean/Utils/Rotation.lean
+++ b/Clean/Utils/Rotation.lean
@@ -4,8 +4,8 @@ import Mathlib.Data.Nat.Bitwise
 import Clean.Utils.Bits
 
 namespace Utils.Rotation
-open Bitwise (rot_right64 rot_right32)
-open Bits (to_bits to_bits_injective)
+open Bitwise (rotRight64 rotRight32)
+open Bits (toBits toBits_injective)
 
 -- Theorems about 64-bit rotation
 
@@ -13,9 +13,9 @@ open Bits (to_bits to_bits_injective)
   Our definition of right rotation of a 64-bit integer is equal to
   the one provided by `BitVec.rotateRight`
 -/
-def rot_right64_eq_bv_rotate (x : ℕ) (h : x < 2^64) (offset : ℕ) :
-    rot_right64 x offset = (x.toUInt64.toBitVec.rotateRight offset).toNat := by
-  simp only [rot_right64]
+def rotRight64_eq_bv_rotate (x : ℕ) (h : x < 2^64) (offset : ℕ) :
+    rotRight64 x offset = (x.toUInt64.toBitVec.rotateRight offset).toNat := by
+  simp only [rotRight64]
   simp only [BitVec.toNat_rotateRight]
   simp only [Nat.shiftLeft_eq, Nat.mul_mod, dvd_refl, Nat.mod_mod_of_dvd]
   simp only [Nat.mod_mod, UInt64.toNat_toBitVec, UInt64.toNat_ofNat]
@@ -137,37 +137,37 @@ def rot_right64_eq_bv_rotate (x : ℕ) (h : x < 2^64) (offset : ℕ) :
     rw [h_eq3]
 
 /--
-  Alternative definition of rot_right64 using bitwise operations.
+  Alternative definition of rotRight64 using bitwise operations.
 -/
-lemma rot_right64_def (x : ℕ) (off : ℕ) (hx : x < 2^64) :
-    rot_right64 x off = x >>> (off % 64) ||| x <<< (64 - off % 64) % 2 ^ 64 := by
-  rw [rot_right64_eq_bv_rotate _ hx]
+lemma rotRight64_def (x : ℕ) (off : ℕ) (hx : x < 2^64) :
+    rotRight64 x off = x >>> (off % 64) ||| x <<< (64 - off % 64) % 2 ^ 64 := by
+  rw [rotRight64_eq_bv_rotate _ hx]
   simp only [Nat.toUInt64_eq, BitVec.toNat_rotateRight, UInt64.toNat_toBitVec, UInt64.toNat_ofNat']
   rw [show x % 2^64 = x by apply Nat.mod_eq_of_lt hx]
 
 /--
   The rotation operation is invariant when taking the offset modulo 64.
 -/
-lemma rot_right_64_off_mod_64 (x : ℕ) (off1 off2 : ℕ) (h : off1 = off2 % 64) :
-    rot_right64 x off1 = rot_right64 x off2 := by
-  simp only [rot_right64]
+lemma rotRight64_off_mod_64 (x : ℕ) (off1 off2 : ℕ) (h : off1 = off2 % 64) :
+    rotRight64 x off1 = rotRight64 x off2 := by
+  simp only [rotRight64]
   rw [←h]
   have h' : off2 % 64 < 64 := Nat.mod_lt off2 (by linarith)
   rw [←h] at h'
   rw [Nat.mod_eq_of_lt h']
 
-lemma rot_right64_fin (x : ℕ) (offset : Fin 64) :
-    rot_right64 x offset.val = x % (2^offset.val) * (2^(64 - offset.val)) + x / (2^offset.val) := by
-  simp only [rot_right64]
+lemma rotRight64_fin (x : ℕ) (offset : Fin 64) :
+    rotRight64 x offset.val = x % (2^offset.val) * (2^(64 - offset.val)) + x / (2^offset.val) := by
+  simp only [rotRight64]
   rw [Nat.mod_eq_of_lt offset.is_lt]
 
 /--
   Testing a bit of the result of a rotation in the range [0, r % 64) is equivalent to testing
   the bit of the original number in the range [i, r % 64 + i).
 -/
-lemma rot_right64_testBit_of_lt (x r i : ℕ) (h : x < 2^64) (hi : i < 64 - r % 64) :
-    (rot_right64 x r).testBit i = x.testBit (r % 64 + i) := by
-  rw [rot_right64_def _ _ h, Nat.testBit_or, Nat.testBit_shiftRight, Nat.testBit_mod_two_pow,
+lemma rotRight64_testBit_of_lt (x r i : ℕ) (h : x < 2^64) (hi : i < 64 - r % 64) :
+    (rotRight64 x r).testBit i = x.testBit (r % 64 + i) := by
+  rw [rotRight64_def _ _ h, Nat.testBit_or, Nat.testBit_shiftRight, Nat.testBit_mod_two_pow,
     Nat.testBit_shiftLeft]
   have h_i : 64 - r % 64 ≤ 64 := by apply Nat.sub_le
   have h_i' : i < 64 := by linarith
@@ -178,9 +178,9 @@ lemma rot_right64_testBit_of_lt (x r i : ℕ) (h : x < 2^64) (hi : i < 64 - r % 
   Testing a bit of the result of a rotation in the range [64 - r % 64, 64) is equivalent to
   testing the bit of the original number in the range [i - (64 - r % 64), i).
 -/
-lemma rot_right64_testBit_of_ge (x r i : ℕ) (h : x < 2^64) (hi : i ≥ 64 - r % 64) :
-    (rot_right64 x r).testBit i = (decide (i < 64) && x.testBit (i - (64 - r % 64))) := by
-  rw [rot_right64_def _ _ h, Nat.testBit_or, Nat.testBit_mod_two_pow]
+lemma rotRight64_testBit_of_ge (x r i : ℕ) (h : x < 2^64) (hi : i ≥ 64 - r % 64) :
+    (rotRight64 x r).testBit i = (decide (i < 64) && x.testBit (i - (64 - r % 64))) := by
+  rw [rotRight64_def _ _ h, Nat.testBit_or, Nat.testBit_mod_two_pow]
   suffices (x >>> (r % 64)).testBit i = false by
     simp [this]
     by_cases h : i < 64 <;> simp [h]; omega
@@ -193,37 +193,37 @@ lemma rot_right64_testBit_of_ge (x r i : ℕ) (h : x < 2^64) (hi : i ≥ 64 - r 
     omega
   linarith
 
-lemma rot_right64_testBit (x r i : ℕ) (h : x < 2^64) :
-    (rot_right64 x r).testBit i =
+lemma rotRight64_testBit (x r i : ℕ) (h : x < 2^64) :
+    (rotRight64 x r).testBit i =
     if i < 64 - r % 64 then
       x.testBit (r % 64 + i)
     else (decide (i < 64) && x.testBit (i - (64 - r % 64))) := by
 
   split
-  · rw [rot_right64_testBit_of_lt]
+  · rw [rotRight64_testBit_of_lt]
     repeat omega
-  · rw [rot_right64_testBit_of_ge]
+  · rw [rotRight64_testBit_of_ge]
     repeat omega
 
 
 /--
   The bits of the result of a rotation are the rotated bits of the input
 -/
-theorem rot_right64_to_bits (x r : ℕ) (h : x < 2^64):
-    to_bits 64 (rot_right64 x r) = (to_bits 64 x).rotate r := by
-  simp [to_bits, Vector.rotate]
+theorem rotRight64_toBits (x r : ℕ) (h : x < 2^64):
+    toBits 64 (rotRight64 x r) = (toBits 64 x).rotate r := by
+  simp [toBits, Vector.rotate]
   ext i hi
   · simp
   simp at ⊢ hi
-  rw [rot_right64_testBit]
+  rw [rotRight64_testBit]
   simp [List.getElem_rotate, hi]
   split <;> (congr; omega)
   linarith
 
 
-theorem rot_right64_lt (x r : ℕ) (h : x < 2^64) :
-    rot_right64 x r < 2^64 := by
-  rw [rot_right64_def _ _ h]
+theorem rotRight64_lt (x r : ℕ) (h : x < 2^64) :
+    rotRight64 x r < 2^64 := by
+  rw [rotRight64_def _ _ h]
   have := Nat.shiftRight_le x (r % 64)
   apply Nat.or_lt_two_pow <;> omega
 
@@ -231,24 +231,24 @@ theorem rot_right64_lt (x r : ℕ) (h : x < 2^64) :
   Rotating a 64-bit value by `n` bits and then by `m` bits is the same
   as rotating it by `n + m` bits.
 -/
-theorem rot_right64_composition (x n m : ℕ) (h : x < 2^64) :
-    rot_right64 (rot_right64 x n) m = rot_right64 x (n + m) := by
-  have h1 : (rot_right64 (rot_right64 x n) m) < 2^64 := by
-    repeat apply rot_right64_lt
+theorem rotRight64_composition (x n m : ℕ) (h : x < 2^64) :
+    rotRight64 (rotRight64 x n) m = rotRight64 x (n + m) := by
+  have h1 : (rotRight64 (rotRight64 x n) m) < 2^64 := by
+    repeat apply rotRight64_lt
     assumption
 
-  have h2 : (rot_right64 x (n + m)) < 2^64 := by
-    apply rot_right64_lt
+  have h2 : (rotRight64 x (n + m)) < 2^64 := by
+    apply rotRight64_lt
     assumption
 
   -- suffices to show equality over bits
-  suffices to_bits 64 (rot_right64 (rot_right64 x n) m) = to_bits 64 (rot_right64 x (n + m)) by
-    exact to_bits_injective 64 h1 h2 this
+  suffices toBits 64 (rotRight64 (rotRight64 x n) m) = toBits 64 (rotRight64 x (n + m)) by
+    exact toBits_injective 64 h1 h2 this
 
   -- rewrite rotation over bits
-  rw [rot_right64_to_bits _ _ h,
-    rot_right64_to_bits _ _ (by apply rot_right64_lt; assumption),
-    rot_right64_to_bits _ _ h]
+  rw [rotRight64_toBits _ _ h,
+    rotRight64_toBits _ _ (by apply rotRight64_lt; assumption),
+    rotRight64_toBits _ _ h]
 
   -- now this is easy, it is just rotation composition over vectors
   rw [Vector.rotate_rotate]
@@ -260,9 +260,9 @@ theorem rot_right64_composition (x n m : ℕ) (h : x < 2^64) :
   Our definition of right rotation of a 32-bit integer is equal to
   the one provided by `BitVec.rotateRight`
 -/
-def rot_right32_eq_bv_rotate (x : ℕ) (h : x < 2^32) (offset : ℕ) :
-    rot_right32 x offset = (x.toUInt32.toBitVec.rotateRight offset).toNat := by
-  simp only [rot_right32]
+def rotRight32_eq_bv_rotate (x : ℕ) (h : x < 2^32) (offset : ℕ) :
+    rotRight32 x offset = (x.toUInt32.toBitVec.rotateRight offset).toNat := by
+  simp only [rotRight32]
   simp only [BitVec.toNat_rotateRight]
   simp only [Nat.shiftLeft_eq, Nat.mul_mod, dvd_refl, Nat.mod_mod_of_dvd]
   simp only [Nat.mod_mod, UInt32.toNat_toBitVec, UInt32.toNat_ofNat]
@@ -384,37 +384,37 @@ def rot_right32_eq_bv_rotate (x : ℕ) (h : x < 2^32) (offset : ℕ) :
     rw [h_eq3]
 
 /--
-  Alternative definition of rot_right32 using bitwise operations.
+  Alternative definition of rotRight32 using bitwise operations.
 -/
-lemma rot_right32_def (x : ℕ) (off : ℕ) (hx : x < 2^32) :
-    rot_right32 x off = x >>> (off % 32) ||| x <<< (32 - off % 32) % 2 ^ 32 := by
-  rw [rot_right32_eq_bv_rotate _ hx]
+lemma rotRight32_def (x : ℕ) (off : ℕ) (hx : x < 2^32) :
+    rotRight32 x off = x >>> (off % 32) ||| x <<< (32 - off % 32) % 2 ^ 32 := by
+  rw [rotRight32_eq_bv_rotate _ hx]
   simp only [Nat.toUInt32_eq, BitVec.toNat_rotateRight, UInt32.toNat_toBitVec, UInt32.toNat_ofNat']
   rw [show x % 2^32 = x by apply Nat.mod_eq_of_lt hx]
 
 /--
   The rotation operation is invariant when taking the offset modulo 32.
 -/
-lemma rot_right_32_off_mod_32 (x : ℕ) (off1 off2 : ℕ) (h : off1 = off2 % 32) :
-    rot_right32 x off1 = rot_right32 x off2 := by
-  simp only [rot_right32]
+lemma rotRight32_off_mod_32 (x : ℕ) (off1 off2 : ℕ) (h : off1 = off2 % 32) :
+    rotRight32 x off1 = rotRight32 x off2 := by
+  simp only [rotRight32]
   rw [←h]
   have h' : off2 % 32 < 32 := Nat.mod_lt off2 (by linarith)
   rw [←h] at h'
   rw [Nat.mod_eq_of_lt h']
 
-lemma rot_right32_fin (x : ℕ) (offset : Fin 32) :
-    rot_right32 x offset.val = x % (2^offset.val) * (2^(32 - offset.val)) + x / (2^offset.val) := by
-  simp only [rot_right32]
+lemma rotRight32_fin (x : ℕ) (offset : Fin 32) :
+    rotRight32 x offset.val = x % (2^offset.val) * (2^(32 - offset.val)) + x / (2^offset.val) := by
+  simp only [rotRight32]
   rw [Nat.mod_eq_of_lt offset.is_lt]
 
 /--
   Testing a bit of the result of a rotation in the range [0, r % 32) is equivalent to testing
   the bit of the original number in the range [i, r % 32 + i).
 -/
-lemma rot_right32_testBit_of_lt (x r i : ℕ) (h : x < 2^32) (hi : i < 32 - r % 32) :
-    (rot_right32 x r).testBit i = x.testBit (r % 32 + i) := by
-  rw [rot_right32_def _ _ h, Nat.testBit_or, Nat.testBit_shiftRight, Nat.testBit_mod_two_pow,
+lemma rotRight32_testBit_of_lt (x r i : ℕ) (h : x < 2^32) (hi : i < 32 - r % 32) :
+    (rotRight32 x r).testBit i = x.testBit (r % 32 + i) := by
+  rw [rotRight32_def _ _ h, Nat.testBit_or, Nat.testBit_shiftRight, Nat.testBit_mod_two_pow,
     Nat.testBit_shiftLeft]
   have h_i : 32 - r % 32 ≤ 32 := by apply Nat.sub_le
   have h_i' : i < 32 := by linarith
@@ -425,9 +425,9 @@ lemma rot_right32_testBit_of_lt (x r i : ℕ) (h : x < 2^32) (hi : i < 32 - r % 
   Testing a bit of the result of a rotation in the range [32 - r % 32, 32) is equivalent to
   testing the bit of the original number in the range [i - (32 - r % 32), i).
 -/
-lemma rot_right32_testBit_of_ge (x r i : ℕ) (h : x < 2^32) (hi : i ≥ 32 - r % 32) :
-    (rot_right32 x r).testBit i = (decide (i < 32) && x.testBit (i - (32 - r % 32))) := by
-  rw [rot_right32_def _ _ h, Nat.testBit_or, Nat.testBit_mod_two_pow]
+lemma rotRight32_testBit_of_ge (x r i : ℕ) (h : x < 2^32) (hi : i ≥ 32 - r % 32) :
+    (rotRight32 x r).testBit i = (decide (i < 32) && x.testBit (i - (32 - r % 32))) := by
+  rw [rotRight32_def _ _ h, Nat.testBit_or, Nat.testBit_mod_two_pow]
   suffices (x >>> (r % 32)).testBit i = false by
     simp [this]
     by_cases h : i < 32 <;> simp [h]; omega
@@ -440,37 +440,37 @@ lemma rot_right32_testBit_of_ge (x r i : ℕ) (h : x < 2^32) (hi : i ≥ 32 - r 
     omega
   linarith
 
-lemma rot_right32_testBit (x r i : ℕ) (h : x < 2^32) :
-    (rot_right32 x r).testBit i =
+lemma rotRight32_testBit (x r i : ℕ) (h : x < 2^32) :
+    (rotRight32 x r).testBit i =
     if i < 32 - r % 32 then
       x.testBit (r % 32 + i)
     else (decide (i < 32) && x.testBit (i - (32 - r % 32))) := by
 
   split
-  · rw [rot_right32_testBit_of_lt]
+  · rw [rotRight32_testBit_of_lt]
     repeat omega
-  · rw [rot_right32_testBit_of_ge]
+  · rw [rotRight32_testBit_of_ge]
     repeat omega
 
 
 /--
   The bits of the result of a rotation are the rotated bits of the input
 -/
-theorem rot_right32_to_bits (x r : ℕ) (h : x < 2^32):
-    to_bits 32 (rot_right32 x r) = (to_bits 32 x).rotate r := by
-  simp [to_bits, Vector.rotate]
+theorem rotRight32_toBits (x r : ℕ) (h : x < 2^32):
+    toBits 32 (rotRight32 x r) = (toBits 32 x).rotate r := by
+  simp [toBits, Vector.rotate]
   ext i hi
   · simp
   simp at ⊢ hi
-  rw [rot_right32_testBit]
+  rw [rotRight32_testBit]
   simp [List.getElem_rotate, hi]
   split <;> (congr; omega)
   linarith
 
 
-theorem rot_right32_lt (x r : ℕ) (h : x < 2^32) :
-    rot_right32 x r < 2^32 := by
-  rw [rot_right32_def _ _ h]
+theorem rotRight32_lt (x r : ℕ) (h : x < 2^32) :
+    rotRight32 x r < 2^32 := by
+  rw [rotRight32_def _ _ h]
   have := Nat.shiftRight_le x (r % 32)
   apply Nat.or_lt_two_pow <;> omega
 
@@ -478,24 +478,24 @@ theorem rot_right32_lt (x r : ℕ) (h : x < 2^32) :
   Rotating a 32-bit value by `n` bits and then by `m` bits is the same
   as rotating it by `n + m` bits.
 -/
-theorem rot_right32_composition (x n m : ℕ) (h : x < 2^32) :
-    rot_right32 (rot_right32 x n) m = rot_right32 x (n + m) := by
-  have h1 : (rot_right32 (rot_right32 x n) m) < 2^32 := by
-    repeat apply rot_right32_lt
+theorem rotRight32_composition (x n m : ℕ) (h : x < 2^32) :
+    rotRight32 (rotRight32 x n) m = rotRight32 x (n + m) := by
+  have h1 : (rotRight32 (rotRight32 x n) m) < 2^32 := by
+    repeat apply rotRight32_lt
     assumption
 
-  have h2 : (rot_right32 x (n + m)) < 2^32 := by
-    apply rot_right32_lt
+  have h2 : (rotRight32 x (n + m)) < 2^32 := by
+    apply rotRight32_lt
     assumption
 
   -- suffices to show equality over bits
-  suffices to_bits 32 (rot_right32 (rot_right32 x n) m) = to_bits 32 (rot_right32 x (n + m)) by
-    exact to_bits_injective 32 h1 h2 this
+  suffices toBits 32 (rotRight32 (rotRight32 x n) m) = toBits 32 (rotRight32 x (n + m)) by
+    exact toBits_injective 32 h1 h2 this
 
   -- rewrite rotation over bits
-  rw [rot_right32_to_bits _ _ h,
-    rot_right32_to_bits _ _ (by apply rot_right32_lt; assumption),
-    rot_right32_to_bits _ _ h]
+  rw [rotRight32_toBits _ _ h,
+    rotRight32_toBits _ _ (by apply rotRight32_lt; assumption),
+    rotRight32_toBits _ _ h]
 
   -- now this is easy, it is just rotation composition over vectors
   rw [Vector.rotate_rotate]
@@ -510,7 +510,7 @@ lemma two_power_val {p : ℕ} {offset : Fin 8} [p_large_enough: Fact (p > 2^16 +
   have h : 2 ^ (8 - offset.val) % 256 < 256 := by apply Nat.mod_lt; linarith
   linarith [h, p_large_enough.elim]
 
-lemma mul_mod_256_off {offset : ℕ} (ho : offset < 8) (x i : ℕ) (h : i > 0):
+lemma mul_mod256_off {offset : ℕ} (ho : offset < 8) (x i : ℕ) (h : i > 0):
     (x * 256^i) % 2^offset = 0 := by
   rw [Nat.mul_mod, Nat.pow_mod]
   repeat (

--- a/Clean/Utils/Tactics.lean
+++ b/Clean/Utils/Tactics.lean
@@ -5,7 +5,7 @@ open Lean.Elab.Tactic
 open Lean.Meta
 
 
-partial def get_max_matching_hyp (e : Lean.Expr) : Lean.Elab.Tactic.TacticM (List Lean.Expr) := do
+partial def getMaxMatchingHyp (e : Lean.Expr) : Lean.Elab.Tactic.TacticM (List Lean.Expr) := do
   -- it suffices to reduce to whnf to look at the outer structure
   let e ← whnf e
   match e with
@@ -22,7 +22,7 @@ partial def get_max_matching_hyp (e : Lean.Expr) : Lean.Elab.Tactic.TacticM (Lis
     -- if we found one, keep it and recurse on the body
     match option_matching_expr with
     | some res => do
-      let other_hyps ← get_max_matching_hyp body
+      let other_hyps ← getMaxMatchingHyp body
       return [res] ++ other_hyps
     | none => do return []
   | _ => return []
@@ -37,7 +37,7 @@ partial def specializeAuto (e_term : Lean.Term): Lean.Elab.Tactic.TacticM Unit :
     let declType ← Lean.Meta.inferType localDecl.toExpr
 
     -- get the maximum number of matching hypotheses
-    let matching ← get_max_matching_hyp declType
+    let matching ← getMaxMatchingHyp declType
 
     -- construct an application expr `t e1 e2 ... en` where `t` is the term we want to specialize
     let h' := Lean.mkAppN e matching.toArray

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -78,7 +78,7 @@ structure ToPush (v : Vector α (n + 1)) where
   a : α
   eq : v = as.push a
 
-def to_push (v : Vector α (n + 1)) : ToPush v where
+def toPush (v : Vector α (n + 1)) : ToPush v where
   as := v.take n |>.cast Nat.min_add_right_self
   a := v[n]
   eq := by
@@ -97,7 +97,7 @@ def to_push (v : Vector α (n + 1)) : ToPush v where
 
 
 /- induction principle for Vector.push -/
-def induct_push {motive : {n: ℕ} → Vector α n → Sort u}
+def inductPush {motive : {n: ℕ} → Vector α n → Sort u}
   (nil: motive #v[])
   (push: ∀ {n: ℕ} (as: Vector α n) (a: α), motive as → motive (as.push a))
   {n: ℕ} (v: Vector α n) : motive v :=
@@ -106,52 +106,52 @@ def induct_push {motive : {n: ℕ} → Vector α n → Sort u}
     cast (by subst h; rfl) nil
   | ⟨ .mk (a::as), h ⟩ =>
     have hlen : as.length + 1 = n := by rw [←h, List.size_toArray, List.length_cons]
-    let ⟨ as', a', is_push ⟩ := to_push ⟨.mk (a :: as), rfl⟩
-    cast (by subst hlen; rw [is_push]) (push as' a' (induct_push nil push as'))
+    let ⟨ as', a', is_push ⟩ := toPush ⟨.mk (a :: as), rfl⟩
+    cast (by subst hlen; rw [is_push]) (push as' a' (inductPush nil push as'))
 
 theorem empty_push (x : α) : #v[].push x = #v[x] := by rfl
 
 theorem cons_push (x y : α) (xs : Vector α n) : (cons x xs).push y = cons x (xs.push y) := by rfl
 
-theorem induct_push_nil {motive : {n: ℕ} → Vector α n → Sort u}
+theorem inductPush_nil {motive : {n: ℕ} → Vector α n → Sort u}
   {nil: motive #v[]}
   {push: ∀ {n: ℕ} (as: Vector α n) (a: α), motive as → motive (as.push a)} :
-    induct_push nil push #v[] = nil := by simp only [induct_push]; rfl
+    inductPush nil push #v[] = nil := by simp only [inductPush]; rfl
 
-lemma induct_push_cons_push {motive : {n: ℕ} → Vector α n → Sort u}
+lemma inductPush_cons_push {motive : {n: ℕ} → Vector α n → Sort u}
   {nil: motive #v[]}
   {push': ∀ {n: ℕ} (as: Vector α n) (a: α), motive as → motive (as.push a)}
   {n: ℕ} (xs: Vector α n) (x a: α) :
-    induct_push nil push' (cons x (xs.push a)) = push' (cons x xs) a (induct_push nil push' (cons x xs)) := by
-  conv => lhs; simp only [cons, induct_push]
+    inductPush nil push' (cons x (xs.push a)) = push' (cons x xs) a (inductPush nil push' (cons x xs)) := by
+  conv => lhs; simp only [cons, inductPush]
   rw [cast_eq_iff_heq]
   have h_push_len : (xs.push a).toList.length = n + 1 := by simp
-  have h_to_push_cons : HEq (to_push ⟨.mk (x :: (xs.push a).toList), rfl⟩).as (cons x xs) := by
-    have : (to_push ⟨.mk (x :: (xs.push a).toList), rfl⟩).as = (cons x xs).cast h_push_len.symm := by
-      simp [cons, to_push, List.dropLast]
+  have h_to_push_cons : HEq (toPush ⟨.mk (x :: (xs.push a).toList), rfl⟩).as (cons x xs) := by
+    have : (toPush ⟨.mk (x :: (xs.push a).toList), rfl⟩).as = (cons x xs).cast h_push_len.symm := by
+      simp [cons, toPush, List.dropLast]
     rw [this]; apply cast_heq
   congr
-  · have : (to_push ⟨.mk (x :: (xs.push a).toList), rfl⟩).a = a := by
-      simp [cons, to_push]
+  · have : (toPush ⟨.mk (x :: (xs.push a).toList), rfl⟩).a = a := by
+      simp [cons, toPush]
     rw [this]
 
-theorem induct_push_push {motive : {n: ℕ} → Vector α n → Sort u}
+theorem inductPush_push {motive : {n: ℕ} → Vector α n → Sort u}
   {nil: motive #v[]}
   {push: ∀ {n: ℕ} (as: Vector α n) (a: α), motive as → motive (as.push a)}
   {n: ℕ} (as: Vector α n) (a: α) :
-    induct_push nil push (as.push a) = push as a (induct_push nil push as) := by
+    inductPush nil push (as.push a) = push as a (inductPush nil push as) := by
   induction as using Vector.induct
   case nil =>
-    suffices induct_push nil push #v[a] = push #v[] a (induct_push nil push #v[]) by congr
-    simp only [induct_push, List.length_nil, Nat.reduceAdd, to_push, take_eq_extract, extract_mk,
+    suffices inductPush nil push #v[a] = push #v[] a (inductPush nil push #v[]) by congr
+    simp only [inductPush, List.length_nil, Nat.reduceAdd, toPush, take_eq_extract, extract_mk,
       Nat.sub_zero, cast_mk, getElem_mk, id_eq, Int.reduceNeg,
       Int.reduceAdd, Int.reduceSub, List.getElem_toArray, List.length_cons, eq_mp_eq_cast, cast_eq,
       List.getElem_cons_zero, push_mk, eq_mpr_eq_cast]
     congr
-    exact induct_push_nil
+    exact inductPush_nil
   case cons x xs ih =>
     simp only [cons_push]
-    rw [induct_push_cons_push]
+    rw [inductPush_cons_push]
 
 theorem getElemFin_finRange {n} (i : Fin n) : (finRange n)[i] = i := by
   simp only [Fin.getElem_fin, getElem_finRange, Fin.eta]


### PR DESCRIPTION
## Summary
- rename definitions in `Clean/Utils` to follow mathlib naming conventions
- update all usages across the codebase
- keep examples compiling after rename

References #130

------
https://chatgpt.com/codex/tasks/task_e_685bdcd83764832387bdacd717bd41a8