### PR TITLE
feat: prove properties for Mux1 circuits

### DIFF
--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -42,6 +42,10 @@ def main (n: ℕ) (input : Var (Inputs n) (F p)) := do
     (c1 - c0) * s + c0
   return out
 
+lemma assignEq_Vector_localLength {F : Type} [Field F] {n : ℕ} (v : Vector (Expression F) n) (offset : ℕ) :
+    (HasAssignEq.assignEq v).localLength offset = n := by
+  simp only [HasAssignEq.assignEq, bind_localLength_eq, pure_localLength_eq, add_zero, circuit_norm]
+
 def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
   main := main n
 

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -59,6 +59,8 @@ lemma Vector.getElem_map_singleton_flatten {α β : Type} {n : ℕ} (v : Vector 
   simp only [Vector.getElem_map (fun x => #v[f x]) hi]
   rfl
 
+-- Note: Use the existing lemma getElem_eval_vector from Provable.lean instead
+
 def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
   main := main n
 

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -245,20 +245,21 @@ def circuit : FormalCircuit (F p) Inputs field where
     rw [h_subcircuit_sound]
     -- Now we need to show the RHS equals our spec
     -- First, simplify the evaluation of the vector
-    simp only [eval_vector, Vector.getElem_singleton]
+    simp only [eval_vector (α := ProvablePair field field)]
+    simp only [Vector.getElem_map]
+    simp only [Vector.getElem_singleton]
     -- The goal is now about pairs (Expression.eval env input_var.c[0], Expression.eval env input_var.c[1])
-    
+
     -- Connect the condition using h_input
     have h_s : Expression.eval env input_var.s = input.s := by
       rw [← h_input]
     rw [h_s]
-    
+
     -- Now we need to show the branches match
     -- First simplify the vector map on the singleton vector
-    simp only [Vector.getElem_map, Vector.getElem_singleton]
     -- Now we have (eval env (input_var.c[0], input_var.c[1])).1 or .2
     simp only [eval, Prod.fst, Prod.snd]
-    
+
     split_ifs with h
     · -- Case: s = 0
       have h_c0 : Expression.eval env input_var.c[0] = input.c[0] := by
@@ -266,7 +267,7 @@ def circuit : FormalCircuit (F p) Inputs field where
         simp only [Vector.getElem_map] at h
         exact h
       exact h_c0
-    · -- Case: s ≠ 0  
+    · -- Case: s ≠ 0
       have h_c1 : Expression.eval env input_var.c[1] = input.c[1] := by
         have h := congrArg (fun x => x.c[1]) h_input
         simp only [Vector.getElem_map] at h

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -235,7 +235,13 @@ def circuit : FormalCircuit (F p) Inputs field where
     output = if s = 0 then c[0] else c[1]
 
   soundness := by
-    simp only [circuit_norm, main, MultiMux1.circuit]
+    simp only [circuit_norm, main]
+    intro offset env input_var input h_input h_assumptions h_subcircuit_sound
+    simp only [MultiMux1.circuit, subcircuit, circuit_norm, FormalCircuit.toSubcircuit] at h_subcircuit_sound h_assumptions ⊢
+    have h_asm' : IsBool (Expression.eval env input_var.s) := by
+      sorry
+    specialize h_subcircuit_sound h_asm' 0 (by omega)
+    rw [h_subcircuit_sound]
     sorry
 
   completeness := by

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -239,10 +239,39 @@ def circuit : FormalCircuit (F p) Inputs field where
     intro offset env input_var input h_input h_assumptions h_subcircuit_sound
     simp only [MultiMux1.circuit, subcircuit, circuit_norm, FormalCircuit.toSubcircuit] at h_subcircuit_sound h_assumptions ⊢
     have h_asm' : IsBool (Expression.eval env input_var.s) := by
-      sorry
+      rw [← h_input] at h_assumptions
+      exact h_assumptions
     specialize h_subcircuit_sound h_asm' 0 (by omega)
     rw [h_subcircuit_sound]
-    sorry
+    -- Now we need to show the RHS equals our spec
+    -- First, simplify the evaluation of the vector
+    simp only [eval_vector, Vector.getElem_singleton]
+    -- The goal is now about pairs (Expression.eval env input_var.c[0], Expression.eval env input_var.c[1])
+    
+    -- Connect the condition using h_input
+    have h_s : Expression.eval env input_var.s = input.s := by
+      rw [← h_input]
+    rw [h_s]
+    
+    -- Now we need to show the branches match
+    -- First simplify the vector map on the singleton vector
+    simp only [Vector.getElem_map, Vector.getElem_singleton]
+    -- Now we have (eval env (input_var.c[0], input_var.c[1])).1 or .2
+    simp only [eval, Prod.fst, Prod.snd]
+    
+    split_ifs with h
+    · -- Case: s = 0
+      have h_c0 : Expression.eval env input_var.c[0] = input.c[0] := by
+        have h := congrArg (fun x => x.c[0]) h_input
+        simp only [Vector.getElem_map] at h
+        exact h
+      exact h_c0
+    · -- Case: s ≠ 0  
+      have h_c1 : Expression.eval env input_var.c[1] = input.c[1] := by
+        have h := congrArg (fun x => x.c[1]) h_input
+        simp only [Vector.getElem_map] at h
+        exact h
+      exact h_c1
 
   completeness := by
     simp only [circuit_norm, main]

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -106,25 +106,19 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
     have h_c : input.c = (eval env input_var.c : ProvableVector (ProvablePair field field) _ _) := by
       rw [← h_input]
 
-    have h_i : (eval env input_var.c : ProvableVector (ProvablePair field field) _ _)[i] = input.c[i] := by
-      rw [h_c]
-      rfl
-
-    simp only [eval_pair] at h_i
-
     have h_c1 : Expression.eval env input_var.c[i].1 = input.c[i].1 := by
       -- First, we know that (eval env input_var.c)[i] = input.c[i]
       -- input_var.c[i] has type Var (ProvablePair field field) F
       -- So eval env input_var.c[i] = (eval env input_var.c[i].1, eval env input_var.c[i].2)
       -- And (eval env input_var.c)[i] = (eval env input_var.c[i].1, eval env input_var.c[i].2)
-      rw [← h_i]
+      rw [h_c]
       simp only [eval_vector (α := (ProvablePair field field))]
       simp only [Vector.getElem_map]
       rfl
 
     have h_c2 : Expression.eval env input_var.c[i].2 = input.c[i].2 := by
       -- First, we know that (eval env input_var.c)[i] = input.c[i]
-      rw [← h_i]
+      rw [h_c]
       simp only [eval_vector (α := (ProvablePair field field))]
       simp only [Vector.getElem_map]
       rfl

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -206,12 +206,7 @@ def circuit : FormalCircuit (F p) Inputs field where
     rw [h_subcircuit_sound]
     -- Now we need to show the RHS equals our spec
     -- First, simplify the evaluation of the vector
-    simp only [eval_vector (α := ProvablePair field field)]
-    -- The goal is now about pairs (Expression.eval env input_var.c[0], Expression.eval env input_var.c[1])
-    simp only [Vector.getElem_map]
-    simp only [id_eq, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero]
-    rw [eval_pair (α := field) (β := field)]
-    simp only []
+    simp only [eval_vector (α := ProvablePair field field), Vector.getElem_map, id_eq, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero, eval_pair (α := field) (β := field)]
     rfl
 
   completeness := by

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -65,10 +65,6 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
   main := main n
 
   localLength _ := n
-  localLength_eq := by
-    intros input offset
-    simp only [main, circuit_norm]
-  subcircuitsConsistent := by sorry -- TODO: prove
 
   Assumptions input :=
     let ⟨c, s⟩ := input

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -106,23 +106,6 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
     have h_c : input.c = (eval env input_var.c : ProvableVector (ProvablePair field field) _ _) := by
       rw [← h_input]
 
-    have h_c1 : Expression.eval env input_var.c[i].1 = input.c[i].1 := by
-      -- First, we know that (eval env input_var.c)[i] = input.c[i]
-      -- input_var.c[i] has type Var (ProvablePair field field) F
-      -- So eval env input_var.c[i] = (eval env input_var.c[i].1, eval env input_var.c[i].2)
-      -- And (eval env input_var.c)[i] = (eval env input_var.c[i].1, eval env input_var.c[i].2)
-      rw [h_c]
-      simp only [eval_vector (α := (ProvablePair field field))]
-      simp only [Vector.getElem_map]
-      rfl
-
-    have h_c2 : Expression.eval env input_var.c[i].2 = input.c[i].2 := by
-      -- First, we know that (eval env input_var.c)[i] = input.c[i]
-      rw [h_c]
-      simp only [eval_vector (α := (ProvablePair field field))]
-      simp only [Vector.getElem_map]
-      rfl
-
     simp only [circuit_norm] at h_output_i
     simp only [h_output_i]
 
@@ -131,19 +114,22 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
     rw [← h_s] at h_assumptions ⊢
     -- Extract the fact that s is boolean
     -- IsBool means s = 0 ∨ s = 1
+    simp only [eval_vector (α := (ProvablePair field field))]
+    simp only [Vector.getElem_map]
+
     cases h_assumptions with
       | inl h0 =>
         -- When s = 0
         rw [h0]
         simp only [mul_zero, add_zero, if_pos rfl, circuit_norm]
         norm_num
-        rw [h_c1, h_c]
+        rfl
       | inr h1 =>
         -- When s = 1
         rw [h1]
         simp only [mul_one, if_neg (by norm_num : (1 : F p) ≠ 0), circuit_norm]
         norm_num
-        rw [h_c2, h_c]
+        rfl
 
   completeness := by
     simp only [circuit_norm, main]

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -109,8 +109,15 @@ def circuit : FormalCircuit (F p) Inputs field where
   main := main
 
   localLength _ := 1
-  localLength_eq := by sorry -- TODO: prove
-  subcircuitsConsistent := by sorry -- TODO: prove
+  localLength_eq := by
+    intro input offset
+    simp only [main, circuit_norm]
+    -- The goal is about MultiMux1.circuit's localLength with n=1
+    -- which is defined as n = 1
+    rfl
+  subcircuitsConsistent := by
+    intro input offset
+    simp only [main, circuit_norm]
 
   Assumptions input :=
     let ⟨_, s⟩ := input

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -202,19 +202,12 @@ def circuit : FormalCircuit (F p) Inputs field where
     clear input
     clear h_input
     simp only [MultiMux1.circuit, subcircuit, circuit_norm, FormalCircuit.toSubcircuit] at h_subcircuit_sound h_assumptions ⊢
-    have h_asm' : IsBool (Expression.eval env input_var.s) := by
-      exact h_assumptions
-    specialize h_subcircuit_sound h_asm' 0 (by omega)
+    specialize h_subcircuit_sound h_assumptions 0 (by omega)
     rw [h_subcircuit_sound]
     -- Now we need to show the RHS equals our spec
     -- First, simplify the evaluation of the vector
     simp only [eval_vector (α := ProvablePair field field)]
     -- The goal is now about pairs (Expression.eval env input_var.c[0], Expression.eval env input_var.c[1])
-
-    -- Now we need to show the branches match
-    -- First simplify the vector map on the singleton vector
-    -- Now we have (eval env (input_var.c[0], input_var.c[1])).1 or .2
-
     simp only [Vector.getElem_map]
     simp only [id_eq, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero]
     rw [eval_pair (α := field) (β := field)]

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -218,12 +218,11 @@ def circuit : FormalCircuit (F p) Inputs field where
     simp only [Vector.getElem_map]
     simp only [id_eq, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero]
     rw [eval_pair (α := field) (β := field)]
+    simp only []
     split_ifs with h
     · -- Case: s = 0
-      simp only []
       rfl
     · -- Case: s ≠ 0
-      simp only []
       rfl
 
   completeness := by

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -42,6 +42,19 @@ def main (n: ℕ) (input : Var (Inputs n) (F p)) := do
     (c1 - c0) * s + c0
   return out
 
+lemma Vector.mapRange_one {α : Type} (f : ℕ → α) :
+  Vector.mapRange 1 f = #v[f 0] := by
+  rfl
+
+-- Helper lemmas for vector operations (to be proved later)
+lemma Vector.getElem_flatten_singleton {α : Type} {n : ℕ} (v : Vector (Vector α 1) n) (i : ℕ) (hi : i < n) :
+    v.flatten[i] = (v[i])[0] := by
+  sorry
+
+lemma Vector.getElem_map_singleton_flatten {α β : Type} {n : ℕ} (v : Vector α n) (f : α → β) (i : ℕ) (hi : i < n) :
+    (v.map (fun x => #v[f x])).flatten[i] = f (v[i]) := by
+  sorry
+
 def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
   main := main n
 
@@ -66,7 +79,18 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
 
   completeness := by
     simp only [circuit_norm, main]
-    sorry -- TODO: prove completeness
+    intro offset env input_var h_env input h_input h_assumptions
+    -- We need to show that the witnessed values equal the computed expressions
+    ext i hi
+    -- Left side: eval of varFromOffset
+    simp only [varFromOffset_vector, eval_vector, Vector.getElem_map, Vector.getElem_mapRange]
+    -- Now simplify the left side: Expression.eval env (var { index := offset + 1 * i })
+    simp only [Expression.eval, mul_one]
+    -- Right side: eval of the computed expression
+    have h_env_i := h_env ⟨i, hi⟩
+    simp only [Fin.val_mk, mul_one] at h_env_i
+    rw [h_env_i]
+    norm_num
 
 end MultiMux1
 

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -44,7 +44,7 @@ def main (n: ℕ) (input : Var (Inputs n) (F p)) := do
 
 lemma Vector.mapRange_one {α : Type} (f : ℕ → α) :
   Vector.mapRange 1 f = #v[f 0] := by
-  rfl
+    rfl
 
 -- Helper lemmas for vector operations (to be proved later)
 lemma Vector.getElem_flatten_singleton {α : Type} {n : ℕ} (v : Vector (Vector α 1) n) (i : ℕ) (hi : i < n) :
@@ -87,9 +87,7 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
     -- The output at position i is (c[i][1] - c[i][0]) * s + c[i][0]
     -- We need to show this equals if s = 0 then c[i][0] else c[i][1]
 
-    -- First, understand what h_output says
-    -- eval env (varFromOffset (ProvableVector field n) offset) =
-    -- eval env (input_var.c.provable_map field fun x => (x.2 - x.1) * input_var.s + x.1)
+    -- h_output gives us the equality of evaluated vectors
 
     -- Get the i-th element equality from h_output
     have h_output_i : Expression.eval env (var { index := offset + i }) =

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -42,10 +42,6 @@ def main (n: ℕ) (input : Var (Inputs n) (F p)) := do
     (c1 - c0) * s + c0
   return out
 
-lemma assignEq_Vector_localLength {F : Type} [Field F] {n : ℕ} (v : Vector (Expression F) n) (offset : ℕ) :
-    (HasAssignEq.assignEq v).localLength offset = n := by
-  simp only [HasAssignEq.assignEq, bind_localLength_eq, pure_localLength_eq, add_zero, circuit_norm]
-
 def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
   main := main n
 

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -86,15 +86,12 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
     -- h_output gives us the equality of evaluated vectors
 
     -- Get the i-th element equality from h_output
-    have h_output_i : Expression.eval env (var { index := offset + i }) =
-                      Expression.eval env ((input_var.c[i].2 - input_var.c[i].1) * input_var.s + input_var.c[i].1) := by
-      -- h_output gives us equality of vectors, extract element i
-      have := congrArg (fun v => v[i]) h_output
-      -- Simplify the outer Vector.map on both sides
-      simp only [Vector.getElem_map] at this
-      -- Now we need to show that (Vector.mapRange n fun i => var { index := offset + i })[i] = var { index := offset + i }
-      simp only [Vector.getElem_mapRange] at this
-      exact this
+    -- h_output gives us equality of vectors, extract element i
+    have h_output_i := congrArg (fun v => v[i]) h_output
+    -- Simplify the outer Vector.map on both sides
+    simp only [Vector.getElem_map] at h_output_i
+    -- Now we need to show that (Vector.mapRange n fun i => var { index := offset + i })[i] = var { index := offset + i }
+    simp only [Vector.getElem_mapRange] at h_output_i
 
     simp only [circuit_norm] at h_output_i
     simp only [h_output_i]

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -219,11 +219,7 @@ def circuit : FormalCircuit (F p) Inputs field where
     simp only [id_eq, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero]
     rw [eval_pair (α := field) (β := field)]
     simp only []
-    split_ifs with h
-    · -- Case: s = 0
-      rfl
-    · -- Case: s ≠ 0
-      rfl
+    rfl
 
   completeness := by
     simp only [circuit_norm, main]

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -96,31 +96,25 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
       simp only [Vector.getElem_mapRange] at this
       exact this
 
-    -- Now we need to evaluate the expression
-    have h_c : input.c = (eval env input_var.c : ProvableVector (ProvablePair field field) _ _) := by
-      rw [← h_input]
-
     simp only [circuit_norm] at h_output_i
     simp only [h_output_i]
 
     -- Now we can work with the components
-    rw [h_c]
     rw [← h_input] at h_assumptions ⊢
     -- Extract the fact that s is boolean
     -- IsBool means s = 0 ∨ s = 1
     simp only [eval_vector (α := (ProvablePair field field))]
     simp only [Vector.getElem_map]
+    simp only [] at h_assumptions
 
     cases h_assumptions with
       | inl h0 =>
-        simp only [] at h0
         -- When s = 0
         rw [h0]
         simp only [mul_zero, add_zero, if_pos rfl, circuit_norm]
         norm_num
         rfl
       | inr h1 =>
-        simp only [] at h1
         -- When s = 1
         rw [h1]
         simp only [mul_one, if_neg (by norm_num : (1 : F p) ≠ 0), circuit_norm]

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -79,7 +79,86 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
 
   soundness := by
     simp only [circuit_norm, main]
-    sorry -- TODO: prove soundness
+    intro offset env input_var input h_input h_assumptions h_output
+    -- We need to show the spec holds for all i < n
+    intro i hi
+    -- The output at position i is (c[i][1] - c[i][0]) * s + c[i][0]
+    -- We need to show this equals if s = 0 then c[i][0] else c[i][1]
+
+    -- First, understand what h_output says
+    -- eval env (varFromOffset (ProvableVector field n) offset) =
+    -- eval env (input_var.c.provable_map field fun x => (x.2 - x.1) * input_var.s + x.1)
+
+    -- This means the i-th elements are also equal
+    have h_eq : eval env (varFromOffset (ProvableVector field n) offset) =
+                eval env (input_var.c.provable_map field fun x => (x.2 - x.1) * input_var.s + x.1) := h_output
+
+    -- Now get the i-th element equality
+    have h_output_i : Expression.eval env ((varFromOffset (ProvableVector field n) offset)[i]) =
+                      Expression.eval env ((input_var.c.provable_map field fun x => (x.2 - x.1) * input_var.s + x.1)[i]) := by
+      simp only [eval_vector] at h_eq
+      -- Extract the i-th element from both sides
+      have h_vec := congrArg (fun v => v[i]) h_eq
+      simp only [Vector.getElem_map] at h_vec
+      exact h_vec
+
+    -- The issue is that varFromOffset returns a Var (ProvableVector field n)
+    -- which is Vector (field (Expression (F p))) n
+    -- But in the goal we need Vector (Expression (F p)) n
+    
+    -- Let's unfold what varFromOffset actually gives us
+    simp only [varFromOffset_vector, eval_vector] at h_output_i ⊢
+    
+    -- Simplify the left side first
+    simp only [Vector.getElem_mapRange] at h_output_i ⊢
+    simp only [size, mul_one] at h_output_i ⊢
+    
+    -- Now we can rewrite
+    rw [h_output_i]
+    -- Now simplify the right side step by step
+    simp only [ProvableVector.provable_map, Vector.getElem_map]
+
+    -- Extract values from h_input
+    -- h_input says: { c := eval env input_var.c, s := Expression.eval env input_var.s } = input
+    -- So: eval env input_var.c = input.c
+    have h_c : eval env input_var.c = input.c := by
+      rw [← h_input]
+    have h_s : Expression.eval env input_var.s = input.s := by
+      rw [← h_input]
+
+    -- Now we need to evaluate the expression
+    -- The goal is: Expression.eval env ((input_var.c[i].2 - input_var.c[i].1) * input_var.s + input_var.c[i].1)
+    simp only [Expression.eval]
+    
+    -- We have input_var.c : Var (ProvableVector (ProvablePair field field) n)
+    -- So eval env input_var.c : Vector (field (F p) × field (F p)) n
+    -- And (eval env input_var.c)[i] : field (F p) × field (F p)
+    
+    -- Get the pair at index i
+    have h_ci : (eval env input_var.c)[i] = input.c[i] := by
+      rw [h_c]
+    
+    -- Now we can work with the components
+    rw [← h_s]
+    conv_lhs => 
+      arg 1; arg 1; arg 2; rw [← h_ci]
+      arg 1; arg 2; rw [← h_ci]
+      arg 2; rw [← h_ci]
+
+    -- Extract the fact that s is boolean
+    -- IsBool means s = 0 ∨ s = 1
+    cases h_assumptions with
+      -- When s = 0 or s = 1
+      cases hs with
+      | inl h0 =>
+        -- When s = 0
+        rw [h0]
+        simp only [mul_zero, add_zero, if_pos rfl]
+      | inr h1 =>
+        -- When s = 1
+        rw [h1]
+        simp only [mul_one, if_neg (by norm_num : (1 : F p) ≠ 0)]
+        ring
 
   completeness := by
     simp only [circuit_norm, main]

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -198,9 +198,11 @@ def circuit : FormalCircuit (F p) Inputs field where
   soundness := by
     simp only [circuit_norm, main]
     intro offset env input_var input h_input h_assumptions h_subcircuit_sound
+    rw[← h_input] at *
+    clear input
+    clear h_input
     simp only [MultiMux1.circuit, subcircuit, circuit_norm, FormalCircuit.toSubcircuit] at h_subcircuit_sound h_assumptions ⊢
     have h_asm' : IsBool (Expression.eval env input_var.s) := by
-      rw [← h_input] at h_assumptions
       exact h_assumptions
     specialize h_subcircuit_sound h_asm' 0 (by omega)
     rw [h_subcircuit_sound]
@@ -209,24 +211,23 @@ def circuit : FormalCircuit (F p) Inputs field where
     simp only [eval_vector (α := ProvablePair field field)]
     -- The goal is now about pairs (Expression.eval env input_var.c[0], Expression.eval env input_var.c[1])
 
-    -- Connect the condition using h_input
-    have h_s : Expression.eval env input_var.s = input.s := by
-      rw [← h_input]
-    rw [h_s]
-
     -- Now we need to show the branches match
     -- First simplify the vector map on the singleton vector
     -- Now we have (eval env (input_var.c[0], input_var.c[1])).1 or .2
 
     split_ifs with h
     · -- Case: s = 0
-      have h := congrArg (fun x => x.c[0]) h_input
-      simp only [Vector.getElem_map] at h
-      exact h
+      simp only [Vector.getElem_map]
+      simp only [id_eq, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero]
+      rw [eval_pair (α := field) (β := field)]
+      simp only []
+      rfl
     · -- Case: s ≠ 0
-      have h := congrArg (fun x => x.c[1]) h_input
-      simp only [Vector.getElem_map] at h
-      exact h
+      simp only [Vector.getElem_map]
+      simp only [id_eq, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero]
+      rw [eval_pair (α := field) (β := field)]
+      simp only []
+      rfl
 
   completeness := by
     simp only [circuit_norm, main]

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -46,7 +46,9 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
   main := main n
 
   localLength _ := n
-  localLength_eq := by sorry -- TODO: prove
+  localLength_eq := by
+    intros input offset
+    simp only [main, circuit_norm]
   subcircuitsConsistent := by sorry -- TODO: prove
 
   Assumptions input :=

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -49,11 +49,15 @@ lemma Vector.mapRange_one {α : Type} (f : ℕ → α) :
 -- Helper lemmas for vector operations (to be proved later)
 lemma Vector.getElem_flatten_singleton {α : Type} {n : ℕ} (v : Vector (Vector α 1) n) (i : ℕ) (hi : i < n) :
     v.flatten[i] = (v[i])[0] := by
-  sorry
+  simp only [Vector.getElem_flatten, Nat.div_one]
+  congr
+  omega
 
 lemma Vector.getElem_map_singleton_flatten {α β : Type} {n : ℕ} (v : Vector α n) (f : α → β) (i : ℕ) (hi : i < n) :
     (v.map (fun x => #v[f x])).flatten[i] = f (v[i]) := by
-  sorry
+  rw [Vector.getElem_flatten_singleton (v.map (fun x => #v[f x])) i hi]
+  simp only [Vector.getElem_map (fun x => #v[f x]) hi]
+  rfl
 
 def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
   main := main n

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -215,17 +215,14 @@ def circuit : FormalCircuit (F p) Inputs field where
     -- First simplify the vector map on the singleton vector
     -- Now we have (eval env (input_var.c[0], input_var.c[1])).1 or .2
 
+    simp only [Vector.getElem_map]
+    simp only [id_eq, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero]
+    rw [eval_pair (α := field) (β := field)]
     split_ifs with h
     · -- Case: s = 0
-      simp only [Vector.getElem_map]
-      simp only [id_eq, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero]
-      rw [eval_pair (α := field) (β := field)]
       simp only []
       rfl
     · -- Case: s ≠ 0
-      simp only [Vector.getElem_map]
-      simp only [id_eq, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero]
-      rw [eval_pair (α := field) (β := field)]
       simp only []
       rfl
 

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -197,7 +197,7 @@ def circuit : FormalCircuit (F p) Inputs field where
 
   soundness := by
     simp only [circuit_norm, main]
-    intro offset env input_var input h_input h_assumptions h_subcircuit_sound
+    intro _ _ _ input h_input h_assumptions h_subcircuit_sound
     rw[← h_input] at *
     clear input
     clear h_input

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -96,12 +96,6 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
       simp only [Vector.getElem_mapRange] at this
       exact this
 
-    -- Extract values from h_input
-    -- h_input says: { c := eval env input_var.c, s := Expression.eval env input_var.s } = input
-    -- So: eval env input_var.c = input.c
-    have h_s : Expression.eval env input_var.s = input.s := by
-      rw [← h_input]
-
     -- Now we need to evaluate the expression
     have h_c : input.c = (eval env input_var.c : ProvableVector (ProvablePair field field) _ _) := by
       rw [← h_input]
@@ -111,7 +105,7 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
 
     -- Now we can work with the components
     rw [h_c]
-    rw [← h_s] at h_assumptions ⊢
+    rw [← h_input] at h_assumptions ⊢
     -- Extract the fact that s is boolean
     -- IsBool means s = 0 ∨ s = 1
     simp only [eval_vector (α := (ProvablePair field field))]
@@ -119,12 +113,14 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
 
     cases h_assumptions with
       | inl h0 =>
+        simp only [] at h0
         -- When s = 0
         rw [h0]
         simp only [mul_zero, add_zero, if_pos rfl, circuit_norm]
         norm_num
         rfl
       | inr h1 =>
+        simp only [] at h1
         -- When s = 1
         rw [h1]
         simp only [mul_one, if_neg (by norm_num : (1 : F p) ≠ 0), circuit_norm]

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -223,17 +223,13 @@ def circuit : FormalCircuit (F p) Inputs field where
 
     split_ifs with h
     · -- Case: s = 0
-      have h_c0 : Expression.eval env input_var.c[0] = input.c[0] := by
-        have h := congrArg (fun x => x.c[0]) h_input
-        simp only [Vector.getElem_map] at h
-        exact h
-      exact h_c0
+      have h := congrArg (fun x => x.c[0]) h_input
+      simp only [Vector.getElem_map] at h
+      exact h
     · -- Case: s ≠ 0
-      have h_c1 : Expression.eval env input_var.c[1] = input.c[1] := by
-        have h := congrArg (fun x => x.c[1]) h_input
-        simp only [Vector.getElem_map] at h
-        exact h
-      exact h_c1
+      have h := congrArg (fun x => x.c[1]) h_input
+      simp only [Vector.getElem_map] at h
+      exact h
 
   completeness := by
     simp only [circuit_norm, main]

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -207,8 +207,6 @@ def circuit : FormalCircuit (F p) Inputs field where
     -- Now we need to show the RHS equals our spec
     -- First, simplify the evaluation of the vector
     simp only [eval_vector (α := ProvablePair field field)]
-    simp only [Vector.getElem_map]
-    simp only [Vector.getElem_singleton]
     -- The goal is now about pairs (Expression.eval env input_var.c[0], Expression.eval env input_var.c[1])
 
     -- Connect the condition using h_input
@@ -219,7 +217,6 @@ def circuit : FormalCircuit (F p) Inputs field where
     -- Now we need to show the branches match
     -- First simplify the vector map on the singleton vector
     -- Now we have (eval env (input_var.c[0], input_var.c[1])).1 or .2
-    simp only [eval, Prod.fst, Prod.snd]
 
     split_ifs with h
     · -- Case: s = 0

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -103,19 +103,20 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
       rw [← h_input]
 
     -- Now we need to evaluate the expression
-    have h_c : (eval env input_var.c : ProvableVector (ProvablePair field field) _ _) = input.c := by
+    have h_c : input.c = (eval env input_var.c : ProvableVector (ProvablePair field field) _ _) := by
       rw [← h_input]
 
     have h_i : (eval env input_var.c : ProvableVector (ProvablePair field field) _ _)[i] = input.c[i] := by
       rw [h_c]
       rfl
 
+    simp only [eval_pair] at h_i
+
     have h_c1 : Expression.eval env input_var.c[i].1 = input.c[i].1 := by
       -- First, we know that (eval env input_var.c)[i] = input.c[i]
       -- input_var.c[i] has type Var (ProvablePair field field) F
       -- So eval env input_var.c[i] = (eval env input_var.c[i].1, eval env input_var.c[i].2)
       -- And (eval env input_var.c)[i] = (eval env input_var.c[i].1, eval env input_var.c[i].2)
-      simp only [eval_pair] at h_i
       rw [← h_i]
       simp only [eval_vector (α := (ProvablePair field field))]
       simp only [Vector.getElem_map]
@@ -123,7 +124,6 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
 
     have h_c2 : Expression.eval env input_var.c[i].2 = input.c[i].2 := by
       -- First, we know that (eval env input_var.c)[i] = input.c[i]
-      simp only [eval_pair] at h_i
       rw [← h_i]
       simp only [eval_vector (α := (ProvablePair field field))]
       simp only [Vector.getElem_map]
@@ -133,22 +133,19 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
     simp only [h_output_i]
 
     -- Now we can work with the components
-    rw [← h_s]
-    rw [← h_c]
-
+    rw [h_c]
+    rw [← h_s] at h_assumptions ⊢
     -- Extract the fact that s is boolean
     -- IsBool means s = 0 ∨ s = 1
     cases h_assumptions with
       | inl h0 =>
         -- When s = 0
-        rw [← h_s] at h0
         rw [h0]
         simp only [mul_zero, add_zero, if_pos rfl, circuit_norm]
         norm_num
         rw [h_c1, h_c]
       | inr h1 =>
         -- When s = 1
-        rw [← h_s] at h1
         rw [h1]
         simp only [mul_one, if_neg (by norm_num : (1 : F p) ≠ 0), circuit_norm]
         norm_num

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -160,8 +160,11 @@ def circuit : FormalCircuit (F p) Inputs field where
     sorry
 
   completeness := by
-    simp only [circuit_norm, main, MultiMux1.circuit]
-    sorry
+    simp only [circuit_norm, main]
+    intros offset env input_var h_env input h_input h_s
+    simp only [MultiMux1.circuit, subcircuit, circuit_norm, FormalCircuit.toSubcircuit]
+    rw [← h_input] at h_s
+    simp_all
 
 end Mux1
 

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -161,6 +161,15 @@ instance {F : Type} [Field F] {n : ℕ} : HasAssignEq (Vector (Expression F) n) 
 
 attribute [circuit_norm] HasAssignEq.assignEq
 
+-- ConstantLength instance for assignEq on a single expression
+instance {F : Type} [Field F] : Circuit.ConstantLength (HasAssignEq.assignEq : Expression F → Circuit F (Expression F)) where
+  localLength := 1
+  localLength_eq := by
+    intros v n
+    simp only [HasAssignEq.assignEq, Circuit.bind_localLength_eq, Circuit.witnessField, Circuit.witnessVar, 
+               Circuit.localLength, Circuit.operations, Circuit.bind_def, Circuit.map_def, Circuit.pure_localLength_eq]
+    simp only [Expression.assertEquals, circuit_norm]
+
 -- Custom syntax to allow `let var <== expr` without monadic arrow
 syntax "let " ident " <== " term : doElem
 syntax "let " ident " : " term " <== " term : doElem

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -166,7 +166,7 @@ instance {F : Type} [Field F] : Circuit.ConstantLength (HasAssignEq.assignEq : E
   localLength := 1
   localLength_eq := by
     intros v n
-    simp only [HasAssignEq.assignEq, Circuit.bind_localLength_eq, Circuit.witnessField, Circuit.witnessVar, 
+    simp only [HasAssignEq.assignEq, Circuit.bind_localLength_eq, Circuit.witnessField, Circuit.witnessVar,
                Circuit.localLength, Circuit.operations, Circuit.bind_def, Circuit.map_def, Circuit.pure_localLength_eq]
     simp only [Expression.assertEquals, circuit_norm]
 

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -161,15 +161,6 @@ instance {F : Type} [Field F] {n : ℕ} : HasAssignEq (Vector (Expression F) n) 
 
 attribute [circuit_norm] HasAssignEq.assignEq
 
--- ConstantLength instance for assignEq on a single expression
-instance {F : Type} [Field F] : Circuit.ConstantLength (HasAssignEq.assignEq : Expression F → Circuit F (Expression F)) where
-  localLength := 1
-  localLength_eq := by
-    intros v n
-    simp only [HasAssignEq.assignEq, Circuit.bind_localLength_eq, Circuit.witnessField, Circuit.witnessVar,
-               Circuit.localLength, Circuit.operations, Circuit.bind_def, Circuit.map_def, Circuit.pure_localLength_eq]
-    simp only [Expression.assertEquals, circuit_norm]
-
 -- Custom syntax to allow `let var <== expr` without monadic arrow
 syntax "let " ident " <== " term : doElem
 syntax "let " ident " : " term " <== " term : doElem


### PR DESCRIPTION
## Summary
- Prove completeness for MultiMux1.circuit
- Prove localLength_eq and subcircuitsConsistent for both MultiMux1 and Mux1 circuits
- Add helper lemmas for vector operations

## Status
- [x] localLength_eq for MultiMux1
- [x] subcircuitsConsistent for MultiMux1
- [x] completeness for MultiMux1
- [x] soundness for MultiMux1
- [x] localLength_eq for Mux1
- [x] subcircuitsConsistent for Mux1
- [x] soundness for Mux1
- [x] completeness for Mux1
- [x] Prove helper lemmas (Vector.getElem_flatten_singleton, Vector.getElem_map_singleton_flatten)

This is a part of #155.

This solves #200.

## Dependencies
This PR depends on #196 (remove-redundant-vector-instance)

🤖 Generated with [Claude Code](https://claude.ai/code)