### PR TITLE
Implement <== operator for circom-style witness assignment

### DIFF
--- a/Clean/Circomlib/Bitify.lean
+++ b/Clean/Circomlib/Bitify.lean
@@ -1,6 +1,7 @@
 import Clean.Circuit
 import Clean.Utils.Bits
 import Clean.Gadgets.Bits
+import Clean.Gadgets.Equality
 
 namespace Circomlib
 open Utils.Bits
@@ -126,8 +127,7 @@ def main (n: ℕ) (input : Vector (Expression (F p)) n) := do
     let e2 := e2 + e2
     (lc1, e2)) (0, 1)
 
-  let out ← witnessField fun env => lc1.eval env
-  out === lc1
+  let out ← <== lc1
   return out
 
 def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) (fields n) field where

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -137,3 +137,24 @@ instance {F : Type} [Field F] {α : TypeMap} [ProvableType α] :
 
 attribute [circuit_norm] HasAssertEq.assert_eq
 infix:50 " === " => HasAssertEq.assert_eq
+
+-- Defines a unified `<==` notation for witness assignment with equality assertion in circuits.
+
+class HasAssignEq (β : Type) (F : outParam Type) [Field F] where
+  assign_eq : β → Circuit F β
+
+instance {F : Type} [Field F] : HasAssignEq (Expression F) F where
+  assign_eq := fun rhs => do
+    let witness ← witnessField fun env => rhs.eval env
+    witness === rhs
+    return witness
+
+instance {F : Type} [Field F] {α : TypeMap} [ProvableType α] :
+  HasAssignEq (α (Expression F)) F where
+  assign_eq := fun rhs => do
+    let witness ← ProvableType.witness fun env => eval env rhs
+    witness === rhs
+    return witness
+
+attribute [circuit_norm] HasAssignEq.assign_eq
+prefix:max " <== " => HasAssignEq.assign_eq


### PR DESCRIPTION
## Summary
- Implements the `<==` operator for GitHub issue #170
- Adds `HasAssignEq` typeclass supporting any ProvableType
- Creates prefix operator with syntax `let var ← <== expr`
- Demonstrates usage in `Circomlib/Bitify.lean`

## Details
The `<==` operator provides circom-style witness assignment that combines:
1. Witness creation using `witnessField` or `ProvableType.witness`  
2. Equality assertion using the existing `===` operator
3. Returns the witness for monadic binding

**Before:**
```lean
let out ← witnessField fun env => lc1.eval env
out === lc1
```

**After:**
```lean  
let out ← <== lc1
```

## Test plan
- [x] Implementation compiles successfully
- [x] Updated existing code in Bitify.lean works

🤖 Generated with [Claude Code](https://claude.ai/code)