### PR TITLE
FormalAssertion.isGeneralFormalCircuit

### DIFF
--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -608,3 +608,26 @@ def FormalCircuit.isGeneralFormalCircuit (F: Type) (Input Output: TypeMap) [Fiel
       intros
       apply orig.completeness <;> trivial
   }
+
+/--
+`FormalAssertion.isGeneralFormalCircuit` explains how `GeneralFormalCircuit` is a generalization of
+`FormalAssertion`.  The idea is to make `FormalAssertion.Spec` available in the completeness
+by putting it within `GeneralFormalCircuit.Assumption`.
+-/
+def FormalAssertion.isGeneralFormalCircuit (F : Type) (Input : TypeMap) [Field F] [ProvableType Input]
+    (orig : FormalAssertion F Input) : GeneralFormalCircuit F Input unit := by
+  let Spec input (_ : Unit) := orig.Assumptions input → orig.Spec input
+  exact {
+    elaborated := orig.elaborated,
+    Assumptions input := orig.Assumptions input ∧ orig.Spec input,
+    Spec,
+    soundness := by
+      simp only [GeneralFormalCircuit.Soundness, forall_eq', Spec]
+      intros
+      apply orig.soundness <;> trivial
+    ,
+    completeness := by
+      simp only [GeneralFormalCircuit.Completeness, forall_eq', Spec]
+      rintro _ _ _ _ ⟨ _, _ ⟩
+      apply orig.completeness <;> trivial
+  }


### PR DESCRIPTION
Following the spirit of `FormalCircuit.isGeneralFormalCircuit`, now I proved that `FormalAssertion` can also be converted into a `GeneralFormalCircuit`.