### PR TITLE
Remove Copy gadgets, replace with <== operator

### DIFF
--- a/Clean/Gadgets/Rotation32/Rotation32.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32.lean
@@ -46,7 +46,7 @@ def elaborated (off : Fin 32) : ElaboratedCircuit (F p) U32 U32 where
 theorem soundness (offset : Fin 32) : Soundness (F p) (circuit := elaborated offset) Assumptions (Spec offset) := by
   intro i0 env x_var x h_input x_normalized h_holds
 
-  simp [circuit_norm, main, elaborated, U32.copy, subcircuit_norm,
+  simp [circuit_norm, main, elaborated, subcircuit_norm,
     Rotation32Bits.circuit, Rotation32Bits.elaborated] at h_holds
 
   -- abstract away intermediate U32

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -47,7 +47,7 @@ def elaborated (off : Fin 64) : ElaboratedCircuit (F p) U64 U64 where
 theorem soundness (offset : Fin 64) : Soundness (F p) (circuit := elaborated offset) Assumptions (Spec offset) := by
   intro i0 env x_var x h_input x_normalized h_holds
 
-  simp [circuit_norm, main, elaborated, U64.copy, subcircuit_norm,
+  simp [circuit_norm, main, elaborated, subcircuit_norm,
     Rotation64Bits.circuit, Rotation64Bits.elaborated] at h_holds
 
   -- abstract away intermediate U64

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -212,53 +212,8 @@ def U32.witness (compute : Environment (F p) → U32 (F p)) := do
   assertion U32.AssertNormalized.circuit x
   return x
 
-namespace U32.Copy
 
-def main (x : Var U32 (F p)) : Circuit (F p) (Var U32 (F p))  := do
-  let y <== x
-  return y
-
-def Assumptions (_input : U32 (F p)) := True
-
-def Spec (x y : U32 (F p)) := x = y
-
-def circuit : FormalCircuit (F p) U32 U32 where
-  main := main
-  Assumptions
-  Spec
-  localLength _ := 4
-  output inputs i0 := varFromOffset U32 i0
-  soundness := by
-    rintro i0 env x_var
-    rintro ⟨ x0, x1, x2, x3 ⟩ h_eval _as
-    simp [circuit_norm, main, Spec, h_eval, explicit_provable_type]
-    injections h_eval
-    intros h0 h1 h2 h3
-    aesop
-  completeness := by
-    rintro i0 env x_var
-    rintro h ⟨ x0, x1, x2, x3 ⟩ h_eval _as
-    simp [circuit_norm, main, Spec, h_eval]
-    simp [circuit_norm, main, Gadgets.Equality.elaborated] at h
-    simp_all [circuit_norm, explicit_provable_type]
-    have h0 := h 0
-    have h1 := h 1
-    have h2 := h 2
-    have h3 := h 3
-    simp only [Fin.isValue, Fin.val_zero, add_zero, List.getElem_cons_zero] at h0
-    simp only [Fin.isValue, Fin.val_one, List.getElem_cons_succ, List.getElem_cons_zero] at h1
-    simp only [Fin.isValue, Fin.val_two, List.getElem_cons_succ, List.getElem_cons_zero] at h2
-    simp only [Fin.isValue, show @Fin.val 4 3 = 3 by rfl, List.getElem_cons_succ,
-      List.getElem_cons_zero] at h3
-    simp_all
-
-end Copy
-
-@[reducible]
-def copy (x : Var U32 (F p)) : Circuit (F p) (Var U32 (F p)) :=
-  subcircuit Copy.circuit x
-
-namespace ByteVector
+namespace U32.ByteVector
 -- results about U32 when viewed as a vector of bytes, via `toLimbs` and `fromLimbs`
 
 theorem fromLimbs_toLimbs {F} (x : U32 F) :

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -224,45 +224,7 @@ def U64.witness (compute : Environment (F p) → U64 (F p)) := do
   assertion U64.AssertNormalized.circuit x
   return x
 
-namespace U64.Copy
-
-def main (x : Var U64 (F p)) : Circuit (F p) (Var U64 (F p))  := do
-  let y ← ProvableType.witness fun env =>
-    U64.mk (env x.x0) (env x.x1) (env x.x2) (env x.x3) (env x.x4) (env x.x5) (env x.x6) (env x.x7)
-  x === y
-  return y
-
-def Assumptions (_input : U64 (F p)) := True
-
-def Spec (x y : U64 (F p)) := x = y
-
-def circuit : FormalCircuit (F p) U64 U64 where
-  main := main
-  Assumptions
-  Spec
-  localLength _ := 8
-  output inputs i0 := varFromOffset U64 i0
-  soundness := by
-    rintro i0 env x_var
-    rintro ⟨x0, x1, x2, x3, x4, x5, x6, x7⟩ h_eval _as
-    simp [circuit_norm, main, Spec, h_eval, explicit_provable_type]
-    injections h_eval
-    intros h0 h1 h2 h3 h4 h5 h6 h7
-    aesop
-
-  completeness := by
-    rintro i0 env x_var
-    rintro h ⟨x0, x1, x2, x3, x4, x5, x6, x7⟩ h_eval _as
-    simp only [circuit_norm, main] at h
-    have h0 : env.get i0 = _ := h 0
-    simp_all [circuit_norm, main, explicit_provable_type, Fin.forall_iff]
-
-end Copy
-
-@[reducible]
-def copy (x : Var U64 (F p)) : Circuit (F p) (Var U64 (F p)) := do
-  subcircuit U64.Copy.circuit x
-
+namespace U64
 def fromByte (x: Fin 256) : U64 (F p) :=
   ⟨ x.val, 0, 0, 0, 0, 0, 0, 0 ⟩
 


### PR DESCRIPTION
## Summary
- Removed Copy namespaces and copy functions from U32 and U64 types
- Removed references to copy functions from rotation gadget proofs

## Context
The Copy gadgets were redundant since they internally used the `<==` operator but wrapped it in unnecessary boilerplate. Developers can now use `<==` directly for creating witnesses and asserting equality.

## Test plan
- [x] Build succeeds (`lake build`)

Resolves #176

🤖 Generated with [Claude Code](https://claude.ai/code)