### PR TITLE
[Codex] apply naming convention updates

### DIFF
--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -67,7 +67,7 @@ lemma tail_len : (trace : Trace F S) → trace.tail.len = trace.len - 1
   | rest +> _ => by rw [tail, len, Nat.succ_sub_one]
 
 @[table_norm]
-def forAllRowsOfTraceWithIndex
+def ForAllRowsOfTraceWithIndex
     (trace : Trace F S) (prop : Row F S → ℕ → Prop) : Prop :=
   inner trace prop
   where
@@ -77,9 +77,9 @@ def forAllRowsOfTraceWithIndex
     | rest +> row, prop => (prop row rest.len) ∧ inner rest prop
 
 /-- variant where the condition receives the entire previous trace instead of just the length -/
-def forAllRowsWithPrevious  : Trace F S → (Row F S → Trace F S → Prop) → Prop
+def ForAllRowsWithPrevious  : Trace F S → (Row F S → Trace F S → Prop) → Prop
   | <+>, _ => true
-  | rest +> row, prop => (prop row rest) ∧ forAllRowsWithPrevious rest prop
+  | rest +> row, prop => (prop row rest) ∧ ForAllRowsWithPrevious rest prop
 
 def toList : Trace F S → List (Row F S)
   | <+> => []
@@ -124,7 +124,7 @@ def tail {M : ℕ} (trace : TraceOfLength F S M) : TraceOfLength F S (M - 1) :=
   Apply a proposition to every row in the trace
 -/
 @[table_norm]
-def forAllRowsOfTrace {N : ℕ}
+def ForAllRowsOfTrace {N : ℕ}
     (trace : TraceOfLength F S N) (prop : Row F S → Prop) : Prop :=
   inner trace.val prop
   where
@@ -137,7 +137,7 @@ def forAllRowsOfTrace {N : ℕ}
   Apply a proposition to every row in the trace except the last one
 -/
 @[table_norm]
-def forAllRowsOfTraceExceptLast {N : ℕ}
+def ForAllRowsOfTraceExceptLast {N : ℕ}
     (trace : TraceOfLength F S N) (prop : Row F S → Prop) : Prop :=
   inner trace.val prop
   where
@@ -150,13 +150,13 @@ def forAllRowsOfTraceExceptLast {N : ℕ}
   Apply a proposition, which could be dependent on the row index, to every row of the trace
 -/
 @[table_norm]
-def forAllRowsOfTraceWithIndex {N : ℕ}
+def ForAllRowsOfTraceWithIndex {N : ℕ}
     (trace : TraceOfLength F S N) (prop : Row F S → ℕ → Prop) : Prop :=
-  trace.val.forAllRowsOfTraceWithIndex prop
+  trace.val.ForAllRowsOfTraceWithIndex prop
 
-def forAllRowsWithPrevious {N : ℕ}
+def ForAllRowsWithPrevious {N : ℕ}
     (trace : TraceOfLength F S N) (prop : Row F S → (i : ℕ) → TraceOfLength F S i → Prop) : Prop :=
-  trace.val.forAllRowsWithPrevious fun row rest => prop row rest.len ⟨ rest, rfl ⟩
+  trace.val.ForAllRowsWithPrevious fun row rest => prop row rest.len ⟨ rest, rfl ⟩
 
 def toList {N : ℕ} (trace : TraceOfLength F S N) : List.Vector (Row F S) N :=
   ⟨ trace.val.toList, by rw [trace.val.toList_length, trace.prop] ⟩
@@ -237,25 +237,25 @@ def empty (W: ℕ+) : CellAssignment W S where
   vars := #v[]
 
 @[table_assignment_norm]
-def push_var_aux (assignment: CellAssignment W S) : CellAssignment W S where
+def pushVarAux (assignment: CellAssignment W S) : CellAssignment W S where
   offset := assignment.offset + 1
   aux_length := assignment.aux_length + 1
   vars := assignment.vars.push (.aux assignment.aux_length)
 
 @[table_assignment_norm]
-def push_vars_aux (assignment: CellAssignment W S) (n : ℕ) : CellAssignment W S where
+def pushVarsAux (assignment: CellAssignment W S) (n : ℕ) : CellAssignment W S where
   offset := assignment.offset + n
   aux_length := assignment.aux_length + n
   vars := assignment.vars ++ (.mapRange n fun i => .aux (assignment.aux_length + i) : Vector (Cell W S) n)
 
 @[table_assignment_norm]
-def push_var_input (assignment: CellAssignment W S) (off: CellOffset W S) : CellAssignment W S where
+def pushVarInput (assignment: CellAssignment W S) (off: CellOffset W S) : CellAssignment W S where
   offset := assignment.offset + 1
   aux_length := assignment.aux_length
   vars := assignment.vars.push (.input off)
 
 @[table_assignment_norm]
-def push_row (assignment: CellAssignment W S) (row: Fin W) : CellAssignment W S :=
+def pushRow (assignment: CellAssignment W S) (row: Fin W) : CellAssignment W S :=
   let row_vars : Vector (Cell W S) (size S) := .mapFinRange _ fun col => .input ⟨ row, col ⟩
   {
     offset := assignment.offset + size S
@@ -264,7 +264,7 @@ def push_row (assignment: CellAssignment W S) (row: Fin W) : CellAssignment W S 
   }
 
 @[table_assignment_norm]
-def set_var_input (assignment: CellAssignment W S) (off: CellOffset W S) (var: ℕ) : CellAssignment W S :=
+def setVarInput (assignment: CellAssignment W S) (off: CellOffset W S) (var: ℕ) : CellAssignment W S :=
   let vars := assignment.vars.set? var (.input off)
   -- note that we don't change the `aux_length` and the indices of existing aux variables.
   -- that would unnecessarily complicate reasoning about the assignment
@@ -273,7 +273,7 @@ def set_var_input (assignment: CellAssignment W S) (off: CellOffset W S) (var: �
 /--
   The number of auxiliary cells in the final assignment
 -/
-def num_aux (assignment: CellAssignment W S) : ℕ :=
+def numAux (assignment: CellAssignment W S) : ℕ :=
   assignment.vars.foldl (fun acc cell =>
     match cell with
     | .input _ => acc
@@ -317,15 +317,15 @@ instance [Repr F] : Repr (TableConstraint W S F α) where
   reprPrec table _ := reprStr (table .empty).2
 
 @[table_assignment_norm]
-def assignment_from_circuit (as: CellAssignment W S) : Operations F → CellAssignment W S
+def assignmentFromCircuit (as: CellAssignment W S) : Operations F → CellAssignment W S
   | [] => as
-  | .witness m _ :: ops => assignment_from_circuit (as.push_vars_aux m) ops
-  | .assert _ :: ops => assignment_from_circuit as ops
-  | .lookup _ :: ops => assignment_from_circuit as ops
-  | .subcircuit s :: ops => assignment_from_circuit (as.push_vars_aux s.localLength) ops
+  | .witness m _ :: ops => assignmentFromCircuit (as.pushVarsAux m) ops
+  | .assert _ :: ops => assignmentFromCircuit as ops
+  | .lookup _ :: ops => assignmentFromCircuit as ops
+  | .subcircuit s :: ops => assignmentFromCircuit (as.pushVarsAux s.localLength) ops
 
--- alternative, simpler definition, but makes it harder for lean to check defeq `(window_env ..).get i = ..`
-def assignment_from_circuit' (as: CellAssignment W S) (ops : Operations F) : CellAssignment W S where
+-- alternative, simpler definition, but makes it harder for lean to check defeq `(windowEnv ..).get i = ..`
+def assignmentFromCircuit' (as: CellAssignment W S) (ops : Operations F) : CellAssignment W S where
   offset := as.offset + ops.localLength
   aux_length := as.aux_length + ops.localLength
   vars := as.vars ++ (.mapRange _ fun i => .aux (as.aux_length + i) : Vector (Cell W S) _)
@@ -340,12 +340,12 @@ instance : MonadLift (Circuit F) (TableConstraint W S F) where
     let (a, ops) := circuit ctx.circuit.localLength
     (a, {
       circuit := ctx.circuit ++ ops,
-      assignment := assignment_from_circuit ctx.assignment ops
+      assignment := assignmentFromCircuit ctx.assignment ops
     })
 
 namespace TableConstraint
 @[reducible, table_norm, table_assignment_norm]
-def final_offset (table : TableConstraint W S F α) : ℕ :=
+def finalOffset (table : TableConstraint W S F α) : ℕ :=
   table .empty |>.snd.circuit.localLength
 
 @[table_norm]
@@ -353,18 +353,18 @@ def operations (table : TableConstraint W S F α) : Operations F :=
   table .empty |>.snd.circuit
 
 @[table_assignment_norm]
-def final_assignment (table : TableConstraint W S F α) : CellAssignment W S :=
+def finalAssignment (table : TableConstraint W S F α) : CellAssignment W S :=
   table .empty |>.snd.assignment
 
 @[table_assignment_norm]
-def offset_consistent (table : TableConstraint W S F α) : Prop :=
-  table.final_offset = table.final_assignment.offset
+def OffsetConsistent (table : TableConstraint W S F α) : Prop :=
+  table.finalOffset = table.finalAssignment.offset
 
 -- construct an env by taking the result of the assignment function for input/output cells,
 -- and allowing arbitrary values for aux cells and invalid variables
-def window_env (table : TableConstraint W S F Unit)
+def windowEnv (table : TableConstraint W S F Unit)
   (window: TraceOfLength F S W) (aux_env : Environment F) : Environment F :=
-  let assignment := table.final_assignment
+  let assignment := table.finalAssignment
   .mk fun i =>
     if hi : i < assignment.offset then
       match assignment.vars[i] with
@@ -378,9 +378,9 @@ def window_env (table : TableConstraint W S F Unit)
   so that every variable evaluate to the trace cell value which is assigned to
 -/
 @[table_norm]
-def constraintsHold_on_window (table : TableConstraint W S F Unit)
+def ConstraintsHoldOnWindow (table : TableConstraint W S F Unit)
   (window: TraceOfLength F S W) (aux_env : Environment F) : Prop :=
-  let env := window_env table window aux_env
+  let env := windowEnv table window aux_env
   Circuit.ConstraintsHold.Soundness env table.operations
 
 @[table_norm]
@@ -391,11 +391,11 @@ def output {α: Type} (table : TableConstraint W S F α) : α :=
   Get a fresh variable for each cell in a given row
 -/
 @[table_norm, table_assignment_norm]
-def get_row (row : Fin W) : TableConstraint W S F (Var S F) :=
+def getRow (row : Fin W) : TableConstraint W S F (Var S F) :=
   modifyGet fun ctx =>
     let ctx' : TableContext W S F := {
       circuit := ctx.circuit ++ [.witness (size S) fun env => .mapRange _ fun i => env.get (ctx.offset + i)],
-      assignment := ctx.assignment.push_row row
+      assignment := ctx.assignment.pushRow row
     }
     (varFromOffset S ctx.offset, ctx')
 
@@ -403,44 +403,44 @@ def get_row (row : Fin W) : TableConstraint W S F (Var S F) :=
   Get a fresh variable for each cell in the current row
 -/
 @[table_norm, table_assignment_norm]
-def get_curr_row : TableConstraint W S F (Var S F) := get_row 0
+def getCurrRow : TableConstraint W S F (Var S F) := getRow 0
 
 /--
   Get a fresh variable for each cell in the next row
 -/
 @[table_norm, table_assignment_norm]
-def get_next_row : TableConstraint W S F (Var S F) := get_row 1
+def getNextRow : TableConstraint W S F (Var S F) := getRow 1
 
 @[table_norm, table_assignment_norm]
-def assign_var (off : CellOffset W S) (v : Variable F) : TableConstraint W S F Unit :=
+def assignVar (off : CellOffset W S) (v : Variable F) : TableConstraint W S F Unit :=
   modify fun ctx =>
-    let assignment := ctx.assignment.set_var_input off v.index
+    let assignment := ctx.assignment.setVarInput off v.index
     { ctx with assignment }
 
 @[table_norm, table_assignment_norm]
 def assign (off : CellOffset W S) : Expression F → TableConstraint W S F Unit
   -- a variable is assigned directly
-  | .var v => assign_var off v
+  | .var v => assignVar off v
   -- a composed expression or constant is first stored in a new variable, which is assigned
   | x => do
     let new_var ← witnessVar x.eval
     assertZero (x - var new_var)
-    assign_var off new_var
+    assignVar off new_var
 
 @[table_norm, table_assignment_norm]
-def assign_curr_row {W: ℕ+} (curr : Var S F) : TableConstraint W S F Unit :=
+def assignCurrRow {W: ℕ+} (curr : Var S F) : TableConstraint W S F Unit :=
   let vars := toVars curr
   forM (List.finRange (size S)) fun i =>
     assign (.curr i) (vars.get i)
 
 @[table_norm, table_assignment_norm]
-def assign_next_row {W: ℕ+} (next : Var S F) : TableConstraint W S F Unit :=
+def assignNextRow {W: ℕ+} (next : Var S F) : TableConstraint W S F Unit :=
   let vars := toVars next
   forM (List.finRange (size S)) fun i =>
     assign (.next i) (vars.get i)
 end TableConstraint
 
-export TableConstraint (window_env get_curr_row get_next_row assign_var assign assign_next_row assign_curr_row)
+export TableConstraint (windowEnv getCurrRow getNextRow assignVar assign assignNextRow assignCurrRow)
 
 @[reducible]
 def SingleRowConstraint (S : Type → Type) (F : Type) [Field F] [ProvableType S] := TableConstraint 1 S F Unit
@@ -457,13 +457,13 @@ inductive TableOperation (S : Type → Type) (F : Type) [Field F] [ProvableType 
   /--
     A `Boundary` constraint is a constraint that is applied only to a specific row
   -/
-  | Boundary: RowIndex → SingleRowConstraint S F → TableOperation S F
+  | boundary: RowIndex → SingleRowConstraint S F → TableOperation S F
 
   /--
     An `EveryRow` constraint is a constraint that is applied to every row.
     It can only reference cells on the same row
   -/
-  | EveryRow: SingleRowConstraint S F → TableOperation S F
+  | everyRow: SingleRowConstraint S F → TableOperation S F
 
   /--
     An `EveryRowExceptLast` constraint is a constraint that is applied to every row except the last.
@@ -471,7 +471,7 @@ inductive TableOperation (S : Type → Type) (F : Type) [Field F] [ProvableType 
 
     Note that this will not apply any constraints to a trace of length one.
   -/
-  | EveryRowExceptLast: TwoRowsConstraint S F → TableOperation S F
+  | everyRowExceptLast: TwoRowsConstraint S F → TableOperation S F
 
 instance : Repr RowIndex where
   reprPrec
@@ -480,11 +480,11 @@ instance : Repr RowIndex where
 
 instance [Repr F] : Repr (TableOperation S F) where
   reprPrec op _ := match op with
-    | .Boundary i c => "Boundary " ++ reprStr i ++ " " ++ reprStr c
-    | .EveryRow c => "EveryRow " ++ reprStr c
-    | .EveryRowExceptLast c => "EveryRowExceptLast " ++ reprStr c
+    | .boundary i c => "boundary " ++ reprStr i ++ " " ++ reprStr c
+    | .everyRow c => "everyRow " ++ reprStr c
+    | .everyRowExceptLast c => "everyRowExceptLast " ++ reprStr c
 
-export TableOperation (Boundary EveryRow EveryRowExceptLast)
+export TableOperation (boundary everyRow everyRowExceptLast)
 
 /--
   The constraints hold over a trace if the hold individually in a suitable environment, where the
@@ -492,7 +492,7 @@ export TableOperation (Boundary EveryRow EveryRowExceptLast)
   is assigned to a field element in the trace `y: F` using a `CellAssignment` function, then ` env x = y`
 -/
 @[table_norm]
-def table_constraintsHold {N : ℕ} (constraints : List (TableOperation S F))
+def TableConstraintsHold {N : ℕ} (constraints : List (TableOperation S F))
   (trace: TraceOfLength F S N) (env: ℕ → ℕ → Environment F) : Prop :=
   let constraints_and_envs := constraints.mapIdx (fun i cs => (cs, env i))
   foldl N constraints_and_envs trace.val constraints_and_envs
@@ -518,29 +518,29 @@ def table_constraintsHold {N : ℕ} (constraints : List (TableOperation S F))
   foldl (N : ℕ) (cs : List (TableOperation S F × (ℕ → (Environment F)))) :
     Trace F S → (cs_iterator: List (TableOperation S F × (ℕ → (Environment F)))) → Prop
     -- if the trace has at least two rows and the constraint is a "every row except last" constraint, we apply the constraint
-    | trace +> curr +> next, (⟨.EveryRowExceptLast constraint, env⟩)::rest =>
+    | trace +> curr +> next, (⟨.everyRowExceptLast constraint, env⟩)::rest =>
         let others := foldl N cs (trace +> curr +> next) rest
         let window : TraceOfLength F S 2 := ⟨<+> +> curr +> next, rfl ⟩
-        constraint.constraintsHold_on_window window (env (trace.len + 1)) ∧ others
+        constraint.ConstraintsHoldOnWindow window (env (trace.len + 1)) ∧ others
 
     -- if the trace has at least one row and the constraint is a boundary constraint, we apply the constraint if the
     -- index is the same as the length of the remaining trace
-    | trace +> row, (⟨.Boundary idx constraint, env⟩)::rest =>
+    | trace +> row, (⟨.boundary idx constraint, env⟩)::rest =>
         let others := foldl N cs (trace +> row) rest
         let window : TraceOfLength F S 1 := ⟨<+> +> row, rfl⟩
         let targetIdx := match idx with
           | .fromStart i => i
           | .fromEnd i => N - 1 - i
-        (if trace.len = targetIdx then constraint.constraintsHold_on_window window (env trace.len) else True) ∧ others
+        (if trace.len = targetIdx then constraint.ConstraintsHoldOnWindow window (env trace.len) else True) ∧ others
 
     -- if the trace has at least one row and the constraint is a "every row" constraint, we apply the constraint
-    | trace +> row, (⟨.EveryRow constraint, env⟩)::rest =>
+    | trace +> row, (⟨.everyRow constraint, env⟩)::rest =>
         let others := foldl N cs (trace +> row) rest
         let window : TraceOfLength F S 1 := ⟨<+> +> row, rfl⟩
-        constraint.constraintsHold_on_window window (env trace.len) ∧ others
+        constraint.ConstraintsHoldOnWindow window (env trace.len) ∧ others
 
     -- if the trace has not enough rows for the "every row except last" constraint, we skip the constraint
-    | trace, (⟨.EveryRowExceptLast _, _⟩)::rest =>
+    | trace, (⟨.everyRowExceptLast _, _⟩)::rest =>
         foldl N cs trace rest
 
     -- if the cs_iterator is empty, we start again with the initial constraints on the next row
@@ -566,7 +566,7 @@ structure FormalTable (F : Type) [Field F] (S : Type → Type) [ProvableType S] 
   soundness :
     ∀ (N : ℕ) (trace: TraceOfLength F S N) (env: ℕ → ℕ → Environment F),
     assumption N →
-    table_constraintsHold constraints trace env →
+    TableConstraintsHold constraints trace env →
     spec trace
 
   /-- this property tells us that that the number of variables contained in the `assignment` of each
@@ -574,9 +574,9 @@ structure FormalTable (F : Type) [Field F] (S : Type → Type) [ProvableType S] 
   offset_consistent :
     constraints.Forall fun cs =>
       match cs with
-      | .Boundary _ constraint => constraint.offset_consistent
-      | .EveryRow constraint => constraint.offset_consistent
-      | .EveryRowExceptLast constraint => constraint.offset_consistent
+      | .boundary _ constraint => constraint.OffsetConsistent
+      | .everyRow constraint => constraint.OffsetConsistent
+      | .everyRowExceptLast constraint => constraint.OffsetConsistent
     := by repeat constructor
 
 def FormalTable.statement (table : FormalTable F S) (N : ℕ) (trace: TraceOfLength F S N) : Prop :=
@@ -596,11 +596,11 @@ attribute [table_norm, table_assignment_norm] modify modifyGet MonadStateOf.modi
 
 -- simp lemma to simplify updated circuit after an assignment
 @[table_norm, table_assignment_norm]
-theorem TableConstraint.assign_var_circuit : ∀ ctx (off : CellOffset W S) (v : Variable F),
-  (assign_var off v ctx).snd.circuit = ctx.circuit := by intros; rfl
+theorem TableConstraint.assignVar_circuit : ∀ ctx (off : CellOffset W S) (v : Variable F),
+  (assignVar off v ctx).snd.circuit = ctx.circuit := by intros; rfl
 
 /--
-Tactic script to unfold `assign_curr_row` and `assign_next_row` in a `TableConstraint`.
+Tactic script to unfold `assignCurrRow` and `assignNextRow` in a `TableConstraint`.
 
 TODO this is fairly useless without support for `at h` syntax
 -/
@@ -608,7 +608,7 @@ syntax "simp_assign_row" : tactic
 macro_rules
   | `(tactic|simp_assign_row) =>
     `(tactic|(
-    simp only [assign_curr_row, assign_next_row, size]
+    simp only [assignCurrRow, assignNextRow, size]
     rw [List.finRange, List.ofFn]
     repeat rw [Fin.foldr_succ]
     rw [Fin.foldr_zero]

--- a/Clean/Table/Inductive.lean
+++ b/Clean/Table/Inductive.lean
@@ -74,21 +74,21 @@ for any given public `input` and `ouput`.
 -/
 
 def inductiveConstraint (table : InductiveTable F State Input) : TableConstraint 2 (ProvablePair State Input) F Unit := do
-  let (acc, x) ← get_curr_row
+  let (acc, x) ← getCurrRow
   let output ← table.step acc x
-  let (output', _) ← get_next_row
+  let (output', _) ← getNextRow
   -- TODO make this more efficient by assigning variables as long as they don't come from the input
   output' === output
 
 def equalityConstraint (Input : TypeMap) [ProvableType Input] (target : State F) : SingleRowConstraint (ProvablePair State Input) F := do
-  let (actual, _) ← get_curr_row
+  let (actual, _) ← getCurrRow
   actual === (const target)
 
 def tableConstraints (table : InductiveTable F State Input) (input_state output_state: State F) :
   List (TableOperation (ProvablePair State Input) F) := [
-    .EveryRowExceptLast table.inductiveConstraint,
-    .Boundary (.fromStart 0) (equalityConstraint Input input_state),
-    .Boundary (.fromEnd 0) (equalityConstraint Input output_state),
+    .everyRowExceptLast table.inductiveConstraint,
+    .boundary (.fromStart 0) (equalityConstraint Input input_state),
+    .boundary (.fromEnd 0) (equalityConstraint Input output_state),
   ]
 
 theorem equalityConstraint.soundness {row : State F × Input F} {input_state : State F} {env : Environment F} :
@@ -120,19 +120,19 @@ lemma traceInputs_length {N : ℕ} (trace : TraceOfLength F (ProvablePair State 
     (traceInputs trace).length = N := by
   rw [traceInputs, List.length_map, trace.val.toList_length, trace.prop]
 
-lemma tableSoundnessAux (table : InductiveTable F State Input) (input output: State F)
+lemma table_soundness_aux (table : InductiveTable F State Input) (input output: State F)
   (N : ℕ+) (trace: TraceOfLength F (ProvablePair State Input) N) (env: ℕ → ℕ → Environment F) :
   table.spec 0 input [] rfl →
-  table_constraintsHold (table.tableConstraints input output) trace env →
-    trace.forAllRowsWithPrevious (fun row i rest => table.spec i row.1 (traceInputs rest) (traceInputs_length rest))
+  TableConstraintsHold (table.tableConstraints input output) trace env →
+    trace.ForAllRowsWithPrevious (fun row i rest => table.spec i row.1 (traceInputs rest) (traceInputs_length rest))
     ∧ trace.lastRow.1 = output := by
   intro input_spec
 
   -- add a condition on the trace length to the goal,
   -- so that we can change the induction to not depend on `N` (which would make it unprovable)
   rcases trace with ⟨ trace, h_trace ⟩
-  suffices goal : table_constraintsHold (table.tableConstraints input output) ⟨ trace, h_trace ⟩ env →
-    trace.forAllRowsWithPrevious (fun row rest => table.spec rest.len row.1 (traceInputs ⟨ rest, rfl ⟩) (traceInputs_length ⟨ rest, rfl ⟩)) ∧
+  suffices goal : TableConstraintsHold (table.tableConstraints input output) ⟨ trace, h_trace ⟩ env →
+    trace.ForAllRowsWithPrevious (fun row rest => table.spec rest.len row.1 (traceInputs ⟨ rest, rfl ⟩) (traceInputs_length ⟨ rest, rfl ⟩)) ∧
     (∀ (h_len : trace.len = N), (trace.lastRow (by rw [h_len]; exact N.pos)).1 = output) by
       intro constraints
       specialize goal constraints
@@ -144,7 +144,7 @@ lemma tableSoundnessAux (table : InductiveTable F State Input) (input output: St
 
   case zero =>
     intro constraints
-    simp only [Trace.forAllRowsWithPrevious, true_and]
+    simp only [Trace.ForAllRowsWithPrevious, true_and]
     intros
     nomatch N
 
@@ -155,7 +155,7 @@ lemma tableSoundnessAux (table : InductiveTable F State Input) (input output: St
       List.length_cons, zero_add, List.cons_append, reduceIte, and_true] at constraints
     obtain ⟨ input_eq, output_eq ⟩ := constraints
     rw [equalityConstraint.soundness] at input_eq output_eq
-    simp only [table_norm, and_true, Trace.lastRow, Trace.forAllRowsWithPrevious]
+    simp only [table_norm, and_true, Trace.lastRow, Trace.ForAllRowsWithPrevious]
     constructor
     · rw [input_eq]
       exact input_spec
@@ -169,7 +169,7 @@ lemma tableSoundnessAux (table : InductiveTable F State Input) (input output: St
     simp only [table_norm, tableConstraints, List.size_toArray, List.length_nil, List.push_toArray,
       List.nil_append, List.length_cons, zero_add, List.cons_append, Nat.add_eq_zero, one_ne_zero,
       and_false, reduceIte, PNat.mk_coe, Nat.add_one_sub_one, tsub_zero, Nat.add_left_inj,
-      Nat.reduceAdd, true_and, Trace.forAllRowsWithPrevious] at constraints ih1 ih2 ⊢
+      Nat.reduceAdd, true_and, Trace.ForAllRowsWithPrevious] at constraints ih1 ih2 ⊢
     rcases constraints with ⟨ constraints, output_eq, h_rest ⟩
     specialize ih2 h_rest
     have spec_previous : table.spec rest.len curr.1 (traceInputs ⟨rest, rfl⟩) (traceInputs_length ⟨rest, rfl⟩) := by
@@ -270,12 +270,12 @@ lemma tableSoundnessAux (table : InductiveTable F State Input) (input output: St
     simp only [add_tsub_cancel_right, Nat.add_left_inj, reduceIte] at output_eq
     exact output_eq
 
-theorem tableSoundness (table : InductiveTable F State Input) (input output: State F)
+theorem table_soundness (table : InductiveTable F State Input) (input output: State F)
   (N : ℕ+) (trace: TraceOfLength F (ProvablePair State Input) N) (env: ℕ → ℕ → Environment F) :
-  table.spec 0 input [] rfl → table_constraintsHold (table.tableConstraints input output) trace env →
+  table.spec 0 input [] rfl → TableConstraintsHold (table.tableConstraints input output) trace env →
     table.spec (N-1) output (traceInputs trace.tail) (traceInputs_length trace.tail) := by
   intro h_input h_constraints
-  have ⟨ h_spec, h_output ⟩ := table.tableSoundnessAux input output N trace env h_input h_constraints
+  have ⟨ h_spec, h_output ⟩ := table.table_soundness_aux input output N trace env h_input h_constraints
   rw [←h_output]
   exact TraceOfLength.lastRow_of_forAllWithPrevious trace h_spec
 
@@ -285,7 +285,7 @@ def toFormal (table : InductiveTable F State Input) (input output: State F) : Fo
   spec {N} trace := table.spec (N-1) output (traceInputs trace.tail) (traceInputs_length trace.tail)
 
   soundness N trace env assumption constraints :=
-    table.tableSoundness input output ⟨N, assumption.left⟩ trace env assumption.right constraints
+    table.table_soundness input output ⟨N, assumption.left⟩ trace env assumption.right constraints
 
   offset_consistent := by
     simp +arith [List.Forall, tableConstraints, inductiveConstraint, equalityConstraint,

--- a/Clean/Table/Json.lean
+++ b/Clean/Table/Json.lean
@@ -19,7 +19,7 @@ instance : ToJson (Cell W S) where
 
 instance : ToJson (CellAssignment W S) where
   toJson assignment :=
-    let aux_map := build_aux_map assignment
+    let aux_map := buildAuxMap assignment
     -- iterate over the vars and convert aux cell to input cell with column from aux_map
     let vars := assignment.vars.mapIdx fun idx cell =>
       match cell with
@@ -28,7 +28,7 @@ instance : ToJson (CellAssignment W S) where
         let col := aux_map[idx]!
         if h: col < (size S)
           then Cell.input { row := 1, column := ⟨col, h⟩ }
-          else cell -- todo: might be better to refactor the build_aux_map to return Fin (size S) instead
+          else cell -- todo: might be better to refactor the buildAuxMap to return Fin (size S) instead
 
     Json.mkObj [
       ("offset", toJson assignment.offset),
@@ -48,16 +48,16 @@ instance : ToJson (TableConstraint W S F α) where
 
 instance : ToJson (TableOperation S F) where
   toJson
-    | .Boundary i c => Json.mkObj [
+    | .boundary i c => Json.mkObj [
       ("type", Json.str "Boundary"),
       ("row", reprStr i),
       ("context", toJson c)
     ]
-    | .EveryRow c => Json.mkObj [
+    | .everyRow c => Json.mkObj [
       ("type", Json.str "EveryRow"),
       ("context", toJson c)
     ]
-    | .EveryRowExceptLast c => Json.mkObj [
+    | .everyRowExceptLast c => Json.mkObj [
       ("type", Json.str "EveryRowExceptLast"),
       ("context", toJson c)
     ]

--- a/Clean/Table/Theorems.lean
+++ b/Clean/Table/Theorems.lean
@@ -77,24 +77,24 @@ def everyRowTwoRowsInduction' {P : (N : ℕ+) → TraceOfLength F S N → Prop}
     exact more N curr next rest h_curr) N trace
   simpa [P', N.pos] using goal'
 
-def twoRowInduction {prop : Row F S → ℕ → Prop}
+def two_row_induction {prop : Row F S → ℕ → Prop}
     (zero : ∀ first_row : Row F S, prop first_row 0)
     (succ : ∀ (N : ℕ) (curr next : Row F S), prop curr N → prop next (N + 1))
-    : ∀ N (trace : TraceOfLength F S N), forAllRowsOfTraceWithIndex trace prop := by
+    : ∀ N (trace : TraceOfLength F S N), ForAllRowsOfTraceWithIndex trace prop := by
   intro N trace
-  simp only [forAllRowsOfTraceWithIndex, Trace.forAllRowsOfTraceWithIndex]
+  simp only [ForAllRowsOfTraceWithIndex, Trace.ForAllRowsOfTraceWithIndex]
   induction trace.val using Trace.everyRowTwoRowsInduction with
   | zero => trivial
   | one first_row =>
-    simp only [Trace.forAllRowsOfTraceWithIndex.inner]
+    simp only [Trace.ForAllRowsOfTraceWithIndex.inner]
     exact ⟨ zero first_row, trivial ⟩
   | more curr next rest _ ih2 =>
-    simp only [Trace.forAllRowsOfTraceWithIndex.inner] at *
+    simp only [Trace.ForAllRowsOfTraceWithIndex.inner] at *
     have h3 : prop next (rest +> curr).len := succ _ _ _ ih2.left
     exact ⟨ h3, ih2.left, ih2.right ⟩
 
 theorem lastRow_of_forAllWithIndex {N: ℕ+} {prop : Row F S → ℕ → Prop}
-  (trace : TraceOfLength F S N) (h : forAllRowsOfTraceWithIndex trace prop) :
+  (trace : TraceOfLength F S N) (h : ForAllRowsOfTraceWithIndex trace prop) :
     prop trace.lastRow (N - 1) := by
   induction N, trace using everyRowTwoRowsInduction' with
   | one row =>
@@ -106,16 +106,16 @@ theorem lastRow_of_forAllWithIndex {N: ℕ+} {prop : Row F S → ℕ → Prop}
     exact h.left
 
 theorem lastRow_of_forAllWithPrevious {N: ℕ+} {prop : Row F S → (i: ℕ) → TraceOfLength F S i → Prop}
-  (trace : TraceOfLength F S N) (h : forAllRowsWithPrevious trace prop) :
+  (trace : TraceOfLength F S N) (h : ForAllRowsWithPrevious trace prop) :
     prop trace.lastRow (N - 1) trace.tail := by
   induction N, trace using everyRowTwoRowsInduction' with
   | one row =>
-    simp only [forAllRowsWithPrevious, Trace.forAllRowsWithPrevious, and_true] at h
+    simp only [ForAllRowsWithPrevious, Trace.ForAllRowsWithPrevious, and_true] at h
     exact h
   | more N curr next rest ih =>
     rcases rest with ⟨ rest, hN ⟩
     subst hN
-    simp only [forAllRowsWithPrevious, Trace.forAllRowsWithPrevious, table_norm, and_true] at h ⊢
+    simp only [ForAllRowsWithPrevious, Trace.ForAllRowsWithPrevious, table_norm, and_true] at h ⊢
     simp only [PNat.mk_coe, Nat.add_one_sub_one, tail, Trace.tail]
     exact h.left
 
@@ -125,27 +125,27 @@ variable {F : Type} [Field F] {S : Type → Type} [ProvableType S] {W : ℕ+}
 
 namespace CellAssignment
 
-def push_var_input_offset (assignment: CellAssignment W S) (off: CellOffset W S) :
-  (assignment.push_var_input off).offset = assignment.offset + 1 := by
-  simp [push_var_input, Vector.push]
+def pushVarInput_offset (assignment: CellAssignment W S) (off: CellOffset W S) :
+  (assignment.pushVarInput off).offset = assignment.offset + 1 := by
+  simp [pushVarInput, Vector.push]
 
-lemma push_row_offset (assignment: CellAssignment W S) (row: Fin W) :
-  (assignment.push_row row).offset = assignment.offset + size S := by rfl
+lemma pushRow_offset (assignment: CellAssignment W S) (row: Fin W) :
+  (assignment.pushRow row).offset = assignment.offset + size S := by rfl
 
-theorem assignment_from_circuit_offset (as: CellAssignment W S) (ops: Operations F) :
-    (assignment_from_circuit as ops).offset = as.offset + ops.localLength := by
+theorem assignmentFromCircuit_offset (as: CellAssignment W S) (ops: Operations F) :
+    (assignmentFromCircuit as ops).offset = as.offset + ops.localLength := by
   induction ops using Operations.induct generalizing as with
   | empty => rfl
   | witness | assert | lookup | subcircuit =>
-    simp_all +arith [assignment_from_circuit, CellAssignment.push_vars_aux, Operations.localLength]
+    simp_all +arith [assignmentFromCircuit, CellAssignment.pushVarsAux, Operations.localLength]
 
-theorem assignment_from_circuit_vars (as: CellAssignment W S) (ops: Operations F) :
-    (assignment_from_circuit as ops).vars = (as.vars ++ (.mapRange ops.localLength fun i => .aux (as.aux_length + i) : Vector (Cell W S) _)
-      ).cast (assignment_from_circuit_offset ..).symm := by
+theorem assignmentFromCircuit_vars (as: CellAssignment W S) (ops: Operations F) :
+    (assignmentFromCircuit as ops).vars = (as.vars ++ (.mapRange ops.localLength fun i => .aux (as.aux_length + i) : Vector (Cell W S) _)
+      ).cast (assignmentFromCircuit_offset ..).symm := by
   induction ops using Operations.induct generalizing as with
   | empty => rfl
   | witness | assert | lookup | subcircuit =>
-    simp_all +arith [assignment_from_circuit, push_vars_aux, Operations.localLength,
+    simp_all +arith [assignmentFromCircuit, pushVarsAux, Operations.localLength,
       Vector.mapRange_add_eq_append, Vector.cast, Array.append_assoc]
 
 end CellAssignment

--- a/Clean/Table/WitnessGeneration.lean
+++ b/Clean/Table/WitnessGeneration.lean
@@ -7,7 +7,7 @@ variable {F : Type} {S : Type → Type} {W: ℕ+} [ProvableType S] [Field F]
   The rule is that the auxiliary cells are appended to the end of the row in order.
   For example: [input<0>, aux<0>, input<1>, input<2>, aux<1>] => {1: 3, 4: 4}
 -/
-def build_aux_map (as : CellAssignment W S) : Std.HashMap Nat Nat := Id.run do
+def buildAuxMap (as : CellAssignment W S) : Std.HashMap Nat Nat := Id.run do
   let (_, _, map) :=
     as.vars.foldl
       fun (idx, offset, m) cell =>
@@ -26,20 +26,20 @@ def build_aux_map (as : CellAssignment W S) : Std.HashMap Nat Nat := Id.run do
 
   Mapping for auxiliary columns:
   - The auxiliary cells' mapping from the `CellAssignment` to the aux columns in the trace row
-  is done using the `build_aux_map` function.
+  is done using the `buildAuxMap` function.
   - The generated witnesses are assigned to the corresponding aux columns in next trace row.
 
   Mapping for input columns:
   - According to `CellAssignment` for input cells, the input columns are assigned to
   the corresponding columns in the trace row.
 -/
-def generate_next_row (tc : TableConstraint W S F Unit) (cur_row: Array F) : Array F :=
+def generateNextRow (tc : TableConstraint W S F Unit) (cur_row: Array F) : Array F :=
   let ctx := (tc .empty).2
 
   let assignment := ctx.assignment
   let generators := ctx.circuit.witnessGenerators
 
-  let aux_map := build_aux_map assignment
+    let aux_map := buildAuxMap assignment
   let next_row := Array.replicate cur_row.size 0
 
   -- rules for fetching the values for expression variables
@@ -87,14 +87,14 @@ def witnesses
   (tc : TableConstraint W S F Unit) (init_row: Row F S) (n: ℕ) : Array (Array F) := Id.run do
 
   -- append auxiliary columns to the current row
-  let aux_cols := Array.replicate tc.final_assignment.num_aux 0
+  let aux_cols := Array.replicate tc.finalAssignment.numAux 0
   let cur_row := (toElements init_row).toArray ++ aux_cols
 
   let mut trace := #[cur_row]
   let mut current := cur_row
 
   for _ in [:n-1] do
-    let next := generate_next_row tc current
+    let next := generateNextRow tc current
     trace := trace.push next
     current := next
   trace

--- a/Clean/Tables/Addition8.lean
+++ b/Clean/Tables/Addition8.lean
@@ -21,7 +21,7 @@ instance : ProvableType RowType where
     ⟨ x, y, z ⟩
 
 def add8_inline : SingleRowConstraint RowType (F p) := do
-  let row ← TableConstraint.get_curr_row
+  let row ← TableConstraint.getCurrRow
   lookup (ByteLookup row.x)
   lookup (ByteLookup row.y)
   let z ← subcircuit Gadgets.Addition8.circuit { x := row.x, y := row.y }
@@ -32,7 +32,7 @@ def add8_table : List (TableOperation RowType (F p)) := [
 ]
 
 def spec_add8 {N : ℕ} (trace : TraceOfLength (F p) RowType N) : Prop :=
-  trace.forAllRowsOfTrace (fun row => (row.z.val = (row.x.val + row.y.val) % 256))
+  trace.ForAllRowsOfTrace (fun row => (row.z.val = (row.x.val + row.y.val) % 256))
 
 def formal_add8_table : FormalTable (F p) RowType := {
   constraints := add8_table,
@@ -52,7 +52,7 @@ def formal_add8_table : FormalTable (F p) RowType := {
         -- simplify constraints
 
         -- first, abstract away `env` to avoid blow-up of expression size
-        let env := add8_inline.window_env ⟨<+> +> row, rfl⟩ (envs 0 rest.len)
+        let env := add8_inline.windowEnv ⟨<+> +> row, rfl⟩ (envs 0 rest.len)
         change Circuit.ConstraintsHold.Soundness env _ at h_holds
 
         -- this is the slowest step, but still ok

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -42,8 +42,8 @@ def assign_U32 (offs : U32 (CellOffset 2 RowType)) (x : Var U32 (F p)) : TwoRows
   inductive contraints that are applied every two rows of the trace.
 -/
 def recursive_relation : TwoRowsConstraint RowType (F p) := do
-  let curr ← TableConstraint.get_curr_row
-  let next ← TableConstraint.get_next_row
+  let curr ← TableConstraint.getCurrRow
+  let next ← TableConstraint.getNextRow
 
   let z ← subcircuit Gadgets.Addition32.circuit { x := curr.x, y := curr.y }
 
@@ -54,7 +54,7 @@ def recursive_relation : TwoRowsConstraint RowType (F p) := do
   Boundary constraints that are applied at the beginning of the trace.
 -/
 def boundary : SingleRowConstraint RowType (F p) := do
-  let row ← TableConstraint.get_curr_row
+  let row ← TableConstraint.getCurrRow
   row.x === (const (U32.fromByte 0))
   row.y === (const (U32.fromByte 1))
 
@@ -73,7 +73,7 @@ def fib32_table : List (TableOperation RowType (F p)) := [
   - both U32 values are normalized
 -/
 def spec {N : ℕ} (trace : TraceOfLength (F p) RowType N) : Prop :=
-  trace.forAllRowsOfTraceWithIndex (fun row index =>
+  trace.ForAllRowsOfTraceWithIndex (fun row index =>
     (row.x.value = fib32 index) ∧
     (row.y.value = fib32 (index + 1)) ∧
     row.x.Normalized ∧ row.y.Normalized
@@ -88,8 +88,8 @@ def spec {N : ℕ} (trace : TraceOfLength (F p) RowType N) : Prop :=
 variable {α : Type}
 
 -- assignment copied from eval:
--- #eval! (recursive_relation (p:=p_babybear)).final_assignment.vars
-lemma fib_assignment : (recursive_relation (p:=p)).final_assignment.vars =
+-- #eval! (recursive_relation (p:=p_babybear)).finalAssignment.vars
+lemma fib_assignment : (recursive_relation (p:=p)).finalAssignment.vars =
    #v[.input ⟨0, 0⟩, .input ⟨0, 1⟩, .input ⟨0, 2⟩, .input ⟨0, 3⟩, .input ⟨0, 4⟩, .input ⟨0, 5⟩, .input ⟨0, 6⟩,
       .input ⟨0, 7⟩, .input ⟨1, 0⟩, .input ⟨1, 1⟩, .input ⟨1, 2⟩, .input ⟨1, 3⟩, .input ⟨1, 4⟩, .input ⟨1, 5⟩,
       .input ⟨1, 6⟩, .input ⟨1, 7⟩, .input ⟨1, 4⟩, .aux 1, .input ⟨1, 5⟩, .aux 3, .input ⟨1, 6⟩, .aux 5,
@@ -98,15 +98,15 @@ lemma fib_assignment : (recursive_relation (p:=p)).final_assignment.vars =
   simp only [table_assignment_norm, circuit_norm, Vector.mapFinRange_succ, Vector.mapFinRange_zero, Vector.mapRange_zero, Vector.mapRange_succ]
 
 lemma fib_vars (curr next : Row (F p) RowType) (aux_env : Environment (F p)) :
-    let env := recursive_relation.window_env ⟨<+> +> curr +> next, rfl⟩ aux_env;
+    let env := recursive_relation.windowEnv ⟨<+> +> curr +> next, rfl⟩ aux_env;
     eval env (varFromOffset U32 0) = curr.x ∧
     eval env (varFromOffset U32 4) = curr.y ∧
     eval env (varFromOffset U32 8) = next.x ∧
     eval env (U32.mk (var ⟨16⟩) (var ⟨18⟩) (var ⟨20⟩) (var ⟨22⟩)) = next.y
   := by
   intro env
-  dsimp only [env, window_env]
-  have h_offset : (recursive_relation (p:=p)).final_assignment.offset = 24 := rfl
+  dsimp only [env, windowEnv]
+  have h_offset : (recursive_relation (p:=p)).finalAssignment.offset = 24 := rfl
   simp only [h_offset]
   rw [fib_assignment]
   simp only [circuit_norm, explicit_provable_type, reduceDIte, Nat.reduceLT, Nat.reduceAdd]
@@ -121,13 +121,13 @@ lemma fib_vars (curr next : Row (F p) RowType) (aux_env : Environment (F p)) :
   then the spec of add32 and equality are satisfied
 -/
 lemma fib_constraints (curr next : Row (F p) RowType) (aux_env : Environment (F p))
-  : recursive_relation.constraintsHold_on_window ⟨<+> +> curr +> next, rfl⟩ aux_env →
+  : recursive_relation.ConstraintsHoldOnWindow ⟨<+> +> curr +> next, rfl⟩ aux_env →
   curr.y = next.x ∧
   (curr.x.Normalized → curr.y.Normalized → next.y.value = (curr.x.value + curr.y.value) % 2^32 ∧ next.y.Normalized)
    := by
   simp only [table_norm]
   obtain ⟨ hcurr_x, hcurr_y, hnext_x, hnext_y ⟩ := fib_vars curr next aux_env
-  set env := recursive_relation.window_env  ⟨<+> +> curr +> next, rfl⟩ aux_env
+  set env := recursive_relation.windowEnv  ⟨<+> +> curr +> next, rfl⟩ aux_env
   simp only [table_norm, circuit_norm, recursive_relation,
     assign_U32, Gadgets.Addition32.circuit]
   rintro ⟨ h_add, h_eq ⟩
@@ -144,10 +144,10 @@ lemma fib_constraints (curr next : Row (F p) RowType) (aux_env : Environment (F 
   exact ⟨h_add_mod, h_norm_next_y⟩
 
 lemma boundary_constraints (first_row : Row (F p) RowType) (aux_env : Environment (F p)) :
-  Circuit.ConstraintsHold.Soundness (window_env boundary ⟨<+> +> first_row, rfl⟩ aux_env) boundary.operations →
+  Circuit.ConstraintsHold.Soundness (windowEnv boundary ⟨<+> +> first_row, rfl⟩ aux_env) boundary.operations →
   first_row.x.value = fib32 0 ∧ first_row.y.value = fib32 1 ∧ first_row.x.Normalized ∧ first_row.y.Normalized
   := by
-  set env := boundary.window_env ⟨<+> +> first_row, rfl⟩ aux_env
+  set env := boundary.windowEnv ⟨<+> +> first_row, rfl⟩ aux_env
   simp only [table_norm, boundary, circuit_norm]
   simp only [and_imp]
   have hx : eval env (varFromOffset U32 0) = first_row.x := by rfl
@@ -169,7 +169,7 @@ def formal_fib32_table : FormalTable (F p) RowType := {
   soundness := by
     intro N trace envs _
     simp only [fib32_table, spec]
-    rw [TraceOfLength.forAllRowsOfTraceWithIndex, Trace.forAllRowsOfTraceWithIndex, table_constraintsHold]
+    rw [TraceOfLength.ForAllRowsOfTraceWithIndex, Trace.ForAllRowsOfTraceWithIndex, TableConstraintsHold]
 
     /-
       We prove the soundness of the table by induction on the trace.


### PR DESCRIPTION
## Summary
- rename props and methods in Table modules to follow Lean naming conventions
- update constructor names to lower camel case
- adjust auxiliary witness generation helpers
- fix usages across table-related modules

References #130

------
https://chatgpt.com/codex/tasks/task_e_685bdca71c5c832388eafedfcfdbebd6