### PR TITLE
Some cleanup and renaming

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -198,7 +198,7 @@ def Environment.UsesLocalWitnessesFlat (env : Environment F) (n : ℕ) (ops : Li
 
 section
 open Circuit (ConstraintsHold)
-variable {α β: TypeMap} [ProvableType α] [ProvableType β]
+variable {Input Output: TypeMap} [ProvableType Input] [ProvableType Output]
 
 /-
 Common base type for circuits that are to be used in formal proofs.
@@ -206,18 +206,18 @@ Common base type for circuits that are to be used in formal proofs.
 It contains the main circuit plus some of its properties in elaborated form, to make it
 faster to reason about them in proofs.
 -/
-class ElaboratedCircuit (F: Type) [Field F] (β α: TypeMap) [ProvableType β] [ProvableType α] where
-  main: Var β F → Circuit F (Var α F)
+class ElaboratedCircuit (F: Type) (Input Output: TypeMap) [Field F] [ProvableType Input] [ProvableType Output] where
+  main : Var Input F → Circuit F (Var Output F)
 
   /-- how many local witnesses this circuit introduces -/
-  localLength: Var β F → ℕ
+  localLength : Var Input F → ℕ
 
   /-- the local length must not depend on the offset. usually automatically proved by `rfl` -/
   localLength_eq : ∀ input offset, (main input).localLength offset = localLength input
     := by intros; rfl
 
   /-- a direct way of computing the output of this circuit (i.e. without having to unfold `main`) -/
-  output : Var β F → ℕ → Var α F := fun input offset => (main input).output offset
+  output : Var Input F → ℕ → Var Output F := fun input offset => (main input).output offset
 
   /-- correctness of `output` -/
   output_eq : ∀ input offset, (main input).output offset = output input offset
@@ -232,29 +232,29 @@ class ElaboratedCircuit (F: Type) [Field F] (β α: TypeMap) [ProvableType β] [
 
 attribute [circuit_norm] ElaboratedCircuit.main ElaboratedCircuit.localLength ElaboratedCircuit.output
 
-def Soundness (F: Type) [Field F] (circuit : ElaboratedCircuit F β α)
-    (Assumptions: β F → Prop) (Spec: β F → α F → Prop) :=
+def Soundness (F: Type) [Field F] (circuit : ElaboratedCircuit F Input Output)
+    (Assumptions: Input F → Prop) (Spec: Input F → Output F → Prop) :=
   -- for all environments that determine witness generation
   ∀ offset : ℕ, ∀ env,
   -- for all inputs that satisfy the assumptions
-  ∀ b_var : Var β F, ∀ b : β F, eval env b_var = b →
-  Assumptions b →
+  ∀ input_var : Var Input F, ∀ input : Input F, eval env input_var = input →
+  Assumptions input →
   -- if the constraints hold
-  ConstraintsHold.Soundness env (circuit.main b_var |>.operations offset) →
+  ConstraintsHold.Soundness env (circuit.main input_var |>.operations offset) →
   -- the spec holds on the input and output
-  let a := eval env (circuit.output b_var offset)
-  Spec b a
+  let output := eval env (circuit.output input_var offset)
+  Spec input output
 
-def Completeness (F: Type) [Field F] (circuit : ElaboratedCircuit F β α)
-    (Assumptions: β F → Prop) :=
+def Completeness (F: Type) [Field F] (circuit : ElaboratedCircuit F Input Output)
+    (Assumptions: Input F → Prop) :=
   -- for all environments which _use the default witness generators for local variables_
-  ∀ offset : ℕ, ∀ env, ∀ b_var : Var β F,
-  env.UsesLocalWitnessesCompleteness offset (circuit.main b_var |>.operations offset) →
+  ∀ offset : ℕ, ∀ env, ∀ input_var : Var Input F,
+  env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the assumptions
-  ∀ b : β F, eval env b_var = b →
-  Assumptions b →
+  ∀ input : Input F, eval env input_var = input →
+  Assumptions input →
   -- the constraints hold
-  ConstraintsHold.Completeness env (circuit.main b_var |>.operations offset)
+  ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset)
 
 /--
 `FormalCircuit` is the main object that encapsulates correctness of a circuit.
@@ -268,26 +268,25 @@ It requires you to provide
 Note that soundness and completeness, taken together, show that the spec will hold for _all_ inputs.
 This means that, when viewed as a black box, the circuit acts similar to a function.
 -/
-structure FormalCircuit (F: Type) (β α: TypeMap) [Field F] [ProvableType α] [ProvableType β]
-  extends elaborated : ElaboratedCircuit F β α where
-  -- β = inputs, α = outputs
-  Assumptions: β F → Prop
-  Spec: β F → α F → Prop
-  soundness: Soundness F elaborated Assumptions Spec
-  completeness: Completeness F elaborated Assumptions
+structure FormalCircuit (F: Type) [Field F] (Input Output: TypeMap) [ProvableType Input] [ProvableType Output]
+  extends elaborated : ElaboratedCircuit F Input Output where
+  Assumptions : Input F → Prop
+  Spec : Input F → Output F → Prop
+  soundness : Soundness F elaborated Assumptions Spec
+  completeness : Completeness F elaborated Assumptions
 
 namespace Circuit
 @[circuit_norm]
-def SubcircuitSoundness (circuit: FormalCircuit F β α) (b_var : Var β F) (offset: ℕ) (env : Environment F) :=
-  let b := eval env b_var
-  let a_var := circuit.output b_var offset
-  let a := eval env a_var
-  circuit.Assumptions b → circuit.Spec b a
+def SubcircuitSoundness (circuit: FormalCircuit F Input Output) (input_var : Var Input F) (offset: ℕ) (env : Environment F) :=
+  let input := eval env input_var
+  let output_var := circuit.output input_var offset
+  let output := eval env output_var
+  circuit.Assumptions input → circuit.Spec input output
 
 @[circuit_norm]
-def SubcircuitCompleteness (circuit: FormalCircuit F β α) (b_var : Var β F) (env : Environment F) :=
-  let b := eval env b_var
-  circuit.Assumptions b
+def SubcircuitCompleteness (circuit: FormalCircuit F Input Output) (input_var : Var Input F) (env : Environment F) :=
+  let input := eval env input_var
+  circuit.Assumptions input
 end Circuit
 
 /--
@@ -302,31 +301,31 @@ However, the _completeness_ statement is weaker: assumptions ∧ spec → constr
 In other words, for `FormalAssertion`s the spec must be an equivalent reformulation of the constraints.
 (In the case of `FormalCircuit`, the spec can be strictly weaker than the constraints.)
 -/
-structure FormalAssertion (F: Type) (β: TypeMap) [Field F] [ProvableType β]
-  extends ElaboratedCircuit F β unit where
-  Assumptions: β F → Prop
-  Spec: β F → Prop
+structure FormalAssertion (F: Type) (Input: TypeMap) [Field F] [ProvableType Input]
+  extends ElaboratedCircuit F Input unit where
+  Assumptions : Input F → Prop
+  Spec : Input F → Prop
 
-  soundness:
+  soundness :
     -- for all environments that determine witness generation
     ∀ offset, ∀ env,
     -- for all inputs that satisfy the assumptions
-    ∀ b_var : Var β F, ∀ b : β F, eval env b_var = b →
-    Assumptions b →
+    ∀ input_var : Var Input F, ∀ input : Input F, eval env input_var = input →
+    Assumptions input →
     -- if the constraints hold
-    ConstraintsHold.Soundness env (main b_var |>.operations offset) →
+    ConstraintsHold.Soundness env (main input_var |>.operations offset) →
     -- the spec holds
-    Spec b
+    Spec input
 
-  completeness:
+  completeness :
     -- for all environments which _use the default witness generators for local variables_
-    ∀ offset, ∀ env, ∀ b_var : Var β F,
-    env.UsesLocalWitnessesCompleteness offset (main b_var |>.operations offset) →
+    ∀ offset, ∀ env, ∀ input_var : Var Input F,
+    env.UsesLocalWitnessesCompleteness offset (main input_var |>.operations offset) →
     -- for all inputs that satisfy the assumptions AND the spec
-    ∀ b : β F, eval env b_var = b →
-    Assumptions b → Spec b →
+    ∀ input : Input F, eval env input_var = input →
+    Assumptions input → Spec input →
     -- the constraints hold
-    ConstraintsHold.Completeness env (main b_var |>.operations offset)
+    ConstraintsHold.Completeness env (main input_var |>.operations offset)
 
   -- assertions commonly don't introduce internal witnesses, so this is a convenient default
   localLength := fun _ => 0
@@ -335,36 +334,36 @@ structure FormalAssertion (F: Type) (β: TypeMap) [Field F] [ProvableType β]
 
 namespace Circuit
 @[circuit_norm]
-def SubassertionSoundness (circuit: FormalAssertion F β) (b_var : Var β F) (env: Environment F) :=
-  let b := eval env b_var
-  circuit.Assumptions b → circuit.Spec b
+def SubassertionSoundness (circuit: FormalAssertion F Input) (input_var : Var Input F) (env: Environment F) :=
+  let input := eval env input_var
+  circuit.Assumptions input → circuit.Spec input
 
 @[circuit_norm]
-def SubassertionCompleteness (circuit: FormalAssertion F β) (b_var : Var β F) (env: Environment F) :=
-  let b := eval env b_var
-  circuit.Assumptions b ∧ circuit.Spec b
+def SubassertionCompleteness (circuit: FormalAssertion F Input) (input_var : Var Input F) (env: Environment F) :=
+  let input := eval env input_var
+  circuit.Assumptions input ∧ circuit.Spec input
 end Circuit
 
-def GeneralFormalCircuit.Soundness (F: Type) [Field F] (circuit : ElaboratedCircuit F β α) (Spec: β F → α F → Prop) :=
+def GeneralFormalCircuit.Soundness (F: Type) [Field F] (circuit : ElaboratedCircuit F Input Output) (Spec: Input F → Output F → Prop) :=
   -- for all environments that determine witness generation
   ∀ offset : ℕ, ∀ env,
   -- for all inputs
-  ∀ b_var : Var β F, ∀ b : β F, eval env b_var = b →
+  ∀ input_var : Var Input F, ∀ input : Input F, eval env input_var = input →
   -- if the constraints hold
-  ConstraintsHold.Soundness env (circuit.main b_var |>.operations offset) →
+  ConstraintsHold.Soundness env (circuit.main input_var |>.operations offset) →
   -- the spec holds on the input and output
-  let a := eval env (circuit.output b_var offset)
-  Spec b a
+  let output := eval env (circuit.output input_var offset)
+  Spec input output
 
-def GeneralFormalCircuit.Completeness (F: Type) [Field F] (circuit : ElaboratedCircuit F β α) (Assumptions: β F → Prop) :=
+def GeneralFormalCircuit.Completeness (F: Type) [Field F] (circuit : ElaboratedCircuit F Input Output) (Assumptions: Input F → Prop) :=
   -- for all environments which _use the default witness generators for local variables_
-  ∀ offset : ℕ, ∀ env, ∀ b_var : Var β F,
-  env.UsesLocalWitnessesCompleteness offset (circuit.main b_var |>.operations offset) →
+  ∀ offset : ℕ, ∀ env, ∀ input_var : Var Input F,
+  env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the "honest prover" assumptions
-  ∀ b : β F, eval env b_var = b →
-  Assumptions b →
+  ∀ input : Input F, eval env input_var = input →
+  Assumptions input →
   -- the constraints hold
-  ConstraintsHold.Completeness env (circuit.main b_var |>.operations offset)
+  ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset)
 
 /--
 `GeneralFormalCircuit` is the most general model of formal circuits, needed in cases where the circuit is a
@@ -381,13 +380,13 @@ this assumption is not needed as the circuit adds that constraint itself. Using 
 add the range assumption to the soundness statement, thus making the circuit hard to use
 (in particular, not usable as a bit range check, because it already _requires_ the bit range assumption).
 -/
-structure GeneralFormalCircuit (F: Type) (β α: TypeMap) [Field F] [ProvableType β] [ProvableType α]
-    extends elaborated : ElaboratedCircuit F β α where
-  Assumptions: β F → Prop -- the statement to be assumed for completeness
-  Spec: β F → α F → Prop -- the statement to be proved for soundness. (Might have to include `Assumptions` on the inputs, as a hypothesis.)
+structure GeneralFormalCircuit (F: Type) (Input Output: TypeMap) [Field F] [ProvableType Input] [ProvableType Output]
+    extends elaborated : ElaboratedCircuit F Input Output where
+  Assumptions : Input F → Prop -- the statement to be assumed for completeness
+  Spec : Input F → Output F → Prop -- the statement to be proved for soundness. (Might have to include `Assumptions` on the inputs, as a hypothesis.)
 
-  soundness: GeneralFormalCircuit.Soundness F elaborated Spec
-  completeness: GeneralFormalCircuit.Completeness F elaborated Assumptions
+  soundness : GeneralFormalCircuit.Soundness F elaborated Spec
+  completeness : GeneralFormalCircuit.Completeness F elaborated Assumptions
 end
 
 export Circuit (witnessVar witness witnessVars witnessVector assertZero lookup)

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -478,9 +478,8 @@ attribute [circuit_norm]
 -- simplify stuff like (3 : Fin 8).val = 3 % 8
 attribute [circuit_norm] Fin.coe_ofNat_eq_mod
 
--- simplify `vector.get i` (which occurs in ProvableType definitions) and similar
-attribute [circuit_norm] Vector.get Fin.val_eq_zero
-  Fin.cast_eq_self Fin.coe_cast Fin.isValue
+-- simplify `vector[i]` (which occurs in ProvableType definitions) and similar
+attribute [circuit_norm] Fin.val_eq_zero Fin.cast_eq_self Fin.coe_cast Fin.isValue
 
 -- simplify constraint expressions and +0 indices
 attribute [circuit_norm] neg_mul one_mul add_zero

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -275,20 +275,6 @@ structure FormalCircuit (F: Type) [Field F] (Input Output: TypeMap) [ProvableTyp
   soundness : Soundness F elaborated Assumptions Spec
   completeness : Completeness F elaborated Assumptions
 
-namespace Circuit
-@[circuit_norm]
-def SubcircuitSoundness (circuit: FormalCircuit F Input Output) (input_var : Var Input F) (offset: ℕ) (env : Environment F) :=
-  let input := eval env input_var
-  let output_var := circuit.output input_var offset
-  let output := eval env output_var
-  circuit.Assumptions input → circuit.Spec input output
-
-@[circuit_norm]
-def SubcircuitCompleteness (circuit: FormalCircuit F Input Output) (input_var : Var Input F) (env : Environment F) :=
-  let input := eval env input_var
-  circuit.Assumptions input
-end Circuit
-
 /--
 `FormalAssertion` models a subcircuit that is "assertion-like":
 - it doesn't return anything
@@ -331,18 +317,6 @@ structure FormalAssertion (F: Type) (Input: TypeMap) [Field F] [ProvableType Inp
   localLength := fun _ => 0
 
   output := fun _ _ => ()
-
-namespace Circuit
-@[circuit_norm]
-def SubassertionSoundness (circuit: FormalAssertion F Input) (input_var : Var Input F) (env: Environment F) :=
-  let input := eval env input_var
-  circuit.Assumptions input → circuit.Spec input
-
-@[circuit_norm]
-def SubassertionCompleteness (circuit: FormalAssertion F Input) (input_var : Var Input F) (env: Environment F) :=
-  let input := eval env input_var
-  circuit.Assumptions input ∧ circuit.Spec input
-end Circuit
 
 def GeneralFormalCircuit.Soundness (F: Type) [Field F] (circuit : ElaboratedCircuit F Input Output) (Spec: Input F → Output F → Prop) :=
   -- for all environments that determine witness generation

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -65,12 +65,10 @@ def FormalCircuit.toSubcircuit (circuit: FormalCircuit F β α)
 
   have imply_soundness : ∀ env : Environment F,
     let input := eval env input_var
-    let output_var := circuit.output input_var n
-    let output := eval env output_var
+    let output := eval env (circuit.output input_var n)
     ConstraintsHoldFlat env ops.toFlat → circuit.Assumptions input → circuit.Spec input output := by
     -- we are given an environment where the constraints hold, and can assume the assumptions are true
-    intro env input output_var output h_holds
-    rintro (as : circuit.Assumptions input)
+    intro env input output h_holds (as : circuit.Assumptions input)
     show circuit.Spec input output
 
     -- by soundness of the circuit, the spec is satisfied if only the constraints hold
@@ -135,16 +133,14 @@ def FormalAssertion.toSubcircuit (circuit: FormalAssertion F β)
 
   {
     ops := ops.toFlat,
-    Soundness := SubassertionSoundness circuit input_var,
-    Completeness := SubassertionCompleteness circuit input_var,
+    Soundness env := circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var),
+    Completeness env := circuit.Assumptions (eval env input_var) ∧ circuit.Spec (eval env input_var),
     UsesLocalWitnesses _ := True,
     localLength := circuit.localLength input_var
 
     imply_soundness := by
       -- we are given an environment where the constraints hold, and can assume the assumptions are true
       intro env h_holds
-      show SubassertionSoundness circuit input_var env
-
       let input : β F := eval env input_var
       rintro (as : circuit.Assumptions input)
       show circuit.Spec input
@@ -341,7 +337,6 @@ theorem Circuit.subcircuit_computableWitnesses (circuit: FormalCircuit F β α) 
 -- simp set to unfold subcircuits
 attribute [subcircuit_norm]
   FormalCircuit.toSubcircuit FormalAssertion.toSubcircuit GeneralFormalCircuit.toSubcircuit
-  Circuit.SubassertionSoundness Circuit.SubassertionCompleteness
 
 -- to just reduce offsets, it's much better to _not_ use `subcircuit_norm`
 -- instead, `circuit_norm` will use these theorems to unfold subcircuits

--- a/Clean/Gadgets/Addition8/Addition8.lean
+++ b/Clean/Gadgets/Addition8/Addition8.lean
@@ -22,10 +22,10 @@ def Addition8Full.circuit : FormalCircuit (F p) Addition8FullCarry.Inputs field 
     z.val = (x.val + y.val + carry_in.val) % 256
 
   -- the proofs are trivial since this just wraps `Addition8FullCarry`
-  soundness := by simp_all [Soundness, circuit_norm, subcircuit_norm,
+  soundness := by simp_all [circuit_norm, subcircuit_norm,
     Addition8FullCarry.circuit, Addition8FullCarry.Assumptions, Addition8FullCarry.Spec]
 
-  completeness := by simp_all [Completeness, circuit_norm, subcircuit_norm,
+  completeness := by simp_all [circuit_norm, subcircuit_norm,
     Addition8FullCarry.circuit, Addition8FullCarry.Assumptions]
 
 namespace Addition8
@@ -54,8 +54,8 @@ def circuit : FormalCircuit (F p) Inputs field where
   Spec | { x, y }, z => z.val = (x.val + y.val) % 256
 
   -- the proofs are trivial since this just wraps `Addition8Full`
-  soundness := by simp_all [Soundness, circuit_norm, subcircuit_norm, Addition8Full.circuit]
-  completeness := by simp_all [Completeness, circuit_norm, subcircuit_norm, Addition8Full.circuit]
+  soundness := by simp_all [circuit_norm, subcircuit_norm, Addition8Full.circuit]
+  completeness := by simp_all [circuit_norm, subcircuit_norm, Addition8Full.circuit]
 
 end Addition8
 end Gadgets

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -60,7 +60,7 @@ def toBits (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields n
     constructor
     · intro i
       rw [h_env i]
-      simp [fieldToBits, Utils.Bits.toBits]
+      simp [fieldToBits, Utils.Bits.toBits, Vector.getElem_mapRange]
 
     let bit_vars : Vector (Expression (F p)) n := .mapRange n (var ⟨k + ·⟩)
 

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -91,7 +91,7 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
 
 -- allow `circuit_norm` to elaborate properties of the `circuit` while keeping main/spec/assumptions opaque
 @[circuit_norm ↓]
-lemma elaborated_eq (α : TypeMap) [ProvableType α] : (circuit α (F:=F)).toElaboratedCircuit = elaborated α := rfl
+lemma elaborated_eq (α : TypeMap) [ProvableType α] : (circuit α (F:=F)).elaborated = elaborated α := rfl
 
 -- rewrite soundness/completeness directly
 

--- a/Clean/Gadgets/Keccak/Chi.lean
+++ b/Clean/Gadgets/Keccak/Chi.lean
@@ -13,9 +13,9 @@ open Not (not64_bytewise not64_bytewise_value)
 
 def main (state : Var KeccakState (F p)) : Circuit (F p) (Var KeccakState (F p)) :=
   .mapFinRange 25 fun i => do
-    let state_not ← subcircuit Not.circuit (state.get (i + 5))
-    let state_and ← subcircuit And.And64.circuit ⟨state_not, state.get (i + 10)⟩
-    subcircuit Xor64.circuit ⟨state.get i, state_and⟩
+    let state_not ← subcircuit Not.circuit (state[i + 5])
+    let state_and ← subcircuit And.And64.circuit ⟨state_not, state[i + 10]⟩
+    subcircuit Xor64.circuit ⟨state[i], state_and⟩
 
 def Assumptions := KeccakState.Normalized (p:=p)
 

--- a/Clean/Gadgets/Keccak/Theta.lean
+++ b/Clean/Gadgets/Keccak/Theta.lean
@@ -24,13 +24,13 @@ def Spec (state : KeccakState (F p)) (out_state: KeccakState (F p)) : Prop :=
   ∧ out_state.value = Specs.Keccak256.theta state.value
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  simp_all [Soundness, circuit_norm, subcircuit_norm, Spec, theta, Assumptions,
+  simp_all [circuit_norm, subcircuit_norm, Spec, theta, Assumptions,
     ThetaC.circuit, ThetaD.circuit, ThetaXor.circuit,
     ThetaC.Assumptions, ThetaD.Assumptions, ThetaXor.Assumptions,
     ThetaC.Spec, ThetaD.Spec, ThetaXor.Spec, Specs.Keccak256.theta]
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  simp_all [Completeness, circuit_norm, subcircuit_norm, theta, Assumptions, Spec,
+  simp_all [circuit_norm, subcircuit_norm, theta, Assumptions, Spec,
     ThetaC.circuit, ThetaD.circuit, ThetaXor.circuit,
     ThetaC.Assumptions, ThetaD.Assumptions, ThetaXor.Assumptions,
     ThetaC.Spec, ThetaD.Spec, ThetaXor.Spec, Specs.Keccak256.theta]

--- a/Clean/Specs/Keccak256.lean
+++ b/Clean/Specs/Keccak256.lean
@@ -132,7 +132,7 @@ def chi (b : Vector ℕ 25) : Vector ℕ 25 :=
   ]
 
 def iota (state : Vector ℕ 25) (rc : UInt64) : Vector ℕ 25 :=
-  state.set 0 ((state.get 0) ^^^ rc.toFin)
+  state.set 0 ((state[0]) ^^^ rc.toFin)
 
 def keccakRound (state : Vector ℕ 25) (rc : UInt64) : Vector ℕ 25 :=
   let theta_state := theta state

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -556,7 +556,7 @@ structure FormalTable (F : Type) [Field F] (S : Type → Type) [ProvableType S] 
   constraints : List (TableOperation S F)
 
   /-- optional assumption on the table length -/
-  assumption : ℕ → Prop := fun _ => True
+  Assumption : ℕ → Prop := fun _ => True
 
   /-- specification for the table -/
   Spec {N : ℕ} : TraceOfLength F S N → Prop
@@ -565,7 +565,7 @@ structure FormalTable (F : Type) [Field F] (S : Type → Type) [ProvableType S] 
       the constraints hold implies that the spec holds. -/
   soundness :
     ∀ (N : ℕ) (trace: TraceOfLength F S N) (env: ℕ → ℕ → Environment F),
-    assumption N →
+    Assumption N →
     TableConstraintsHold constraints trace env →
     Spec trace
 
@@ -580,7 +580,7 @@ structure FormalTable (F : Type) [Field F] (S : Type → Type) [ProvableType S] 
     := by repeat constructor
 
 def FormalTable.statement (table : FormalTable F S) (N : ℕ) (trace: TraceOfLength F S N) : Prop :=
-  table.assumption N → table.Spec trace
+  table.Assumption N → table.Spec trace
 
 -- add some important lemmas to simp sets
 attribute [table_norm] List.mapIdx List.mapIdx.go

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -19,8 +19,7 @@ variable {F : Type} {S : Type → Type} [ProvableType S]
 
 @[table_norm, table_assignment_norm]
 def Row.get (row : Row F S) (i : Fin (size S)) : F :=
-  let elems := toElements row
-  elems.get i
+  (toElements row)[i.val]
 
 /--
   A trace is an inductive list of rows. It can be viewed as a structured
@@ -431,13 +430,13 @@ def assign (off : CellOffset W S) : Expression F → TableConstraint W S F Unit
 def assignCurrRow {W: ℕ+} (curr : Var S F) : TableConstraint W S F Unit :=
   let vars := toVars curr
   forM (List.finRange (size S)) fun i =>
-    assign (.curr i) (vars.get i)
+    assign (.curr i) vars[i]
 
 @[table_norm, table_assignment_norm]
 def assignNextRow {W: ℕ+} (next : Var S F) : TableConstraint W S F Unit :=
   let vars := toVars next
   forM (List.finRange (size S)) fun i =>
-    assign (.next i) (vars.get i)
+    assign (.next i) vars[i]
 end TableConstraint
 
 export TableConstraint (windowEnv getCurrRow getNextRow assignVar assign assignNextRow assignCurrRow)
@@ -614,5 +613,5 @@ macro_rules
     rw [Fin.foldr_zero]
     repeat rw [List.forM_cons]
     rw [List.forM_nil, bind_pure_unit]
-    simp only [seval, toVars, toElements, Vector.get, Fin.cast_eq_self, Fin.val_zero, Fin.val_one, Fin.isValue,
+    simp only [seval, toVars, toElements, Fin.cast_eq_self, Fin.val_zero, Fin.val_one, Fin.isValue,
       List.getElem_toArray, List.getElem_cons_zero, List.getElem_cons_succ, Fin.succ_zero_eq_one]))

--- a/Clean/Table/Inductive.lean
+++ b/Clean/Table/Inductive.lean
@@ -102,7 +102,7 @@ theorem equalityConstraint.soundness {row : State F × Input F} {input_state : S
     have h_env' : env' = windowEnv (equalityConstraint Input input_state) ⟨<+> +> row, _⟩ env := rfl
     simp only [windowEnv, table_assignment_norm, equalityConstraint, circuit_norm] at h_env'
     have hi' : i < size State + size Input := by linarith
-    simp [h_env', hi, hi', Vector.getElem_mapFinRange, Trace.getLeFromBottom, _root_.Row.get, Vector.get_eq,
+    simp [h_env', hi, hi', Vector.getElem_mapFinRange, Trace.getLeFromBottom, _root_.Row.get,
       Vector.mapRange_zero, Vector.append_empty, ProvablePair.instance]
 
   have h_env : eval env' (varFromOffset State 0) = row.1 := by

--- a/Clean/Table/Inductive.lean
+++ b/Clean/Table/Inductive.lean
@@ -27,9 +27,9 @@ structure InductiveTable (F : Type) [Field F] (State Input : Type → Type) [Pro
     assumptions on inputs for completeness.
     explanation: in general, we expect the `step` circuit to impose some constraints on the `input`.
     in the completeness proof, we therefore need to restrict the possible inputs a prover can provide in order to satisfy the constraints.
-    by design, completeness for the full table holds for any list of inputs that satisfy the `input_assumptions`.
+    by design, completeness for the full table holds for any list of inputs that satisfy the `InputAssumptions`.
   -/
-  input_assumptions : ℕ → Input F → Prop := fun _ _ => True
+  InputAssumptions : ℕ → Input F → Prop := fun _ _ => True
 
   soundness : ∀ (row_index : ℕ) (env : Environment F),
     -- for all rows and inputs
@@ -51,7 +51,7 @@ structure InductiveTable (F : Type) [Field F] (State Input : Type → Type) [Pro
     -- when using honest-prover witnesses
     env.UsesLocalWitnessesCompleteness ((size State) + (size Input)) (step acc_var x_var |>.operations ((size State) + (size Input))) →
     -- assuming the spec on the current row, and the input_spec on the input
-    Spec row_index acc xs xs_len ∧ input_assumptions row_index x →
+    Spec row_index acc xs xs_len ∧ InputAssumptions row_index x →
     -- the constraints hold
     Circuit.ConstraintsHold.Completeness env (step acc_var x_var |>.operations ((size State) + (size Input)))
 
@@ -281,7 +281,7 @@ theorem table_soundness (table : InductiveTable F State Input) (input output: St
 
 def toFormal (table : InductiveTable F State Input) (input output: State F) : FormalTable F (ProvablePair State Input) where
   constraints := table.tableConstraints input output
-  assumption N := N > 0 ∧ table.Spec 0 input [] rfl
+  Assumption N := N > 0 ∧ table.Spec 0 input [] rfl
   Spec {N} trace := table.Spec (N-1) output (traceInputs trace.tail) (traceInputs_length trace.tail)
 
   soundness N trace env assumption constraints :=

--- a/Clean/Table/WitnessGeneration.lean
+++ b/Clean/Table/WitnessGeneration.lean
@@ -45,7 +45,7 @@ def generateNextRow (tc : TableConstraint W S F Unit) (cur_row: Array F) : Array
   -- rules for fetching the values for expression variables
   let env i :=
     if h : i < assignment.offset then
-      match assignment.vars.get ⟨i, h⟩ with
+      match assignment.vars[i] with
       | .input ⟨r, c⟩ =>
         -- fetch input values
           if r = 0 then cur_row[c]! else next_row[c]!
@@ -63,7 +63,7 @@ def generateNextRow (tc : TableConstraint W S F Unit) (cur_row: Array F) : Array
 
       -- insert the witness value to the next row
       let next_row := if h : idx < assignment.offset then
-        let var := assignment.vars.get ⟨idx, h⟩
+        let var := assignment.vars[idx]
 
         match var with
           | .input ⟨r, c⟩ => if r = 1 then next_row.set! c wit else next_row

--- a/Clean/Tables/Addition8.lean
+++ b/Clean/Tables/Addition8.lean
@@ -22,13 +22,13 @@ instance : ProvableType RowType where
 
 def add8Inline : SingleRowConstraint RowType (F p) := do
   let row ← TableConstraint.getCurrRow
-  lookup (ByteLookup row.x)
-  lookup (ByteLookup row.y)
+  lookup ByteTable row.x
+  lookup ByteTable row.y
   let z ← subcircuit Gadgets.Addition8.circuit { x := row.x, y := row.y }
   assign (.curr 2) z
 
 def add8Table : List (TableOperation RowType (F p)) := [
-  EveryRow add8Inline
+  .everyRow add8Inline
 ]
 
 def Spec_add8 {N : ℕ} (trace : TraceOfLength (F p) RowType N) : Prop :=
@@ -57,7 +57,7 @@ def formalAdd8Table : FormalTable (F p) RowType := {
 
         -- this is the slowest step, but still ok
         simp [table_norm, circuit_norm, subcircuit_norm, varFromOffset, Vector.mapRange,
-          add8Inline, Gadgets.Addition8.circuit, ByteLookup
+          add8Inline, Gadgets.Addition8.circuit, ByteTable
         ] at h_holds
 
         change _ ∧ _ ∧ (_ → _) at h_holds
@@ -70,11 +70,7 @@ def formalAdd8Table : FormalTable (F p) RowType := {
 
         -- now we prove a local property about the current row, from the constraints
         obtain ⟨ lookup_x, lookup_y, h_add⟩ := h_holds
-
-        replace lookup_x := ByteTable.soundness row.x lookup_x
-        replace lookup_y := ByteTable.soundness row.y lookup_y
-        rw [Gadgets.Addition8.Assumptions, Gadgets.Addition8.Spec] at h_add
-        exact h_add ⟨ lookup_x, lookup_y ⟩
+        exact h_add lookup_x lookup_y
 }
 
 end Tables.Addition8

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -73,11 +73,10 @@ def fib32Table : List (TableOperation RowType (F p)) := [
   - both U32 values are normalized
 -/
 def Spec {N : ℕ} (trace : TraceOfLength (F p) RowType N) : Prop :=
-  trace.ForAllRowsOfTraceWithIndex (fun row index =>
+  trace.ForAllRowsOfTraceWithIndex fun row index =>
     (row.x.value = fib32 index) ∧
     (row.y.value = fib32 (index + 1)) ∧
     row.x.Normalized ∧ row.y.Normalized
-  )
 
 /-
   First of all, we prove some lemmas about the mapping variables -> cell offsets

--- a/Clean/Tables/Fibonacci8.lean
+++ b/Clean/Tables/Fibonacci8.lean
@@ -81,9 +81,8 @@ lemma boundary_step (first_row: Row (F p) RowType) (aux_env : Environment (F p))
   -- simplify constraints
   simp only [boundaryFib]
   simp_assign_row
-  simp only [circuit_norm, table_norm]
-  simp only [zero_add, neg_eq_zero, and_imp]
-  intro boundary1 boundary2
+  simp only [circuit_norm, table_norm, Nat.reduceAdd, Nat.reduceMod, zero_add, neg_eq_zero]
+  intro ⟨ boundary1, boundary2 ⟩
 
   have hx : first_row.x = env.get 0 := by rfl
   have hy : first_row.y = env.get 1 := by rfl

--- a/Clean/Tables/Fibonacci8.lean
+++ b/Clean/Tables/Fibonacci8.lean
@@ -56,10 +56,9 @@ def fib8 : ℕ -> ℕ
   | (n + 2) => (fib8 n + fib8 (n + 1)) % 256
 
 def Spec {N : ℕ} (trace : TraceOfLength (F p) RowType N) : Prop :=
-  trace.ForAllRowsOfTraceWithIndex (fun row index =>
+  trace.ForAllRowsOfTraceWithIndex fun row index =>
     (row.x.val = fib8 index) ∧
     (row.y.val = fib8 (index + 1))
-  )
 
 lemma fib8_less_than_256 (n : ℕ) : fib8 n < 256 := by
   induction' n using Nat.twoStepInduction

--- a/Clean/Tables/KeccakInductive.lean
+++ b/Clean/Tables/KeccakInductive.lean
@@ -18,7 +18,7 @@ def table : InductiveTable (F p) KeccakState KeccakBlock where
     state.Normalized
     ∧ state.value = absorbBlocks (blocks.map KeccakBlock.value)
 
-  input_assumptions i block := block.Normalized
+  InputAssumptions i block := block.Normalized
 
   soundness := by
     intro i env state_var block_var state block blocks _ h_input h_holds spec_previous

--- a/Clean/Utils/Bits.lean
+++ b/Clean/Utils/Bits.lean
@@ -96,7 +96,7 @@ theorem toBits_injective (n: ℕ) {x y : ℕ} : x < 2^n → y < 2^n →
 theorem fromBits_toBits {n: ℕ} {x : ℕ} (hx : x < 2^n) :
     fromBits (toBits n x) = x := by
   have h_bits : ∀ i (hi : i < n), (toBits n x)[i] = 0 ∨ (toBits n x)[i] = 1 := by
-    intro i hi; simp [toBits]
+    intro i hi; simp [toBits, Vector.getElem_mapRange]
   apply toBits_injective n (fromBits_lt _ h_bits) hx
   rw [toBits_fromBits _ h_bits]
 
@@ -208,7 +208,7 @@ theorem fieldFromBits_fieldToBits {n: ℕ} (hn : 2^n < p) {x : F p} (hx : x.val 
     fieldFromBits (fieldToBits n x) = x := by
   have h_bits : ∀ i (hi : i < n), (fieldToBits n x)[i] = 0 ∨ (fieldToBits n x)[i] = 1 := by
     intro i hi
-    simp [fieldToBits, toBits]
+    simp [fieldToBits, toBits, Vector.getElem_mapRange]
 
   apply fieldToBits_injective n (fieldFromBits_lt hn _ h_bits) hx
   rw [fieldToBits_fieldFromBits hn _ h_bits]

--- a/Clean/Utils/Rotation.lean
+++ b/Clean/Utils/Rotation.lean
@@ -214,9 +214,10 @@ theorem rotRight64_toBits (x r : ℕ) (h : x < 2^64):
   simp [toBits, Vector.rotate]
   ext i hi
   · simp
-  simp at ⊢ hi
+  simp only [Vector.size_toArray, Vector.getElem_toArray, Array.getElem_toList,
+    Vector.getElem_mapRange, List.getElem_toArray, List.getElem_rotate] at ⊢ hi
   rw [rotRight64_testBit]
-  simp [List.getElem_rotate, hi]
+  simp only [hi, decide_true, Bool.true_and, Bool.ite_eq_true_distrib]
   split <;> (congr; omega)
   linarith
 
@@ -461,9 +462,10 @@ theorem rotRight32_toBits (x r : ℕ) (h : x < 2^32):
   simp [toBits, Vector.rotate]
   ext i hi
   · simp
-  simp at ⊢ hi
+  simp only [Vector.size_toArray, Vector.getElem_toArray, Array.getElem_toList,
+    Vector.getElem_mapRange, List.getElem_toArray, List.getElem_rotate] at ⊢ hi
   rw [rotRight32_testBit]
-  simp [List.getElem_rotate, hi]
+  simp only [hi, decide_true, Bool.true_and, Bool.ite_eq_true_distrib]
   split <;> (congr; omega)
   linarith
 

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -17,18 +17,6 @@ def cons (a: α) (v: Vector α n) : Vector α (n + 1) :=
 theorem toList_cons {a: α} {v: Vector α n} : (cons a v).toList = a :: v.toList := by
   simp [cons]
 
-def get_eq {n} (v: Vector α n) (i: Fin n) : v.get i = v.toArray[i.val] := by
-  simp only [get, List.get_eq_getElem, Fin.coe_cast]
-
-/-- this is exactly what's needed to rewrite `v.get i` into a `List.getElem` if `n` is a concrete Nat -/
-def get_eq_lt {n} [NeZero n] (v: Vector α n) (i : ℕ) (h: i < n := by norm_num) :
-  v.get ((Fin.instOfNat (i:=i)).ofNat : Fin n) = v.toArray[i]'(by rw [v.size_toArray]; exact h) := by
-  simp only [get_eq, OfNat.ofNat, Fin.val_ofNat', Nat.mod_eq_of_lt h]
-
-@[simp]
-theorem get_map {n} {f: α → β} {v: Vector α n} {i: Fin n} : get (map f v) i = f (get v i) := by
-  simp only [get, map, Fin.coe_cast, Array.getElem_map, getElem_toArray]
-
 @[simp]
 def set? (v: Vector α n) (i: ℕ) (a: α) : Vector α n :=
   ⟨ .mk <| v.toList.set i a, by rw [Array.size_eq_length_toList, List.length_set, ← Array.size_eq_length_toList, v.size_toArray] ⟩

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -17,7 +17,6 @@ def cons (a: α) (v: Vector α n) : Vector α (n + 1) :=
 theorem toList_cons {a: α} {v: Vector α n} : (cons a v).toList = a :: v.toList := by
   simp [cons]
 
-@[simp]
 def set? (v: Vector α n) (i: ℕ) (a: α) : Vector α n :=
   ⟨ .mk <| v.toList.set i a, by rw [Array.size_eq_length_toList, List.length_set, ← Array.size_eq_length_toList, v.size_toArray] ⟩
 
@@ -180,7 +179,6 @@ theorem cast_mapRange {n} {create: ℕ → α} (h : n = m) :
     mapRange n create = (mapRange m create).cast h.symm := by
   subst h; simp
 
-@[simp]
 theorem getElem_mapRange {n} {create: ℕ → α} :
     ∀ (i : ℕ) (hi : i < n), (mapRange n create)[i] = create i := by
   intros i hi
@@ -200,7 +198,6 @@ theorem mapRange_add_eq_append {n m} (create: ℕ → α) :
   | zero => simp only [Nat.add_zero, mapRange, append_empty]
   | succ m ih => simp only [mapRange, Nat.add_eq, append_push, ih]
 
-@[simp]
 def fill (n : ℕ) (a: α) : Vector α n :=
   match n with
   | 0 => #v[]


### PR DESCRIPTION
various small things I wanted to clean up:
* rename a few more definitions according to lean conventions
* change the alpha and beta types in formal circuit definition to much clearer `Input` and `Output`
* get rid of `SubcircuitSoundness`, `SubcircuitCompleteness` definitions which were only used in one place and had to be unfolded in every proof
* consistently use `vector[i]` instead of `vector.get i`
* remove changes to the default `simp` set, I feel like we're not supposed to do that given that we maintain our own simp sets already
