### PR TITLE
[Codex] rename spec and assumptions fields

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -271,10 +271,10 @@ This means that, when viewed as a black box, the circuit acts similar to a funct
 structure FormalCircuit (F: Type) (β α: TypeMap) [Field F] [ProvableType α] [ProvableType β]
   extends elaborated : ElaboratedCircuit F β α where
   -- β = inputs, α = outputs
-  assumptions: β F → Prop
-  spec: β F → α F → Prop
-  soundness: Soundness F elaborated assumptions spec
-  completeness: Completeness F elaborated assumptions
+  Assumptions: β F → Prop
+  Spec: β F → α F → Prop
+  soundness: Soundness F elaborated Assumptions Spec
+  completeness: Completeness F elaborated Assumptions
 
 namespace Circuit
 @[circuit_norm]
@@ -282,12 +282,12 @@ def SubcircuitSoundness (circuit: FormalCircuit F β α) (b_var : Var β F) (off
   let b := eval env b_var
   let a_var := circuit.output b_var offset
   let a := eval env a_var
-  circuit.assumptions b → circuit.spec b a
+  circuit.Assumptions b → circuit.Spec b a
 
 @[circuit_norm]
 def SubcircuitCompleteness (circuit: FormalCircuit F β α) (b_var : Var β F) (env : Environment F) :=
   let b := eval env b_var
-  circuit.assumptions b
+  circuit.Assumptions b
 end Circuit
 
 /--
@@ -304,19 +304,19 @@ In other words, for `FormalAssertion`s the spec must be an equivalent reformulat
 -/
 structure FormalAssertion (F: Type) (β: TypeMap) [Field F] [ProvableType β]
   extends ElaboratedCircuit F β unit where
-  assumptions: β F → Prop
-  spec: β F → Prop
+  Assumptions: β F → Prop
+  Spec: β F → Prop
 
   soundness:
     -- for all environments that determine witness generation
     ∀ offset, ∀ env,
     -- for all inputs that satisfy the assumptions
     ∀ b_var : Var β F, ∀ b : β F, eval env b_var = b →
-    assumptions b →
+    Assumptions b →
     -- if the constraints hold
     ConstraintsHold.Soundness env (main b_var |>.operations offset) →
     -- the spec holds
-    spec b
+    Spec b
 
   completeness:
     -- for all environments which _use the default witness generators for local variables_
@@ -324,7 +324,7 @@ structure FormalAssertion (F: Type) (β: TypeMap) [Field F] [ProvableType β]
     env.UsesLocalWitnessesCompleteness offset (main b_var |>.operations offset) →
     -- for all inputs that satisfy the assumptions AND the spec
     ∀ b : β F, eval env b_var = b →
-    assumptions b → spec b →
+    Assumptions b → Spec b →
     -- the constraints hold
     ConstraintsHold.Completeness env (main b_var |>.operations offset)
 
@@ -337,12 +337,12 @@ namespace Circuit
 @[circuit_norm]
 def SubassertionSoundness (circuit: FormalAssertion F β) (b_var : Var β F) (env: Environment F) :=
   let b := eval env b_var
-  circuit.assumptions b → circuit.spec b
+  circuit.Assumptions b → circuit.Spec b
 
 @[circuit_norm]
 def SubassertionCompleteness (circuit: FormalAssertion F β) (b_var : Var β F) (env: Environment F) :=
   let b := eval env b_var
-  circuit.assumptions b ∧ circuit.spec b
+  circuit.Assumptions b ∧ circuit.Spec b
 end Circuit
 end
 

--- a/Clean/Circuit/Foundations.lean
+++ b/Clean/Circuit/Foundations.lean
@@ -19,12 +19,12 @@ open Circuit (ConstraintsHold)
   in the `FormalCircuit` definition.
 -/
 theorem FormalCircuit.original_soundness (circuit : FormalCircuit F β α) :
-    ∀ (offset : ℕ) env (b_var : Var β F) (b : β F), eval env b_var = b → circuit.assumptions b →
+    ∀ (offset : ℕ) env (b_var : Var β F) (b : β F), eval env b_var = b → circuit.Assumptions b →
     -- if the constraints hold (original definition)
     ConstraintsHold env (circuit.main b_var |>.operations offset) →
     -- the spec holds
     let a := eval env (circuit.output b_var offset)
-    circuit.spec b a := by
+    circuit.Spec b a := by
 
   intro offset env b_var b h_input h_assumptions h_holds
   have h_holds' := Circuit.can_replace_soundness h_holds
@@ -35,7 +35,7 @@ theorem FormalCircuit.original_soundness (circuit : FormalCircuit F β α) :
   and `ConstraintsHold` in the `FormalCircuit` definition.
 -/
 theorem FormalCircuit.original_completeness (circuit : FormalCircuit F β α) :
-    ∀ (offset : ℕ) env (b_var : Var β F) (b : β F), eval env b_var = b → circuit.assumptions b →
+    ∀ (offset : ℕ) env (b_var : Var β F) (b : β F), eval env b_var = b → circuit.Assumptions b →
     -- if the environment uses default witness generators (original definition)
     env.UsesLocalWitnesses offset (circuit.main b_var |>.operations offset) →
     -- the constraints hold (original definition)
@@ -51,11 +51,11 @@ theorem FormalCircuit.original_completeness (circuit : FormalCircuit F β α) :
   in the `FormalAssertion` definition.
 -/
 theorem FormalAssertion.original_soundness (circuit : FormalAssertion F β) :
-    ∀ (offset : ℕ) env (b_var : Var β F) (b : β F), eval env b_var = b → circuit.assumptions b →
+    ∀ (offset : ℕ) env (b_var : Var β F) (b : β F), eval env b_var = b → circuit.Assumptions b →
     -- if the constraints hold (original definition)
     ConstraintsHold env (circuit.main b_var |>.operations offset) →
     -- the spec holds
-    circuit.spec b := by
+    circuit.Spec b := by
 
   intro offset env b_var b h_input h_assumptions h_holds
   have h_holds' := Circuit.can_replace_soundness h_holds
@@ -66,11 +66,11 @@ theorem FormalAssertion.original_soundness (circuit : FormalAssertion F β) :
   and `ConstraintsHold` in the `FormalAssertion` definition.
 -/
 theorem FormalAssertion.original_completeness (circuit : FormalAssertion F β) :
-    ∀ (offset : ℕ) env (b_var : Var β F) (b : β F), eval env b_var = b → circuit.assumptions b →
+    ∀ (offset : ℕ) env (b_var : Var β F) (b : β F), eval env b_var = b → circuit.Assumptions b →
     -- if the environment uses default witness generators (original definition)
     env.UsesLocalWitnesses offset (circuit.main b_var |>.operations offset) →
     -- the spec implies that the constraints hold (original definition)
-    circuit.spec b → ConstraintsHold env (circuit.main b_var |>.operations offset) := by
+    circuit.Spec b → ConstraintsHold env (circuit.main b_var |>.operations offset) := by
 
   intro offset env b_var b h_input h_assumptions h_env h_spec
   apply Circuit.can_replace_completeness (circuit.subcircuitsConsistent ..) h_env

--- a/Clean/Circuit/LookupCircuit.lean
+++ b/Clean/Circuit/LookupCircuit.lean
@@ -41,8 +41,8 @@ def toTable (circuit : LookupCircuit F α β) : Table F (ProvablePair α β) whe
     -- and the output matches
     ∧ output = eval env (circuit.output (const input) n)
 
-  Soundness := fun (input, output) => circuit.assumptions input → circuit.spec input output
-  Completeness := fun (input, output) => circuit.assumptions input ∧ output = circuit.constantOutput input
+  Soundness := fun (input, output) => circuit.Assumptions input → circuit.Spec input output
+  Completeness := fun (input, output) => circuit.Assumptions input ∧ output = circuit.constantOutput input
 
   imply_soundness := by
     intro (input, output) ⟨n, env, h_holds, h_output⟩ h_assumptions
@@ -72,8 +72,8 @@ def lookupCircuit (circuit : LookupCircuit F α β) : FormalCircuit F α β wher
   localLength n := size β
   output _ n := varFromOffset β n
 
-  assumptions := circuit.assumptions
-  spec := circuit.spec
+  Assumptions := circuit.Assumptions
+  Spec := circuit.Spec
 
   soundness := by
     intro n env input_var input h_input h_assumptions h_holds

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -72,8 +72,8 @@ def FormalCircuit.toSubcircuit (circuit: FormalCircuit F β α)
 
     let b : β F := eval env b_var
     let a : α F := eval env (circuit.output b_var n)
-    rintro (as : circuit.assumptions b)
-    show circuit.spec b a
+    rintro (as : circuit.Assumptions b)
+    show circuit.Spec b a
 
     -- by soundness of the circuit, the spec is satisfied if only the constraints hold
     suffices h: ConstraintsHold.Soundness env ops by
@@ -90,7 +90,7 @@ def FormalCircuit.toSubcircuit (circuit: FormalCircuit F β α)
     -- we are given that the assumptions are true
     intro env h_env
     let b := eval env b_var
-    intro (as : circuit.assumptions b)
+    intro (as : circuit.Assumptions b)
 
     have h_env : env.UsesLocalWitnesses n ops := by
       guard_hyp h_env : env.ExtendsVector (FlatOperation.localWitnesses env flat_ops) n
@@ -147,8 +147,8 @@ def FormalAssertion.toSubcircuit (circuit: FormalAssertion F β)
       show SubassertionSoundness circuit b_var env
 
       let b : β F := eval env b_var
-      rintro (as : circuit.assumptions b)
-      show circuit.spec b
+      rintro (as : circuit.Assumptions b)
+      show circuit.Spec b
 
       -- by soundness of the circuit, the spec is satisfied if only the constraints hold
       suffices h: ConstraintsHold.Soundness env ops by
@@ -164,7 +164,7 @@ def FormalAssertion.toSubcircuit (circuit: FormalAssertion F β)
       intro env h_env h_completeness
 
       let b := eval env b_var
-      have as : circuit.assumptions b ∧ circuit.spec b := h_completeness
+      have as : circuit.Assumptions b ∧ circuit.Spec b := h_completeness
 
       have h_env : env.UsesLocalWitnesses n ops := by
         guard_hyp h_env : env.ExtendsVector (FlatOperation.localWitnesses env flat_ops) n

--- a/Clean/Gadgets/Addition32/Addition32.lean
+++ b/Clean/Gadgets/Addition32/Addition32.lean
@@ -51,8 +51,8 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   Addition32Full.assumptions, Addition32Full.spec, assumptions]
 
 def circuit : FormalCircuit (F p) Inputs U32 where
-  assumptions
-  spec
-  soundness
-  completeness
+  Assumptions := assumptions
+  Spec := spec
+  soundness := soundness
+  completeness := completeness
 end Gadgets.Addition32

--- a/Clean/Gadgets/Addition32/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32/Addition32Full.lean
@@ -158,8 +158,8 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   exact ⟨ z0_byte, c0_bool, h0, z1_byte, c1_bool, h1, z2_byte, c2_bool, h2, z3_byte, c3_bool, h3 ⟩
 
 def circuit : FormalCircuit (F p) Inputs Outputs where
-  assumptions
-  spec
-  soundness
-  completeness
+  Assumptions := assumptions
+  Spec := spec
+  soundness := soundness
+  completeness := completeness
 end Gadgets.Addition32Full

--- a/Clean/Gadgets/Addition8/Addition8.lean
+++ b/Clean/Gadgets/Addition8/Addition8.lean
@@ -15,10 +15,10 @@ def Addition8Full.circuit : FormalCircuit (F p) Addition8FullCarry.Inputs field 
   localLength _ := 2
   output _ i0 := var ⟨i0⟩
 
-  assumptions := fun { x, y, carry_in } =>
+  Assumptions := fun { x, y, carry_in } =>
     x.val < 256 ∧ y.val < 256 ∧ (carry_in = 0 ∨ carry_in = 1)
 
-  spec := fun { x, y, carry_in } z =>
+  Spec := fun { x, y, carry_in } z =>
     z.val = (x.val + y.val + carry_in.val) % 256
 
   -- the proofs are trivial since this just wraps `Addition8FullCarry`
@@ -49,9 +49,9 @@ def circuit : FormalCircuit (F p) Inputs field where
   localLength _ := 2
   output _ i0 := var ⟨i0⟩
 
-  assumptions | { x, y } => x.val < 256 ∧ y.val < 256
+  Assumptions | { x, y } => x.val < 256 ∧ y.val < 256
 
-  spec | { x, y }, z => z.val = (x.val + y.val) % 256
+  Spec | { x, y }, z => z.val = (x.val + y.val) % 256
 
   -- the proofs are trivial since this just wraps `Addition8Full`
   soundness := by simp_all [Soundness, circuit_norm, subcircuit_norm, Addition8Full.circuit]

--- a/Clean/Gadgets/Addition8/Addition8FullCarry.lean
+++ b/Clean/Gadgets/Addition8/Addition8FullCarry.lean
@@ -57,8 +57,8 @@ def spec (input : Inputs (F p)) (out : Outputs (F p)) :=
 -/
 def circuit : FormalCircuit (F p) Inputs Outputs where
   main := add8_full_carry
-  assumptions
-  spec
+  Assumptions := assumptions
+  Spec := spec
   localLength _ := 2
   output _ i0 := { z := var ⟨i0⟩, carry_out := var ⟨i0 + 1⟩ }
 

--- a/Clean/Gadgets/And/And64.lean
+++ b/Clean/Gadgets/And/And64.lean
@@ -87,9 +87,9 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   simp_all
 
 def circuit : FormalCircuit (F p) Inputs U64 where
-  assumptions
-  spec
-  soundness
-  completeness
+  Assumptions := assumptions
+  Spec := spec
+  soundness := soundness
+  completeness := completeness
 
 end Gadgets.And.And64

--- a/Clean/Gadgets/And/And8.lean
+++ b/Clean/Gadgets/And/And8.lean
@@ -139,6 +139,9 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
     ←and_times_two_add_xor hx_byte hy_byte, add_comm, Nat.add_sub_cancel]
 
 def circuit : FormalCircuit (F p) Inputs field :=
-  { assumptions, spec, soundness, completeness }
+  { Assumptions := assumptions,
+    Spec := spec,
+    soundness := soundness,
+    completeness := completeness }
 
 end Gadgets.And.And8

--- a/Clean/Gadgets/BLAKE3/BLAKE3G.lean
+++ b/Clean/Gadgets/BLAKE3/BLAKE3G.lean
@@ -140,8 +140,8 @@ theorem completeness (a b c d : Fin 16) : Completeness (F p) (elaborated a b c d
 
 def circuit (a b c d : Fin 16) : FormalCircuit (F p) Inputs BLAKE3State := {
   elaborated a b c d with
-  assumptions := assumptions
-  spec := spec a b c d
+  Assumptions := assumptions
+  Spec := spec a b c d
   soundness := soundness a b c d
   completeness := completeness a b c d
 }

--- a/Clean/Gadgets/BLAKE3/Permute.lean
+++ b/Clean/Gadgets/BLAKE3/Permute.lean
@@ -40,7 +40,11 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
     Environment.UsesLocalWitnessesCompleteness.eq_1, Circuit.ConstraintsHold.Completeness.eq_1]
 
 def circuit : FormalCircuit (F p) BLAKE3State BLAKE3State := {
-  elaborated with assumptions, spec, soundness, completeness
+  elaborated with
+    Assumptions := assumptions,
+    Spec := spec,
+    soundness := soundness,
+    completeness := completeness
 }
 
 end Gadgets.BLAKE3.Permute

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -28,9 +28,9 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (fields n) wher
   subcircuitsConsistent x i0 := by simp +arith only [main, circuit_norm]
     -- TODO arith is needed because forAll passes `localLength + offset` while bind passes `offset + localLength`
 
-  assumptions (x : F p) := x.val < 2^n
+  Assumptions (x : F p) := x.val < 2^n
 
-  spec (x : F p) (bits : Vector (F p) n) :=
+  Spec (x : F p) (bits : Vector (F p) n) :=
     bits = field_to_bits n x
 
   soundness := by
@@ -81,8 +81,8 @@ def range_check (n : ℕ) (hn : 2^n < p) : FormalAssertion (F p) field where
   subcircuitsConsistent _ n := by simp +arith only [main, circuit_norm]
   localLength_eq _ _ := by simp only [main, circuit_norm, Boolean.circuit]; ac_rfl
 
-  assumptions _ := True
-  spec (x : F p) := x.val < 2^n
+  Assumptions _ := True
+  Spec (x : F p) := x.val < 2^n
 
   soundness := by
     simp only [circuit_norm, main, Boolean.circuit]

--- a/Clean/Gadgets/Boolean.lean
+++ b/Clean/Gadgets/Boolean.lean
@@ -32,8 +32,8 @@ Asserts that x = 0 ∨ x = 1 by adding the constraint x * (x - 1) = 0
 -/
 def circuit : FormalAssertion (F p) field where
   main (x : Expression (F p)) := assertZero (x * (x - 1))
-  assumptions _ := True
-  spec (x : F p) := x = 0 ∨ x = 1
+  Assumptions _ := True
+  Spec (x : F p) := x = 0 ∨ x = 1
 
   soundness := by simp_all only [circuit_norm, equiv]
   completeness := by simp_all only [circuit_norm, equiv]

--- a/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
@@ -126,8 +126,8 @@ theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) a
 def circuit (offset : Fin 8) : FormalCircuit (F p) field Outputs := {
   elaborated offset with
   main := byte_decomposition offset
-  assumptions
-  spec := spec offset
+  Assumptions := assumptions
+  Spec := spec offset
   soundness := soundness offset
   completeness := completeness offset
 }

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -39,9 +39,9 @@ instance elaborated (α : TypeMap) [ProvableType α] : ElaboratedCircuit F (Prov
   subcircuitsConsistent n := by simp only [main, circuit_norm]
 
 def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair α α) where
-  assumptions _ := True
+  Assumptions _ := True
 
-  spec : α F × α F → Prop
+  Spec : α F × α F → Prop
   | (x, y) => x = y
 
   soundness := by

--- a/Clean/Gadgets/Keccak/AbsorbBlock.lean
+++ b/Clean/Gadgets/Keccak/AbsorbBlock.lean
@@ -116,5 +116,9 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
     simp only [this, getElem_eval_vector, h_input, h_assumptions.left ⟨i, hi⟩, Nat.xor_zero, and_self]
 
 def circuit : FormalCircuit (F p) Input KeccakState :=
-  { elaborated with assumptions, spec, soundness, completeness }
+  { elaborated with
+      Assumptions := assumptions,
+      Spec := spec,
+      soundness := soundness,
+      completeness := completeness }
 end Gadgets.Keccak256.AbsorbBlock

--- a/Clean/Gadgets/Keccak/Chi.lean
+++ b/Clean/Gadgets/Keccak/Chi.lean
@@ -71,5 +71,9 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
     Xor64.assumptions, Xor64.spec, And.And64.assumptions, And.And64.spec, Nat.reduceAdd]
 
 def circuit : FormalCircuit (F p) KeccakState KeccakState :=
-  { elaborated with assumptions, spec, soundness, completeness }
+  { elaborated with
+      Assumptions := assumptions,
+      Spec := spec,
+      soundness := soundness,
+      completeness := completeness }
 end Gadgets.Keccak256.Chi

--- a/Clean/Gadgets/Keccak/KeccakRound.lean
+++ b/Clean/Gadgets/Keccak/KeccakRound.lean
@@ -100,8 +100,8 @@ theorem completeness (rc : UInt64) : Completeness (F p) (elaborated rc) assumpti
 
 def circuit (rc : UInt64) : FormalCircuit (F p) KeccakState KeccakState := {
   elaborated rc with
-  spec := spec rc
-  assumptions,
+  Spec := spec rc
+  Assumptions := assumptions
   soundness := soundness rc,
   completeness := completeness rc,
 }

--- a/Clean/Gadgets/Keccak/KeccakState.lean
+++ b/Clean/Gadgets/Keccak/KeccakState.lean
@@ -72,8 +72,8 @@ lemma KeccakRow.normalized_value_ext (row : KeccakRow (F p)) (rhs : Vector ℕ 5
 
 def KeccakBlock.normalized : FormalAssertion (F p) KeccakBlock where
   main block := .forEach block (assertion U64.AssertNormalized.circuit)
-  assumptions _ := True
-  spec block := block.Normalized
+  Assumptions _ := True
+  Spec block := block.Normalized
   localLength_eq _ _ := by simp +arith only [circuit_norm, U64.AssertNormalized.circuit]
   soundness := by
     simp only [circuit_norm, subcircuit_norm, U64.AssertNormalized.circuit]

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -113,7 +113,9 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
 
 def circuit : FormalCircuit (F p) KeccakState KeccakState := {
   elaborated with
-  assumptions, spec, soundness
+  Assumptions := assumptions,
+  Spec := spec,
+  soundness := soundness
   -- TODO why does this time out??
   -- completeness
   completeness := by simp only [completeness]

--- a/Clean/Gadgets/Keccak/RhoPi.lean
+++ b/Clean/Gadgets/Keccak/RhoPi.lean
@@ -69,6 +69,10 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
     Rotation64.circuit, Rotation64.assumptions, Rotation64.spec]
 
 def circuit : FormalCircuit (F p) KeccakState KeccakState := {
-  elaborated with assumptions, spec, soundness, completeness
+  elaborated with
+    Assumptions := assumptions,
+    Spec := spec,
+    soundness := soundness,
+    completeness := completeness
 }
 end Gadgets.Keccak256.RhoPi

--- a/Clean/Gadgets/Keccak/Theta.lean
+++ b/Clean/Gadgets/Keccak/Theta.lean
@@ -36,6 +36,10 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
     ThetaC.spec, ThetaD.spec, ThetaXor.spec, Specs.Keccak256.theta]
 
 def circuit : FormalCircuit (F p) KeccakState KeccakState := {
-  elaborated with assumptions, spec, soundness, completeness
+  elaborated with
+    Assumptions := assumptions,
+    Spec := spec,
+    soundness := soundness,
+    completeness := completeness
 }
 end Gadgets.Keccak256.Theta

--- a/Clean/Gadgets/Keccak/ThetaC.lean
+++ b/Clean/Gadgets/Keccak/ThetaC.lean
@@ -66,7 +66,11 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   simp_all
 
 def circuit : FormalCircuit (F p) KeccakState KeccakRow := {
-  elaborated with assumptions, spec, soundness, completeness
+  elaborated with
+    Assumptions := assumptions,
+    Spec := spec,
+    soundness := soundness,
+    completeness := completeness
 }
 
 end Gadgets.Keccak256.ThetaC

--- a/Clean/Gadgets/Keccak/ThetaD.lean
+++ b/Clean/Gadgets/Keccak/ThetaD.lean
@@ -83,10 +83,10 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
 
 def circuit : FormalCircuit (F p) KeccakRow KeccakRow := {
   elaborated with
-  assumptions
-  spec
-  soundness
-  completeness
+  Assumptions := assumptions
+  Spec := spec
+  soundness := soundness
+  completeness := completeness
 }
 
 end Gadgets.Keccak256.ThetaD

--- a/Clean/Gadgets/Keccak/ThetaXor.lean
+++ b/Clean/Gadgets/Keccak/ThetaXor.lean
@@ -65,7 +65,11 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   exact ⟨ state_norm i, d_norm ⟨i.val / 5, by omega⟩ ⟩
 
 def circuit : FormalCircuit (F p) Inputs KeccakState := {
-  elaborated with assumptions, spec, soundness, completeness
+  elaborated with
+    Assumptions := assumptions,
+    Spec := spec,
+    soundness := soundness,
+    completeness := completeness
 }
 
 end Gadgets.Keccak256.ThetaXor

--- a/Clean/Gadgets/Not/Not64.lean
+++ b/Clean/Gadgets/Not/Not64.lean
@@ -55,8 +55,8 @@ theorem not_bytewise_value_spec {x : U64 (F p)} (x_lt : x.Normalized) :
 
 def circuit : FormalCircuit (F p) U64 U64 where
   main x := pure (not64_bytewise x)
-  assumptions x := x.Normalized
-  spec x z := z.value = not64 x.value ∧ z.Normalized
+  Assumptions x := x.Normalized
+  Spec x z := z.value = not64 x.value ∧ z.Normalized
 
   localLength _ := 0
   output x _ := not64_bytewise x

--- a/Clean/Gadgets/Rotation32/Rotation32.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32.lean
@@ -101,8 +101,8 @@ theorem completeness (offset : Fin 32) : Completeness (F p) (elaborated offset) 
 
 def circuit (offset : Fin 32) : FormalCircuit (F p) U32 U32 := {
   elaborated offset with
-  assumptions := assumptions
-  spec := spec offset
+  Assumptions := assumptions
+  Spec := spec offset
   soundness := soundness offset
   completeness := completeness offset
 }

--- a/Clean/Gadgets/Rotation32/Rotation32Bits.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32Bits.lean
@@ -123,8 +123,8 @@ theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) a
 
 def circuit (offset : Fin 8) : FormalCircuit (F p) U32 U32 := {
   elaborated offset with
-  assumptions
-  spec := spec offset
+  Assumptions := assumptions
+  Spec := spec offset
   soundness := soundness offset
   completeness := completeness offset
 }

--- a/Clean/Gadgets/Rotation32/Rotation32Bytes.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32Bytes.lean
@@ -79,8 +79,8 @@ theorem completeness (off : Fin 4) : Completeness (F p) (elaborated off) assumpt
 def circuit (off : Fin 4) : FormalCircuit (F p) U32 U32 := {
   elaborated off with
   main := rot32_bytes off
-  assumptions := assumptions
-  spec := spec off
+  Assumptions := assumptions
+  Spec := spec off
   soundness := soundness off
   completeness := completeness off
 }

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -102,8 +102,8 @@ theorem completeness (offset : Fin 64) : Completeness (F p) (elaborated offset) 
 
 def circuit (offset : Fin 64) : FormalCircuit (F p) U64 U64 := {
   elaborated offset with
-  assumptions := assumptions
-  spec := spec offset
+  Assumptions := assumptions
+  Spec := spec offset
   soundness := soundness offset
   completeness := completeness offset
 }

--- a/Clean/Gadgets/Rotation64/Rotation64Bits.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bits.lean
@@ -120,8 +120,8 @@ theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) a
 
 def circuit (offset : Fin 8) : FormalCircuit (F p) U64 U64 := {
   elaborated offset with
-  assumptions
-  spec := spec offset
+  Assumptions := assumptions
+  Spec := spec offset
   soundness := soundness offset
   completeness := completeness offset
 }

--- a/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
@@ -92,8 +92,8 @@ theorem completeness (off : Fin 8) : Completeness (F p) (elaborated off) assumpt
 def circuit (off : Fin 8) : FormalCircuit (F p) U64 U64 := {
   elaborated off with
   main := rot64_bytes off
-  assumptions := assumptions
-  spec := spec off
+  Assumptions := assumptions
+  Spec := spec off
   soundness := soundness off
   completeness := completeness off
 }

--- a/Clean/Gadgets/Xor/Xor32.lean
+++ b/Clean/Gadgets/Xor/Xor32.lean
@@ -118,8 +118,8 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   simp_all [xor_val]
 
 def circuit : FormalCircuit (F p) Inputs U32 where
-  assumptions
-  spec
-  soundness
-  completeness
+  Assumptions := assumptions
+  Spec := spec
+  soundness := soundness
+  completeness := completeness
 end Gadgets.Xor32

--- a/Clean/Gadgets/Xor/Xor64.lean
+++ b/Clean/Gadgets/Xor/Xor64.lean
@@ -124,8 +124,8 @@ theorem completeness : Completeness (F p) elaborated assumptions := by
   simp_all [xor_val]
 
 def circuit : FormalCircuit (F p) Inputs U64 where
-  assumptions
-  spec
-  soundness
-  completeness
+  Assumptions := assumptions
+  Spec := spec
+  soundness := soundness
+  completeness := completeness
 end Gadgets.Xor64

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -191,8 +191,8 @@ def main (inputs : Var U32 (F p)) : Circuit (F p) Unit  := do
 
 def circuit : FormalAssertion (F p) U32 where
   main
-  assumptions _ := True
-  spec inputs := inputs.Normalized
+  Assumptions _ := True
+  Spec inputs := inputs.Normalized
 
   soundness := by
     rintro i0 env x_var ⟨ x0, x1, x2, x3 ⟩ h_eval _as
@@ -226,8 +226,8 @@ def spec (x y : U32 (F p)) := x = y
 
 def circuit : FormalCircuit (F p) U32 U32 where
   main := main
-  assumptions := assumptions
-  spec := spec
+  Assumptions := assumptions
+  Spec := spec
   localLength _ := 4
   output inputs i0 := varFromOffset U32 i0
   soundness := by

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -201,8 +201,8 @@ def main (inputs : Var U64 (F p)) : Circuit (F p) Unit  := do
 def circuit : FormalAssertion (F p) U64 where
   main
 
-  assumptions _ := True
-  spec inputs := inputs.Normalized
+  Assumptions _ := True
+  Spec inputs := inputs.Normalized
 
   soundness := by
     rintro i0 env x_var
@@ -238,8 +238,8 @@ def spec (x y : U64 (F p)) := x = y
 
 def circuit : FormalCircuit (F p) U64 U64 where
   main := main
-  assumptions := assumptions
-  spec := spec
+  Assumptions := assumptions
+  Spec := spec
   localLength _ := 8
   output inputs i0 := varFromOffset U64 i0
   soundness := by


### PR DESCRIPTION
## Summary
- rename `spec` and `assumptions` fields on `FormalCircuit` and `FormalAssertion` to `Spec` and `Assumptions`
- update all circuit definitions to use the new field names
- adjust helper definitions and proofs

References #130

------
https://chatgpt.com/codex/tasks/task_e_685bf053aee88323bed69e599c4c8df2