### PR TITLE
Rename byteDecomposition to main

### DIFF
--- a/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
@@ -23,7 +23,7 @@ instance : ProvableStruct Outputs where
   The low part is the least significant `offset` bits,
   and the high part is the most significant `8 - offset` bits.
 -/
-def byteDecomposition (offset : Fin 8) (x :  Expression (F p)) : Circuit (F p) (Var Outputs (F p)) := do
+def main (offset : Fin 8) (x :  Expression (F p)) : Circuit (F p) (Var Outputs (F p)) := do
   let low ← witness fun env => mod (env x) (2^offset.val) (by simp [two_pow_lt])
   let high ← witness fun env => floorDiv (env x) (2^offset.val)
 
@@ -42,14 +42,14 @@ def Spec (offset : Fin 8) (x : F p) (out: Outputs (F p)) :=
   ∧ (low.val < 2^offset.val ∧ high.val < 2^(8 - offset.val))
 
 def elaborated (offset : Fin 8) : ElaboratedCircuit (F p) field Outputs where
-  main := byteDecomposition offset
+  main := main offset
   localLength _ := 2
   output _ i0 := varFromOffset Outputs i0
 
 theorem soundness (offset : Fin 8) : Soundness (F p) (circuit := elaborated offset) Assumptions (Spec offset) := by
   intro i0 env x_var (x : F p) h_input (x_byte : x.val < 256) h_holds
   simp only [id_eq, circuit_norm] at h_input
-  simp only [circuit_norm, elaborated, byteDecomposition, Spec, ByteTable, h_input] at h_holds ⊢
+  simp only [circuit_norm, elaborated, main, Spec, ByteTable, h_input] at h_holds ⊢
   clear h_input
 
   obtain ⟨low_lt, high_lt, h_eq⟩ := h_holds
@@ -101,7 +101,7 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (circuit := elaborated offs
 theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) Assumptions := by
   rintro i0 env x_var henv (x : F p) h_input (x_byte : x.val < 256)
   simp only [ProvableType.eval_field] at h_input
-  simp only [circuit_norm, byteDecomposition, elaborated, h_input, ByteTable] at henv ⊢
+  simp only [circuit_norm, main, elaborated, h_input, ByteTable] at henv ⊢
   simp only [henv]
   have pow_8_nat : 2^8 = 2^(8-offset.val) * 2^offset.val := by simp [←pow_add]
 
@@ -125,7 +125,7 @@ theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) A
 
 def circuit (offset : Fin 8) : FormalCircuit (F p) field Outputs := {
   elaborated offset with
-  main := byteDecomposition offset
+  main := main offset
   Assumptions
   Spec := Spec offset
   soundness := soundness offset


### PR DESCRIPTION
## Summary
- Rename `byteDecomposition` function to `main` in ByteDecomposition gadget
- Update all references

## Test plan
- [x] Build passes with `lake build`

🤖 Generated with [Claude Code](https://claude.ai/code)