### PR TITLE
Begin gates.circom formalization: Complete XOR gate (issue #164)

### DIFF
--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -37,13 +37,12 @@ def circuit : FormalCircuit (F p) fieldPair field where
     output.val = input.1.val ^^^ input.2.val
 
   soundness := by
-    rintro offset env ⟨ a_var, b_var ⟩ ⟨ a, b ⟩ h_env ⟨ (h_a | h_a), (h_b | h_b) ⟩
+    rintro _ _ ⟨ _, _ ⟩ ⟨ _, _ ⟩ h_env ⟨ (h_a | h_a), (h_b | h_b) ⟩
     all_goals {
-      simp only [circuit_norm, main, explicit_provable_type] at h_env ⊢
-      rcases h_env with ⟨ h_env_a, h_env_b ⟩
-      simp_all only [ZMod.val_zero, Nat.xor_self, ZMod.val_eq_zero, h_a, h_b]
-      ring_nf
-      simp
+      simp only [circuit_norm, main] at h_env ⊢
+      rcases h_env with ⟨ _, _ ⟩
+      simp_all only [h_a, h_b]
+      ring_nf; simp
     }
 
   completeness := by

--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -7,7 +7,7 @@ https://github.com/iden3/circomlib/blob/master/circuits/gates.circom
 -/
 
 namespace Circomlib
-variable {p : ℕ} [Fact p.Prime] [Fact (p > 2)]
+variable {p : ℕ} [Fact p.Prime]
 
 namespace XOR
 /-
@@ -32,13 +32,29 @@ def circuit : FormalCircuit (F p) fieldPair field where
   localLength_eq := by simp [circuit_norm, main]
   subcircuitsConsistent := by simp +arith [circuit_norm, main]
 
-  Assumptions _ := True
-  Spec input output := 
-    output = (if input.1 = 0 then input.2 else if input.2 = 0 then 1 else 0)
+  Assumptions input := (input.1 = 0 ∨ input.1 = 1) ∧ (input.2 = 0 ∨ input.2 = 1)
+  Spec input output :=
+    output.val = input.1.val ^^^ input.2.val
 
   soundness := by
-    simp only [circuit_norm, main]
-    sorry
+    rintro offset env ⟨ a_var, b_var ⟩ ⟨ a, b ⟩ h_env ⟨ (h_a | h_a), (h_b | h_b) ⟩
+    · simp only [circuit_norm, main, explicit_provable_type] at h_env ⊢
+      rcases h_env with ⟨ h_env_a, h_env_b ⟩
+      simp_all only [ZMod.val_zero, Nat.xor_self, ZMod.val_eq_zero]
+      aesop
+    · simp only [circuit_norm, main, explicit_provable_type] at h_env ⊢
+      rcases h_env with ⟨ h_env_a, h_env_b ⟩
+      simp_all only [ZMod.val_zero, Nat.xor_self, ZMod.val_eq_zero]
+      aesop
+    · simp only [circuit_norm, main, explicit_provable_type] at h_env ⊢
+      rcases h_env with ⟨ h_env_a, h_env_b ⟩
+      simp_all only [ZMod.val_zero, Nat.xor_self, ZMod.val_eq_zero]
+      aesop
+    · simp only [circuit_norm, main, explicit_provable_type] at h_env ⊢
+      rcases h_env with ⟨ h_env_a, h_env_b ⟩
+      simp_all only [ZMod.val_zero, Nat.xor_self, ZMod.val_eq_zero]
+      intros _
+      ring
 
   completeness := by
     simp only [circuit_norm, main]

--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -22,8 +22,7 @@ template XOR() {
 def main (input : Expression (F p) × Expression (F p)) := do
   let a := input.1
   let b := input.2
-  let out ← witnessField fun env => (a + b - 2*a*b).eval env
-  out === a + b - 2*a*b
+  let out <== a + b - 2*a*b
   return out
 
 def circuit : FormalCircuit (F p) fieldPair field where
@@ -35,14 +34,17 @@ def circuit : FormalCircuit (F p) fieldPair field where
   Assumptions input := (input.1 = 0 ∨ input.1 = 1) ∧ (input.2 = 0 ∨ input.2 = 1)
   Spec input output :=
     output.val = input.1.val ^^^ input.2.val
+    ∧ (output = 0 ∨ output = 1)
 
   soundness := by
-    rintro _ _ ⟨ _, _ ⟩ ⟨ _, _ ⟩ h_env ⟨ (h_a | h_a), (h_b | h_b) ⟩
+    rintro _ _ ⟨ _, _ ⟩ ⟨ _, _ ⟩ h_env ⟨ (h_a | h_a), (h_b | h_b) ⟩ h_hold
     all_goals {
-      simp only [circuit_norm, main] at h_env ⊢
+      simp only [circuit_norm, main] at h_env h_hold ⊢
       rcases h_env with ⟨ _, _ ⟩
-      simp_all only [h_a, h_b]
-      ring_nf; simp
+      simp_all only [h_a, h_b, h_hold]
+      constructor
+      · ring_nf; simp
+      · ring_nf; simp
     }
 
   completeness := by

--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -1,0 +1,48 @@
+import Clean.Circuit
+import Clean.Utils.Field
+
+/-
+Original source code:
+https://github.com/iden3/circomlib/blob/master/circuits/gates.circom
+-/
+
+namespace Circomlib
+variable {p : ℕ} [Fact p.Prime] [Fact (p > 2)]
+
+namespace XOR
+/-
+template XOR() {
+    signal input a;
+    signal input b;
+    signal output out;
+
+    out <== a + b - 2*a*b;
+}
+-/
+def main (input : Expression (F p) × Expression (F p)) := do
+  let a := input.1
+  let b := input.2
+  let out ← witnessField fun env => (a + b - 2*a*b).eval env
+  out === a + b - 2*a*b
+  return out
+
+def circuit : FormalCircuit (F p) fieldPair field where
+  main
+  localLength _ := 1
+  localLength_eq := by simp [circuit_norm, main]
+  subcircuitsConsistent := by simp +arith [circuit_norm, main]
+
+  Assumptions _ := True
+  Spec input output := 
+    output = (if input.1 = 0 then input.2 else if input.2 = 0 then 1 else 0)
+
+  soundness := by
+    simp only [circuit_norm, main]
+    sorry
+
+  completeness := by
+    simp only [circuit_norm, main]
+    sorry
+end XOR
+
+end Circomlib

--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -38,23 +38,13 @@ def circuit : FormalCircuit (F p) fieldPair field where
 
   soundness := by
     rintro offset env ⟨ a_var, b_var ⟩ ⟨ a, b ⟩ h_env ⟨ (h_a | h_a), (h_b | h_b) ⟩
-    · simp only [circuit_norm, main, explicit_provable_type] at h_env ⊢
+    all_goals {
+      simp only [circuit_norm, main, explicit_provable_type] at h_env ⊢
       rcases h_env with ⟨ h_env_a, h_env_b ⟩
-      simp_all only [ZMod.val_zero, Nat.xor_self, ZMod.val_eq_zero]
-      aesop
-    · simp only [circuit_norm, main, explicit_provable_type] at h_env ⊢
-      rcases h_env with ⟨ h_env_a, h_env_b ⟩
-      simp_all only [ZMod.val_zero, Nat.xor_self, ZMod.val_eq_zero]
-      aesop
-    · simp only [circuit_norm, main, explicit_provable_type] at h_env ⊢
-      rcases h_env with ⟨ h_env_a, h_env_b ⟩
-      simp_all only [ZMod.val_zero, Nat.xor_self, ZMod.val_eq_zero]
-      aesop
-    · simp only [circuit_norm, main, explicit_provable_type] at h_env ⊢
-      rcases h_env with ⟨ h_env_a, h_env_b ⟩
-      simp_all only [ZMod.val_zero, Nat.xor_self, ZMod.val_eq_zero]
-      intros _
-      ring
+      simp_all only [ZMod.val_zero, Nat.xor_self, ZMod.val_eq_zero, h_a, h_b]
+      ring_nf
+      simp
+    }
 
   completeness := by
     simp only [circuit_norm, main]

--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -46,8 +46,7 @@ def circuit : FormalCircuit (F p) fieldPair field where
     }
 
   completeness := by
-    simp only [circuit_norm, main]
-    sorry
+    simp_all only [circuit_norm, main]
 end XOR
 
 end Circomlib


### PR DESCRIPTION
## Summary

This PR begins the formalization of [gates.circom](https://github.com/iden3/circomlib/blob/master/circuits/gates.circom) as requested in issue #164. **I'm creating this PR early to seek feedback on the approach before implementing additional gates.**

### Completed: XOR Gate
- ✅ **Maintains exact constraint structure**: `out <== a + b - 2*a*b`
- ✅ **Boolean assumptions**: Inputs must be 0 or 1
- ✅ **Clean spec**: `output.val = input.1.val ^^^ input.2.val` using natural number XOR
- ✅ **Complete proofs**: Both soundness and completeness proven
- ✅ **Follows PR #163 style**: Similar structure to existing Circomlib formalizations

## Key design decisions

1. **Field element XOR**: Used `output.val = input.1.val ^^^ input.2.val` for clean specification
2. **Boolean assumptions**: Required `(input.1 = 0 ∨ input.1 = 1) ∧ (input.2 = 0 ∨ input.2 = 1)`

## Questions for reviewers

1. Is the approach for boolean assumptions and XOR specification appropriate?
2. Should we use a similar pattern for additional gates?

## Test plan

- [x] Lake build succeeds with no warnings
- [x] All proofs complete (no sorry statements)

🤖 Generated with [Claude Code](https://claude.ai/code)