### PR TITLE
Add FormalCircuitWithUniqueOutput class for deterministic circuits

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -287,6 +287,17 @@ structure FormalCircuit (F: Type) [Field F] (Input Output: TypeMap) [ProvableTyp
   soundness : Soundness F elaborated Assumptions Spec
   completeness : Completeness F elaborated Assumptions
 
+/--
+`FormalCircuitWithUniqueOutput` extends `FormalCircuit` with an explicit uniqueness constraint.
+This ensures that for any input satisfying the assumptions, the specification uniquely determines the output.
+Use this class when you want to formally guarantee that constraints uniquely determine the output,
+preventing ambiguity in deterministic circuits.
+-/
+structure FormalCircuitWithUniqueOutput (F: Type) [Field F] (Input Output: TypeMap) [ProvableType Input] [ProvableType Output]
+    extends circuit : FormalCircuit F Input Output where
+  uniqueness : ∀ (input : Input F) (out1 out2 : Output F), 
+    circuit.Assumptions input → circuit.Spec input out1 → circuit.Spec input out2 → out1 = out2
+
 @[circuit_norm]
 def FormalAssertion.Soundness (F: Type) [Field F] (circuit : ElaboratedCircuit F Input unit)
     (Assumptions : Input F → Prop) (Spec : Input F → Prop) :=

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -254,6 +254,13 @@ def circuit : FormalCircuit (F p) U32 U32 where
       List.getElem_cons_zero] at h3
     simp_all
 
+def circuitWithUniqueOutput : FormalCircuitWithUniqueOutput (F p) U32 U32 where
+  circuit
+  uniqueness := by
+    intro _ _ _ _ h₁ h₂
+    simp only [circuit, Spec] at h₁ h₂
+    rw[←h₁, ←h₂]
+
 end Copy
 
 @[reducible]


### PR DESCRIPTION
## Summary
- Add new `FormalCircuitWithUniqueOutput` class that extends `FormalCircuit` with explicit uniqueness constraints
- Include U32 copy circuit example as a sanity check for the new class

## Test plan
- [x] Code builds successfully (`lake build` passes)
- [x] Uniqueness proof works for simple deterministic circuit (U32 copy)

🤖 Generated with [Claude Code](https://claude.ai/code)