### PR TITLE
Rename everyRowTwoRowsInduction to every_row_two_rows_induction

### DIFF
--- a/Clean/Table/Inductive.lean
+++ b/Clean/Table/Inductive.lean
@@ -140,7 +140,7 @@ lemma table_soundness_aux (table : InductiveTable F State Input) (input output: 
 
   simp only [table_norm, tableConstraints]
   clear h_trace
-  induction trace using Trace.everyRowTwoRowsInduction
+  induction trace using Trace.every_row_two_rows_induction
 
   case zero =>
     intro constraints

--- a/Clean/Table/Theorems.lean
+++ b/Clean/Table/Theorems.lean
@@ -7,7 +7,7 @@ variable {F : Type} {S : Type → Type} [ProvableType S]
   Induction principle that applies for every row in the trace, where the inductive step takes into
   account the previous two rows.
 -/
-def everyRowTwoRowsInduction {P : Trace F S → Sort*}
+def every_row_two_rows_induction {P : Trace F S → Sort*}
     (zero : P (<+>))
     (one : ∀ row : Row F S, P (empty +> row))
     (more : ∀ curr next : Row F S,
@@ -16,8 +16,8 @@ def everyRowTwoRowsInduction {P : Trace F S → Sort*}
   | <+> => zero
   | <+> +> first => one first
   | rest +> curr +> _ => more _ _ _
-    (everyRowTwoRowsInduction zero one more (rest))
-    (everyRowTwoRowsInduction zero one more (rest +> curr))
+    (every_row_two_rows_induction zero one more (rest))
+    (every_row_two_rows_induction zero one more (rest +> curr))
 
 /--
   This induction principle states that if a trace length is at least two, then to prove a property
@@ -47,7 +47,7 @@ variable {F : Type} {S : Type → Type} [ProvableType S] (N : ℕ)
   Induction principle that applies for every row in the trace, where the inductive step takes into
   account the previous two rows.
 -/
-def everyRowTwoRowsInduction {P : (N : ℕ) → TraceOfLength F S N → Sort*}
+def every_row_two_rows_induction {P : (N : ℕ) → TraceOfLength F S N → Sort*}
     (zero : P 0 ⟨<+>, rfl⟩)
     (one : ∀ row : Row F S, P 1 ⟨<+> +> row, rfl⟩)
     (more : ∀ (N : ℕ) (curr next : Row F S),
@@ -60,8 +60,8 @@ def everyRowTwoRowsInduction {P : (N : ℕ) → TraceOfLength F S N → Sort*}
   | N + 2, ⟨rest +> curr +> next, (h : rest.len + 2 = N + 2)⟩ => by
     have eq : rest.len = N := by rw [Nat.add_left_inj] at h; exact h
     exact more N curr next ⟨rest, eq⟩
-      (everyRowTwoRowsInduction zero one more N ⟨rest, eq⟩)
-      (everyRowTwoRowsInduction zero one more (N + 1) ⟨rest +> curr, by rw [Trace.len, eq]⟩)
+      (every_row_two_rows_induction zero one more N ⟨rest, eq⟩)
+      (every_row_two_rows_induction zero one more (N + 1) ⟨rest +> curr, by rw [Trace.len, eq]⟩)
 
 def everyRowTwoRowsInduction' {P : (N : ℕ+) → TraceOfLength F S N → Prop}
     (one : ∀ row : Row F S, P 1 ⟨<+> +> row, rfl⟩)
@@ -72,7 +72,7 @@ def everyRowTwoRowsInduction' {P : (N : ℕ+) → TraceOfLength F S N → Prop}
   intro N trace
   let P' (N : ℕ) (trace : TraceOfLength F S N) : Prop :=
     if h : N = 0 then True else P ⟨N, Nat.pos_iff_ne_zero.mpr h⟩ trace
-  have goal' := everyRowTwoRowsInduction (P:=P') trivial one (by
+  have goal' := every_row_two_rows_induction (P:=P') trivial one (by
     intro N curr next rest h_rest h_curr
     exact more N curr next rest h_curr) N trace
   simpa [P', N.pos] using goal'
@@ -83,7 +83,7 @@ def two_row_induction {prop : Row F S → ℕ → Prop}
     : ∀ N (trace : TraceOfLength F S N), ForAllRowsOfTraceWithIndex trace prop := by
   intro N trace
   simp only [ForAllRowsOfTraceWithIndex, Trace.ForAllRowsOfTraceWithIndex]
-  induction trace.val using Trace.everyRowTwoRowsInduction with
+  induction trace.val using Trace.every_row_two_rows_induction with
   | zero => trivial
   | one first_row =>
     simp only [Trace.ForAllRowsOfTraceWithIndex.inner]

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -174,7 +174,7 @@ def formal_fib32_table : FormalTable (F p) RowType := {
     /-
       We prove the soundness of the table by induction on the trace.
     -/
-    induction' trace.val using Trace.everyRowTwoRowsInduction with first_row curr next rest _ ih2
+    induction' trace.val using Trace.every_row_two_rows_induction with first_row curr next rest _ ih2
     -- base case 1
     · simp [table_norm]
 

--- a/Clean/Tables/Fibonacci8.lean
+++ b/Clean/Tables/Fibonacci8.lean
@@ -103,7 +103,7 @@ def formal_fib_table : FormalTable (F p) RowType := {
     simp only [gt_iff_lt, TraceOfLength.ForAllRowsOfTrace, TableConstraintsHold,
       fib_table, Spec, TraceOfLength.ForAllRowsOfTraceWithIndex, Trace.ForAllRowsOfTraceWithIndex, and_imp]
 
-    induction' trace.val using Trace.everyRowTwoRowsInduction with first_row curr next rest _ ih2
+    induction' trace.val using Trace.every_row_two_rows_induction with first_row curr next rest _ ih2
     · simp [table_norm]
     · simp [table_norm]
       exact boundary_step first_row (envs 0 0)


### PR DESCRIPTION
## Summary
- Renamed `everyRowTwoRowsInduction` to `every_row_two_rows_induction`
- Updated all references across the codebase
- Build passes successfully

## Rationale
This function is primarily used for Prop-based reasoning in the codebase, so it uses `snake_case` with the `_induction` suffix for induction principles.

## Test plan
- [x] Build passes with `lake build`
- [x] All references updated consistently across codebase

🤖 Generated with [Claude Code](https://claude.ai/code)