### PR TITLE
Fix Mathlib naming conventions in Tables directory

### DIFF
--- a/Clean/Examples/ToJson.lean
+++ b/Clean/Examples/ToJson.lean
@@ -4,7 +4,7 @@ import Clean.Tables.Fibonacci32Inductive
 import Clean.Table.Json
 
 -- serialize constraints of the Fibonacci8 table to JSON
-def fib8json := Lean.toJson (Tables.Fibonacci8Table.fib_table (p:= pBabybear))
+def fib8json := Lean.toJson (Tables.Fibonacci8Table.fibTable (p:= pBabybear))
 -- #eval fib8json
 
 -- serialize constraints of the Fibonacci32 table to JSON


### PR DESCRIPTION
## Summary
Fixed function naming conventions in Tables directory to follow Mathlib standards by changing from snake_case to lowerCamelCase

## Changes
Updated function names: nextRowOff, assignU32, recursiveRelation, fib32Table, formalFib32Table, fibRelation, boundaryFib, fibTable, formalFibTable, add8Inline, add8Table, formalAdd8Table

Theorem names containing these functions were also updated accordingly

## Test plan
- [x] Lake build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)