### PR TITLE
Fix ambiguous indentation in multi-line def argument lists

### DIFF
--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -117,12 +117,12 @@ end Gadgets
 
 @[circuit_norm]
 def assertEquals {F : Type} [Field F] {α : TypeMap} [ProvableType α]
-  (x y : α (Expression F)) : Circuit F Unit :=
+    (x y : α (Expression F)) : Circuit F Unit :=
   Gadgets.Equality.circuit α (x, y)
 
 @[circuit_norm, reducible]
 def Expression.assertEquals {F : Type} [Field F]
-  (x y : Expression F) : Circuit F Unit :=
+    (x y : Expression F) : Circuit F Unit :=
   Gadgets.Equality.circuit id (x, y)
 
 class HasAssertEq (β : Type) (F : outParam Type) [Field F] where

--- a/Clean/Table/WitnessGeneration.lean
+++ b/Clean/Table/WitnessGeneration.lean
@@ -84,7 +84,7 @@ def generateNextRow (tc : TableConstraint W S F Unit) (cur_row: Array F) : Array
   table constraint's witness generators.
 -/
 def witnesses
-  (tc : TableConstraint W S F Unit) (init_row: Row F S) (n: ℕ) : Array (Array F) := Id.run do
+    (tc : TableConstraint W S F Unit) (init_row: Row F S) (n: ℕ) : Array (Array F) := Id.run do
 
   -- append auxiliary columns to the current row
   let aux_cols := Array.replicate tc.finalAssignment.numAux 0

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -45,9 +45,9 @@ theorem heq_cast {v : Vector α n} (h : n = m) : HEq v (v.cast h) := by
 universe u
 
 def induct {motive : {n: ℕ} → Vector α n → Sort u}
-  (nil: motive #v[])
-  (cons: ∀ {n: ℕ} (a: α) (as: Vector α n), motive as → motive (cons a as))
-  {n: ℕ} (v: Vector α n) : motive v :=
+    (nil: motive #v[])
+    (cons: ∀ {n: ℕ} (a: α) (as: Vector α n), motive as → motive (cons a as))
+    {n: ℕ} (v: Vector α n) : motive v :=
   match v with
   | ⟨ .mk [], h ⟩ => by
     have : n = 0 := by rw [←h, List.length_eq_zero_iff]


### PR DESCRIPTION
## Summary
- Fixed ambiguous indentation in multi-line `def` function signatures
- Changed continuation lines from 2-space to 4-space indentation to visually distinguish argument lists from function bodies
- Affects 3 files with minimal, targeted changes

## Test plan
- [x] Code compiles successfully with `lake build`

🤖 Generated with [Claude Code](https://claude.ai/code)