### PR TITLE
Formalize sign.circom

### DIFF
--- a/Clean.lean
+++ b/Clean.lean
@@ -7,6 +7,7 @@ import Clean.Circomlib.Gates
 import Clean.Circomlib.Comparators
 import Clean.Circomlib.CompConstant
 import Clean.Circomlib.Mux1
+import Clean.Circomlib.Sign
 import Clean.Examples.AddOperations
 import Clean.Examples.Add32Explicit
 import Clean.Examples.ToJson

--- a/Clean/Circomlib/Sign.lean
+++ b/Clean/Circomlib/Sign.lean
@@ -1,0 +1,65 @@
+import Clean.Circuit
+import Clean.Utils.Field
+import Clean.Utils.Bits
+import Clean.Circomlib.CompConstant
+
+/-
+Original source code:
+https://github.com/iden3/circomlib/blob/master/circuits/sign.circom
+
+The original Sign circuit uses a specific constant for the BN128 curve.
+We generalize this to work with any prime field by using (p-1)/2.
+-/
+
+namespace Circomlib
+variable {p : ℕ} [Fact p.Prime] [Fact (p < 2^254)] [Fact (p > 2^253)]
+
+namespace Sign
+/-
+template Sign() {
+    signal input in[254];
+    signal output sign;
+
+    component comp = CompConstant(10944121435919637611123202872628637544274182200208017171849102093287904247808);
+
+    var i;
+
+    for (i=0; i<254; i++) {
+        comp.in[i] <== in[i];
+    }
+
+    sign <== comp.out;
+}
+-/
+
+def main (input : Vector (Expression (F p)) 254) := do
+  -- Use (p-1)/2 as the constant for comparison
+  let halfPrime := (p - 1) / 2
+  
+  -- Instantiate CompConstant subcircuit
+  let compOut ← CompConstant.circuit halfPrime input
+  return compOut
+
+def circuit : FormalCircuit (F p) (fields 254) field where
+  main
+  localLength _ := 0  -- No local variables besides the subcircuit output
+  localLength_eq := by sorry
+  subcircuitsConsistent := by simp +arith [circuit_norm, main]
+
+  Assumptions input := 
+    -- Input should be binary representation of a field element
+    ∀ i (_ : i < 254), IsBool input[i]
+
+  Spec input output :=
+    -- The output is 1 if the input (as a number) is greater than (p-1)/2
+    -- This effectively checks if the field element is in the "upper half" of the field
+    output = if Utils.Bits.fromBits (input.map ZMod.val) > (p - 1) / 2 then 1 else 0
+
+  soundness := by
+    sorry -- TODO: prove soundness using CompConstant's soundness
+  
+  completeness := by
+    sorry -- TODO: prove completeness
+
+end Sign
+end Circomlib

--- a/Clean/Circomlib/Sign.lean
+++ b/Clean/Circomlib/Sign.lean
@@ -32,17 +32,13 @@ template Sign() {
 }
 -/
 
-def main (input : Vector (Expression (F p)) 254) := do
+def main (input : Vector (Expression (F p)) 254) :=
   -- Use (p-1)/2 as the constant for comparison
-  let halfPrime := (p - 1) / 2
-  
-  -- Instantiate CompConstant subcircuit
-  let compOut ← CompConstant.circuit halfPrime input
-  return compOut
+  CompConstant.circuit ((p - 1) / 2) input
 
 def circuit : FormalCircuit (F p) (fields 254) field where
   main
-  localLength _ := 0  -- No local variables besides the subcircuit output
+  localLength input := (CompConstant.circuit ((p - 1) / 2)).localLength input
   localLength_eq := by sorry
   subcircuitsConsistent := by simp +arith [circuit_norm, main]
 

--- a/Clean/Circomlib/Sign.lean
+++ b/Clean/Circomlib/Sign.lean
@@ -39,8 +39,6 @@ def main (input : Vector (Expression (F p)) 254) :=
 def circuit : FormalCircuit (F p) (fields 254) field where
   main
   localLength input := (CompConstant.circuit ((p - 1) / 2)).localLength input
-  localLength_eq := by sorry
-  subcircuitsConsistent := by simp +arith [circuit_norm, main]
 
   Assumptions input := 
     -- Input should be binary representation of a field element


### PR DESCRIPTION
## Summary
Formalize the Sign circuit from circomlib, which checks if a field element is in the "upper half" of the field.

## Implementation details
- Generalized the circuit to work with any prime field by using `(p-1)/2` as the comparison constant instead of the BN128-specific constant
- Uses the CompConstant subcircuit to perform the comparison
- Takes a 254-bit binary input and outputs 1 if the value > (p-1)/2, otherwise 0

## Dependencies
**This PR depends on #205** - it's built on top of the fix-circomlib-builds branch which fixes the CompConstant build errors.

## Changes
- Add `Clean/Circomlib/Sign.lean` implementing the Sign circuit
- Add Sign import to `Clean.lean`
- Proofs are marked with `sorry` for now

## Test plan
- [x] Run `lake build Clean.Circomlib.Sign` - builds successfully with sorry warnings
- [x] Run `lake build` - all modules build successfully

Part of #202

🤖 Generated with [Claude Code](https://claude.ai/code)