### PR TITLE
Fix Mathlib naming conventions for functions

### DIFF
--- a/Clean/Examples/Trace.lean
+++ b/Clean/Examples/Trace.lean
@@ -7,13 +7,13 @@ open Tables.Fibonacci8Table
 
 
 -- generate trace using the witness generators from `EveryRowExceptLast` table constraint
-def fib_relation_babybear := fib_relation (p := p_babybear)
-def init_row : RowType (F p_babybear) := { x := 0, y := 1 }
+def fibRelationBabybear := fibRelation (p := p_babybear)
+def initRow : RowType (F p_babybear) := { x := 0, y := 1 }
 
-#eval witnesses fib_relation_babybear init_row 20
+#eval witnesses fibRelationBabybear initRow 20
 
 
--- def data := Lean.toJson (witnesses fib_relation_babybear init_row 1000000)
+-- def data := Lean.toJson (witnesses fibRelationBabybear initRow 1000000)
 
 -- def dumpJson (j : Lean.Json) (path := "trace.json") : IO Unit := do
 --   IO.FS.writeFile path j.compress   -- or `j.pretty`

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -130,7 +130,7 @@ def decomposeNatExpr (x: ℕ) : U32 (Expression (F p)) :=
 def fromUInt32 (x : UInt32) : U32 (F p) :=
   decomposeNat x.toFin
 
-def value_u32 (x : U32 (F p)) (h : x.Normalized) : UInt32 :=
+def valueU32 (x : U32 (F p)) (h : x.Normalized) : UInt32 :=
   UInt32.ofNatLT x.value (value_lt_of_normalized h)
 
 lemma fromUInt32_normalized (x : UInt32) : (fromUInt32 (p:=p) x).Normalized := by
@@ -143,7 +143,7 @@ lemma fromUInt32_normalized (x : UInt32) : (fromUInt32 (p:=p) x).Normalized := b
   simp [h]
 
 theorem value_fromUInt32 (x : UInt32) : value (fromUInt32 (p:=p) x) = x.toNat := by
-  simp only [value_u32, value_horner, fromUInt32, decomposeNat, UInt32.toFin_val]
+  simp only [valueU32, value_horner, fromUInt32, decomposeNat, UInt32.toFin_val]
   set x := x.toNat
   have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) = x % 256 := by
     rw [ZMod.val_cast_of_lt]

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -148,7 +148,7 @@ def decomposeNatExpr (x: ℕ) : U64 (Expression (F p)) :=
 def fromUInt64 (x : UInt64) : U64 (F p) :=
   decomposeNat x.toFin
 
-def value_u64 (x : U64 (F p)) (h : x.Normalized) : UInt64 :=
+def valueU64 (x : U64 (F p)) (h : x.Normalized) : UInt64 :=
   UInt64.ofNatLT x.value (value_lt_of_normalized h)
 
 lemma fromUInt64_normalized (x : UInt64) : (fromUInt64 (p:=p) x).Normalized := by
@@ -161,7 +161,7 @@ lemma fromUInt64_normalized (x : UInt64) : (fromUInt64 (p:=p) x).Normalized := b
   simp [h]
 
 theorem value_fromUInt64 (x : UInt64) : value (fromUInt64 (p:=p) x) = x.toNat := by
-  simp only [value_u64, value_horner, fromUInt64, decomposeNat, UInt64.toFin_val]
+  simp only [valueU64, value_horner, fromUInt64, decomposeNat, UInt64.toFin_val]
   set x := x.toNat
   have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) = x % 256 := by
     rw [ZMod.val_cast_of_lt]


### PR DESCRIPTION
## Summary
Fixed function naming conventions to follow Mathlib standards by changing from snake_case to lowerCamelCase

## Changes
Updated function names: fibRelationBabybear, initRow, valueU64, valueU32

## Test plan
- [x] Lake build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)