### PR TITLE
Fix Mathlib naming conventions in Specs directory

### DIFF
--- a/Clean/Gadgets/Keccak/AbsorbBlock.lean
+++ b/Clean/Gadgets/Keccak/AbsorbBlock.lean
@@ -41,13 +41,13 @@ instance elaborated : ElaboratedCircuit (F p) Input KeccakState where
 
 @[reducible] def Spec (input : Input (F p)) (out_state : KeccakState (F p)) :=
   out_state.Normalized ∧
-  out_state.value = absorb_block input.state.value input.block.value
+  out_state.value = absorbBlock input.state.value input.block.value
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   intro i0 env ⟨ state_var, block_var ⟩ ⟨ state, block ⟩ h_input h_assumptions h_holds
 
   -- simplify goal and constraints
-  simp only [circuit_norm, RATE, main, Spec, Assumptions, absorb_block, subcircuit_norm,
+  simp only [circuit_norm, RATE, main, Spec, Assumptions, absorbBlock, subcircuit_norm,
     Xor64.circuit, Xor64.Assumptions, Xor64.Spec,
     Permutation.circuit, Permutation.Assumptions, Permutation.Spec,
     Input.mk.injEq] at *
@@ -82,7 +82,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
   intro i0 env ⟨ state_var, block_var ⟩ h_env ⟨ state, block ⟩ h_input h_assumptions
 
   -- simplify goal and witnesses
-  simp only [circuit_norm, RATE, main, Spec, Assumptions, absorb_block, subcircuit_norm,
+  simp only [circuit_norm, RATE, main, Spec, Assumptions, absorbBlock, subcircuit_norm,
     Xor64.circuit, Xor64.Assumptions, Xor64.Spec,
     Permutation.circuit, Permutation.Assumptions, Permutation.Spec,
     Input.mk.injEq] at *

--- a/Clean/Gadgets/Keccak/KeccakRound.lean
+++ b/Clean/Gadgets/Keccak/KeccakRound.lean
@@ -21,7 +21,7 @@ def Assumptions (state : KeccakState (F p)) := state.Normalized
 
 def Spec (rc : UInt64) (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
   out_state.Normalized
-  ∧ out_state.value = keccak_round state.value rc
+  ∧ out_state.value = keccakRound state.value rc
 
 instance elaborated (rc : UInt64) : ElaboratedCircuit (F p) KeccakState KeccakState where
   main := main rc
@@ -37,7 +37,7 @@ theorem soundness (rc : UInt64) : Soundness (F p) (elaborated rc) Assumptions (S
 
   -- simplify goal
   apply KeccakState.normalized_value_ext
-  simp only [circuit_norm, elaborated, eval_vector, keccak_round, iota]
+  simp only [circuit_norm, elaborated, eval_vector, keccakRound, iota]
 
   -- simplify constraints
   simp only [Assumptions] at state_norm
@@ -59,7 +59,7 @@ theorem soundness (rc : UInt64) : Soundness (F p) (elaborated rc) Assumptions (S
   have h_rc_norm : state0_before_rc.Normalized := by
     simp only [KeccakState.Normalized, eval_vector, circuit_norm] at chi_norm
     exact chi_norm 0
-  have h_rc_eq : state0_before_rc.value = (chi (rho_pi (theta state.value)))[0] := by
+  have h_rc_eq : state0_before_rc.value = (chi (rhoPi (theta state.value)))[0] := by
     simp only [Vector.ext_iff] at chi_eq
     specialize chi_eq 0 (by linarith)
     rw [←chi_eq]

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -13,7 +13,7 @@ def Assumptions (state : KeccakState (F p)) := state.Normalized
 
 def Spec (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
   out_state.Normalized
-  ∧ out_state.value = keccak_permutation state.value
+  ∧ out_state.value = keccakPermutation state.value
 
 /-- state in the ith round, starting from offset n -/
 def stateVar (n : ℕ) (i : ℕ) : Var KeccakState (F p) :=
@@ -34,8 +34,8 @@ instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where
 
 -- interestingly, `Fin.foldl` is defeq to `List.foldl`. the proofs below use this fact!
 example (state : Vector ℕ 25) :
-  Fin.foldl 24 (fun state j => keccak_round state roundConstants[j]) state
-  = roundConstants.foldl keccak_round state := rfl
+  Fin.foldl 24 (fun state j => keccakRound state roundConstants[j]) state
+  = roundConstants.foldl keccakRound state := rfl
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   intro n env initial_state_var initial_state h_input h_assumptions h_holds
@@ -52,17 +52,17 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   let state (i : ℕ) : KeccakState (F p) := eval env (stateVar n i)
 
   change (state 0).Normalized ∧
-    (state 0).value = keccak_round initial_state.value roundConstants[0]
+    (state 0).value = keccakRound initial_state.value roundConstants[0]
   at h_init
 
   change ∀ (i : ℕ) (hi : i + 1 < 24), (state i).Normalized → (state (i + 1)).Normalized ∧
-    (state (i + 1)).value = keccak_round (state i).value roundConstants[i + 1]
+    (state (i + 1)).value = keccakRound (state i).value roundConstants[i + 1]
   at h_succ
 
   -- inductive proof
   have h_inductive (i : ℕ) (hi : i < 24) :
     (state i).Normalized ∧ (state i).value =
-      Fin.foldl (i + 1) (fun state j => keccak_round state roundConstants[j.val]) initial_state.value := by
+      Fin.foldl (i + 1) (fun state j => keccakRound state roundConstants[j.val]) initial_state.value := by
     induction i with
     | zero => simp [Fin.foldl_succ, h_init]
     | succ i ih =>

--- a/Clean/Gadgets/Keccak/RhoPi.lean
+++ b/Clean/Gadgets/Keccak/RhoPi.lean
@@ -24,7 +24,7 @@ def Assumptions := KeccakState.Normalized (p:=p)
 
 def Spec (state : KeccakState (F p)) (out_state : KeccakState (F p)) :=
   out_state.Normalized
-  ∧ out_state.value = Specs.Keccak256.rho_pi state.value
+  ∧ out_state.value = Specs.Keccak256.rhoPi state.value
 
 instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where
   main
@@ -32,10 +32,10 @@ instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakState where
   localLength_eq _ _ := by simp only [main, circuit_norm, Rotation64.circuit, Rotation64.elaborated]
   subcircuitsConsistent _ _ := by simp only [main, circuit_norm]
 
--- recharacterize rho_phi as a loop
-lemma rho_pi_loop (state : Vector ℕ 25) :
-    Specs.Keccak256.rho_pi state = rhoPiConstants.map fun (i, s) => rotLeft64 state[i.val] s := by
-  simp only [Specs.Keccak256.rho_pi, circuit_norm]
+-- recharacterize rhoPi as a loop
+lemma rhoPi_loop (state : Vector ℕ 25) :
+    Specs.Keccak256.rhoPi state = rhoPiConstants.map fun (i, s) => rotLeft64 state[i.val] s := by
+  simp only [Specs.Keccak256.rhoPi, circuit_norm]
   rw [Vector.map_mk]
   simp only
   rw [List.map_toArray]
@@ -47,7 +47,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   -- simplify goal
   apply KeccakState.normalized_value_ext
   simp only [elaborated, eval_vector, Vector.getElem_map, Vector.getElem_mapIdx,
-    KeccakState.value, rho_pi_loop]
+    KeccakState.value, rhoPi_loop]
 
   -- simplify constraints
   simp only [circuit_norm, eval_vector, Vector.ext_iff] at h_input

--- a/Clean/Gadgets/Keccak/ThetaC.lean
+++ b/Clean/Gadgets/Keccak/ThetaC.lean
@@ -21,7 +21,7 @@ def Assumptions (state : KeccakState (F p)) := state.Normalized
 
 def Spec (state : KeccakState (F p)) (out: KeccakRow (F p)) :=
   out.Normalized
-  ∧ out.value = Specs.Keccak256.theta_c state.value
+  ∧ out.value = Specs.Keccak256.thetaC state.value
 
 -- #eval! theta_c (p:=p_babybear) default |>.localLength
 instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakRow where
@@ -30,11 +30,11 @@ instance elaborated : ElaboratedCircuit (F p) KeccakState KeccakRow where
   localLength_eq _ _ := by simp only [main, circuit_norm, Xor64.circuit]
   subcircuitsConsistent _ _ := by simp only [main, circuit_norm]; intro; and_intros <;> ac_rfl
 
--- rewrite theta_c as a loop
-lemma theta_c_loop (state : Vector ℕ 25) :
-    Specs.Keccak256.theta_c state = .mapFinRange 5 fun i =>
+-- rewrite thetaC as a loop
+lemma thetaC_loop (state : Vector ℕ 25) :
+    Specs.Keccak256.thetaC state = .mapFinRange 5 fun i =>
       state[5*i.val] ^^^ state[5*i.val + 1] ^^^ state[5*i.val + 2] ^^^ state[5*i.val + 3] ^^^ state[5*i.val + 4] := by
-  rw [Specs.Keccak256.theta_c, Vector.mapFinRange, Vector.finRange, Vector.map_mk, Vector.eq_mk, List.map_toArray]
+  rw [Specs.Keccak256.thetaC, Vector.mapFinRange, Vector.finRange, Vector.map_mk, Vector.eq_mk, List.map_toArray]
   rfl
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
@@ -42,7 +42,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
 
   -- rewrite goal
   apply KeccakRow.normalized_value_ext
-  simp only [main, theta_c_loop, circuit_norm, eval_vector, KeccakState.value, Xor64.circuit]
+  simp only [main, thetaC_loop, circuit_norm, eval_vector, KeccakState.value, Xor64.circuit]
 
   -- simplify constraints
   simp only [circuit_norm, eval_vector, Vector.ext_iff] at h_input

--- a/Clean/Gadgets/Keccak/ThetaD.lean
+++ b/Clean/Gadgets/Keccak/ThetaD.lean
@@ -34,7 +34,7 @@ def Assumptions (state : KeccakRow (F p)) := state.Normalized
 
 def Spec (row : KeccakRow (F p)) (out: KeccakRow (F p)) : Prop :=
   out.Normalized
-  ∧ out.value = Specs.Keccak256.theta_d row.value
+  ∧ out.value = Specs.Keccak256.thetaD row.value
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   intro i0 env row_var row h_input row_norm h_holds
@@ -71,7 +71,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   specialize h_xor4 (row_norm 3) h_rot4.right
   rw [h_rot4.left] at h_xor4
 
-  simp [Specs.Keccak256.theta_d, h_xor0, h_xor1, h_xor2, h_xor3, h_xor4, Bitwise.rotLeft64]
+  simp [Specs.Keccak256.thetaD, h_xor0, h_xor1, h_xor2, h_xor3, h_xor4, Bitwise.rotLeft64]
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
   intro i0 env row_var h_env row h_input h_assumptions

--- a/Clean/Gadgets/Keccak/ThetaXor.lean
+++ b/Clean/Gadgets/Keccak/ThetaXor.lean
@@ -33,19 +33,19 @@ def Assumptions (inputs : Inputs (F p)) : Prop :=
 def Spec (inputs : Inputs (F p)) (out: KeccakState (F p)) : Prop :=
   let ⟨state, d⟩ := inputs
   out.Normalized
-  ∧ out.value = Specs.Keccak256.theta_xor state.value d.value
+  ∧ out.value = Specs.Keccak256.thetaXor state.value d.value
 
--- rewrite theta_xor as a loop
-lemma theta_xor_loop (state : Vector ℕ 25) (d : Vector ℕ 5) :
-    Specs.Keccak256.theta_xor state d = .mapFinRange 25 fun i => state[i.val] ^^^ d[i.val / 5] := by
-  simp only [Specs.Keccak256.theta_xor, circuit_norm, Vector.mapFinRange_succ, Vector.mapFinRange_zero]
+-- rewrite thetaXor as a loop
+lemma thetaXor_loop (state : Vector ℕ 25) (d : Vector ℕ 5) :
+    Specs.Keccak256.thetaXor state d = .mapFinRange 25 fun i => state[i.val] ^^^ d[i.val / 5] := by
+  simp only [Specs.Keccak256.thetaXor, circuit_norm, Vector.mapFinRange_succ, Vector.mapFinRange_zero]
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   intro i0 env ⟨state_var, d_var⟩ ⟨state, d⟩ h_input ⟨state_norm, d_norm⟩ h_holds
 
   -- rewrite goal
   apply KeccakState.normalized_value_ext
-  simp only [main, circuit_norm, theta_xor_loop, Xor64.circuit, varFromOffset_vector, eval_vector,
+  simp only [main, circuit_norm, thetaXor_loop, Xor64.circuit, varFromOffset_vector, eval_vector,
     mul_comm, KeccakState.value, KeccakRow.value]
 
   -- simplify constraints

--- a/Clean/Specs/Keccak256.lean
+++ b/Clean/Specs/Keccak256.lean
@@ -21,7 +21,7 @@ def roundConstants : Vector UInt64 24 := #v[
 def bits2bytes (x : Nat) : Nat :=
   (x + 7) / 8
 
-def theta_c (state : Vector ℕ 25) : Vector ℕ 5 :=
+def thetaC (state : Vector ℕ 25) : Vector ℕ 5 :=
   #v[
     state[0] ^^^ state[1] ^^^ state[2] ^^^ state[3] ^^^ state[4],
     state[5] ^^^ state[6] ^^^ state[7] ^^^ state[8] ^^^ state[9],
@@ -30,7 +30,7 @@ def theta_c (state : Vector ℕ 25) : Vector ℕ 5 :=
     state[20] ^^^ state[21] ^^^ state[22] ^^^ state[23] ^^^ state[24]
   ]
 
-def theta_d (c : Vector ℕ 5) : Vector ℕ 5 :=
+def thetaD (c : Vector ℕ 5) : Vector ℕ 5 :=
   #v[
     c[4] ^^^ (rotLeft64 c[1] 1),
     c[0] ^^^ (rotLeft64 c[2] 1),
@@ -39,7 +39,7 @@ def theta_d (c : Vector ℕ 5) : Vector ℕ 5 :=
     c[3] ^^^ (rotLeft64 c[0] 1)
   ]
 
-def theta_xor (state : Vector ℕ 25) (d : Vector ℕ 5) : Vector ℕ 25 :=
+def thetaXor (state : Vector ℕ 25) (d : Vector ℕ 5) : Vector ℕ 25 :=
   #v[
     state[0] ^^^ d[0],
     state[1] ^^^ d[0],
@@ -69,11 +69,11 @@ def theta_xor (state : Vector ℕ 25) (d : Vector ℕ 5) : Vector ℕ 25 :=
   ]
 
 def theta (state : Vector ℕ 25) : Vector ℕ 25 :=
-  let c := theta_c state
-  let d := theta_d c
-  theta_xor state d
+  let c := thetaC state
+  let d := thetaD c
+  thetaXor state d
 
-def rho_pi (state : Vector ℕ 25) : Vector ℕ 25 :=
+def rhoPi (state : Vector ℕ 25) : Vector ℕ 25 :=
   #v[
     rotLeft64 state[0] 0,
     rotLeft64 state[15] 28,
@@ -134,29 +134,29 @@ def chi (b : Vector ℕ 25) : Vector ℕ 25 :=
 def iota (state : Vector ℕ 25) (rc : UInt64) : Vector ℕ 25 :=
   state.set 0 ((state.get 0) ^^^ rc.toFin)
 
-def keccak_round (state : Vector ℕ 25) (rc : UInt64) : Vector ℕ 25 :=
+def keccakRound (state : Vector ℕ 25) (rc : UInt64) : Vector ℕ 25 :=
   let theta_state := theta state
-  let rho_pi_state := rho_pi theta_state
+  let rho_pi_state := rhoPi theta_state
   let chi_state := chi rho_pi_state
   iota chi_state rc
 
-def keccak_permutation (state : Vector ℕ 25): Vector ℕ 25 :=
-  roundConstants.foldl keccak_round state
+def keccakPermutation (state : Vector ℕ 25): Vector ℕ 25 :=
+  roundConstants.foldl keccakRound state
 
 @[reducible] def CAPACITY := 8
 @[reducible] def RATE := 17
 example : RATE + CAPACITY = 25 := rfl
 
-def initial_state : Vector ℕ 25 := .fill 25 0
+def initialState : Vector ℕ 25 := .fill 25 0
 
-def absorb_block (state : Vector ℕ 25) (block : Vector ℕ RATE) : Vector ℕ 25 :=
+def absorbBlock (state : Vector ℕ 25) (block : Vector ℕ RATE) : Vector ℕ 25 :=
   -- absorb the block into the state by XORing with the first RATE elements
   let state' := Vector.mapFinRange 25 fun i => state[i] ^^^ (if _ : i.val < RATE then block[i] else 0)
   -- apply the permutation
-  keccak_permutation state'
+  keccakPermutation state'
 
-def absorb_blocks (blocks : List (Vector ℕ RATE)) : Vector ℕ 25 :=
-  blocks.foldl absorb_block initial_state
+def absorbBlocks (blocks : List (Vector ℕ RATE)) : Vector ℕ 25 :=
+  blocks.foldl absorbBlock initialState
 
 end Specs.Keccak256
 

--- a/Clean/Tables/KeccakInductive.lean
+++ b/Clean/Tables/KeccakInductive.lean
@@ -16,7 +16,7 @@ def table : InductiveTable (F p) KeccakState KeccakBlock where
 
   Spec i state blocks _ : Prop :=
     state.Normalized
-    ∧ state.value = absorb_blocks (blocks.map KeccakBlock.value)
+    ∧ state.value = absorbBlocks (blocks.map KeccakBlock.value)
 
   input_assumptions i block := block.Normalized
 
@@ -24,7 +24,7 @@ def table : InductiveTable (F p) KeccakState KeccakBlock where
     intro i env state_var block_var state block blocks _ h_input h_holds spec_previous
     simp_all only [circuit_norm, subcircuit_norm,
       AbsorbBlock.circuit, AbsorbBlock.Assumptions, AbsorbBlock.Spec,
-      KeccakBlock.normalized, absorb_blocks]
+      KeccakBlock.normalized, absorbBlocks]
     rw [List.concat_eq_append, List.map_append, List.map_cons, List.map_nil, List.foldl_concat]
 
   completeness := by
@@ -48,13 +48,13 @@ def formalTable (output : KeccakState (F p)) := table.toFormal initialState outp
 -- The table's statement implies that the output state is the result of keccak-hashing some list of input blocks
 theorem tableStatement (output : KeccakState (F p)) : ∀ n > 0, ∀ trace, ∃ blocks, blocks.length = n - 1 ∧
   (formalTable output).statement n trace →
-    output.Normalized ∧ output.value = absorb_blocks blocks := by
+    output.Normalized ∧ output.value = absorbBlocks blocks := by
   intro n hn trace
   use (InductiveTable.traceInputs trace.tail).map KeccakBlock.value
   intro Spec
   simp only [formalTable, FormalTable.statement, table, InductiveTable.toFormal] at Spec
   simp only [List.length_map, Trace.toList_length, trace.tail.prop, InductiveTable.traceInputs, hn] at Spec
-  simp only [initialState_value, initialState_normalized, absorb_blocks, initial_state, true_and] at Spec
+  simp only [initialState_value, initialState_normalized, absorbBlocks, Specs.Keccak256.initialState, true_and] at Spec
   exact Spec rfl
 
 end Tables.KeccakInductive


### PR DESCRIPTION
## Summary
- Update 9 function definitions to use lowerCamelCase instead of snake_case
- Update 3 theorem names that reference the renamed functions
- All changes follow Mathlib naming conventions

## Changes Made

### Function Renames
- `theta_c` → `thetaC`
- `theta_d` → `thetaD`  
- `theta_xor` → `thetaXor`
- `rho_pi` → `rhoPi`
- `keccak_round` → `keccakRound`
- `keccak_permutation` → `keccakPermutation`
- `initial_state` → `initialState`
- `absorb_block` → `absorbBlock`
- `absorb_blocks` → `absorbBlocks`

### Related Theorem Renames
- `theta_c_loop` → `thetaC_loop`
- `theta_xor_loop` → `thetaXor_loop`  
- `rho_pi_loop` → `rhoPi_loop`

## Test plan
- [x] `lake build` completes successfully
- [x] All function and theorem references updated consistently
- [x] Namespace qualification used to resolve naming conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)