### PR TITLE
refactor: remove redundant Vector instance and add ProvableVector utilities

### DIFF
--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -38,7 +38,7 @@ def main (n: ℕ) (input : Var (Inputs n) (F p)) := do
   let { c, s } := input
 
   -- Witness and constrain output vector
-  let out : Var (ProvableVector field n) (F p) <== c.map fun (c0, c1) =>
+  let out <== c.provable_map field fun (c0, c1) =>
     (c1 - c0) * s + c0
   return out
 

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -38,7 +38,7 @@ def main (n: ℕ) (input : Var (Inputs n) (F p)) := do
   let { c, s } := input
 
   -- Witness and constrain output vector
-  let out <== c.map fun (c0, c1) =>
+  let out : Var (ProvableVector field n) (F p) <== c.map fun (c0, c1) =>
     (c1 - c0) * s + c0
   return out
 

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -16,8 +16,8 @@ https://github.com/iden3/circomlib/blob/master/circuits/mux1.circom
 namespace MultiMux1
 
 structure Inputs (n : ℕ) (F : Type) where
-  c : Vector (F × F) n  -- n pairs of constants
-  s : F                 -- selector
+  c : ProvableVector (ProvablePair field field) n F  -- n pairs of constants
+  s : F                                               -- selector
 
 instance {n : ℕ} : ProvableStruct (Inputs n) where
   components := [ProvableVector (ProvablePair field field) n, field]
@@ -71,7 +71,7 @@ end MultiMux1
 namespace Mux1
 
 structure Inputs (F : Type) where
-  c : Vector F 2  -- 2 constants
+  c : fields 2 F  -- 2 constants
   s : F           -- selector
 
 instance : ProvableStruct Inputs where

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -169,6 +169,12 @@ def ProvableVector (α: TypeMap) (n: ℕ) := fun F => Vector (α F) n
 @[reducible]
 def fields (n: ℕ) := fun F => Vector F n
 
+-- beta is the ProvableType of the target, and it's explicit because omitting this has caused type inference failures
+namespace ProvableVector
+def provable_map {α : TypeMap} {n : ℕ} {F : Type} (x : ProvableVector α n F) (β : TypeMap) (f : α F → β F) : ProvableVector β n F :=
+  Vector.map f x
+end ProvableVector
+
 @[circuit_norm]
 instance : ProvableType (fields n) where
   size := n

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -156,13 +156,6 @@ instance {F : Type} [Field F] {α : TypeMap} [ProvableType α] :
     witness === rhs
     return witness
 
-instance {F : Type} [Field F] {n : ℕ} : HasAssignEq (Vector (Expression F) n) F where
-  assignEq vals := do
-    vals.mapM fun v => do
-      let witness ← witnessField fun env => v.eval env
-      witness === v
-      return witness
-
 attribute [circuit_norm] HasAssignEq.assignEq
 
 -- Custom syntax to allow `let var <== expr` without monadic arrow


### PR DESCRIPTION
## Summary
- Removed redundant `HasAssignEq` instance for `Vector` since it's already covered by `ProvableType`
- Updated `Inputs` structures in `Mux1.lean` to use `ProvableVector` directly instead of `Vector`
- Added `ProvableVector.provable_map` utility function to map over ProvableVectors while preserving the type

## Test plan
- [x] `lake build` succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)