### PR TITLE
Make witnessing a type class for better inference

### DIFF
--- a/Clean/Circomlib/Comparators.lean
+++ b/Clean/Circomlib/Comparators.lean
@@ -26,7 +26,7 @@ template IsZero() {
 }
 -/
 def main (input : Expression (F p)) := do
-  let inv ← witnessField fun env =>
+  let inv ← witness fun env =>
     let x := input.eval env
     if x ≠ 0 then x⁻¹ else 0
 

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -27,23 +27,21 @@ template MultiMux1(n) {
     signal input s; // Selector
     signal output out[n];
 
-    for (var i=0; i<n; i++) {
+    for (var i=0; i < n; i++) {
         out[i] <== (c[i][1] - c[i][0])*s + c[i][0];
     }
 }
 -/
-def main (n: ℕ) [NeZero n] (input : Var (Inputs n) (F p)) := do
-  -- Extract vector of pairs and selector
-  let {c, s} := input
+def main (n: ℕ) (input : Var (Inputs n) (F p)) := do
+  let { c, s } := input
 
-  -- Create output vector where each element is witnessed and constrained
-  -- Note: We assume n > 0 (enforced by NeZero instance)
+  -- Witness and constrain output vector
   let out <== c.map fun (c0, c1) =>
     (c1 - c0) * s + c0
   return out
 
 -- Note: This circuit requires n > 0. In practice, a 0-output multiplexer doesn't make sense.
-def circuit (n : ℕ) [NeZero n] : FormalCircuit (F p) (Inputs n) (fields n) where
+def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
   main := main n
 
   localLength _ := n
@@ -60,11 +58,11 @@ def circuit (n : ℕ) [NeZero n] : FormalCircuit (F p) (Inputs n) (fields n) whe
       output[i] = if s = 0 then (c[i]).1 else (c[i]).2
 
   soundness := by
-    simp only [circuit_norm, main, MultiMux1.main]
+    simp only [circuit_norm, main]
     sorry -- TODO: prove soundness
 
   completeness := by
-    simp only [circuit_norm, main, MultiMux1.main]
+    simp only [circuit_norm, main]
     sorry -- TODO: prove completeness
 
 end MultiMux1
@@ -98,13 +96,10 @@ template Mux1() {
 }
 -/
 def main (input : Var Inputs (F p)) := do
-  -- Extract inputs
-  let {c, s} := input
+  let { c, s } := input
 
   -- Call MultiMux1 with n=1
-  let mux_out ← MultiMux1.circuit 1 {c := #v[(c[0], c[1])], s := s}
-
-  -- Extract single output
+  let mux_out ← MultiMux1.circuit 1 { c := #v[(c[0], c[1])], s }
   return mux_out[0]
 
 def circuit : FormalCircuit (F p) Inputs field where
@@ -123,11 +118,11 @@ def circuit : FormalCircuit (F p) Inputs field where
     output = if s = 0 then c[0] else c[1]
 
   soundness := by
-    simp only [circuit_norm, main, MultiMux1.main]
+    simp only [circuit_norm, main, MultiMux1.circuit]
     sorry
 
   completeness := by
-    simp only [circuit_norm, main, MultiMux1.main]
+    simp only [circuit_norm, main, MultiMux1.circuit]
     sorry
 
 end Mux1

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -40,7 +40,6 @@ def main (n: ℕ) (input : Var (Inputs n) (F p)) := do
     (c1 - c0) * s + c0
   return out
 
--- Note: This circuit requires n > 0. In practice, a 0-output multiplexer doesn't make sense.
 def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
   main := main n
 

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -397,28 +397,25 @@ export Circuit (witnessVar witnessField witnessVars witnessVector assertZero loo
 
 -- general `witness` method
 
-class Witnessable (F : outParam Type) [Field F] (value : outParam Type) (var : Type) where
-  witness : ((Environment F) → value) → Circuit F var
+class Witnessable (F : Type) [Field F] (value : outParam TypeMap) (var : TypeMap) [ProvableType value] where
+  witness : ((Environment F) → value F) → Circuit F (var F)
+  var_eq : var F = value (Expression F) := by rfl
+  witness_eq (compute : Environment F → value F) :
+    witness compute = var_eq ▸ ProvableType.witness compute := by intros; rfl
 
 export Witnessable (witness)
 
-instance : Witnessable F F (Variable F) where
-  witness := witnessVar
-
-instance : Witnessable F F (Expression F) where
+instance : Witnessable F field Expression where
   witness := witnessField
 
-instance {m : ℕ} : Witnessable F (Vector F m) (Vector (Variable F) m) where
-  witness := witnessVars m
-
-instance {m : ℕ} : Witnessable F (Vector F m) (Vector (Expression F) m) where
+instance {m : ℕ} : Witnessable F (Vector · m) (fun F => Vector (Expression F) m) where
   witness := witnessVector m
 
-instance (α : TypeMap) [ProvableType α] : Witnessable F (α F) (Var α F) where
+instance (α : TypeMap) [ProvableType α] : Witnessable F α (Var α) where
   witness := ProvableType.witness
 
 instance {m : ℕ} (α : TypeMap) [NonEmptyProvableType α] :
-    Witnessable F (Vector (α F) m) (Vector (α (Expression F)) m) where
+    Witnessable F (ProvableVector α m) (Var (ProvableVector α m)) where
   witness := ProvableVector.witness m
 
 -- witness generation

--- a/Clean/Circuit/Explicit.lean
+++ b/Clean/Circuit/Explicit.lean
@@ -115,7 +115,7 @@ instance {k : ℕ} {c : Environment F → Vector F k} : ExplicitCircuit (witness
   localLength _ := k
   operations n := [.witness k c]
 
-instance {α: TypeMap} [ProvableType α] : ExplicitCircuits (witness (α:=α) (F:=F)) where
+instance {α: TypeMap} [ProvableType α] : ExplicitCircuits (ProvableType.witness (α:=α) (F:=F)) where
   output _ n := varFromOffset α n
   localLength _ _ := size α
   operations c n := [.witness (size α) (toElements ∘ c)]
@@ -170,11 +170,11 @@ example : ExplicitCircuit (witnessField fun _ => (0 : F)) := by infer_explicit_c
 
 example :
   let add := do
-    let x : Expression F ← witnessField fun _ => 0
-    let y ← witnessField fun _ => 1
-    let z ← witnessField fun eval => eval (x + y)
+    let x : Expression F ← witness fun _ => 0
+    let y ← witness fun _ => 1
+    let z ← witness fun eval => eval (x + y)
     assertZero (x + y - z)
-    pure z
+    return z
 
   ExplicitCircuit add := by infer_explicit_circuit
 
@@ -183,10 +183,10 @@ example : ExplicitCircuits (witnessField (F:=F)) := by infer_explicit_circuits
 
 example :
   let add (x : Expression F) := do
-    let y ← witnessField fun _ => (1 : F)
-    let z ← witnessField fun eval => eval (x + y)
+    let y : Expression F ← witness fun _ => 1
+    let z ← witness fun eval => eval (x + y)
     assertZero (x + y - z)
-    pure z
+    return z
 
   ExplicitCircuits add := by infer_explicit_circuits
 end

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -577,6 +577,9 @@ instance : HMul (field (Expression F)) F (field (Expression F)) where
 instance : HMul (field (Expression F)) (field (Expression F)) (field (Expression F)) where
   hMul (a : Expression F) (b : Expression F) := a * b
 
+instance : Inv (field F) where
+  inv (x : F) : F := x⁻¹
+
 instance {n: ℕ} [OfNat F n] : OfNat (field F) n where
   ofNat : F := OfNat.ofNat n
 

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -134,28 +134,6 @@ instance : ProvableType unit where
 
 @[reducible] def fieldVar (F : Type) := field (Expression F)
 
--- Instances for arithmetic operations on field expressions
--- Since field is defined as id, field (Expression F) = Expression F
-variable {F : Type} [Field F]
-
-instance : HSub (field (Expression F)) (field (Expression F)) (field (Expression F)) where
-  hSub a b :=
-    let a : Expression F := a
-    let b : Expression F := b
-    a - b
-
-instance : HMul (field (Expression F)) (field (Expression F)) (field (Expression F)) where
-  hMul a b :=
-    let a : Expression F := a
-    let b : Expression F := b
-    a * b
-
-instance : HAdd (field (Expression F)) (field (Expression F)) (field (Expression F)) where
-  hAdd a b :=
-    let a : Expression F := a
-    let b : Expression F := b
-    a + b
-
 @[circuit_norm]
 instance : ProvableType field where
   size := 1
@@ -542,9 +520,9 @@ instance ProvablePair.instance {α β: TypeMap} [ProvableType α] [ProvableType 
   toElements_fromElements v := by
     simp [ProvableType.toElements_fromElements, Vector.cast]
 
-instance {α β: TypeMap} [NonEmptyProvableType α] [NonEmptyProvableType β] : 
+instance {α β: TypeMap} [NonEmptyProvableType α] [NonEmptyProvableType β] :
   NonEmptyProvableType (ProvablePair α β) where
-  nonempty := by 
+  nonempty := by
     simp only [ProvablePair.instance, size]
     have h1 := NonEmptyProvableType.nonempty (M := α)
     have h2 := NonEmptyProvableType.nonempty (M := β)
@@ -578,11 +556,15 @@ instance : HAdd (field (Expression F)) (Expression F) (Expression F) where
   hAdd (x : Expression F) y := x + y
 instance : HAdd (Expression F) (field (Expression F)) (Expression F) where
   hAdd x (y : Expression F) := x + y
+instance : HAdd (field (Expression F)) (field (Expression F)) (field (Expression F)) where
+  hAdd (a : Expression F) (b : Expression F) := a + b
 
 instance : HSub (field (Expression F)) (Expression F) (Expression F) where
   hSub (x : Expression F) y := x - y
 instance : HSub (Expression F) (field (Expression F)) (Expression F) where
   hSub x (y : Expression F) := x - y
+instance : HSub (field (Expression F)) (field (Expression F)) (field (Expression F)) where
+  hSub (a : Expression F) (b : Expression F) := a - b
 
 instance : HMul (field (Expression F)) (Expression F) (Expression F) where
   hMul (x : Expression F) y := x * y
@@ -592,6 +574,8 @@ instance : HMul F (field (Expression F)) (field (Expression F)) where
   hMul x y : Expression F := x * y
 instance : HMul (field (Expression F)) F (field (Expression F)) where
   hMul x y : Expression F := x * y
+instance : HMul (field (Expression F)) (field (Expression F)) (field (Expression F)) where
+  hMul (a : Expression F) (b : Expression F) := a * b
 
 instance {n: ℕ} [OfNat F n] : OfNat (field F) n where
   ofNat : F := OfNat.ofNat n

--- a/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
@@ -10,8 +10,8 @@ namespace Gadgets.ByteDecomposition
 open FieldUtils (mod floorDiv two_lt two_pow_lt two_val two_pow_val)
 
 structure Outputs (F : Type) where
-  low : field F
-  high : field F
+  low : F
+  high : F
 
 instance : ProvableStruct Outputs where
   components := [field, field]
@@ -30,7 +30,7 @@ def main (offset : Fin 8) (x :  Expression (F p)) : Circuit (F p) (Var Outputs (
   lookup ByteTable ((2^(8 - offset.val) : F p) * low)
   lookup ByteTable high
 
-  x.assertEquals (low + high * (2^offset.val : F p))
+  x === low + high * (2^offset.val : F p)
 
   return { low, high }
 

--- a/Clean/Utils/Misc.lean
+++ b/Clean/Utils/Misc.lean
@@ -12,6 +12,30 @@ theorem funext_heq {α α' β : Type} (h : α = α') {f : α → β} {g : α' �
   funext x
   exact hfg x
 
+theorem cast_apply {α β β' : Type} (h : β = β') (f : α → β) (x : α) :
+    (cast (h ▸ rfl) f : α → β') x = cast (h ▸ rfl) (f x) := by
+  subst h; rfl
+
+theorem cast_apply' {α α' β : Type} (h : α = α') (f : α → β) (x : α') :
+    (cast (h ▸ rfl) f : α' → β) x = f (cast (h ▸ rfl) x : α) := by
+  subst h; rfl
+
+theorem cast_fst {α α' β : Type} (h : α = α') (p : α × β) :
+    (cast h p.1 : α') = (cast (h ▸ rfl) p : α' × β).1 := by
+  subst h; rfl
+
+theorem cast_snd {α β β' : Type} (h : β = β') (p : α × β) :
+    (cast h p.2 : β') = (cast (h ▸ rfl) p : α × β').2 := by
+  subst h; rfl
+
+theorem fst_cast {α β β' : Type} (h : β = β') (p : α × β) :
+    (cast (h ▸ rfl) p : α × β').1 = p.1 := by
+  subst h; rfl
+
+theorem snd_cast {α α' β : Type} (h : α = α') (p : α × β) :
+    (cast (h ▸ rfl) p : α' × β).2 = p.2 := by
+  subst h; rfl
+
 theorem Fin.foldl_const_succ (n : ℕ) (f : Fin (n + 1) → α) (init : α) :
     Fin.foldl (n + 1) (fun _ i => f i) init = f n := by
   induction n generalizing init with

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -75,7 +75,6 @@ def inductPush {motive : {n: ℕ} → Vector α n → Sort u}
     cast (by subst h; rfl) nil
   | ⟨ .mk (a::as), h ⟩ =>
     have hlen : as.length + 1 = n := by rw [←h, List.size_toArray, List.length_cons]
-    let v : Vector α (as.length + 1) := ⟨.mk (a :: as), rfl⟩
     let ⟨ as', a', is_push ⟩ := toPush ⟨.mk (a :: as), rfl⟩
     cast (by subst hlen; rw [is_push]) (push as' a' (inductPush nil push as'))
 


### PR DESCRIPTION
* add `Witnessable` type class to improve witnessing of pure `Expression F` and get rid of `witnessField`
* some simplifications here and there