### PR TITLE
Fix Mathlib naming conventions in Gadgets directory

### DIFF
--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -74,7 +74,7 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (fields n) wher
 
 -- formal assertion that uses the same circuit to implement a range check. without input assumption
 
-def range_check (n : ℕ) (hn : 2^n < p) : FormalAssertion (F p) field where
+def rangeCheck (n : ℕ) (hn : 2^n < p) : FormalAssertion (F p) field where
   main x := do _ ← main n x -- discard the output
   localLength _ := n
 

--- a/Clean/Gadgets/Boolean.lean
+++ b/Clean/Gadgets/Boolean.lean
@@ -4,7 +4,7 @@ import Clean.Utils.Field
 section
 variable {p : ℕ} [Fact p.Prime]
 
-def assert_bool (x: Expression (F p)) := do
+def assertBool (x: Expression (F p)) := do
   assertZero (x * (x - 1))
 
 inductive Boolean (F: Type) where
@@ -15,7 +15,7 @@ def var (b: Boolean (F p)) := Expression.var b.1
 
 def witness (compute : Environment (F p) → F p) := do
   let x ← witnessVar compute
-  assert_bool (Expression.var x)
+  assertBool (Expression.var x)
   return Boolean.mk x
 
 instance : Coe (Boolean (F p)) (Expression (F p)) where

--- a/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
@@ -23,7 +23,7 @@ instance : ProvableStruct Outputs where
   The low part is the least significant `offset` bits,
   and the high part is the most significant `8 - offset` bits.
 -/
-def byte_decomposition (offset : Fin 8) (x :  Expression (F p)) : Circuit (F p) (Var Outputs (F p)) := do
+def byteDecomposition (offset : Fin 8) (x :  Expression (F p)) : Circuit (F p) (Var Outputs (F p)) := do
   let low ← witness fun env => mod (env x) (2^offset.val) (by simp [two_pow_lt])
   let high ← witness fun env => floorDiv (env x) (2^offset.val)
 
@@ -42,14 +42,14 @@ def Spec (offset : Fin 8) (x : F p) (out: Outputs (F p)) :=
   ∧ (low.val < 2^offset.val ∧ high.val < 2^(8 - offset.val))
 
 def elaborated (offset : Fin 8) : ElaboratedCircuit (F p) field Outputs where
-  main := byte_decomposition offset
+  main := byteDecomposition offset
   localLength _ := 2
   output _ i0 := varFromOffset Outputs i0
 
 theorem soundness (offset : Fin 8) : Soundness (F p) (circuit := elaborated offset) Assumptions (Spec offset) := by
   intro i0 env x_var (x : F p) h_input (x_byte : x.val < 256) h_holds
   simp only [id_eq, circuit_norm] at h_input
-  simp only [circuit_norm, elaborated, byte_decomposition, Spec, ByteTable, h_input] at h_holds ⊢
+  simp only [circuit_norm, elaborated, byteDecomposition, Spec, ByteTable, h_input] at h_holds ⊢
   clear h_input
 
   obtain ⟨low_lt, high_lt, h_eq⟩ := h_holds
@@ -101,7 +101,7 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (circuit := elaborated offs
 theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) Assumptions := by
   rintro i0 env x_var henv (x : F p) h_input (x_byte : x.val < 256)
   simp only [ProvableType.eval_field] at h_input
-  simp only [circuit_norm, byte_decomposition, elaborated, h_input, ByteTable] at henv ⊢
+  simp only [circuit_norm, byteDecomposition, elaborated, h_input, ByteTable] at henv ⊢
   simp only [henv]
   have pow_8_nat : 2^8 = 2^(8-offset.val) * 2^offset.val := by simp [←pow_add]
 
@@ -125,7 +125,7 @@ theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) A
 
 def circuit (offset : Fin 8) : FormalCircuit (F p) field Outputs := {
   elaborated offset with
-  main := byte_decomposition offset
+  main := byteDecomposition offset
   Assumptions
   Spec := Spec offset
   soundness := soundness offset

--- a/Clean/Gadgets/ByteDecomposition/Theorems.lean
+++ b/Clean/Gadgets/ByteDecomposition/Theorems.lean
@@ -9,7 +9,7 @@ instance : Fact (p > 512) := .mk (by linarith [p_large_enough.elim])
 
 open FieldUtils (two_val two_pow_val)
 
-theorem byte_decomposition_lift {low high two_power : F p}
+theorem byteDecomposition_lift {low high two_power : F p}
   (h_low : low.val < 2^8) (h_high : high.val < 2^8) (h_two_power : two_power.val ≤ 2^8) :
     (low + high * two_power).val = low.val + high.val * two_power.val := by
   field_to_nat
@@ -19,7 +19,7 @@ theorem byte_decomposition_lift {low high two_power : F p}
   trivial
 
 -- version of the above which requires stronger assumptions and provides a tight bound
-theorem byte_decomposition_lt (o : ℕ) (ho : o ≤ 8) {low high : F p} (h_low : low.val < 2^o) (h_high : high.val < 2^(8-o)) :
+theorem byteDecomposition_lt (o : ℕ) (ho : o ≤ 8) {low high : F p} (h_low : low.val < 2^o) (h_high : high.val < 2^(8-o)) :
     (low + high * (2^o : ℕ)).val < 2^8
     ∧ (low + high * (2^o : ℕ)).val = low.val + high.val * 2^o
      := by
@@ -47,7 +47,7 @@ theorem soundness (offset : Fin 8) (x low high : F p)
   have two_power_le : (2^offset.val : F p).val ≤ 2^8 := by rw [two_power_val]; linarith
 
   have low_byte : low.val < 256 := by linarith
-  have h := byte_decomposition_lift low_byte high_lt two_power_le
+  have h := byteDecomposition_lift low_byte high_lt two_power_le
   rw [two_power_val, ←h_eq] at h
 
   set low_b := UInt32.ofNat low.val

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -8,18 +8,18 @@ variable {F : Type} [Field F]
 open Circuit (ConstraintsHold)
 
 namespace Gadgets
-def all_zero {n} (xs : Vector (Expression F) n) : Circuit F Unit := .forEach xs assertZero
+def allZero {n} (xs : Vector (Expression F) n) : Circuit F Unit := .forEach xs assertZero
 
-theorem all_zero.soundness {offset : ℕ} {env : Environment F} {n} {xs : Vector (Expression F) n} :
-    ConstraintsHold.Soundness env ((all_zero xs).operations offset) → ∀ x ∈ xs, x.eval env = 0 := by
-  simp only [all_zero, circuit_norm]
+theorem allZero.soundness {offset : ℕ} {env : Environment F} {n} {xs : Vector (Expression F) n} :
+    ConstraintsHold.Soundness env ((allZero xs).operations offset) → ∀ x ∈ xs, x.eval env = 0 := by
+  simp only [allZero, circuit_norm]
   intro h_holds x hx
   obtain ⟨i, hi, rfl⟩ := Vector.getElem_of_mem hx
   exact h_holds ⟨i, hi⟩
 
-theorem all_zero.completeness {offset : ℕ} {env : Environment F} {n} {xs : Vector (Expression F) n} :
-    (∀ x ∈ xs, x.eval env = 0) → ConstraintsHold.Completeness env ((all_zero xs).operations offset) := by
-  simp only [all_zero, circuit_norm]
+theorem allZero.completeness {offset : ℕ} {env : Environment F} {n} {xs : Vector (Expression F) n} :
+    (∀ x ∈ xs, x.eval env = 0) → ConstraintsHold.Completeness env ((allZero xs).operations offset) := by
+  simp only [allZero, circuit_norm]
   intro h_holds i
   exact h_holds xs[i] (Vector.mem_of_getElem rfl)
 
@@ -46,7 +46,7 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
 
   soundness := by
     intro offset env input_var input h_input _ h_holds
-    replace h_holds := all_zero.soundness h_holds
+    replace h_holds := allZero.soundness h_holds
     simp only at h_holds
 
     let ⟨x, y⟩ := input
@@ -68,7 +68,7 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
 
   completeness := by
     intro offset env input_var h_env input  h_input _ h_spec
-    apply all_zero.completeness
+    apply allZero.completeness
     simp only
 
     let ⟨x, y⟩ := input

--- a/Clean/Gadgets/Keccak/AbsorbBlock.lean
+++ b/Clean/Gadgets/Keccak/AbsorbBlock.lean
@@ -30,7 +30,7 @@ def main (input : Var Input (F p)) : Circuit (F p) (Var KeccakState (F p)) := do
 instance elaborated : ElaboratedCircuit (F p) Input KeccakState where
   main
   localLength _ := 31048
-  output _ i0 := Permutation.state_var (i0 + 136) 23
+  output _ i0 := Permutation.stateVar (i0 + 136) 23
 
   localLength_eq _ _ := by simp only [main, circuit_norm, Xor64.circuit, Permutation.circuit, RATE]
   output_eq input i0 := by simp only [main, circuit_norm, Xor64.circuit, Permutation.circuit, RATE]

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -16,7 +16,7 @@ def Spec (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
   ∧ out_state.value = keccak_permutation state.value
 
 /-- state in the ith round, starting from offset n -/
-def state_var (n : ℕ) (i : ℕ) : Var KeccakState (F p) :=
+def stateVar (n : ℕ) (i : ℕ) : Var KeccakState (F p) :=
   Vector.mapRange 25 (fun j => varFromOffset U64 (n + i * 1288 + j * 16 + 888))
   |>.set 0 (varFromOffset U64 (n + i * 1288 + 1280))
 
@@ -26,11 +26,11 @@ set_option linter.constructorNameAsVariable false
 instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where
   main
   localLength _ := 30912
-  output _ i0 := state_var i0 23
+  output _ i0 := stateVar i0 23
 
   localLength_eq state i0 := by simp only [main, circuit_norm, KeccakRound.circuit]
   subcircuitsConsistent state i0 := by simp only [main, circuit_norm]
-  output_eq state i0 := by simp only [main, state_var, circuit_norm, KeccakRound.circuit]
+  output_eq state i0 := by simp only [main, stateVar, circuit_norm, KeccakRound.circuit]
 
 -- interestingly, `Fin.foldl` is defeq to `List.foldl`. the proofs below use this fact!
 example (state : Vector ℕ 25) :
@@ -49,7 +49,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   specialize h_init h_assumptions
 
   -- clean up formulation
-  let state (i : ℕ) : KeccakState (F p) := eval env (state_var n i)
+  let state (i : ℕ) : KeccakState (F p) := eval env (stateVar n i)
 
   change (state 0).Normalized ∧
     (state 0).value = keccak_round initial_state.value roundConstants[0]
@@ -91,7 +91,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
   intro i hi
 
   -- clean up formulation
-  let state (i : ℕ) : KeccakState (F p) := eval env (state_var n i)
+  let state (i : ℕ) : KeccakState (F p) := eval env (stateVar n i)
 
   change (state 0).Normalized at h_init
 

--- a/Clean/Gadgets/Keccak/ThetaD.lean
+++ b/Clean/Gadgets/Keccak/ThetaD.lean
@@ -8,7 +8,7 @@ variable {p : ℕ} [Fact p.Prime] [p_large_enough: Fact (p > 2^16 + 2^8)]
 
 instance : Fact (p > 512) := .mk (by linarith [p_large_enough.elim])
 
-def theta_d (row : Var KeccakRow (F p)) : Circuit (F p) (Var KeccakRow (F p)) := do
+def thetaD (row : Var KeccakRow (F p)) : Circuit (F p) (Var KeccakRow (F p)) := do
   let c0 ← subcircuit (Rotation64.circuit (64 - 1)) row[1]
   let c0 ← subcircuit Xor64.circuit ⟨row[4], c0⟩
 
@@ -27,7 +27,7 @@ def theta_d (row : Var KeccakRow (F p)) : Circuit (F p) (Var KeccakRow (F p)) :=
   return #v[c0, c1, c2, c3, c4]
 
 instance elaborated : ElaboratedCircuit (F p) KeccakRow KeccakRow where
-  main := theta_d
+  main := thetaD
   localLength _ := 120
 
 def Assumptions (state : KeccakRow (F p)) := state.Normalized
@@ -40,7 +40,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   intro i0 env row_var row h_input row_norm h_holds
   simp only [circuit_norm, eval_vector] at h_input
   dsimp only [Assumptions] at row_norm
-  dsimp only [circuit_norm, Spec, theta_d, Xor64.circuit, Rotation64.circuit, Rotation64.elaborated] at h_holds ⊢
+  dsimp only [circuit_norm, Spec, thetaD, Xor64.circuit, Rotation64.circuit, Rotation64.elaborated] at h_holds ⊢
   simp only [circuit_norm, subcircuit_norm, Xor64.Assumptions, Xor64.Spec, Rotation64.Assumptions, Rotation64.Spec] at h_holds
   simp only [Nat.reduceMod, zero_sub, Fin.coe_neg_one, and_imp, add_assoc, Nat.reduceAdd, and_assoc] at h_holds
   simp only [circuit_norm, KeccakRow.normalized_iff, KeccakRow.value, KeccakState.value, eval_vector]
@@ -76,7 +76,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
 theorem completeness : Completeness (F p) elaborated Assumptions := by
   intro i0 env row_var h_env row h_input h_assumptions
   simp only [Assumptions, KeccakRow.normalized_iff] at h_assumptions
-  dsimp only [circuit_norm, theta_d, Xor64.circuit, Rotation64.circuit, Rotation64.elaborated] at h_env ⊢
+  dsimp only [circuit_norm, thetaD, Xor64.circuit, Rotation64.circuit, Rotation64.elaborated] at h_env ⊢
   simp_all only [circuit_norm, subcircuit_norm, getElem_eval_vector, h_input,
     Xor64.Assumptions, Xor64.Spec, Rotation64.Assumptions, Rotation64.Spec,
     add_assoc, seval, h_assumptions, true_and, true_implies]

--- a/Clean/Gadgets/Rotation32/Rotation32Bits.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32Bits.lean
@@ -16,7 +16,7 @@ instance : Fact (p > 512) := by
 open Bitwise (rotRight32)
 open Gadgets.Rotation32.Theorems
 open ByteDecomposition (Outputs)
-open ByteDecomposition.Theorems (byte_decomposition_lt)
+open ByteDecomposition.Theorems (byteDecomposition_lt)
 
 /--
   Rotate the 32-bit integer by `offset` bits
@@ -90,7 +90,7 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumpt
     have ⟨⟨_, high_eq⟩, ⟨_, high_lt⟩⟩ := h_holds i hi
     have ⟨⟨next_low_eq, _⟩, ⟨next_low_lt, _⟩⟩ := h_holds ((i + 1) % 4) (Nat.mod_lt _ (by norm_num))
     have next_low_lt' : next_low.val < 2^(8 - (8 - o)) := by rw [Nat.sub_sub_self offset.is_le']; exact next_low_lt
-    have ⟨lt, eq⟩ := byte_decomposition_lt (8-o) neg_offset_le high_lt next_low_lt'
+    have ⟨lt, eq⟩ := byteDecomposition_lt (8-o) neg_offset_le high_lt next_low_lt'
     use lt
     rw [eq, high_eq, next_low_eq]
 

--- a/Clean/Gadgets/Rotation32/Theorems.lean
+++ b/Clean/Gadgets/Rotation32/Theorems.lean
@@ -9,7 +9,7 @@ variable [p_large_enough: Fact (p > 2^16 + 2^8)]
 
 namespace Gadgets.Rotation32.Theorems
 open Bitwise (rotRight32)
-open Gadgets.ByteDecomposition.Theorems (byte_decomposition_lift)
+open Gadgets.ByteDecomposition.Theorems (byteDecomposition_lift)
 open Utils.Rotation
 
 /--

--- a/Clean/Gadgets/Rotation64/Rotation64Bits.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bits.lean
@@ -15,7 +15,7 @@ instance : Fact (p > 512) := by
 open Bitwise (rotRight64)
 open Rotation64.Theorems
 open ByteDecomposition (Outputs)
-open ByteDecomposition.Theorems (byte_decomposition_lt)
+open ByteDecomposition.Theorems (byteDecomposition_lt)
 /--
   Rotate the 64-bit integer by `offset` bits
 -/
@@ -87,7 +87,7 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumpt
     have ⟨⟨_, high_eq⟩, ⟨_, high_lt⟩⟩ := h_holds i hi
     have ⟨⟨next_low_eq, _⟩, ⟨next_low_lt, _⟩⟩ := h_holds ((i + 1) % 8) (Nat.mod_lt _ (by norm_num))
     have next_low_lt' : next_low.val < 2^(8 - (8 - o)) := by rw [Nat.sub_sub_self offset.is_le']; exact next_low_lt
-    have ⟨lt, eq⟩ := byte_decomposition_lt (8-o) neg_offset_le high_lt next_low_lt'
+    have ⟨lt, eq⟩ := byteDecomposition_lt (8-o) neg_offset_le high_lt next_low_lt'
     use lt
     rw [eq, high_eq, next_low_eq]
 


### PR DESCRIPTION
## Summary
- Update 6 function definitions to use lowerCamelCase instead of snake_case
- Update 2 theorem names that reference the renamed functions
- All changes follow Mathlib naming conventions

## Changes Made

### Function Renames
- `byte_decomposition` → `byteDecomposition`
- `assert_bool` → `assertBool`  
- `range_check` → `rangeCheck`
- `state_var` → `stateVar`
- `theta_d` → `thetaD`
- `all_zero` → `allZero`

### Related Theorem Renames
- `byte_decomposition_lift` → `byteDecomposition_lift`
- `byte_decomposition_lt` → `byteDecomposition_lt`

## Test plan
- [x] `lake build` completes successfully
- [x] All function and theorem references updated consistently

🤖 Generated with [Claude Code](https://claude.ai/code)