### PR TITLE
Unify function field definition style

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -334,9 +334,9 @@ structure FormalAssertion (F: Type) (Input: TypeMap) [Field F] [ProvableType Inp
   completeness : FormalAssertion.Completeness F elaborated Assumptions Spec
 
   -- assertions commonly don't introduce internal witnesses, so this is a convenient default
-  localLength := fun _ => 0
+  localLength _ := 0
   -- the output has to be unit
-  output := fun _ _ => ()
+  output _ _ := ()
 
 @[circuit_norm]
 def GeneralFormalCircuit.Soundness (F: Type) [Field F] (circuit : ElaboratedCircuit F Input Output) (Spec: Input F → Output F → Prop) :=

--- a/Clean/Circuit/Expression.lean
+++ b/Clean/Circuit/Expression.lean
@@ -72,13 +72,13 @@ instance {n: ℕ} [OfNat F n] : OfNat (Expression F) n where
   ofNat := const (OfNat.ofNat n)
 
 instance : HMul F (Expression F) (Expression F) where
-  hMul := fun f e => mul f e
+  hMul f e := mul f e
 
 instance : HDiv (Expression F) F (Expression F) where
-  hDiv := fun e f => mul (f⁻¹ : F) e
+  hDiv e f := mul (f⁻¹ : F) e
 
 instance : HDiv (Expression F) ℕ (Expression F) where
-  hDiv := fun e f => mul (f⁻¹ : F) e
+  hDiv e f := mul (f⁻¹ : F) e
 
 -- TODO probably should just make Variable F := ℕ
 instance {n: ℕ} : OfNat (Variable F) n where

--- a/Clean/Circuit/Operations.lean
+++ b/Clean/Circuit/Operations.lean
@@ -211,9 +211,9 @@ current operation as well as the current offset.
 -/
 structure Condition (F: Type) [Field F] where
   witness (offset: ℕ) : (m : ℕ) → (Environment F → Vector F m) → Prop := fun _ _ => True
-  assert (offset: ℕ) : Expression F → Prop := fun _ => True
-  lookup (offset: ℕ) : Lookup F → Prop := fun _ => True
-  subcircuit (offset: ℕ) : {m : ℕ} → Subcircuit F m → Prop := fun _ => True
+  assert (offset: ℕ) (_ : Expression F) : Prop := True
+  lookup (offset: ℕ) (_ : Lookup F) : Prop := True
+  subcircuit (offset: ℕ) {m : ℕ} (_ : Subcircuit F m) : Prop := True
 
 @[circuit_norm]
 def Condition.apply (condition: Condition F) (offset: ℕ) : Operation F → Prop
@@ -286,7 +286,7 @@ where motive' : (ops: Operations F) → (n : ℕ) → (h : ops.SubcircuitsConsis
 end Operations
 
 def Condition.ignoreSubcircuit (condition : Condition F) : Condition F :=
-  { condition with subcircuit := fun _ _ _ => True }
+  { condition with subcircuit _ _ _ := True }
 
 def Condition.applyFlat (condition: Condition F) (offset: ℕ) : FlatOperation F → Prop
   | .witness m c => condition.witness offset m c


### PR DESCRIPTION
## Summary

This PR unifies the style of defining function fields in records across the codebase. Changes the syntax from `fieldName := fun a b c => ...` to `fieldName a b c := ...` where syntactically valid.

## Changes Made

- **Circuit/Operations.lean**: Updated `Condition` structure field definitions and structure update syntax
- **Circuit/Basic.lean**: Updated `FormalAssertion` field definitions  
- **Circuit/Expression.lean**: Updated `HMul` and `HDiv` instance definitions

## Technical Details

- Simple parameter functions are converted to the new style
- Complex patterns involving destructuring (tuples, pattern matching) maintain `fun` syntax for compatibility
- All changes preserve exact functionality while improving style consistency

## Test Plan

- [x] All changes compile successfully with `lake build`

🤖 Generated with [Claude Code](https://claude.ai/code)