### PR TITLE
Complete BLAKE3 ApplyRounds circuit with FormalCircuit combinators

### DIFF
--- a/Clean.lean
+++ b/Clean.lean
@@ -17,6 +17,7 @@ import Clean.Tables.Fibonacci32
 import Clean.Tables.Fibonacci32Inductive
 import Clean.Tables.KeccakInductive
 import Clean.Gadgets.Bits
+import Clean.Gadgets.BLAKE3.ApplyRounds
 import Clean.Gadgets.BLAKE3.BLAKE3G
 import Clean.Gadgets.BLAKE3.Permute
 import Clean.Gadgets.BLAKE3.FinalStateUpdate

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -203,14 +203,13 @@ def FormalCircuit.concat
     · simp only [subcircuit_norm]
       apply h_compat
       · apply asm1
-      · simp only [subcircuit_norm] at use1
-        simp only [h_input] at use1
+      · simp only [subcircuit_norm, h_input] at use1
         apply use1
         assumption
 }
 
 @[circuit_norm]
-lemma concat_Assumptions {F Input Mid Output} [Field F] [ProvableType Input] [ProvableType Mid] [ProvableType Output]
+lemma FormalCircuit.concat_Assumptions {F Input Mid Output} [Field F] [ProvableType Input] [ProvableType Mid] [ProvableType Output]
     (c1 : FormalCircuit F Input Mid) (c2 : FormalCircuit F Mid Output) p0 p1 :
     (c1.concat c2 p0 p1).Assumptions = c1.Assumptions := by
   simp only [FormalCircuit.concat]

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -96,7 +96,7 @@ def FormalCircuit.concat
 }
 
 @[circuit_norm]
-lemma FormalCircuit.concat_Assumptions {F Input Mid Output} [Field F] [ProvableType Input] [ProvableType Mid] [ProvableType Output]
+lemma FormalCircuit.assumptions {F Input Mid Output} [Field F] [ProvableType Input] [ProvableType Mid] [ProvableType Output]
     (c1 : FormalCircuit F Input Mid) (c2 : FormalCircuit F Mid Output) p0 p1 :
     (c1.concat c2 p0 p1).Assumptions = c1.Assumptions := by
   simp only [FormalCircuit.concat]
@@ -140,7 +140,7 @@ def FormalCircuit.weakenSpec
 }
 
 @[circuit_norm]
-lemma FormalCircuit.weakenSpec_Assumptions {F Input Output} [Field F] [ProvableType Input] [ProvableType Output]
+lemma FormalCircuit.weakenSpec_assumptions {F Input Output} [Field F] [ProvableType Input] [ProvableType Output]
     (c : FormalCircuit F Input Output) (WeakerSpec : Input F → Output F → Prop) h_spec_implication :
     (c.weakenSpec WeakerSpec h_spec_implication).Assumptions = c.Assumptions := by
   simp only [FormalCircuit.weakenSpec]

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -235,3 +235,9 @@ def FormalCircuit.weakenSpec
     -- and the same assumptions
     exact circuit.completeness
 }
+
+@[circuit_norm]
+lemma FormalCircuit.weakenSpec_Assumptions {F Input Output} [Field F] [ProvableType Input] [ProvableType Output]
+    (c : FormalCircuit F Input Output) (WeakerSpec : Input F → Output F → Prop) h_spec_implication :
+    (c.weakenSpec WeakerSpec h_spec_implication).Assumptions = c.Assumptions := by
+  simp only [FormalCircuit.weakenSpec]

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -66,8 +66,8 @@ a new FormalCircuit with a weaker specification. This is useful when:
 - You need to adapt a specific circuit to a more general interface
 
 The requirements are:
-- The assumptions remain the same or can be strengthened
-- The stronger spec implies the weaker spec
+- The assumptions remain the same
+- The stronger spec and the assumption imply the weaker spec
 -/
 def FormalCircuit.weakenSpec
     {F : Type} [Field F]

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -186,19 +186,9 @@ def FormalCircuit.concat
   Assumptions := circuit1.Assumptions
   Spec := fun input output => ∃ mid, circuit1.Spec input mid ∧ circuit2.Spec mid output
   soundness := by
-    apply Circuit.soundness_compose_circuits (Mid := Mid)
-    · intro; rfl
-    · intro input offset
-      simp only [ElaboratedCircuit.output]
-    · intro input h; exact h
-    · intro input mid h_assumptions h_spec1
-      exact h_compat input mid h_assumptions h_spec1
-    · intro input mid output h_input h_spec1 h_spec2
-      exact ⟨mid, h_spec1, h_spec2⟩
+    apply Circuit.soundness_compose_circuits (Mid := Mid) <;> aesop
   completeness := by
     simp only [circuit_norm]
-    rintro offset env input_var ⟨ use1, use2 ⟩ input h_input asm1
-    simp only [subcircuit_norm, h_input, asm1] at use1 ⊢
     aesop
 }
 

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -142,7 +142,6 @@ theorem soundness_compose_circuits
   -- Apply the spec composition
   apply h_spec_composition input mid _ h_assumptions h_circuit1_spec h_circuit2_spec
 
-
 end Circuit
 
 /--

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -210,6 +210,12 @@ def FormalCircuit.concat
         assumption
 }
 
+@[circuit_norm]
+lemma concat_Assumptions {F Input Mid Output} [Field F] [ProvableType Input] [ProvableType Mid] [ProvableType Output]
+    (c1 : FormalCircuit F Input Mid) (c2 : FormalCircuit F Mid Output) p0 p1 :
+    (c1.concat c2 p0 p1).Assumptions = c1.Assumptions := by
+  simp only [FormalCircuit.concat]
+
 /--
 Weaken the specification of a FormalCircuit.
 
@@ -228,9 +234,9 @@ def FormalCircuit.weakenSpec
     {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : FormalCircuit F Input Output)
     (WeakerSpec : Input F → Output F → Prop)
-    (h_spec_implication : ∀ input output, 
-      circuit.Assumptions input → 
-      circuit.Spec input output → 
+    (h_spec_implication : ∀ input output,
+      circuit.Assumptions input →
+      circuit.Spec input output →
       WeakerSpec input output) :
     FormalCircuit F Input Output := {
   elaborated := circuit.elaborated

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -159,14 +159,18 @@ def FormalCircuit.concat
     (circuit1 : FormalCircuit F Input Mid)
     (circuit2 : FormalCircuit F Mid Output)
     (h_compat : ∀ input mid, circuit1.Assumptions input → circuit1.Spec input mid → circuit2.Assumptions mid)
-    (h_output_stable : ∀ input offset offset', circuit1.output input offset = circuit1.output input offset') :
+    (h_localLength_stable : ∀ mid mid', circuit2.localLength mid = circuit2.localLength mid') :
     FormalCircuit F Input Output := {
   elaborated := {
     main := fun input => circuit1 input >>= circuit2
     localLength := fun input => circuit1.localLength input + circuit2.localLength (circuit1.output input 0)
     localLength_eq := by
       intro input offset
-      simp only [Circuit.bind_def, Circuit.localLength, circuit_norm, h_output_stable _ offset 0]
+      simp only [Circuit.bind_def, Circuit.localLength, circuit_norm]
+      -- We need to show that circuit2.localLength at different offsets is the same
+      -- This requires that circuit2.localLength is stable (doesn't depend on its input)
+      congr 1
+      apply h_localLength_stable
     output := fun input offset =>
       circuit2.output (circuit1.output input offset) (offset + circuit1.localLength input)
     output_eq := by

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -96,7 +96,7 @@ def FormalCircuit.concat
 }
 
 @[circuit_norm]
-lemma FormalCircuit.assumptions {F Input Mid Output} [Field F] [ProvableType Input] [ProvableType Mid] [ProvableType Output]
+lemma FormalCircuit.concat_assumptions {F Input Mid Output} [Field F] [ProvableType Input] [ProvableType Mid] [ProvableType Output]
     (c1 : FormalCircuit F Input Mid) (c2 : FormalCircuit F Mid Output) p0 p1 :
     (c1.concat c2 p0 p1).Assumptions = c1.Assumptions := by
   simp only [FormalCircuit.concat]

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -36,10 +36,6 @@ def FormalCircuit.concat
     output_eq := by
       intro input offset
       simp only [Circuit.bind_def, Circuit.output, circuit_norm]
-    subcircuitsConsistent := by
-      intro input offset
-      simp only [Circuit.bind_def, Circuit.operations, circuit_norm]
-      ring
   }
   Assumptions := circuit1.Assumptions
   Spec := fun input output => ∃ mid, circuit1.Spec input mid ∧ circuit2.Spec mid output

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -198,14 +198,8 @@ def FormalCircuit.concat
   completeness := by
     simp only [circuit_norm]
     rintro offset env input_var ⟨ use1, use2 ⟩ input h_input asm1
-    constructor
-    · simp only [subcircuit_norm, h_input, asm1]
-    · simp only [subcircuit_norm]
-      apply h_compat
-      · apply asm1
-      · simp only [subcircuit_norm, h_input] at use1
-        apply use1
-        assumption
+    simp only [subcircuit_norm, h_input, asm1] at use1 ⊢
+    aesop
 }
 
 @[circuit_norm]

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -22,7 +22,7 @@ def FormalCircuit.concat
     (h_localLength_stable : ∀ mid mid', circuit2.localLength mid = circuit2.localLength mid') :
     FormalCircuit F Input Output := {
   elaborated := {
-    main := fun input => circuit1 input >>= circuit2
+    main := (circuit1 · >>= circuit2)
     localLength := fun input => circuit1.localLength input + circuit2.localLength (circuit1.output input 0)
     localLength_eq := by
       intro input offset

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -142,6 +142,9 @@ theorem soundness_compose_circuits
   -- Apply the spec composition
   apply h_spec_composition input mid _ h_assumptions h_circuit1_spec h_circuit2_spec
 
+
+end Circuit
+
 /--
 Concatenate two FormalCircuits into a single FormalCircuit.
 
@@ -156,6 +159,8 @@ The composite circuit:
 Note: The completeness proof is left as sorry due to complexity of witness generation.
 -/
 def FormalCircuit.concat
+    {F : Type} [Field F]
+    {Input Mid Output : TypeMap} [ProvableType Input] [ProvableType Mid] [ProvableType Output]
     (circuit1 : FormalCircuit F Input Mid)
     (circuit2 : FormalCircuit F Mid Output)
     (h_compat : ∀ input mid, circuit1.Assumptions input → circuit1.Spec input mid → circuit2.Assumptions mid)
@@ -184,7 +189,7 @@ def FormalCircuit.concat
   Assumptions := circuit1.Assumptions
   Spec := fun input output => ∃ mid, circuit1.Spec input mid ∧ circuit2.Spec mid output
   soundness := by
-    apply soundness_compose_circuits (Mid := Mid)
+    apply Circuit.soundness_compose_circuits (Mid := Mid)
     · intro; rfl
     · intro input offset
       simp only [ElaboratedCircuit.output]
@@ -206,8 +211,6 @@ def FormalCircuit.concat
         apply use1
         assumption
 }
-
-end Circuit
 
 /--
 Weaken the specification of a FormalCircuit.

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -155,8 +155,6 @@ This combinator requires:
 The composite circuit:
 - Has the assumptions of the first circuit
 - Has a spec stating that there exists an intermediate value such that both component specs hold
-
-Note: The completeness proof is left as sorry due to complexity of witness generation.
 -/
 def FormalCircuit.concat
     {F : Type} [Field F]

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -207,6 +207,8 @@ def FormalCircuit.concat
         assumption
 }
 
+end Circuit
+
 /--
 Weaken the specification of a FormalCircuit.
 
@@ -221,6 +223,8 @@ The requirements are:
 - The stronger spec implies the weaker spec
 -/
 def FormalCircuit.weakenSpec
+    {F : Type} [Field F]
+    {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : FormalCircuit F Input Output)
     (WeakerSpec : Input F → Output F → Prop)
     (h_spec_implication : ∀ input output, 
@@ -242,5 +246,3 @@ def FormalCircuit.weakenSpec
     -- and the same assumptions
     exact circuit.completeness
 }
-
-end Circuit

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -681,6 +681,16 @@ lemma eval_decomposeNatExpr_iv_3 (env : Environment (F p)) :
   have h4 : ZMod.val (165 : F p) = 165 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 165 < p)
   rw [h1, h2, h3, h4]
 
+-- Tactic for common steps in state vector normalization proof
+syntax "state_vec_norm_simp" : tactic
+macro_rules
+  | `(tactic| state_vec_norm_simp) => `(tactic|
+      simp only [Vector.getElem_mk];
+      rw [Vector.getElem_map, getElem_eval_vector];
+      simp only [eval_vector];
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero])
+
 -- Helper lemma for extracting elements from chaining_value evaluation
 omit p_large_enough in
 lemma eval_chaining_value_elem {env : Environment (F p)}
@@ -803,96 +813,48 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     intro i
     fin_cases i
     -- First 8 elements are from chaining_value
-    case «0» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_zero, state_vec, state_vec_0_Normalized]
-    )
-    case «1» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_1_Normalized]
-    )
-    case «2» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_2_Normalized]
-    )
-    case «3» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_3_Normalized]
-    )
-    case «4» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_4_Normalized]
-    )
-    case «5» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_5_Normalized]
-    )
-    case «6» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_6_Normalized]
-    )
-    case «7» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_7_Normalized]
-    )
+    case «0» => state_vec_norm_simp; simp only [state_vec, state_vec_0_Normalized]
+    case «1» => state_vec_norm_simp; simp only [state_vec, state_vec_1_Normalized]
+    case «2» => state_vec_norm_simp; simp only [state_vec, state_vec_2_Normalized]
+    case «3» => state_vec_norm_simp; simp only [state_vec, state_vec_3_Normalized]
+    case «4» => state_vec_norm_simp; simp only [state_vec, state_vec_4_Normalized]
+    case «5» => state_vec_norm_simp; simp only [state_vec, state_vec_5_Normalized]
+    case «6» => state_vec_norm_simp; simp only [state_vec, state_vec_6_Normalized]
+    case «7» => state_vec_norm_simp; simp only [state_vec, state_vec_7_Normalized]
     -- Next 4 are IV constants
-    case «8» => (
+    case «8» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_8_Normalized]
-    )
-    case «9» => (
+    case «9» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_9_Normalized]
-    )
-    case «10» => (
+    case «10» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_10_Normalized]
-    )
-    case «11» => (
+    case «11» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_11_Normalized]
-    )
     -- Last 4 are counter_low, counter_high, block_len, flags
-    case «12» => (
+    case «12» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_12_Normalized]
-    )
-    case «13» => (
+    case «13» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_13_Normalized]
-    )
-    case «14» => (
+    case «14» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_14_Normalized]
-    )
-    case «15» => (
+    case «15» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_15_Normalized]
-    )
 
   -- Show the message is normalized
   have h_message_normalized : ∀ (i : Fin 16), (eval env block_words_var : BLAKE3State _)[i].Normalized := by
@@ -1084,96 +1046,48 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     intro i
     fin_cases i
     -- First 8 elements are from chaining_value
-    case «0» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_zero, state_vec, state_vec_0_Normalized]
-    )
-    case «1» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_1_Normalized]
-    )
-    case «2» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_2_Normalized]
-    )
-    case «3» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_3_Normalized]
-    )
-    case «4» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_4_Normalized]
-    )
-    case «5» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_5_Normalized]
-    )
-    case «6» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_6_Normalized]
-    )
-    case «7» => (
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
-      simp only [eval_vector]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_7_Normalized]
-    )
+    case «0» => state_vec_norm_simp; simp only [state_vec, state_vec_0_Normalized]
+    case «1» => state_vec_norm_simp; simp only [state_vec, state_vec_1_Normalized]
+    case «2» => state_vec_norm_simp; simp only [state_vec, state_vec_2_Normalized]
+    case «3» => state_vec_norm_simp; simp only [state_vec, state_vec_3_Normalized]
+    case «4» => state_vec_norm_simp; simp only [state_vec, state_vec_4_Normalized]
+    case «5» => state_vec_norm_simp; simp only [state_vec, state_vec_5_Normalized]
+    case «6» => state_vec_norm_simp; simp only [state_vec, state_vec_6_Normalized]
+    case «7» => state_vec_norm_simp; simp only [state_vec, state_vec_7_Normalized]
     -- Next 4 are IV constants
-    case «8» => (
+    case «8» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_8_Normalized]
-    )
-    case «9» => (
+    case «9» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_9_Normalized]
-    )
-    case «10» => (
+    case «10» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_10_Normalized]
-    )
-    case «11» => (
+    case «11» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_11_Normalized]
-    )
     -- Last 4 are counter_low, counter_high, block_len, flags
-    case «12» => (
+    case «12» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_12_Normalized]
-    )
-    case «13» => (
+    case «13» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_13_Normalized]
-    )
-    case «14» => (
+    case «14» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_14_Normalized]
-    )
-    case «15» => (
+    case «15» =>
       simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_15_Normalized]
-    )
 
   -- Show the message is normalized
   have h_message_normalized : ∀ (i : Fin 16), (eval env block_words_var : BLAKE3State _)[i].Normalized := by

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -525,87 +525,6 @@ def sevenRoundsApplyStyle : FormalCircuit (F p) Round.Inputs BLAKE3State :=
       exact h_spec2.2
   )
 
-/--
-The assumptions for roundWithPermute are exactly Round.Assumptions.
--/
-lemma roundWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
-    roundWithPermute.Assumptions input = Round.Assumptions input := by
-  simp only [roundWithPermute]
-
-/--
-The assumptions for twoRoundsWithPermute are exactly Round.Assumptions.
--/
-lemma twoRoundsWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
-    twoRoundsWithPermute.Assumptions input = Round.Assumptions input := by
-  simp only [twoRoundsWithPermute, FormalCircuit.concat]
-  rfl
-
-/--
-The assumptions for twoRoundsApplyStyle are exactly Round.Assumptions.
--/
-lemma twoRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
-    twoRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
-  simp only [twoRoundsApplyStyle, FormalCircuit.weakenSpec]
-  rw [twoRoundsWithPermute_assumptions_eq]
-
-/--
-The assumptions for fourRoundsWithPermute are exactly Round.Assumptions.
--/
-lemma fourRoundsWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
-    fourRoundsWithPermute.Assumptions input = Round.Assumptions input := by
-  simp only [fourRoundsWithPermute, FormalCircuit.concat]
-  rw [twoRoundsWithPermute_assumptions_eq]
-
-/--
-The assumptions for fourRoundsApplyStyle are exactly Round.Assumptions.
--/
-lemma fourRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
-    fourRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
-  simp only [fourRoundsApplyStyle, FormalCircuit.weakenSpec]
-  rw [fourRoundsWithPermute_assumptions_eq]
-
-/--
-The assumptions for sixRoundsWithPermute are exactly Round.Assumptions.
--/
-lemma sixRoundsWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
-    sixRoundsWithPermute.Assumptions input = Round.Assumptions input := by
-  simp only [sixRoundsWithPermute, FormalCircuit.concat]
-  rw [fourRoundsWithPermute_assumptions_eq]
-
-/--
-The assumptions for sixRoundsApplyStyle are exactly Round.Assumptions.
--/
-lemma sixRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
-    sixRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
-  simp only [sixRoundsApplyStyle, FormalCircuit.weakenSpec]
-  rw [sixRoundsWithPermute_assumptions_eq]
-
-/--
-The assumptions for sevenRoundsFinal are exactly Round.Assumptions.
--/
-lemma sevenRoundsFinal_assumptions_eq (input : Round.Inputs (F p)) :
-    sevenRoundsFinal.Assumptions input = Round.Assumptions input := by
-  simp only [sevenRoundsFinal, FormalCircuit.concat]
-  rw [sixRoundsApplyStyle_assumptions_eq]
-
-/--
-The assumptions for sevenRoundsApplyStyle are exactly Round.Assumptions.
-This means the input state and message must be normalized.
--/
-lemma sevenRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
-    sevenRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
-  simp only [sevenRoundsApplyStyle, FormalCircuit.weakenSpec]
-  rw [sevenRoundsFinal_assumptions_eq]
-
-/--
-The concrete assumptions for sevenRoundsApplyStyle: both state and message must be normalized.
--/
-lemma sevenRoundsApplyStyle_assumptions_concrete (input : Round.Inputs (F p)) :
-    sevenRoundsApplyStyle.Assumptions input ↔
-    (input.state.Normalized ∧ ∀ i : Fin 16, input.message[i].Normalized) := by
-  rw [sevenRoundsApplyStyle_assumptions_eq]
-  simp only [Round.Assumptions]
-
 structure Inputs (F : Type) where
   chaining_value : Vector (U32 F) 8
   block_words : Vector (U32 F) 16
@@ -773,7 +692,6 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
 
   simp only [circuit_norm, main, Spec]
   simp only [circuit_norm, main, subcircuit_norm] at h_holds
-  simp only [sevenRoundsApplyStyle_assumptions_concrete] at h_holds
   simp only [Assumptions] at h_normalized
 
   -- Apply h_holds by proving its assumptions
@@ -1063,7 +981,6 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
 
   -- Simplify goal using circuit_norm and use sevenRoundsApplyStyle completeness
   simp only [circuit_norm, main, subcircuit_norm] at henv ⊢
-  simp only [sevenRoundsApplyStyle_assumptions_concrete] at henv ⊢
 
   simp [circuit_norm] at h_input
   obtain ⟨h_eval_chaining_block_value, h_eval_block_words, h_eval_counter_high,

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -779,19 +779,11 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     intro i
     fin_cases i
     -- First 8 elements are from chaining_value
-    case «0» => state_vec_norm_simp; simp [h_chaining_value_normalized]
-    case «1» => state_vec_norm_simp; simp [h_chaining_value_normalized]
-    case «2» => state_vec_norm_simp; simp [h_chaining_value_normalized]
-    case «3» => state_vec_norm_simp; simp [h_chaining_value_normalized]
-    case «4» => state_vec_norm_simp; simp [h_chaining_value_normalized]
-    case «5» => state_vec_norm_simp; simp [h_chaining_value_normalized]
-    case «6» => state_vec_norm_simp; simp [h_chaining_value_normalized]
-    case «7» => state_vec_norm_simp; simp [h_chaining_value_normalized]
+    case «0» | «1» | «2» | «3» | «4» | «5» | «6» | «7» => 
+      state_vec_norm_simp; simp [h_chaining_value_normalized]
     -- Next 4 are IV constants
-    case «8» => state_vec_norm_simp_simple
-    case «9» => state_vec_norm_simp_simple
-    case «10» => state_vec_norm_simp_simple
-    case «11» => state_vec_norm_simp_simple
+    case «8» | «9» | «10» | «11» => 
+      state_vec_norm_simp_simple
     -- Last 4 are counter_low, counter_high, block_len, flags
     case «12» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_12_Normalized]
     case «13» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_13_Normalized]

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -519,7 +519,38 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   simp [circuit_norm] at h_input
   obtain ⟨h_eval_chaining_block_value, h_eval_block_words, h_eval_counter_high,
     h_eval_counter_low, h_eval_block_len, h_eval_flags⟩ := h_input
-
+  -- Extract the constraints from the main function structure
+  obtain ⟨h_six_rounds, h_final_round⟩ := h_holds
+  
+  -- We need to prove that the output satisfies the full applyRounds specification
+  -- The main function structure is:
+  -- 1. Initialize state with chaining_value, IV, counter, block_len, flags
+  -- 2. Apply sixRoundsApplyStyle to get intermediate result
+  -- 3. Apply final Round.circuit to get final result
+  
+  -- First, let's establish what the initial state looks like
+  have h_initial_state : eval env ⟨{
+    toArray := #v[
+      chaining_value_var[0], chaining_value_var[1], chaining_value_var[2], chaining_value_var[3],
+      chaining_value_var[4], chaining_value_var[5], chaining_value_var[6], chaining_value_var[7],
+      U32.decomposeNatExpr iv[0], U32.decomposeNatExpr iv[1], U32.decomposeNatExpr iv[2], U32.decomposeNatExpr iv[3],
+      counter_low_var, counter_high_var, block_len_var, flags_var
+    ]
+  }, block_words_var⟩ = ⟨{
+    toArray := #v[
+      chaining_value[0], chaining_value[1], chaining_value[2], chaining_value[3],
+      chaining_value[4], chaining_value[5], chaining_value[6], chaining_value[7],
+      eval env (U32.decomposeNatExpr iv[0]), eval env (U32.decomposeNatExpr iv[1]), 
+      eval env (U32.decomposeNatExpr iv[2]), eval env (U32.decomposeNatExpr iv[3]),
+      counter_low, counter_high, block_len, flags
+    ]
+  }, block_words⟩ := by
+    simp only [ProvableStruct.eval_eq_eval, ProvableStruct.eval, ProvableStruct.eval.go]
+    simp only [h_eval_chaining_block_value, h_eval_block_words, h_eval_counter_high, 
+               h_eval_counter_low, h_eval_block_len, h_eval_flags]
+    simp only [eval_vector]
+    rfl
+  
   sorry
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -706,8 +706,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     const (U32.fromUInt32 iv[3]), counter_low_var, counter_high_var, block_len_var, flags_var
   ]
   -- Helper to prove normalization of chaining value elements
-  have h_chaining_value_normalized : ∀ (i : Fin 8), (eval env chaining_value_var[i]).Normalized := by
-    rintro ⟨ i, h_i ⟩
+  have h_chaining_value_normalized (i : ℕ) (h_i : i < 8) : (eval env chaining_value_var[i]).Normalized := by
     have h : (eval env chaining_value_var : ProvableVector _ _ _) = chaining_value := h_eval_chaining_block_value
     have h_i : (eval env chaining_value_var : ProvableVector _ _ _)[i] = chaining_value[i] := by
       rw [h]
@@ -780,19 +779,19 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     intro i
     fin_cases i
     -- First 8 elements are from chaining_value
-    case «0» => state_vec_norm_simp; exact h_chaining_value_normalized 0
-    case «1» => state_vec_norm_simp; exact h_chaining_value_normalized 1
-    case «2» => state_vec_norm_simp; exact h_chaining_value_normalized 2
-    case «3» => state_vec_norm_simp; exact h_chaining_value_normalized 3
-    case «4» => state_vec_norm_simp; exact h_chaining_value_normalized 4
-    case «5» => state_vec_norm_simp; exact h_chaining_value_normalized 5
-    case «6» => state_vec_norm_simp; exact h_chaining_value_normalized 6
-    case «7» => state_vec_norm_simp; exact h_chaining_value_normalized 7
+    case «0» => state_vec_norm_simp; simp [h_chaining_value_normalized]
+    case «1» => state_vec_norm_simp; simp [h_chaining_value_normalized]
+    case «2» => state_vec_norm_simp; simp [h_chaining_value_normalized]
+    case «3» => state_vec_norm_simp; simp [h_chaining_value_normalized]
+    case «4» => state_vec_norm_simp; simp [h_chaining_value_normalized]
+    case «5» => state_vec_norm_simp; simp [h_chaining_value_normalized]
+    case «6» => state_vec_norm_simp; simp [h_chaining_value_normalized]
+    case «7» => state_vec_norm_simp; simp [h_chaining_value_normalized]
     -- Next 4 are IV constants
-    case «8» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_8_Normalized]
-    case «9» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_9_Normalized]
-    case «10» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_10_Normalized]
-    case «11» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_11_Normalized]
+    case «8» => state_vec_norm_simp_simple
+    case «9» => state_vec_norm_simp_simple
+    case «10» => state_vec_norm_simp_simple
+    case «11» => state_vec_norm_simp_simple
     -- Last 4 are counter_low, counter_high, block_len, flags
     case «12» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_12_Normalized]
     case «13» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_13_Normalized]

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -908,37 +908,54 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   } := by rfl
 
   have h_chaining_0_eq : (eval env chaining_value_var[0]).value = chaining_value[0].value := by
-    sorry
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
   have h_chaining_1_eq : (eval env chaining_value_var[1]).value = chaining_value[1].value := by
-    sorry
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
   have h_chaining_2_eq : (eval env chaining_value_var[2]).value = chaining_value[2].value := by
-    sorry
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
   have h_chaining_3_eq : (eval env chaining_value_var[3]).value = chaining_value[3].value := by
-    sorry
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
   have h_chaining_4_eq : (eval env chaining_value_var[4]).value = chaining_value[4].value := by
-    sorry
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
   have h_chaining_5_eq : (eval env chaining_value_var[5]).value = chaining_value[5].value := by
-    sorry
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
   have h_chaining_6_eq : (eval env chaining_value_var[6]).value = chaining_value[6].value := by
-    sorry
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
   have h_chaining_7_eq : (eval env chaining_value_var[7]).value = chaining_value[7].value := by
-    sorry
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
 
   -- Equations for IV constants
   have h_iv_0_eq : (eval env (U32.decomposeNatExpr iv[0])).value = iv[0] := by
+    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
+    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
     sorry
   have h_iv_1_eq : (eval env (U32.decomposeNatExpr iv[1])).value = iv[1] := by
+    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
+    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
     sorry
   have h_iv_2_eq : (eval env (U32.decomposeNatExpr iv[2])).value = iv[2] := by
+    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
+    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
     sorry
   have h_iv_3_eq : (eval env (U32.decomposeNatExpr iv[3])).value = iv[3] := by
+    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
+    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
     sorry
 
   -- Equations for counter values
   have h_counter_low_eq : counter_low.value % 4294967296 = counter_low.value := by
-    sorry
+    apply Nat.mod_eq_of_lt
+    exact U32.value_lt_of_normalized h_normalized.2.2.2.1
   have h_counter_high_eq : (counter_low.value + 4294967296 * counter_high.value) / 4294967296 = counter_high.value := by
-    sorry
+    -- We want to show (counter_low.value + 2^32 * counter_high.value) / 2^32 = counter_high.value
+    -- Since counter_low.value < 2^32, this follows from properties of division
+    have h1 : counter_low.value < 4294967296 := U32.value_lt_of_normalized h_normalized.2.2.2.1
+    have h2 : 4294967296 > 0 := by norm_num
+    -- Now we have (2^32 * counter_high.value + counter_low.value) / 2^32
+    -- This equals counter_high.value + counter_low.value / 2^32
+    rw [Nat.add_mul_div_left _ _ h2]
+    rw [Nat.div_eq_of_lt h1]
+    simp
 
   -- Apply h_holds with the proven assumptions
   rw [← h_state_vec_eq] at h_state_normalized

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -227,12 +227,12 @@ def twoRoundsApplyStyle : FormalCircuit (F p) Round.Inputs Round.Inputs :=
     -- Unpack what each roundWithPermute spec gives us
     simp only [roundWithPermute] at h_spec1 h_spec2
     simp only [TwoRoundsSpec, applyTwoRounds]
-    
+
     -- From h_spec1: mid.state.value = round input.state.value (BLAKE3State.value input.message)
     -- From h_spec1: BLAKE3State.value mid.message = permute (BLAKE3State.value input.message)
     -- From h_spec2: output.state.value = round mid.state.value (BLAKE3State.value mid.message)
     -- From h_spec2: BLAKE3State.value output.message = permute (BLAKE3State.value mid.message)
-    
+
     constructor
     · -- Prove: output.state.value = round (round input.state.value (input.message.map U32.value)) (permute (input.message.map U32.value))
       rw [h_spec2.1, h_spec1.1]
@@ -287,7 +287,7 @@ def fourRoundsWithPermute : FormalCircuit (F p) Round.Inputs Round.Inputs :=
 Apply four rounds of BLAKE3 compression, starting from a Round.Inputs state.
 This follows the same pattern as applyRounds but for only 4 rounds:
 - First round, permute message
-- Second round, permute message  
+- Second round, permute message
 - Third round, permute message
 - Fourth round, permute message
 Returns the final state and permuted message.
@@ -325,10 +325,10 @@ def fourRoundsApplyStyle : FormalCircuit (F p) Round.Inputs Round.Inputs :=
     -- Each twoRoundsWithPermute.Spec says ∃ mid', roundWithPermute.Spec ... ∧ roundWithPermute.Spec ...
     obtain ⟨mid1, h_spec1_1, h_spec1_2⟩ := h_spec1
     obtain ⟨mid2, h_spec2_1, h_spec2_2⟩ := h_spec2
-    
+
     simp only [roundWithPermute] at h_spec1_1 h_spec1_2 h_spec2_1 h_spec2_2
     simp only [FourRoundsSpec, applyFourRounds, applyTwoRounds]
-    
+
     -- Build the result by chaining the four rounds
     constructor
     · -- Prove: output.state.value = final_state after 4 rounds
@@ -422,10 +422,10 @@ def sixRoundsApplyStyle : FormalCircuit (F p) Round.Inputs Round.Inputs :=
     obtain ⟨mid1_2, h_spec1_2_1, h_spec1_2_2⟩ := h_spec1_2
     -- Break down twoRoundsWithPermute.Spec
     obtain ⟨mid2, h_spec2_1, h_spec2_2⟩ := h_spec2
-    
+
     simp only [roundWithPermute] at h_spec1_1_1 h_spec1_1_2 h_spec1_2_1 h_spec1_2_2 h_spec2_1 h_spec2_2
     simp only [SixRoundsSpec, applySixRounds]
-    
+
     -- Build the result by chaining the six rounds
     constructor
     · -- Prove: output.state.value = final_state after 6 rounds
@@ -491,12 +491,6 @@ def main (input : Var Inputs (F p)) : Circuit (F p) (Var BLAKE3State (F p)) := d
   let block_words ← subcircuit Permute.circuit block_words
 
   let state ← subcircuit Round.circuit ⟨state, block_words⟩
-  let block_words ← subcircuit Permute.circuit block_words
-
-  let state ← subcircuit Round.circuit ⟨state, block_words⟩
-  let block_words ← subcircuit Permute.circuit block_words
-
-  let state ← subcircuit Round.circuit ⟨state, block_words⟩
 
   return state
 
@@ -504,7 +498,7 @@ def main (input : Var Inputs (F p)) : Circuit (F p) (Var BLAKE3State (F p)) := d
 -- #eval! main (p:=pBabybear) default |>.output
 instance elaborated : ElaboratedCircuit (F p) Inputs BLAKE3State where
   main := main
-  localLength _ := 6912
+  localLength _ := 5376
   localLength_eq input i0 := by
     dsimp only [main, Round.circuit, Permute.circuit, Circuit.pure_def, Circuit.bind_def,
       subcircuit.eq_1, ElaboratedCircuit.output, Circuit.output, FormalCircuit.toSubcircuit.eq_1,

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -43,11 +43,6 @@ def roundWithPermute : FormalCircuit (F p) Round.Inputs Round.Inputs where
   output_eq := by
     intro input offset
     simp only [Circuit.bind_def, Circuit.output, circuit_norm]
-  subcircuitsConsistent := by
-    intro input offset
-    simp only [Circuit.bind_def, Circuit.operations, circuit_norm]
-    have h : offset + Round.circuit.localLength input = Round.circuit.localLength input + offset := by ring
-    rw [h]
 
   Assumptions := Round.Assumptions
   Spec := fun input output =>

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -474,7 +474,7 @@ lemma eval_chaining_value_elem {env : Environment (F p)}
     {chaining_value_var : Vector (U32 (Expression (F p))) 8}
     {chaining_value : Vector (U32 (F p)) 8}
     (h_eval : (eval env chaining_value_var : ProvableVector _ _ _) = chaining_value)
-    (i : Fin 8) :
+    (i : ℕ) (_ : i < 8) :
     (eval env chaining_value_var[i]).value = chaining_value[i].value := by
   have h := congrArg (fun v => v[i]) h_eval
   simp only [eval_vector, Vector.getElem_map, circuit_norm] at h
@@ -672,14 +672,14 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     size_toArray := by simp
   } := by rfl
 
-  have h_chaining_0_eq : (eval env chaining_value_var[0]).value = chaining_value[0].value := eval_chaining_value_elem h_eval_chaining_block_value 0
-  have h_chaining_1_eq : (eval env chaining_value_var[1]).value = chaining_value[1].value := eval_chaining_value_elem h_eval_chaining_block_value 1
-  have h_chaining_2_eq : (eval env chaining_value_var[2]).value = chaining_value[2].value := eval_chaining_value_elem h_eval_chaining_block_value 2
-  have h_chaining_3_eq : (eval env chaining_value_var[3]).value = chaining_value[3].value := eval_chaining_value_elem h_eval_chaining_block_value 3
-  have h_chaining_4_eq : (eval env chaining_value_var[4]).value = chaining_value[4].value := eval_chaining_value_elem h_eval_chaining_block_value 4
-  have h_chaining_5_eq : (eval env chaining_value_var[5]).value = chaining_value[5].value := eval_chaining_value_elem h_eval_chaining_block_value 5
-  have h_chaining_6_eq : (eval env chaining_value_var[6]).value = chaining_value[6].value := eval_chaining_value_elem h_eval_chaining_block_value 6
-  have h_chaining_7_eq : (eval env chaining_value_var[7]).value = chaining_value[7].value := eval_chaining_value_elem h_eval_chaining_block_value 7
+  have h_chaining_0_eq := eval_chaining_value_elem h_eval_chaining_block_value 0 (by omega)
+  have h_chaining_1_eq := eval_chaining_value_elem h_eval_chaining_block_value 1 (by omega)
+  have h_chaining_2_eq := eval_chaining_value_elem h_eval_chaining_block_value 2 (by omega)
+  have h_chaining_3_eq := eval_chaining_value_elem h_eval_chaining_block_value 3 (by omega)
+  have h_chaining_4_eq := eval_chaining_value_elem h_eval_chaining_block_value 4 (by omega)
+  have h_chaining_5_eq := eval_chaining_value_elem h_eval_chaining_block_value 5 (by omega)
+  have h_chaining_6_eq := eval_chaining_value_elem h_eval_chaining_block_value 6 (by omega)
+  have h_chaining_7_eq := eval_chaining_value_elem h_eval_chaining_block_value 7 (by omega)
 
   -- Equations for counter values
   have h_counter_low_eq : counter_low.value % 4294967296 = counter_low.value := by

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -560,12 +560,11 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   let state_vec : Var BLAKE3State (F p) := #v[
     chaining_value_var[0], chaining_value_var[1], chaining_value_var[2], chaining_value_var[3],
     chaining_value_var[4], chaining_value_var[5], chaining_value_var[6], chaining_value_var[7],
-    U32.decomposeNatExpr iv[0].toNat, U32.decomposeNatExpr iv[1].toNat, U32.decomposeNatExpr iv[2].toNat,
-    U32.decomposeNatExpr iv[3].toNat, counter_low_var, counter_high_var, block_len_var, flags_var
+    const (U32.fromUInt32 iv[0]), const (U32.fromUInt32 iv[1]), const (U32.fromUInt32 iv[2]),
+    const (U32.fromUInt32 iv[3]), counter_low_var, counter_high_var, block_len_var, flags_var
   ]
   -- Helper to prove normalization of chaining value elements
-  have h_chaining_value_normalized : ∀ (i : Fin 8), (eval env chaining_value_var[i]).Normalized := by
-    rintro ⟨ i, h_i ⟩
+  have h_chaining_value_normalized (i : ℕ) (h_i : i < 8) : (eval env chaining_value_var[i]).Normalized := by
     have h : (eval env chaining_value_var : ProvableVector _ _ _) = chaining_value := h_eval_chaining_block_value
     have h_i : (eval env chaining_value_var : ProvableVector _ _ _)[i] = chaining_value[i] := by
       rw [h]
@@ -575,50 +574,6 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     congr
     norm_num
     omega
-  have state_vec_8_Normalized : (eval env (U32.decomposeNatExpr iv[0].toNat)).Normalized := by
-    -- decomposeNatExpr produces a U32 of Expression.const values
-    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
-    -- Prove each limb is normalized
-    have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) < 256 := by
-      have : x % 256 < 256 := Nat.mod_lt _ (by norm_num)
-      rw [FieldUtils.val_lt_p]
-      assumption
-      linarith [p_large_enough.elim]
-    exact ⟨h _, h _, h _, h _⟩
-  have state_vec_9_Normalized : (eval env (U32.decomposeNatExpr iv[1].toNat)).Normalized := by
-    -- decomposeNatExpr produces a U32 of Expression.const values
-    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
-    -- Prove each limb is normalized
-    have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) < 256 := by
-      have : x % 256 < 256 := Nat.mod_lt _ (by norm_num)
-      rw [FieldUtils.val_lt_p]
-      assumption
-      linarith [p_large_enough.elim]
-    exact ⟨h _, h _, h _, h _⟩
-  have state_vec_10_Normalized : (eval env (U32.decomposeNatExpr iv[2].toNat)).Normalized := by
-    -- decomposeNatExpr produces a U32 of Expression.const values
-    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
-    -- Prove each limb is normalized
-    have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) < 256 := by
-      have : x % 256 < 256 := Nat.mod_lt _ (by norm_num)
-      rw [FieldUtils.val_lt_p]
-      assumption
-      linarith [p_large_enough.elim]
-    exact ⟨h _, h _, h _, h _⟩
-  have state_vec_11_Normalized : (eval env (U32.decomposeNatExpr iv[3].toNat)).Normalized := by
-    -- decomposeNatExpr produces a U32 of Expression.const values
-    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
-    -- Prove each limb is normalized
-    have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) < 256 := by
-      have : x % 256 < 256 := Nat.mod_lt _ (by norm_num)
-      rw [FieldUtils.val_lt_p]
-      assumption
-      linarith [p_large_enough.elim]
-    exact ⟨h _, h _, h _, h _⟩
   have state_vec_12_Normalized : (eval env counter_low_var).Normalized := by
     rw [h_eval_counter_low]
     exact h_normalized.2.2.2.1
@@ -638,19 +593,19 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     intro i
     fin_cases i
     -- First 8 elements are from chaining_value
-    case «0» => state_vec_norm_simp; exact h_chaining_value_normalized 0
-    case «1» => state_vec_norm_simp; exact h_chaining_value_normalized 1
-    case «2» => state_vec_norm_simp; exact h_chaining_value_normalized 2
-    case «3» => state_vec_norm_simp; exact h_chaining_value_normalized 3
-    case «4» => state_vec_norm_simp; exact h_chaining_value_normalized 4
-    case «5» => state_vec_norm_simp; exact h_chaining_value_normalized 5
-    case «6» => state_vec_norm_simp; exact h_chaining_value_normalized 6
-    case «7» => state_vec_norm_simp; exact h_chaining_value_normalized 7
+    case «0» => state_vec_norm_simp; exact h_chaining_value_normalized 0 (by omega)
+    case «1» => state_vec_norm_simp; exact h_chaining_value_normalized 1 (by omega)
+    case «2» => state_vec_norm_simp; exact h_chaining_value_normalized 2 (by omega)
+    case «3» => state_vec_norm_simp; exact h_chaining_value_normalized 3 (by omega)
+    case «4» => state_vec_norm_simp; exact h_chaining_value_normalized 4 (by omega)
+    case «5» => state_vec_norm_simp; exact h_chaining_value_normalized 5 (by omega)
+    case «6» => state_vec_norm_simp; exact h_chaining_value_normalized 6 (by omega)
+    case «7» => state_vec_norm_simp; exact h_chaining_value_normalized 7 (by omega)
     -- Next 4 are IV constants
-    case «8» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_8_Normalized]
-    case «9» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_9_Normalized]
-    case «10» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_10_Normalized]
-    case «11» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_11_Normalized]
+    case «8» => state_vec_norm_simp_simple; simp only [circuit_norm, U32.fromUInt32_normalized]
+    case «9» => state_vec_norm_simp_simple; simp only [circuit_norm, U32.fromUInt32_normalized]
+    case «10» => state_vec_norm_simp_simple; simp only [circuit_norm, U32.fromUInt32_normalized]
+    case «11» => state_vec_norm_simp_simple; simp only [circuit_norm, U32.fromUInt32_normalized]
     -- Last 4 are counter_low, counter_high, block_len, flags
     case «12» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_12_Normalized]
     case «13» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_13_Normalized]
@@ -697,7 +652,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     simp
 
   -- Apply h_holds with the proven assumptions
-  rw [← h_state_vec_eq] at h_state_normalized
+  rw [h_state_vec_eq] at h_state_normalized
   have h_spec := h_holds ⟨h_state_normalized, h_message_normalized⟩
   clear h_holds
 

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -443,12 +443,6 @@ lemma eval_decomposeNatExpr_small (env : Environment (F p)) (x : ℕ) :
   apply U32.value_of_decomposedNat_of_small
   assumption
 
-lemma eval_fromUInt32_value (env : Environment (F p)) (x : UInt32) :
-    (eval env (const (U32.fromUInt32 x))).value = x.toNat := by
-  refine eval_decomposeNatExpr_small env x.toNat ?_
-  have := UInt32.toNat_lt_size x
-  omega
-
 -- Tactic for common steps in state vector normalization proof
 syntax "state_vec_norm_simp" : tactic
 macro_rules
@@ -591,10 +585,10 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     intro i
     fin_cases i
     -- First 8 elements are from chaining_value
-    case «0» | «1» | «2» | «3» | «4» | «5» | «6» | «7» => 
+    case «0» | «1» | «2» | «3» | «4» | «5» | «6» | «7» =>
       state_vec_norm_simp; simp [h_chaining_value_normalized]
     -- Next 4 are IV constants
-    case «8» | «9» | «10» | «11» => 
+    case «8» | «9» | «10» | «11» =>
       state_vec_norm_simp_simple
     -- Last 4 are counter_low, counter_high, block_len, flags
     case «12» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_12_Normalized]
@@ -674,7 +668,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
         simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_map,
           Nat.reducePow, Nat.add_mul_mod_self_left, state_vec, h_eval_chaining_block_value, h_eval_block_words, h_eval_counter_high, h_eval_counter_low, h_eval_block_len, h_eval_flags]
         simp [h_chaining_0_eq, h_chaining_1_eq, h_chaining_2_eq, h_chaining_3_eq, h_chaining_4_eq, h_chaining_5_eq,
-          h_chaining_6_eq, h_chaining_7_eq, eval_fromUInt32_value, h_counter_low_eq, h_counter_high_eq]
+          h_chaining_6_eq, h_chaining_7_eq, circuit_norm, U32.value_fromUInt32, h_counter_low_eq, h_counter_high_eq]
 
   · -- Show out.Normalized
     exact h_normalized

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -552,11 +552,7 @@ def main (input : Var Inputs (F p)) : Circuit (F p) (Var BLAKE3State (F p)) := d
   ]
 
   -- Apply 7 rounds with message permutation between rounds (except the last)
-  let result ← subcircuit sixRoundsApplyStyle ⟨state, block_words⟩
-  let state := result.state
-  let block_words := result.message
-
-  let state ← subcircuit Round.circuit ⟨state, block_words⟩
+  let state ← subcircuit sevenRoundsApplyStyle ⟨state, block_words⟩
 
   return state
 
@@ -566,7 +562,7 @@ instance elaborated : ElaboratedCircuit (F p) Inputs BLAKE3State where
   main := main
   localLength _ := 5376
   localLength_eq input i0 := by
-    dsimp only [main, Round.circuit, sixRoundsApplyStyle, sixRoundsWithPermute,
+    dsimp only [main, Round.circuit, sevenRoundsApplyStyle, sevenRoundsFinal, sixRoundsApplyStyle, sixRoundsWithPermute,
       fourRoundsWithPermute, twoRoundsWithPermute, roundWithPermute, FormalCircuit.weakenSpec,
       FormalCircuit.concat,
       Permute.circuit, Circuit.pure_def, Circuit.bind_def,

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -691,6 +691,15 @@ macro_rules
       simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero])
 
+-- Tactic for cases 8-15 which don't use getElem_eval_vector
+syntax "state_vec_norm_simp_simple" : tactic
+macro_rules
+  | `(tactic| state_vec_norm_simp_simple) => `(tactic|
+      simp only [Vector.getElem_mk];
+      rw [Vector.getElem_map];
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero])
+
 -- Helper lemma for extracting elements from chaining_value evaluation
 omit p_large_enough in
 lemma eval_chaining_value_elem {env : Environment (F p)}
@@ -822,39 +831,15 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     case «6» => state_vec_norm_simp; simp only [state_vec, state_vec_6_Normalized]
     case «7» => state_vec_norm_simp; simp only [state_vec, state_vec_7_Normalized]
     -- Next 4 are IV constants
-    case «8» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_8_Normalized]
-    case «9» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_9_Normalized]
-    case «10» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_10_Normalized]
-    case «11» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_11_Normalized]
+    case «8» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_8_Normalized]
+    case «9» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_9_Normalized]
+    case «10» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_10_Normalized]
+    case «11» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_11_Normalized]
     -- Last 4 are counter_low, counter_high, block_len, flags
-    case «12» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_12_Normalized]
-    case «13» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_13_Normalized]
-    case «14» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_14_Normalized]
-    case «15» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_15_Normalized]
+    case «12» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_12_Normalized]
+    case «13» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_13_Normalized]
+    case «14» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_14_Normalized]
+    case «15» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_15_Normalized]
 
   -- Show the message is normalized
   have h_message_normalized : ∀ (i : Fin 16), (eval env block_words_var : BLAKE3State _)[i].Normalized := by
@@ -1055,39 +1040,15 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     case «6» => state_vec_norm_simp; simp only [state_vec, state_vec_6_Normalized]
     case «7» => state_vec_norm_simp; simp only [state_vec, state_vec_7_Normalized]
     -- Next 4 are IV constants
-    case «8» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_8_Normalized]
-    case «9» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_9_Normalized]
-    case «10» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_10_Normalized]
-    case «11» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_11_Normalized]
+    case «8» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_8_Normalized]
+    case «9» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_9_Normalized]
+    case «10» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_10_Normalized]
+    case «11» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_11_Normalized]
     -- Last 4 are counter_low, counter_high, block_len, flags
-    case «12» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_12_Normalized]
-    case «13» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_13_Normalized]
-    case «14» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_14_Normalized]
-    case «15» =>
-      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_15_Normalized]
+    case «12» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_12_Normalized]
+    case «13» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_13_Normalized]
+    case «14» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_14_Normalized]
+    case «15» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_15_Normalized]
 
   -- Show the message is normalized
   have h_message_normalized : ∀ (i : Fin 16), (eval env block_words_var : BLAKE3State _)[i].Normalized := by

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -463,10 +463,8 @@ macro_rules
 syntax "state_vec_norm_simp_simple" : tactic
 macro_rules
   | `(tactic| state_vec_norm_simp_simple) => `(tactic|
-      simp only [Vector.getElem_mk];
-      rw [Vector.getElem_map];
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
-        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero])
+      simp only [Vector.getElem_mk, Vector.getElem_map, Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, circuit_norm, U32.fromUInt32_normalized])
 
 -- Helper lemma for extracting elements from chaining_value evaluation
 omit p_large_enough in
@@ -602,10 +600,10 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     case «6» => state_vec_norm_simp; exact h_chaining_value_normalized 6 (by omega)
     case «7» => state_vec_norm_simp; exact h_chaining_value_normalized 7 (by omega)
     -- Next 4 are IV constants
-    case «8» => state_vec_norm_simp_simple; simp only [circuit_norm, U32.fromUInt32_normalized]
-    case «9» => state_vec_norm_simp_simple; simp only [circuit_norm, U32.fromUInt32_normalized]
-    case «10» => state_vec_norm_simp_simple; simp only [circuit_norm, U32.fromUInt32_normalized]
-    case «11» => state_vec_norm_simp_simple; simp only [circuit_norm, U32.fromUInt32_normalized]
+    case «8» => state_vec_norm_simp_simple
+    case «9» => state_vec_norm_simp_simple
+    case «10» => state_vec_norm_simp_simple
+    case «11» => state_vec_norm_simp_simple
     -- Last 4 are counter_low, counter_high, block_len, flags
     case «12» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_12_Normalized]
     case «13» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_13_Normalized]

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -536,7 +536,7 @@ lemma roundWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
 The assumptions for twoRoundsWithPermute are exactly Round.Assumptions.
 -/
 lemma twoRoundsWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
-  twoRoundsWithPermute.Assumptions input = Round.Assumptions input := by
+    twoRoundsWithPermute.Assumptions input = Round.Assumptions input := by
   simp only [twoRoundsWithPermute, FormalCircuit.concat]
   rfl
 
@@ -544,7 +544,7 @@ lemma twoRoundsWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
 The assumptions for twoRoundsApplyStyle are exactly Round.Assumptions.
 -/
 lemma twoRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
-  twoRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
+    twoRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
   simp only [twoRoundsApplyStyle, FormalCircuit.weakenSpec]
   rw [twoRoundsWithPermute_assumptions_eq]
 
@@ -552,7 +552,7 @@ lemma twoRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
 The assumptions for fourRoundsWithPermute are exactly Round.Assumptions.
 -/
 lemma fourRoundsWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
-  fourRoundsWithPermute.Assumptions input = Round.Assumptions input := by
+    fourRoundsWithPermute.Assumptions input = Round.Assumptions input := by
   simp only [fourRoundsWithPermute, FormalCircuit.concat]
   rw [twoRoundsWithPermute_assumptions_eq]
 
@@ -560,7 +560,7 @@ lemma fourRoundsWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
 The assumptions for fourRoundsApplyStyle are exactly Round.Assumptions.
 -/
 lemma fourRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
-  fourRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
+    fourRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
   simp only [fourRoundsApplyStyle, FormalCircuit.weakenSpec]
   rw [fourRoundsWithPermute_assumptions_eq]
 
@@ -568,7 +568,7 @@ lemma fourRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
 The assumptions for sixRoundsWithPermute are exactly Round.Assumptions.
 -/
 lemma sixRoundsWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
-  sixRoundsWithPermute.Assumptions input = Round.Assumptions input := by
+    sixRoundsWithPermute.Assumptions input = Round.Assumptions input := by
   simp only [sixRoundsWithPermute, FormalCircuit.concat]
   rw [fourRoundsWithPermute_assumptions_eq]
 
@@ -576,7 +576,7 @@ lemma sixRoundsWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
 The assumptions for sixRoundsApplyStyle are exactly Round.Assumptions.
 -/
 lemma sixRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
-  sixRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
+    sixRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
   simp only [sixRoundsApplyStyle, FormalCircuit.weakenSpec]
   rw [sixRoundsWithPermute_assumptions_eq]
 
@@ -584,7 +584,7 @@ lemma sixRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
 The assumptions for sevenRoundsFinal are exactly Round.Assumptions.
 -/
 lemma sevenRoundsFinal_assumptions_eq (input : Round.Inputs (F p)) :
-  sevenRoundsFinal.Assumptions input = Round.Assumptions input := by
+    sevenRoundsFinal.Assumptions input = Round.Assumptions input := by
   simp only [sevenRoundsFinal, FormalCircuit.concat]
   rw [sixRoundsApplyStyle_assumptions_eq]
 
@@ -593,7 +593,7 @@ The assumptions for sevenRoundsApplyStyle are exactly Round.Assumptions.
 This means the input state and message must be normalized.
 -/
 lemma sevenRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
-  sevenRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
+    sevenRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
   simp only [sevenRoundsApplyStyle, FormalCircuit.weakenSpec]
   rw [sevenRoundsFinal_assumptions_eq]
 

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -693,38 +693,74 @@ lemma applyRounds_eq_applySevenRounds
 /--
 Lemma showing that evaluating U32.decomposeNatExpr of iv[0] gives iv[0].
 -/
-lemma eval_decomposeNatExpr_iv_0 (env : Environment (F p)) : 
+lemma eval_decomposeNatExpr_iv_0 (env : Environment (F p)) :
     (eval env (U32.decomposeNatExpr iv[0])).value = iv[0] := by
   simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
   simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
-  sorry
+  simp only [iv, Vector.getElem_mk]
+  simp only [List.getElem_toArray, List.getElem_cons_zero, Nat.reduceMod, Nat.cast_ofNat,
+    Nat.reduceDiv, Nat.reducePow, List.map_toArray, List.map_cons, List.map_nil]
+  simp only [Expression.eval]
+  -- All these values are less than p, so ZMod.val gives back the original value
+  have h1 : ZMod.val (103 : F p) = 103 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 103 < p)
+  have h2 : ZMod.val (230 : F p) = 230 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 230 < p)
+  have h3 : ZMod.val (9 : F p) = 9 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 9 < p)
+  have h4 : ZMod.val (106 : F p) = 106 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 106 < p)
+  rw [h1, h2, h3, h4]
 
 /--
 Lemma showing that evaluating U32.decomposeNatExpr of iv[1] gives iv[1].
 -/
-lemma eval_decomposeNatExpr_iv_1 (env : Environment (F p)) : 
+lemma eval_decomposeNatExpr_iv_1 (env : Environment (F p)) :
     (eval env (U32.decomposeNatExpr iv[1])).value = iv[1] := by
   simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
   simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
-  sorry
+  simp only [iv, Vector.getElem_mk]
+  simp only [List.getElem_toArray, List.getElem_cons_zero, List.getElem_cons_succ,
+    Nat.reduceMod, Nat.cast_ofNat, Nat.reduceDiv, Nat.reducePow, List.map_toArray, List.map_cons, List.map_nil]
+  simp only [Expression.eval]
+  -- All these values are less than p, so ZMod.val gives back the original value
+  have h1 : ZMod.val (133 : F p) = 133 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 133 < p)
+  have h2 : ZMod.val (174 : F p) = 174 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 174 < p)
+  have h3 : ZMod.val (103 : F p) = 103 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 103 < p)
+  have h4 : ZMod.val (187 : F p) = 187 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 187 < p)
+  rw [h1, h2, h3, h4]
 
 /--
 Lemma showing that evaluating U32.decomposeNatExpr of iv[2] gives iv[2].
 -/
-lemma eval_decomposeNatExpr_iv_2 (env : Environment (F p)) : 
+lemma eval_decomposeNatExpr_iv_2 (env : Environment (F p)) :
     (eval env (U32.decomposeNatExpr iv[2])).value = iv[2] := by
   simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
   simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
-  sorry
+  simp only [iv, Vector.getElem_mk]
+  simp only [List.getElem_toArray, List.getElem_cons_zero, List.getElem_cons_succ,
+    Nat.reduceMod, Nat.cast_ofNat, Nat.reduceDiv, Nat.reducePow, List.map_toArray, List.map_cons, List.map_nil]
+  simp only [Expression.eval]
+  -- All these values are less than p, so ZMod.val gives back the original value
+  have h1 : ZMod.val (114 : F p) = 114 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 114 < p)
+  have h2 : ZMod.val (243 : F p) = 243 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 243 < p)
+  have h3 : ZMod.val (60 : F p) = 60 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 60 < p)
+  have h4 : ZMod.val (110 : F p) = 110 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : _ < p)
+  rw [h1, h2, h3, h4]
 
 /--
 Lemma showing that evaluating U32.decomposeNatExpr of iv[3] gives iv[3].
 -/
-lemma eval_decomposeNatExpr_iv_3 (env : Environment (F p)) : 
+lemma eval_decomposeNatExpr_iv_3 (env : Environment (F p)) :
     (eval env (U32.decomposeNatExpr iv[3])).value = iv[3] := by
   simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
   simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
-  sorry
+  simp only [iv, Vector.getElem_mk]
+  simp only [List.getElem_toArray, List.getElem_cons_zero, List.getElem_cons_succ,
+    Nat.reduceMod, Nat.cast_ofNat, Nat.reduceDiv, Nat.reducePow, List.map_toArray, List.map_cons, List.map_nil]
+  simp only [Expression.eval]
+  -- All these values are less than p, so ZMod.val gives back the original value
+  have h1 : ZMod.val (58 : F p) = 58 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 58 < p)
+  have h2 : ZMod.val (245 : F p) = 245 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 245 < p)
+  have h3 : ZMod.val (79 : F p) = 79 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 79 < p)
+  have h4 : ZMod.val (165 : F p) = 165 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 165 < p)
+  rw [h1, h2, h3, h4]
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   intro i0 env ⟨chaining_value_var, block_words_var, counter_high_var, counter_low_var, block_len_var, flags_var⟩

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -26,30 +26,29 @@ The spec follows the pattern from the applyRounds function:
 - Apply round to get new state
 - Permute the message
 -/
-def roundWithPermute : FormalCircuit (F p) Round.Inputs Round.Inputs := {
-  elaborated := {
-    main := fun input => do
-      let state ← subcircuit Round.circuit input
-      let permuted_message ← subcircuit Permute.circuit input.message
-      return ⟨state, permuted_message⟩
-    localLength := fun _ => Round.circuit.localLength _ + Permute.circuit.localLength _
-    localLength_eq := by
-      intro input offset
-      simp only [Circuit.bind_def, Circuit.localLength, circuit_norm]
-      rfl
-    output := fun input offset =>
-      let state_out := Round.circuit.output input offset
-      let msg_out := Permute.circuit.output input.message (offset + Round.circuit.localLength input)
-      ⟨state_out, msg_out⟩
-    output_eq := by
-      intro input offset
-      simp only [Circuit.bind_def, Circuit.output, circuit_norm]
-    subcircuitsConsistent := by
-      intro input offset
-      simp only [Circuit.bind_def, Circuit.operations, circuit_norm]
-      have h : offset + Round.circuit.localLength input = Round.circuit.localLength input + offset := by ring
-      rw [h]
-  }
+def roundWithPermute : FormalCircuit (F p) Round.Inputs Round.Inputs where
+  main := fun input => do
+    let state ← subcircuit Round.circuit input
+    let permuted_message ← subcircuit Permute.circuit input.message
+    return ⟨state, permuted_message⟩
+  localLength := fun _ => Round.circuit.localLength _ + Permute.circuit.localLength _
+  localLength_eq := by
+    intro input offset
+    simp only [Circuit.bind_def, Circuit.localLength, circuit_norm]
+    rfl
+  output := fun input offset =>
+    let state_out := Round.circuit.output input offset
+    let msg_out := Permute.circuit.output input.message (offset + Round.circuit.localLength input)
+    ⟨state_out, msg_out⟩
+  output_eq := by
+    intro input offset
+    simp only [Circuit.bind_def, Circuit.output, circuit_norm]
+  subcircuitsConsistent := by
+    intro input offset
+    simp only [Circuit.bind_def, Circuit.operations, circuit_norm]
+    have h : offset + Round.circuit.localLength input = Round.circuit.localLength input + offset := by ring
+    rw [h]
+
   Assumptions := Round.Assumptions
   Spec := fun input output =>
     let state' := round input.state.value (BLAKE3State.value input.message)
@@ -163,7 +162,6 @@ def roundWithPermute : FormalCircuit (F p) Round.Inputs Round.Inputs := {
       -- Now we can rewrite and apply h_msg_norm
       rw [h_cast]
       exact h_msg_norm
-}
 
 /--
 Combines two roundWithPermute operations using the concat combinator.

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -681,6 +681,18 @@ lemma eval_decomposeNatExpr_iv_3 (env : Environment (F p)) :
   have h4 : ZMod.val (165 : F p) = 165 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 165 < p)
   rw [h1, h2, h3, h4]
 
+-- Helper lemma for extracting elements from chaining_value evaluation
+omit p_large_enough in
+lemma eval_chaining_value_elem {env : Environment (F p)}
+    {chaining_value_var : Vector (U32 (Expression (F p))) 8}
+    {chaining_value : Vector (U32 (F p)) 8}
+    (h_eval : (eval env chaining_value_var : ProvableVector _ _ _) = chaining_value)
+    (i : Fin 8) :
+    (eval env chaining_value_var[i]).value = chaining_value[i].value := by
+  have h := congrArg (fun v => v[i]) h_eval
+  simp only [eval_vector, Vector.getElem_map, circuit_norm] at h
+  congr
+
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   intro i0 env ⟨chaining_value_var, block_words_var, counter_high_var, counter_low_var, block_len_var, flags_var⟩
   intro ⟨chaining_value, block_words, counter_high, counter_low, block_len, flags⟩ h_input h_normalized h_holds
@@ -897,22 +909,14 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     size_toArray := by simp
   } := by rfl
 
-  have h_chaining_0_eq : (eval env chaining_value_var[0]).value = chaining_value[0].value := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-  have h_chaining_1_eq : (eval env chaining_value_var[1]).value = chaining_value[1].value := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-  have h_chaining_2_eq : (eval env chaining_value_var[2]).value = chaining_value[2].value := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-  have h_chaining_3_eq : (eval env chaining_value_var[3]).value = chaining_value[3].value := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-  have h_chaining_4_eq : (eval env chaining_value_var[4]).value = chaining_value[4].value := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-  have h_chaining_5_eq : (eval env chaining_value_var[5]).value = chaining_value[5].value := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-  have h_chaining_6_eq : (eval env chaining_value_var[6]).value = chaining_value[6].value := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-  have h_chaining_7_eq : (eval env chaining_value_var[7]).value = chaining_value[7].value := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
+  have h_chaining_0_eq : (eval env chaining_value_var[0]).value = chaining_value[0].value := eval_chaining_value_elem h_eval_chaining_block_value 0
+  have h_chaining_1_eq : (eval env chaining_value_var[1]).value = chaining_value[1].value := eval_chaining_value_elem h_eval_chaining_block_value 1
+  have h_chaining_2_eq : (eval env chaining_value_var[2]).value = chaining_value[2].value := eval_chaining_value_elem h_eval_chaining_block_value 2
+  have h_chaining_3_eq : (eval env chaining_value_var[3]).value = chaining_value[3].value := eval_chaining_value_elem h_eval_chaining_block_value 3
+  have h_chaining_4_eq : (eval env chaining_value_var[4]).value = chaining_value[4].value := eval_chaining_value_elem h_eval_chaining_block_value 4
+  have h_chaining_5_eq : (eval env chaining_value_var[5]).value = chaining_value[5].value := eval_chaining_value_elem h_eval_chaining_block_value 5
+  have h_chaining_6_eq : (eval env chaining_value_var[6]).value = chaining_value[6].value := eval_chaining_value_elem h_eval_chaining_block_value 6
+  have h_chaining_7_eq : (eval env chaining_value_var[7]).value = chaining_value[7].value := eval_chaining_value_elem h_eval_chaining_block_value 7
 
   -- Equations for IV constants (using the external lemmas)
   have h_iv_0_eq := eval_decomposeNatExpr_iv_0 env

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -601,8 +601,8 @@ lemma sevenRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
 The concrete assumptions for sevenRoundsApplyStyle: both state and message must be normalized.
 -/
 lemma sevenRoundsApplyStyle_assumptions_concrete (input : Round.Inputs (F p)) :
-  sevenRoundsApplyStyle.Assumptions input ↔
-  (input.state.Normalized ∧ ∀ i : Fin 16, input.message[i].Normalized) := by
+    sevenRoundsApplyStyle.Assumptions input ↔
+    (input.state.Normalized ∧ ∀ i : Fin 16, input.message[i].Normalized) := by
   rw [sevenRoundsApplyStyle_assumptions_eq]
   simp only [Round.Assumptions]
 

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -692,10 +692,119 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     U32.decomposeNatExpr iv[0], U32.decomposeNatExpr iv[1], U32.decomposeNatExpr iv[2],
     U32.decomposeNatExpr iv[3], counter_low_var, counter_high_var, block_len_var, flags_var
   ]
+  have state_vec_0_Normalized : (eval env chaining_value_var[0]).Normalized := by sorry
+  have state_vec_1_Normalized : (eval env chaining_value_var[1]).Normalized := by sorry
+  have state_vec_2_Normalized : (eval env chaining_value_var[2]).Normalized := by sorry
+  have state_vec_3_Normalized : (eval env chaining_value_var[3]).Normalized := by sorry
+  have state_vec_4_Normalized : (eval env chaining_value_var[4]).Normalized := by sorry
+  have state_vec_5_Normalized : (eval env chaining_value_var[5]).Normalized := by sorry
+  have state_vec_6_Normalized : (eval env chaining_value_var[6]).Normalized := by sorry
+  have state_vec_7_Normalized : (eval env chaining_value_var[7]).Normalized := by sorry
+  have state_vec_8_Normalized : (eval env (U32.decomposeNatExpr iv[0])).Normalized := by sorry
+  have state_vec_9_Normalized : (eval env (U32.decomposeNatExpr iv[1])).Normalized := by sorry
+  have state_vec_10_Normalized : (eval env (U32.decomposeNatExpr iv[2])).Normalized := by sorry
+  have state_vec_11_Normalized : (eval env (U32.decomposeNatExpr iv[3])).Normalized := by sorry
+  have state_vec_12_Normalized : (eval env counter_low_var).Normalized := by sorry
+  have state_vec_13_Normalized : (eval env counter_high_var).Normalized := by sorry
+  have state_vec_14_Normalized : (eval env block_len_var).Normalized := by sorry
+  have state_vec_15_Normalized : (eval env flags_var).Normalized := by sorry
 
   -- Show the state is normalized
   have h_state_normalized : (eval env state_vec).Normalized := by
-    sorry -- The full proof requires showing each element is normalized
+    simp only [BLAKE3State.Normalized, state_vec, eval_vector]
+    intro i
+    fin_cases i
+    -- First 8 elements are from chaining_value
+    case «0» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_zero, state_vec, state_vec_0_Normalized]
+    )
+    case «1» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_1_Normalized]
+    )
+    case «2» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_2_Normalized]
+    )
+    case «3» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_3_Normalized]
+    )
+    case «4» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_4_Normalized]
+    )
+    case «5» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_5_Normalized]
+    )
+    case «6» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_6_Normalized]
+    )
+    case «7» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_7_Normalized]
+    )
+    -- Next 4 are IV constants
+    case «8» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_8_Normalized]
+    )
+    case «9» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_9_Normalized]
+    )
+    case «10» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_10_Normalized]
+    )
+    case «11» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_11_Normalized]
+    )
+    -- Last 4 are counter_low, counter_high, block_len, flags
+    case «12» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_12_Normalized]
+    )
+    case «13» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_13_Normalized]
+    )
+    case «14» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_14_Normalized]
+    )
+    case «15» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_15_Normalized]
+    )
 
   -- Show the message is normalized
   have h_message_normalized : ∀ (i : Fin 16), (eval env block_words_var : BLAKE3State _)[i].Normalized := by

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -428,7 +428,7 @@ lemma applyRounds_eq_applySevenRounds
       (#v[
         chaining_value[0], chaining_value[1], chaining_value[2], chaining_value[3],
         chaining_value[4], chaining_value[5], chaining_value[6], chaining_value[7],
-        iv[0], iv[1], iv[2], iv[3],
+        iv[0].toNat, iv[1].toNat, iv[2].toNat, iv[3].toNat,
         counter % 2^32, counter / 2^32, block_len, flags
       ])
       block_words := by
@@ -443,37 +443,11 @@ lemma eval_decomposeNatExpr_small (env : Environment (F p)) (x : ℕ) :
   apply U32.value_of_decomposedNat_of_small
   assumption
 
-/--
-Lemma showing that evaluating U32.decomposeNatExpr of iv[0] gives iv[0].
--/
-lemma eval_decomposeNatExpr_iv_0 (env : Environment (F p)) :
-    (eval env (U32.decomposeNatExpr iv[0])).value = iv[0] := by
-  apply eval_decomposeNatExpr_small
-  simp [iv]
-
-/--
-Lemma showing that evaluating U32.decomposeNatExpr of iv[1] gives iv[1].
--/
-lemma eval_decomposeNatExpr_iv_1 (env : Environment (F p)) :
-    (eval env (U32.decomposeNatExpr iv[1])).value = iv[1] := by
-  apply eval_decomposeNatExpr_small
-  simp [iv]
-
-/--
-Lemma showing that evaluating U32.decomposeNatExpr of iv[2] gives iv[2].
--/
-lemma eval_decomposeNatExpr_iv_2 (env : Environment (F p)) :
-    (eval env (U32.decomposeNatExpr iv[2])).value = iv[2] := by
-  apply eval_decomposeNatExpr_small
-  simp [iv]
-
-/--
-Lemma showing that evaluating U32.decomposeNatExpr of iv[3] gives iv[3].
--/
-lemma eval_decomposeNatExpr_iv_3 (env : Environment (F p)) :
-    (eval env (U32.decomposeNatExpr iv[3])).value = iv[3] := by
-  apply eval_decomposeNatExpr_small
-  simp [iv]
+lemma eval_decomposeNatExpr_toNat_value (env : Environment (F p)) (x : UInt32) :
+    (eval env (U32.decomposeNatExpr x.toNat)).value = x.toNat := by
+  refine eval_decomposeNatExpr_small env x.toNat ?_
+  have := UInt32.toNat_lt_size x
+  omega
 
 -- Tactic for common steps in state vector normalization proof
 syntax "state_vec_norm_simp" : tactic
@@ -527,8 +501,8 @@ def main (input : Var Inputs (F p)) : Circuit (F p) (Var BLAKE3State (F p)) := d
   let state : Var BLAKE3State (F p) := #v[
     chaining_value[0], chaining_value[1], chaining_value[2], chaining_value[3],
     chaining_value[4], chaining_value[5], chaining_value[6], chaining_value[7],
-    U32.decomposeNatExpr iv[0], U32.decomposeNatExpr iv[1],
-    U32.decomposeNatExpr iv[2], U32.decomposeNatExpr iv[3],
+    U32.decomposeNatExpr iv[0].toNat, U32.decomposeNatExpr iv[1].toNat,
+    U32.decomposeNatExpr iv[2].toNat, U32.decomposeNatExpr iv[3].toNat,
     counter_low, counter_high, block_len, flags
   ]
 
@@ -586,8 +560,8 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   let state_vec : Var BLAKE3State (F p) := #v[
     chaining_value_var[0], chaining_value_var[1], chaining_value_var[2], chaining_value_var[3],
     chaining_value_var[4], chaining_value_var[5], chaining_value_var[6], chaining_value_var[7],
-    U32.decomposeNatExpr iv[0], U32.decomposeNatExpr iv[1], U32.decomposeNatExpr iv[2],
-    U32.decomposeNatExpr iv[3], counter_low_var, counter_high_var, block_len_var, flags_var
+    U32.decomposeNatExpr iv[0].toNat, U32.decomposeNatExpr iv[1].toNat, U32.decomposeNatExpr iv[2].toNat,
+    U32.decomposeNatExpr iv[3].toNat, counter_low_var, counter_high_var, block_len_var, flags_var
   ]
   -- Helper to prove normalization of chaining value elements
   have h_chaining_value_normalized : ∀ (i : Fin 8), (eval env chaining_value_var[i]).Normalized := by
@@ -601,7 +575,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     congr
     norm_num
     omega
-  have state_vec_8_Normalized : (eval env (U32.decomposeNatExpr iv[0])).Normalized := by
+  have state_vec_8_Normalized : (eval env (U32.decomposeNatExpr iv[0].toNat)).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
     simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
@@ -612,7 +586,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
       assumption
       linarith [p_large_enough.elim]
     exact ⟨h _, h _, h _, h _⟩
-  have state_vec_9_Normalized : (eval env (U32.decomposeNatExpr iv[1])).Normalized := by
+  have state_vec_9_Normalized : (eval env (U32.decomposeNatExpr iv[1].toNat)).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
     simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
@@ -623,7 +597,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
       assumption
       linarith [p_large_enough.elim]
     exact ⟨h _, h _, h _, h _⟩
-  have state_vec_10_Normalized : (eval env (U32.decomposeNatExpr iv[2])).Normalized := by
+  have state_vec_10_Normalized : (eval env (U32.decomposeNatExpr iv[2].toNat)).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
     simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
@@ -634,7 +608,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
       assumption
       linarith [p_large_enough.elim]
     exact ⟨h _, h _, h _, h _⟩
-  have state_vec_11_Normalized : (eval env (U32.decomposeNatExpr iv[3])).Normalized := by
+  have state_vec_11_Normalized : (eval env (U32.decomposeNatExpr iv[3].toNat)).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
     simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
@@ -693,8 +667,8 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   have h_state_vec_eq : eval env state_vec = eval env {
     toArray := #[chaining_value_var[0], chaining_value_var[1], chaining_value_var[2], chaining_value_var[3],
                  chaining_value_var[4], chaining_value_var[5], chaining_value_var[6], chaining_value_var[7],
-                 U32.decomposeNatExpr iv[0], U32.decomposeNatExpr iv[1], U32.decomposeNatExpr iv[2],
-                 U32.decomposeNatExpr iv[3], counter_low_var, counter_high_var, block_len_var, flags_var],
+                 U32.decomposeNatExpr iv[0].toNat, U32.decomposeNatExpr iv[1].toNat, U32.decomposeNatExpr iv[2].toNat,
+                 U32.decomposeNatExpr iv[3].toNat, counter_low_var, counter_high_var, block_len_var, flags_var],
     size_toArray := by simp
   } := by rfl
 
@@ -706,12 +680,6 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   have h_chaining_5_eq : (eval env chaining_value_var[5]).value = chaining_value[5].value := eval_chaining_value_elem h_eval_chaining_block_value 5
   have h_chaining_6_eq : (eval env chaining_value_var[6]).value = chaining_value[6].value := eval_chaining_value_elem h_eval_chaining_block_value 6
   have h_chaining_7_eq : (eval env chaining_value_var[7]).value = chaining_value[7].value := eval_chaining_value_elem h_eval_chaining_block_value 7
-
-  -- Equations for IV constants (using the external lemmas)
-  have h_iv_0_eq := eval_decomposeNatExpr_iv_0 env
-  have h_iv_1_eq := eval_decomposeNatExpr_iv_1 env
-  have h_iv_2_eq := eval_decomposeNatExpr_iv_2 env
-  have h_iv_3_eq := eval_decomposeNatExpr_iv_3 env
 
   -- Equations for counter values
   have h_counter_low_eq : counter_low.value % 4294967296 = counter_low.value := by
@@ -760,10 +728,8 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
         simp only[eval_vector]
         simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_map,
           Nat.reducePow, Nat.add_mul_mod_self_left, state_vec, h_eval_chaining_block_value, h_eval_block_words, h_eval_counter_high, h_eval_counter_low, h_eval_block_len, h_eval_flags]
-        simp only [h_chaining_0_eq, h_chaining_1_eq, h_chaining_2_eq, h_chaining_3_eq, h_chaining_4_eq, h_chaining_5_eq,
-          h_chaining_6_eq, h_chaining_7_eq]
-        simp only [h_iv_0_eq, h_iv_1_eq, h_iv_2_eq, h_iv_3_eq]
-        simp only [h_counter_low_eq, h_counter_high_eq]
+        simp [h_chaining_0_eq, h_chaining_1_eq, h_chaining_2_eq, h_chaining_3_eq, h_chaining_4_eq, h_chaining_5_eq,
+          h_chaining_6_eq, h_chaining_7_eq, eval_decomposeNatExpr_toNat_value, h_counter_low_eq, h_counter_high_eq]
 
   · -- Show out.Normalized
     exact h_normalized
@@ -783,8 +749,8 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
   let state_vec : Var BLAKE3State (F p) := #v[
     chaining_value_var[0], chaining_value_var[1], chaining_value_var[2], chaining_value_var[3],
     chaining_value_var[4], chaining_value_var[5], chaining_value_var[6], chaining_value_var[7],
-    U32.decomposeNatExpr iv[0], U32.decomposeNatExpr iv[1], U32.decomposeNatExpr iv[2],
-    U32.decomposeNatExpr iv[3], counter_low_var, counter_high_var, block_len_var, flags_var
+    U32.decomposeNatExpr iv[0].toNat, U32.decomposeNatExpr iv[1].toNat, U32.decomposeNatExpr iv[2].toNat,
+    U32.decomposeNatExpr iv[3].toNat, counter_low_var, counter_high_var, block_len_var, flags_var
   ]
   -- Helper to prove normalization of chaining value elements
   have h_chaining_value_normalized : ∀ (i : Fin 8), (eval env chaining_value_var[i]).Normalized := by
@@ -798,7 +764,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     congr
     norm_num
     omega
-  have state_vec_8_Normalized : (eval env (U32.decomposeNatExpr iv[0])).Normalized := by
+  have state_vec_8_Normalized : (eval env (U32.decomposeNatExpr iv[0].toNat)).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
     simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
@@ -809,7 +775,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
       assumption
       linarith [p_large_enough.elim]
     exact ⟨h _, h _, h _, h _⟩
-  have state_vec_9_Normalized : (eval env (U32.decomposeNatExpr iv[1])).Normalized := by
+  have state_vec_9_Normalized : (eval env (U32.decomposeNatExpr iv[1].toNat)).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
     simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
@@ -820,7 +786,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
       assumption
       linarith [p_large_enough.elim]
     exact ⟨h _, h _, h _, h _⟩
-  have state_vec_10_Normalized : (eval env (U32.decomposeNatExpr iv[2])).Normalized := by
+  have state_vec_10_Normalized : (eval env (U32.decomposeNatExpr iv[2].toNat)).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
     simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
@@ -831,7 +797,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
       assumption
       linarith [p_large_enough.elim]
     exact ⟨h _, h _, h _, h _⟩
-  have state_vec_11_Normalized : (eval env (U32.decomposeNatExpr iv[3])).Normalized := by
+  have state_vec_11_Normalized : (eval env (U32.decomposeNatExpr iv[3].toNat)).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
     simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -637,7 +637,7 @@ def main (input : Var Inputs (F p)) : Circuit (F p) (Var BLAKE3State (F p)) := d
 
   return state
 
-#eval! main (p:=pBabybear) default |>.localLength
+-- #eval! main (p:=pBabybear) default |>.localLength
 -- #eval! main (p:=pBabybear) default |>.output
 instance elaborated : ElaboratedCircuit (F p) Inputs BLAKE3State where
   main := main
@@ -1058,7 +1058,212 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     exact h_normalized
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  sorry
+  intro i0 env ⟨chaining_value_var, block_words_var, counter_high_var, counter_low_var, block_len_var, flags_var⟩
+  intro henv ⟨chaining_value, block_words, counter_high, counter_low, block_len, flags⟩ h_input h_normalized
+
+  -- Simplify goal using circuit_norm and use sevenRoundsApplyStyle completeness
+  simp only [circuit_norm, main, subcircuit_norm] at henv ⊢
+  simp only [sevenRoundsApplyStyle_assumptions_concrete] at henv ⊢
+
+  simp [circuit_norm] at h_input
+  obtain ⟨h_eval_chaining_block_value, h_eval_block_words, h_eval_counter_high,
+    h_eval_counter_low, h_eval_block_len, h_eval_flags⟩ := h_input
+
+  -- Create the state vector variable
+  let state_vec : Var BLAKE3State (F p) := #v[
+    chaining_value_var[0], chaining_value_var[1], chaining_value_var[2], chaining_value_var[3],
+    chaining_value_var[4], chaining_value_var[5], chaining_value_var[6], chaining_value_var[7],
+    U32.decomposeNatExpr iv[0], U32.decomposeNatExpr iv[1], U32.decomposeNatExpr iv[2],
+    U32.decomposeNatExpr iv[3], counter_low_var, counter_high_var, block_len_var, flags_var
+  ]
+  have state_vec_0_Normalized : (eval env chaining_value_var[0]).Normalized := by
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
+    exact h_normalized.1 0
+  have state_vec_1_Normalized : (eval env chaining_value_var[1]).Normalized := by
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
+    exact h_normalized.1 1
+  have state_vec_2_Normalized : (eval env chaining_value_var[2]).Normalized := by
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
+    exact h_normalized.1 2
+  have state_vec_3_Normalized : (eval env chaining_value_var[3]).Normalized := by
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
+    exact h_normalized.1 3
+  have state_vec_4_Normalized : (eval env chaining_value_var[4]).Normalized := by
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
+    exact h_normalized.1 4
+  have state_vec_5_Normalized : (eval env chaining_value_var[5]).Normalized := by
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
+    exact h_normalized.1 5
+  have state_vec_6_Normalized : (eval env chaining_value_var[6]).Normalized := by
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
+    exact h_normalized.1 6
+  have state_vec_7_Normalized : (eval env chaining_value_var[7]).Normalized := by
+    rw [getElem_eval_vector, h_eval_chaining_block_value]
+    exact h_normalized.1 7
+  have state_vec_8_Normalized : (eval env (U32.decomposeNatExpr iv[0])).Normalized := by
+    -- decomposeNatExpr produces a U32 of Expression.const values
+    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
+    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
+    -- Prove each limb is normalized
+    have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) < 256 := by
+      have : x % 256 < 256 := Nat.mod_lt _ (by norm_num)
+      rw [FieldUtils.val_lt_p]
+      assumption
+      linarith [p_large_enough.elim]
+    exact ⟨h _, h _, h _, h _⟩
+  have state_vec_9_Normalized : (eval env (U32.decomposeNatExpr iv[1])).Normalized := by
+    -- decomposeNatExpr produces a U32 of Expression.const values
+    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
+    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
+    -- Prove each limb is normalized
+    have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) < 256 := by
+      have : x % 256 < 256 := Nat.mod_lt _ (by norm_num)
+      rw [FieldUtils.val_lt_p]
+      assumption
+      linarith [p_large_enough.elim]
+    exact ⟨h _, h _, h _, h _⟩
+  have state_vec_10_Normalized : (eval env (U32.decomposeNatExpr iv[2])).Normalized := by
+    -- decomposeNatExpr produces a U32 of Expression.const values
+    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
+    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
+    -- Prove each limb is normalized
+    have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) < 256 := by
+      have : x % 256 < 256 := Nat.mod_lt _ (by norm_num)
+      rw [FieldUtils.val_lt_p]
+      assumption
+      linarith [p_large_enough.elim]
+    exact ⟨h _, h _, h _, h _⟩
+  have state_vec_11_Normalized : (eval env (U32.decomposeNatExpr iv[3])).Normalized := by
+    -- decomposeNatExpr produces a U32 of Expression.const values
+    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
+    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
+    -- Prove each limb is normalized
+    have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) < 256 := by
+      have : x % 256 < 256 := Nat.mod_lt _ (by norm_num)
+      rw [FieldUtils.val_lt_p]
+      assumption
+      linarith [p_large_enough.elim]
+    exact ⟨h _, h _, h _, h _⟩
+  have state_vec_12_Normalized : (eval env counter_low_var).Normalized := by
+    rw [h_eval_counter_low]
+    exact h_normalized.2.2.2.1
+  have state_vec_13_Normalized : (eval env counter_high_var).Normalized := by
+    rw [h_eval_counter_high]
+    exact h_normalized.2.2.1
+  have state_vec_14_Normalized : (eval env block_len_var).Normalized := by
+    rw [h_eval_block_len]
+    exact h_normalized.2.2.2.2.1
+  have state_vec_15_Normalized : (eval env flags_var).Normalized := by
+    rw [h_eval_flags]
+    exact h_normalized.2.2.2.2.2
+
+  -- Show the state is normalized
+  have h_state_normalized : (eval env state_vec).Normalized := by
+    simp only [BLAKE3State.Normalized, state_vec, eval_vector]
+    intro i
+    fin_cases i
+    -- First 8 elements are from chaining_value
+    case «0» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_zero, state_vec, state_vec_0_Normalized]
+    )
+    case «1» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_1_Normalized]
+    )
+    case «2» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_2_Normalized]
+    )
+    case «3» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_3_Normalized]
+    )
+    case «4» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_4_Normalized]
+    )
+    case «5» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_5_Normalized]
+    )
+    case «6» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_6_Normalized]
+    )
+    case «7» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map, getElem_eval_vector]
+      simp only [eval_vector]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_7_Normalized]
+    )
+    -- Next 4 are IV constants
+    case «8» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_8_Normalized]
+    )
+    case «9» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_9_Normalized]
+    )
+    case «10» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_10_Normalized]
+    )
+    case «11» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_11_Normalized]
+    )
+    -- Last 4 are counter_low, counter_high, block_len, flags
+    case «12» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_12_Normalized]
+    )
+    case «13» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_13_Normalized]
+    )
+    case «14» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_14_Normalized]
+    )
+    case «15» => (
+      simp only [Vector.getElem_mk]; rw [Vector.getElem_map]
+      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+        List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero, state_vec, state_vec_15_Normalized]
+    )
+
+  -- Show the message is normalized
+  have h_message_normalized : ∀ (i : Fin 16), (eval env block_words_var : BLAKE3State _)[i].Normalized := by
+    intro i
+    rw [h_eval_block_words]
+    exact h_normalized.2.1 i
+
+  constructor
+  · apply h_state_normalized
+  · apply h_message_normalized
+
 
 def circuit : FormalCircuit (F p) Inputs BLAKE3State := {
   elaborated with Assumptions, Spec, soundness, completeness

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -164,7 +164,7 @@ Combines two roundWithPermute operations using the concat combinator.
 This performs two rounds with message permutation between them.
 -/
 def twoRoundsWithPermute : FormalCircuit (F p) Round.Inputs Round.Inputs :=
-  Circuit.FormalCircuit.concat roundWithPermute roundWithPermute (by
+  roundWithPermute.concat roundWithPermute (by
     -- Prove compatibility: for all inputs, if circuit1 assumptions and spec hold,
     -- then circuit2 assumptions hold
     intro input mid h_asm h_spec

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -525,6 +525,87 @@ def sevenRoundsApplyStyle : FormalCircuit (F p) Round.Inputs BLAKE3State :=
       exact h_spec2.2
   )
 
+/--
+The assumptions for roundWithPermute are exactly Round.Assumptions.
+-/
+lemma roundWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
+  roundWithPermute.Assumptions input = Round.Assumptions input := by
+  simp only [roundWithPermute]
+
+/--
+The assumptions for twoRoundsWithPermute are exactly Round.Assumptions.
+-/
+lemma twoRoundsWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
+  twoRoundsWithPermute.Assumptions input = Round.Assumptions input := by
+  simp only [twoRoundsWithPermute, FormalCircuit.concat]
+  rfl
+
+/--
+The assumptions for twoRoundsApplyStyle are exactly Round.Assumptions.
+-/
+lemma twoRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
+  twoRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
+  simp only [twoRoundsApplyStyle, FormalCircuit.weakenSpec]
+  rw [twoRoundsWithPermute_assumptions_eq]
+
+/--
+The assumptions for fourRoundsWithPermute are exactly Round.Assumptions.
+-/
+lemma fourRoundsWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
+  fourRoundsWithPermute.Assumptions input = Round.Assumptions input := by
+  simp only [fourRoundsWithPermute, FormalCircuit.concat]
+  rw [twoRoundsWithPermute_assumptions_eq]
+
+/--
+The assumptions for fourRoundsApplyStyle are exactly Round.Assumptions.
+-/
+lemma fourRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
+  fourRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
+  simp only [fourRoundsApplyStyle, FormalCircuit.weakenSpec]
+  rw [fourRoundsWithPermute_assumptions_eq]
+
+/--
+The assumptions for sixRoundsWithPermute are exactly Round.Assumptions.
+-/
+lemma sixRoundsWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
+  sixRoundsWithPermute.Assumptions input = Round.Assumptions input := by
+  simp only [sixRoundsWithPermute, FormalCircuit.concat]
+  rw [fourRoundsWithPermute_assumptions_eq]
+
+/--
+The assumptions for sixRoundsApplyStyle are exactly Round.Assumptions.
+-/
+lemma sixRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
+  sixRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
+  simp only [sixRoundsApplyStyle, FormalCircuit.weakenSpec]
+  rw [sixRoundsWithPermute_assumptions_eq]
+
+/--
+The assumptions for sevenRoundsFinal are exactly Round.Assumptions.
+-/
+lemma sevenRoundsFinal_assumptions_eq (input : Round.Inputs (F p)) :
+  sevenRoundsFinal.Assumptions input = Round.Assumptions input := by
+  simp only [sevenRoundsFinal, FormalCircuit.concat]
+  rw [sixRoundsApplyStyle_assumptions_eq]
+
+/--
+The assumptions for sevenRoundsApplyStyle are exactly Round.Assumptions.
+This means the input state and message must be normalized.
+-/
+lemma sevenRoundsApplyStyle_assumptions_eq (input : Round.Inputs (F p)) :
+  sevenRoundsApplyStyle.Assumptions input = Round.Assumptions input := by
+  simp only [sevenRoundsApplyStyle, FormalCircuit.weakenSpec]
+  rw [sevenRoundsFinal_assumptions_eq]
+
+/--
+The concrete assumptions for sevenRoundsApplyStyle: both state and message must be normalized.
+-/
+lemma sevenRoundsApplyStyle_assumptions_concrete (input : Round.Inputs (F p)) :
+  sevenRoundsApplyStyle.Assumptions input ↔ 
+  (input.state.Normalized ∧ ∀ i : Fin 16, input.message[i].Normalized) := by
+  rw [sevenRoundsApplyStyle_assumptions_eq]
+  simp only [Round.Assumptions]
+
 structure Inputs (F : Type) where
   chaining_value : Vector (U32 F) 8
   block_words : Vector (U32 F) 16
@@ -596,8 +677,11 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   obtain ⟨h_eval_chaining_block_value, h_eval_block_words, h_eval_counter_high,
     h_eval_counter_low, h_eval_block_len, h_eval_flags⟩ := h_input
 
-  simp only [circuit_norm, main]
-  sorry
+  simp only [circuit_norm, main, Spec]
+  constructor
+  · sorry
+  · simp only [circuit_norm, main, subcircuit_norm] at h_holds
+    sorry
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
   sorry

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -442,8 +442,7 @@ macro_rules
   | `(tactic| state_vec_norm_simp) => `(tactic|
       simp only [Vector.getElem_mk];
       rw [Vector.getElem_map, getElem_eval_vector];
-      simp only [eval_vector];
-      simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
+      simp only [eval_vector, Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_mk,
         List.getElem_toArray, List.getElem_cons_succ, List.getElem_cons_zero])
 
 -- Tactic for cases 8-15 which don't use getElem_eval_vector
@@ -695,50 +694,6 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     congr
     norm_num
     omega
-  have state_vec_8_Normalized : (eval env (const (U32.fromUInt32 iv[0]))).Normalized := by
-    -- decomposeNatExpr produces a U32 of Expression.const values
-    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
-    -- Prove each limb is normalized
-    have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) < 256 := by
-      have : x % 256 < 256 := Nat.mod_lt _ (by norm_num)
-      rw [FieldUtils.val_lt_p]
-      assumption
-      linarith [p_large_enough.elim]
-    exact ⟨h _, h _, h _, h _⟩
-  have state_vec_9_Normalized : (eval env (const (U32.fromUInt32 iv[1]))).Normalized := by
-    -- decomposeNatExpr produces a U32 of Expression.const values
-    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
-    -- Prove each limb is normalized
-    have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) < 256 := by
-      have : x % 256 < 256 := Nat.mod_lt _ (by norm_num)
-      rw [FieldUtils.val_lt_p]
-      assumption
-      linarith [p_large_enough.elim]
-    exact ⟨h _, h _, h _, h _⟩
-  have state_vec_10_Normalized : (eval env (const (U32.fromUInt32 iv[2]))).Normalized := by
-    -- decomposeNatExpr produces a U32 of Expression.const values
-    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
-    -- Prove each limb is normalized
-    have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) < 256 := by
-      have : x % 256 < 256 := Nat.mod_lt _ (by norm_num)
-      rw [FieldUtils.val_lt_p]
-      assumption
-      linarith [p_large_enough.elim]
-    exact ⟨h _, h _, h _, h _⟩
-  have state_vec_11_Normalized : (eval env (const (U32.fromUInt32 iv[3]))).Normalized := by
-    -- decomposeNatExpr produces a U32 of Expression.const values
-    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
-    -- Prove each limb is normalized
-    have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) < 256 := by
-      have : x % 256 < 256 := Nat.mod_lt _ (by norm_num)
-      rw [FieldUtils.val_lt_p]
-      assumption
-      linarith [p_large_enough.elim]
-    exact ⟨h _, h _, h _, h _⟩
   have state_vec_12_Normalized : (eval env counter_low_var).Normalized := by
     rw [h_eval_counter_low]
     exact h_normalized.2.2.2.1

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -505,24 +505,10 @@ Seven rounds with spec matching the applyRounds pattern.
 def sevenRoundsApplyStyle : FormalCircuit (F p) Round.Inputs BLAKE3State :=
   sevenRoundsFinal.weakenSpec SevenRoundsSpec (by
     -- Prove that sevenRoundsFinal's spec implies our SevenRoundsSpec
-    intro input output h_assumptions h_spec
-    -- sevenRoundsFinal.Spec says ∃ mid, sixRoundsApplyStyle.Spec input mid ∧ Round.circuit.Spec mid output
-    obtain ⟨mid, h_spec1, h_spec2⟩ := h_spec
+    rintro input output h_assumptions ⟨mid, h_spec1, h_spec2⟩
     -- Break down the specs similar to previous proofs
-    simp only [sixRoundsApplyStyle, FormalCircuit.weakenSpec, SixRoundsSpec] at h_spec1
-    simp only [Round.circuit, Round.Spec] at h_spec2
-    simp only [SevenRoundsSpec, applySevenRounds, applySixRounds]
-
-    -- Build the result by chaining all seven rounds
-    constructor
-    · -- Prove: output.value = final_state after 7 rounds
-      rw [h_spec2.1, h_spec1.1]
-      simp only [applySixRounds]
-      congr 1
-      rw [h_spec1.2.1]
-      simp only [applySixRounds]
-    · -- Prove: output.Normalized
-      exact h_spec2.2
+    simp_all only [sixRoundsApplyStyle, FormalCircuit.weakenSpec, SixRoundsSpec, Round.circuit, Round.Spec, SevenRoundsSpec, applySevenRounds, applySixRounds]
+    aesop
   )
 
 structure Inputs (F : Type) where

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -621,30 +621,18 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     U32.decomposeNatExpr iv[0], U32.decomposeNatExpr iv[1], U32.decomposeNatExpr iv[2],
     U32.decomposeNatExpr iv[3], counter_low_var, counter_high_var, block_len_var, flags_var
   ]
-  have state_vec_0_Normalized : (eval env chaining_value_var[0]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 0
-  have state_vec_1_Normalized : (eval env chaining_value_var[1]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 1
-  have state_vec_2_Normalized : (eval env chaining_value_var[2]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 2
-  have state_vec_3_Normalized : (eval env chaining_value_var[3]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 3
-  have state_vec_4_Normalized : (eval env chaining_value_var[4]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 4
-  have state_vec_5_Normalized : (eval env chaining_value_var[5]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 5
-  have state_vec_6_Normalized : (eval env chaining_value_var[6]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 6
-  have state_vec_7_Normalized : (eval env chaining_value_var[7]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 7
+  -- Helper to prove normalization of chaining value elements
+  have h_chaining_value_normalized : ∀ (i : Fin 8), (eval env chaining_value_var[i]).Normalized := by
+    rintro ⟨ i, h_i ⟩
+    have h : (eval env chaining_value_var : ProvableVector _ _ _) = chaining_value := h_eval_chaining_block_value
+    have h_i : (eval env chaining_value_var : ProvableVector _ _ _)[i] = chaining_value[i] := by
+      rw [h]
+    simp only [eval_vector, Vector.getElem_map] at h_i
+    convert h_normalized.1 i
+    simp_all only [circuit_norm]
+    congr
+    norm_num
+    omega
   have state_vec_8_Normalized : (eval env (U32.decomposeNatExpr iv[0])).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
@@ -708,14 +696,14 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     intro i
     fin_cases i
     -- First 8 elements are from chaining_value
-    case «0» => state_vec_norm_simp; simp only [state_vec, state_vec_0_Normalized]
-    case «1» => state_vec_norm_simp; simp only [state_vec, state_vec_1_Normalized]
-    case «2» => state_vec_norm_simp; simp only [state_vec, state_vec_2_Normalized]
-    case «3» => state_vec_norm_simp; simp only [state_vec, state_vec_3_Normalized]
-    case «4» => state_vec_norm_simp; simp only [state_vec, state_vec_4_Normalized]
-    case «5» => state_vec_norm_simp; simp only [state_vec, state_vec_5_Normalized]
-    case «6» => state_vec_norm_simp; simp only [state_vec, state_vec_6_Normalized]
-    case «7» => state_vec_norm_simp; simp only [state_vec, state_vec_7_Normalized]
+    case «0» => state_vec_norm_simp; exact h_chaining_value_normalized 0
+    case «1» => state_vec_norm_simp; exact h_chaining_value_normalized 1
+    case «2» => state_vec_norm_simp; exact h_chaining_value_normalized 2
+    case «3» => state_vec_norm_simp; exact h_chaining_value_normalized 3
+    case «4» => state_vec_norm_simp; exact h_chaining_value_normalized 4
+    case «5» => state_vec_norm_simp; exact h_chaining_value_normalized 5
+    case «6» => state_vec_norm_simp; exact h_chaining_value_normalized 6
+    case «7» => state_vec_norm_simp; exact h_chaining_value_normalized 7
     -- Next 4 are IV constants
     case «8» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_8_Normalized]
     case «9» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_9_Normalized]
@@ -830,30 +818,18 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     U32.decomposeNatExpr iv[0], U32.decomposeNatExpr iv[1], U32.decomposeNatExpr iv[2],
     U32.decomposeNatExpr iv[3], counter_low_var, counter_high_var, block_len_var, flags_var
   ]
-  have state_vec_0_Normalized : (eval env chaining_value_var[0]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 0
-  have state_vec_1_Normalized : (eval env chaining_value_var[1]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 1
-  have state_vec_2_Normalized : (eval env chaining_value_var[2]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 2
-  have state_vec_3_Normalized : (eval env chaining_value_var[3]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 3
-  have state_vec_4_Normalized : (eval env chaining_value_var[4]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 4
-  have state_vec_5_Normalized : (eval env chaining_value_var[5]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 5
-  have state_vec_6_Normalized : (eval env chaining_value_var[6]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 6
-  have state_vec_7_Normalized : (eval env chaining_value_var[7]).Normalized := by
-    rw [getElem_eval_vector, h_eval_chaining_block_value]
-    exact h_normalized.1 7
+  -- Helper to prove normalization of chaining value elements
+  have h_chaining_value_normalized : ∀ (i : Fin 8), (eval env chaining_value_var[i]).Normalized := by
+    rintro ⟨ i, h_i ⟩
+    have h : (eval env chaining_value_var : ProvableVector _ _ _) = chaining_value := h_eval_chaining_block_value
+    have h_i : (eval env chaining_value_var : ProvableVector _ _ _)[i] = chaining_value[i] := by
+      rw [h]
+    simp only [eval_vector, Vector.getElem_map] at h_i
+    convert h_normalized.1 i
+    simp_all only [circuit_norm]
+    congr
+    norm_num
+    omega
   have state_vec_8_Normalized : (eval env (U32.decomposeNatExpr iv[0])).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
@@ -917,14 +893,14 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     intro i
     fin_cases i
     -- First 8 elements are from chaining_value
-    case «0» => state_vec_norm_simp; simp only [state_vec, state_vec_0_Normalized]
-    case «1» => state_vec_norm_simp; simp only [state_vec, state_vec_1_Normalized]
-    case «2» => state_vec_norm_simp; simp only [state_vec, state_vec_2_Normalized]
-    case «3» => state_vec_norm_simp; simp only [state_vec, state_vec_3_Normalized]
-    case «4» => state_vec_norm_simp; simp only [state_vec, state_vec_4_Normalized]
-    case «5» => state_vec_norm_simp; simp only [state_vec, state_vec_5_Normalized]
-    case «6» => state_vec_norm_simp; simp only [state_vec, state_vec_6_Normalized]
-    case «7» => state_vec_norm_simp; simp only [state_vec, state_vec_7_Normalized]
+    case «0» => state_vec_norm_simp; exact h_chaining_value_normalized 0
+    case «1» => state_vec_norm_simp; exact h_chaining_value_normalized 1
+    case «2» => state_vec_norm_simp; exact h_chaining_value_normalized 2
+    case «3» => state_vec_norm_simp; exact h_chaining_value_normalized 3
+    case «4» => state_vec_norm_simp; exact h_chaining_value_normalized 4
+    case «5» => state_vec_norm_simp; exact h_chaining_value_normalized 5
+    case «6» => state_vec_norm_simp; exact h_chaining_value_normalized 6
+    case «7» => state_vec_norm_simp; exact h_chaining_value_normalized 7
     -- Next 4 are IV constants
     case «8» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_8_Normalized]
     case «9» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_9_Normalized]

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -177,9 +177,11 @@ def twoRoundsWithPermute : FormalCircuit (F p) Round.Inputs Round.Inputs :=
     · -- ∀ i : Fin 16, mid.message[i].Normalized
       exact h_spec.2.2.2
   ) (by
-    -- Prove h_output_stable: output doesn't depend on offset
-    -- This might not hold for roundWithPermute as the output depends on offset
-    sorry
+    -- Prove h_localLength_stable: roundWithPermute.localLength doesn't depend on input
+    intro mid mid'
+    -- roundWithPermute.localLength is defined as fun _ => constant
+    -- So it's the same for any input
+    rfl
   )
 
 structure Inputs (F : Type) where

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -192,11 +192,9 @@ def twoRoundsWithPermute : FormalCircuit (F p) Round.Inputs Round.Inputs :=
 
 /--
 Apply two rounds of BLAKE3 compression, starting from a Round.Inputs state.
-This is a truncated version of the full applyRounds, performing only:
-- First round
-- Permute message
-- Second round
-- Permute message
+This follows the same pattern as applyRounds but for only 2 rounds:
+- First round, permute message
+- Second round, permute message
 Returns the final state and permuted message.
 -/
 def applyTwoRounds (state : Vector Nat 16) (message : Vector Nat 16) : Vector Nat 16 × Vector Nat 16 :=
@@ -287,7 +285,7 @@ def fourRoundsWithPermute : FormalCircuit (F p) Round.Inputs Round.Inputs :=
 
 /--
 Apply four rounds of BLAKE3 compression, starting from a Round.Inputs state.
-This performs:
+This follows the same pattern as applyRounds but for only 4 rounds:
 - First round, permute message
 - Second round, permute message  
 - Third round, permute message
@@ -295,8 +293,15 @@ This performs:
 Returns the final state and permuted message.
 -/
 def applyFourRounds (state : Vector Nat 16) (message : Vector Nat 16) : Vector Nat 16 × Vector Nat 16 :=
-  let (state2, msg2) := applyTwoRounds state message
-  applyTwoRounds state2 msg2
+  let state1 := round state message
+  let msg1 := permute message
+  let state2 := round state1 msg1
+  let msg2 := permute msg1
+  let state3 := round state2 msg2
+  let msg3 := permute msg2
+  let state4 := round state3 msg3
+  let msg4 := permute msg3
+  (state4, msg4)
 
 /--
 Specification for four rounds that matches the pattern of the full ApplyRounds.Spec.

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -443,8 +443,8 @@ lemma eval_decomposeNatExpr_small (env : Environment (F p)) (x : ℕ) :
   apply U32.value_of_decomposedNat_of_small
   assumption
 
-lemma eval_decomposeNatExpr_toNat_value (env : Environment (F p)) (x : UInt32) :
-    (eval env (U32.decomposeNatExpr x.toNat)).value = x.toNat := by
+lemma eval_fromUInt32_value (env : Environment (F p)) (x : UInt32) :
+    (eval env (const (U32.fromUInt32 x))).value = x.toNat := by
   refine eval_decomposeNatExpr_small env x.toNat ?_
   have := UInt32.toNat_lt_size x
   omega
@@ -501,8 +501,8 @@ def main (input : Var Inputs (F p)) : Circuit (F p) (Var BLAKE3State (F p)) := d
   let state : Var BLAKE3State (F p) := #v[
     chaining_value[0], chaining_value[1], chaining_value[2], chaining_value[3],
     chaining_value[4], chaining_value[5], chaining_value[6], chaining_value[7],
-    U32.decomposeNatExpr iv[0].toNat, U32.decomposeNatExpr iv[1].toNat,
-    U32.decomposeNatExpr iv[2].toNat, U32.decomposeNatExpr iv[3].toNat,
+    const (U32.fromUInt32 iv[0]), const (U32.fromUInt32 iv[1]),
+    const (U32.fromUInt32 iv[2]), const (U32.fromUInt32 iv[3]),
     counter_low, counter_high, block_len, flags
   ]
 
@@ -729,7 +729,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
         simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_map,
           Nat.reducePow, Nat.add_mul_mod_self_left, state_vec, h_eval_chaining_block_value, h_eval_block_words, h_eval_counter_high, h_eval_counter_low, h_eval_block_len, h_eval_flags]
         simp [h_chaining_0_eq, h_chaining_1_eq, h_chaining_2_eq, h_chaining_3_eq, h_chaining_4_eq, h_chaining_5_eq,
-          h_chaining_6_eq, h_chaining_7_eq, eval_decomposeNatExpr_toNat_value, h_counter_low_eq, h_counter_high_eq]
+          h_chaining_6_eq, h_chaining_7_eq, eval_fromUInt32_value, h_counter_low_eq, h_counter_high_eq]
 
   · -- Show out.Normalized
     exact h_normalized
@@ -749,8 +749,8 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
   let state_vec : Var BLAKE3State (F p) := #v[
     chaining_value_var[0], chaining_value_var[1], chaining_value_var[2], chaining_value_var[3],
     chaining_value_var[4], chaining_value_var[5], chaining_value_var[6], chaining_value_var[7],
-    U32.decomposeNatExpr iv[0].toNat, U32.decomposeNatExpr iv[1].toNat, U32.decomposeNatExpr iv[2].toNat,
-    U32.decomposeNatExpr iv[3].toNat, counter_low_var, counter_high_var, block_len_var, flags_var
+    const (U32.fromUInt32 iv[0]), const (U32.fromUInt32 iv[1]), const (U32.fromUInt32 iv[2]),
+    const (U32.fromUInt32 iv[3]), counter_low_var, counter_high_var, block_len_var, flags_var
   ]
   -- Helper to prove normalization of chaining value elements
   have h_chaining_value_normalized : ∀ (i : Fin 8), (eval env chaining_value_var[i]).Normalized := by
@@ -764,7 +764,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     congr
     norm_num
     omega
-  have state_vec_8_Normalized : (eval env (U32.decomposeNatExpr iv[0].toNat)).Normalized := by
+  have state_vec_8_Normalized : (eval env (const (U32.fromUInt32 iv[0]))).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
     simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
@@ -775,7 +775,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
       assumption
       linarith [p_large_enough.elim]
     exact ⟨h _, h _, h _, h _⟩
-  have state_vec_9_Normalized : (eval env (U32.decomposeNatExpr iv[1].toNat)).Normalized := by
+  have state_vec_9_Normalized : (eval env (const (U32.fromUInt32 iv[1]))).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
     simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
@@ -786,7 +786,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
       assumption
       linarith [p_large_enough.elim]
     exact ⟨h _, h _, h _, h _⟩
-  have state_vec_10_Normalized : (eval env (U32.decomposeNatExpr iv[2].toNat)).Normalized := by
+  have state_vec_10_Normalized : (eval env (const (U32.fromUInt32 iv[2]))).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
     simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]
@@ -797,7 +797,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
       assumption
       linarith [p_large_enough.elim]
     exact ⟨h _, h _, h _, h _⟩
-  have state_vec_11_Normalized : (eval env (U32.decomposeNatExpr iv[3].toNat)).Normalized := by
+  have state_vec_11_Normalized : (eval env (const (U32.fromUInt32 iv[3]))).Normalized := by
     -- decomposeNatExpr produces a U32 of Expression.const values
     simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
     simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.Normalized]

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -134,7 +134,28 @@ def roundWithPermute : FormalCircuit (F p) Round.Inputs Round.Inputs := {
       -- and h_msg_eq : (eval env input_var.message : ProvableVector U32 16 (F p)) = input_msg
 
       dsimp only [Permute.circuit, Permute.Assumptions]
-      sorry
+      -- We need to show (eval env input_var.message).Normalized
+      -- We know from h_eval that eval env input_var = { state := input_state, message := input_msg }
+      -- So eval env input_var.message = input_msg
+      -- We need to show that eval env input_var.message = input_msg
+      -- From h1 and h_eval we can derive this
+      have h_eq : Round.Inputs.mk (eval env input_var.state) (eval env input_var.message : ProvableVector U32 16 (F p)) =
+                  Round.Inputs.mk input_state input_msg := by
+        calc Round.Inputs.mk (eval env input_var.state) (eval env input_var.message : ProvableVector U32 16 (F p))
+          _ = eval env input_var := h1
+          _ = Round.Inputs.mk input_state input_msg := h_eval
+
+      -- Extract the message equality
+      have h_msg_eq : (eval env input_var.message : ProvableVector U32 16 (F p)) = input_msg := by
+        injection h_eq
+
+      -- Now we need to cast this to the right type for Normalized
+      have h_cast : (eval env input_var.message : BLAKE3State (F p)) = input_msg := by
+        exact h_msg_eq
+
+      -- Now we can rewrite and apply h_msg_norm
+      rw [h_cast]
+      exact h_msg_norm
 }
 
 structure Inputs (F : Type) where

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -435,77 +435,45 @@ lemma applyRounds_eq_applySevenRounds
   -- applyRounds constructs the same initial state and then applies 7 rounds
   simp only [applyRounds, applySevenRounds]
 
+lemma eval_decomposeNatExpr_small (env : Environment (F p)) (x : ℕ) :
+    x < 256^4 ->
+    (eval env (U32.decomposeNatExpr x)).value = x := by
+  intro _
+  simp only [U32.decomposeNatExpr]
+  apply U32.value_of_decomposedNat_of_small
+  assumption
+
 /--
 Lemma showing that evaluating U32.decomposeNatExpr of iv[0] gives iv[0].
 -/
 lemma eval_decomposeNatExpr_iv_0 (env : Environment (F p)) :
     (eval env (U32.decomposeNatExpr iv[0])).value = iv[0] := by
-  simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-  simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
-  simp only [iv, Vector.getElem_mk]
-  simp only [List.getElem_toArray, List.getElem_cons_zero, Nat.reduceMod, Nat.cast_ofNat,
-    Nat.reduceDiv, Nat.reducePow, List.map_toArray, List.map_cons, List.map_nil]
-  simp only [Expression.eval]
-  -- All these values are less than p, so ZMod.val gives back the original value
-  have h1 : ZMod.val (103 : F p) = 103 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 103 < p)
-  have h2 : ZMod.val (230 : F p) = 230 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 230 < p)
-  have h3 : ZMod.val (9 : F p) = 9 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 9 < p)
-  have h4 : ZMod.val (106 : F p) = 106 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 106 < p)
-  rw [h1, h2, h3, h4]
+  apply eval_decomposeNatExpr_small
+  simp [iv]
 
 /--
 Lemma showing that evaluating U32.decomposeNatExpr of iv[1] gives iv[1].
 -/
 lemma eval_decomposeNatExpr_iv_1 (env : Environment (F p)) :
     (eval env (U32.decomposeNatExpr iv[1])).value = iv[1] := by
-  simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-  simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
-  simp only [iv, Vector.getElem_mk]
-  simp only [List.getElem_toArray, List.getElem_cons_zero, List.getElem_cons_succ,
-    Nat.reduceMod, Nat.cast_ofNat, Nat.reduceDiv, Nat.reducePow, List.map_toArray, List.map_cons, List.map_nil]
-  simp only [Expression.eval]
-  -- All these values are less than p, so ZMod.val gives back the original value
-  have h1 : ZMod.val (133 : F p) = 133 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 133 < p)
-  have h2 : ZMod.val (174 : F p) = 174 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 174 < p)
-  have h3 : ZMod.val (103 : F p) = 103 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 103 < p)
-  have h4 : ZMod.val (187 : F p) = 187 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 187 < p)
-  rw [h1, h2, h3, h4]
+  apply eval_decomposeNatExpr_small
+  simp [iv]
 
 /--
 Lemma showing that evaluating U32.decomposeNatExpr of iv[2] gives iv[2].
 -/
 lemma eval_decomposeNatExpr_iv_2 (env : Environment (F p)) :
     (eval env (U32.decomposeNatExpr iv[2])).value = iv[2] := by
-  simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-  simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
-  simp only [iv, Vector.getElem_mk]
-  simp only [List.getElem_toArray, List.getElem_cons_zero, List.getElem_cons_succ,
-    Nat.reduceMod, Nat.cast_ofNat, Nat.reduceDiv, Nat.reducePow, List.map_toArray, List.map_cons, List.map_nil]
-  simp only [Expression.eval]
-  -- All these values are less than p, so ZMod.val gives back the original value
-  have h1 : ZMod.val (114 : F p) = 114 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 114 < p)
-  have h2 : ZMod.val (243 : F p) = 243 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 243 < p)
-  have h3 : ZMod.val (60 : F p) = 60 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 60 < p)
-  have h4 : ZMod.val (110 : F p) = 110 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : _ < p)
-  rw [h1, h2, h3, h4]
+  apply eval_decomposeNatExpr_small
+  simp [iv]
 
 /--
 Lemma showing that evaluating U32.decomposeNatExpr of iv[3] gives iv[3].
 -/
 lemma eval_decomposeNatExpr_iv_3 (env : Environment (F p)) :
     (eval env (U32.decomposeNatExpr iv[3])).value = iv[3] := by
-  simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-  simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
-  simp only [iv, Vector.getElem_mk]
-  simp only [List.getElem_toArray, List.getElem_cons_zero, List.getElem_cons_succ,
-    Nat.reduceMod, Nat.cast_ofNat, Nat.reduceDiv, Nat.reducePow, List.map_toArray, List.map_cons, List.map_nil]
-  simp only [Expression.eval]
-  -- All these values are less than p, so ZMod.val gives back the original value
-  have h1 : ZMod.val (58 : F p) = 58 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 58 < p)
-  have h2 : ZMod.val (245 : F p) = 245 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 245 < p)
-  have h3 : ZMod.val (79 : F p) = 79 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 79 < p)
-  have h4 : ZMod.val (165 : F p) = 165 := ZMod.val_cast_of_lt (by linarith [p_large_enough.elim] : 165 < p)
-  rw [h1, h2, h3, h4]
+  apply eval_decomposeNatExpr_small
+  simp [iv]
 
 -- Tactic for common steps in state vector normalization proof
 syntax "state_vec_norm_simp" : tactic

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -907,6 +907,39 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     size_toArray := by simp
   } := by rfl
 
+  have h_chaining_0_eq : (eval env chaining_value_var[0]).value = chaining_value[0].value := by
+    sorry
+  have h_chaining_1_eq : (eval env chaining_value_var[1]).value = chaining_value[1].value := by
+    sorry
+  have h_chaining_2_eq : (eval env chaining_value_var[2]).value = chaining_value[2].value := by
+    sorry
+  have h_chaining_3_eq : (eval env chaining_value_var[3]).value = chaining_value[3].value := by
+    sorry
+  have h_chaining_4_eq : (eval env chaining_value_var[4]).value = chaining_value[4].value := by
+    sorry
+  have h_chaining_5_eq : (eval env chaining_value_var[5]).value = chaining_value[5].value := by
+    sorry
+  have h_chaining_6_eq : (eval env chaining_value_var[6]).value = chaining_value[6].value := by
+    sorry
+  have h_chaining_7_eq : (eval env chaining_value_var[7]).value = chaining_value[7].value := by
+    sorry
+
+  -- Equations for IV constants
+  have h_iv_0_eq : (eval env (U32.decomposeNatExpr iv[0])).value = iv[0] := by
+    sorry
+  have h_iv_1_eq : (eval env (U32.decomposeNatExpr iv[1])).value = iv[1] := by
+    sorry
+  have h_iv_2_eq : (eval env (U32.decomposeNatExpr iv[2])).value = iv[2] := by
+    sorry
+  have h_iv_3_eq : (eval env (U32.decomposeNatExpr iv[3])).value = iv[3] := by
+    sorry
+
+  -- Equations for counter values
+  have h_counter_low_eq : counter_low.value % 4294967296 = counter_low.value := by
+    sorry
+  have h_counter_high_eq : (counter_low.value + 4294967296 * counter_high.value) / 4294967296 = counter_high.value := by
+    sorry
+
   -- Apply h_holds with the proven assumptions
   rw [← h_state_vec_eq] at h_state_normalized
   have h_spec := h_holds ⟨h_state_normalized, h_message_normalized⟩
@@ -934,7 +967,15 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     calc
       _ = _ := h_value
       _ = _ := by
-        sorry
+        clear h_value
+        rw [h_eval_block_words]
+        simp only[eval_vector]
+        simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, Vector.getElem_map,
+          Nat.reducePow, Nat.add_mul_mod_self_left, state_vec, h_eval_chaining_block_value, h_eval_block_words, h_eval_counter_high, h_eval_counter_low, h_eval_block_len, h_eval_flags]
+        simp only [h_chaining_0_eq, h_chaining_1_eq, h_chaining_2_eq, h_chaining_3_eq, h_chaining_4_eq, h_chaining_5_eq,
+          h_chaining_6_eq, h_chaining_7_eq]
+        simp only [h_iv_0_eq, h_iv_1_eq, h_iv_2_eq, h_iv_3_eq]
+        simp only [h_counter_low_eq, h_counter_high_eq]
 
   · -- Show out.Normalized
     exact h_normalized

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -591,19 +591,11 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     intro i
     fin_cases i
     -- First 8 elements are from chaining_value
-    case «0» => state_vec_norm_simp; exact h_chaining_value_normalized 0 (by omega)
-    case «1» => state_vec_norm_simp; exact h_chaining_value_normalized 1 (by omega)
-    case «2» => state_vec_norm_simp; exact h_chaining_value_normalized 2 (by omega)
-    case «3» => state_vec_norm_simp; exact h_chaining_value_normalized 3 (by omega)
-    case «4» => state_vec_norm_simp; exact h_chaining_value_normalized 4 (by omega)
-    case «5» => state_vec_norm_simp; exact h_chaining_value_normalized 5 (by omega)
-    case «6» => state_vec_norm_simp; exact h_chaining_value_normalized 6 (by omega)
-    case «7» => state_vec_norm_simp; exact h_chaining_value_normalized 7 (by omega)
+    case «0» | «1» | «2» | «3» | «4» | «5» | «6» | «7» => 
+      state_vec_norm_simp; simp [h_chaining_value_normalized]
     -- Next 4 are IV constants
-    case «8» => state_vec_norm_simp_simple
-    case «9» => state_vec_norm_simp_simple
-    case «10» => state_vec_norm_simp_simple
-    case «11» => state_vec_norm_simp_simple
+    case «8» | «9» | «10» | «11» => 
+      state_vec_norm_simp_simple
     -- Last 4 are counter_low, counter_high, block_len, flags
     case «12» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_12_Normalized]
     case «13» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_13_Normalized]
@@ -779,10 +771,10 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     intro i
     fin_cases i
     -- First 8 elements are from chaining_value
-    case «0» | «1» | «2» | «3» | «4» | «5» | «6» | «7» => 
+    case «0» | «1» | «2» | «3» | «4» | «5» | «6» | «7» =>
       state_vec_norm_simp; simp [h_chaining_value_normalized]
     -- Next 4 are IV constants
-    case «8» | «9» | «10» | «11» => 
+    case «8» | «9» | «10» | «11» =>
       state_vec_norm_simp_simple
     -- Last 4 are counter_low, counter_high, block_len, flags
     case «12» => state_vec_norm_simp_simple; simp only [state_vec, state_vec_12_Normalized]

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -690,6 +690,42 @@ lemma applyRounds_eq_applySevenRounds
   -- applyRounds constructs the same initial state and then applies 7 rounds
   simp only [applyRounds, applySevenRounds]
 
+/--
+Lemma showing that evaluating U32.decomposeNatExpr of iv[0] gives iv[0].
+-/
+lemma eval_decomposeNatExpr_iv_0 (env : Environment (F p)) : 
+    (eval env (U32.decomposeNatExpr iv[0])).value = iv[0] := by
+  simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
+  simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
+  sorry
+
+/--
+Lemma showing that evaluating U32.decomposeNatExpr of iv[1] gives iv[1].
+-/
+lemma eval_decomposeNatExpr_iv_1 (env : Environment (F p)) : 
+    (eval env (U32.decomposeNatExpr iv[1])).value = iv[1] := by
+  simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
+  simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
+  sorry
+
+/--
+Lemma showing that evaluating U32.decomposeNatExpr of iv[2] gives iv[2].
+-/
+lemma eval_decomposeNatExpr_iv_2 (env : Environment (F p)) : 
+    (eval env (U32.decomposeNatExpr iv[2])).value = iv[2] := by
+  simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
+  simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
+  sorry
+
+/--
+Lemma showing that evaluating U32.decomposeNatExpr of iv[3] gives iv[3].
+-/
+lemma eval_decomposeNatExpr_iv_3 (env : Environment (F p)) : 
+    (eval env (U32.decomposeNatExpr iv[3])).value = iv[3] := by
+  simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
+  simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
+  sorry
+
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   intro i0 env ⟨chaining_value_var, block_words_var, counter_high_var, counter_low_var, block_len_var, flags_var⟩
   intro ⟨chaining_value, block_words, counter_high, counter_low, block_len, flags⟩ h_input h_normalized h_holds
@@ -924,23 +960,11 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   have h_chaining_7_eq : (eval env chaining_value_var[7]).value = chaining_value[7].value := by
     rw [getElem_eval_vector, h_eval_chaining_block_value]
 
-  -- Equations for IV constants
-  have h_iv_0_eq : (eval env (U32.decomposeNatExpr iv[0])).value = iv[0] := by
-    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
-    sorry
-  have h_iv_1_eq : (eval env (U32.decomposeNatExpr iv[1])).value = iv[1] := by
-    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
-    sorry
-  have h_iv_2_eq : (eval env (U32.decomposeNatExpr iv[2])).value = iv[2] := by
-    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
-    sorry
-  have h_iv_3_eq : (eval env (U32.decomposeNatExpr iv[3])).value = iv[3] := by
-    simp only [U32.decomposeNatExpr, U32.decomposeNat, eval, toVars, fromElements, toElements]
-    simp only [Vector.map, Vector.getElem_mk, Expression.eval, U32.value, U32.vals]
-    sorry
+  -- Equations for IV constants (using the external lemmas)
+  have h_iv_0_eq := eval_decomposeNatExpr_iv_0 env
+  have h_iv_1_eq := eval_decomposeNatExpr_iv_1 env
+  have h_iv_2_eq := eval_decomposeNatExpr_iv_2 env
+  have h_iv_3_eq := eval_decomposeNatExpr_iv_3 env
 
   -- Equations for counter values
   have h_counter_low_eq : counter_low.value % 4294967296 = counter_low.value := by

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -529,7 +529,7 @@ def sevenRoundsApplyStyle : FormalCircuit (F p) Round.Inputs BLAKE3State :=
 The assumptions for roundWithPermute are exactly Round.Assumptions.
 -/
 lemma roundWithPermute_assumptions_eq (input : Round.Inputs (F p)) :
-  roundWithPermute.Assumptions input = Round.Assumptions input := by
+    roundWithPermute.Assumptions input = Round.Assumptions input := by
   simp only [roundWithPermute]
 
 /--

--- a/Clean/Gadgets/BLAKE3/Round.lean
+++ b/Clean/Gadgets/BLAKE3/Round.lean
@@ -21,14 +21,14 @@ instance : ProvableStruct Inputs where
 def main (input : Var Inputs (F p)) : Circuit (F p) (Var BLAKE3State (F p)) := do
   let { state, message } := input
   -- TODO: refactor using a for loop
-  let state ← subcircuit (G.circuit 0 4 8 12) ⟨state, message[0], message[1]⟩
-  let state ← subcircuit (G.circuit 1 5 9 13) ⟨state, message[2], message[3]⟩
-  let state ← subcircuit (G.circuit 2 6 10 14) ⟨state, message[4], message[5]⟩
-  let state ← subcircuit (G.circuit 3 7 11 15) ⟨state, message[6], message[7]⟩
-  let state ← subcircuit (G.circuit 0 5 10 15) ⟨state, message[8], message[9]⟩
-  let state ← subcircuit (G.circuit 1 6 11 12) ⟨state, message[10], message[11]⟩
-  let state ← subcircuit (G.circuit 2 7 8 13) ⟨state, message[12], message[13]⟩
-  let state ← subcircuit (G.circuit 3 4 9 14) ⟨state, message[14], message[15]⟩
+  let state ← G.circuit 0 4 8 12 ⟨state, message[0], message[1]⟩
+  let state ← G.circuit 1 5 9 13 ⟨state, message[2], message[3]⟩
+  let state ← G.circuit 2 6 10 14 ⟨state, message[4], message[5]⟩
+  let state ← G.circuit 3 7 11 15 ⟨state, message[6], message[7]⟩
+  let state ← G.circuit 0 5 10 15 ⟨state, message[8], message[9]⟩
+  let state ← G.circuit 1 6 11 12 ⟨state, message[10], message[11]⟩
+  let state ← G.circuit 2 7 8 13 ⟨state, message[12], message[13]⟩
+  let state ← G.circuit 3 4 9 14 ⟨state, message[14], message[15]⟩
   return state
 
 -- #eval! main (p:=pBabybear) default |>.localLength

--- a/Clean/Gadgets/BLAKE3/Round.lean
+++ b/Clean/Gadgets/BLAKE3/Round.lean
@@ -39,7 +39,6 @@ instance elaborated : ElaboratedCircuit (F p) Inputs BLAKE3State where
   localLength_eq input i0 := by
     simp only [main, circuit_norm, G.circuit, subcircuit_norm, G.elaborated]
 
-
 def Assumptions (input : Inputs (F p)) :=
   let { state, message } := input
   state.Normalized ∧ (∀ i : Fin 16, message[i].Normalized)
@@ -140,7 +139,6 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     Fin.val_eq_zero, IsEmpty.forall_iff, and_true] at h_normalized
 
   simp only [h_normalized, getElem_eval_vector, h_input.right, and_self]
-
 
 def circuit : FormalCircuit (F p) Inputs BLAKE3State := {
   elaborated with Assumptions, Spec, soundness, completeness

--- a/Clean/Specs/BLAKE3.lean
+++ b/Clean/Specs/BLAKE3.lean
@@ -46,7 +46,7 @@ def deriveKeyMaterial : Nat := 2^6
 The initialization constants for BLAKE3.
 (Same as in BLAKE2s. See Table 1 in the BLAKE3 paper.)
 -/
-def iv : Vector Nat 8 := #v[
+def iv : Vector UInt32 8 := #v[
   0x6a09e667,
   0xbb67ae85,
   0x3c6ef372,
@@ -145,7 +145,7 @@ def applyRounds (chaining_value: Vector Nat 8) (block_words: Vector Nat 16) (cou
   let state := #v[
     chaining_value[0], chaining_value[1], chaining_value[2], chaining_value[3],
     chaining_value[4], chaining_value[5], chaining_value[6], chaining_value[7],
-    iv[0], iv[1], iv[2], iv[3],
+    iv[0].toNat, iv[1].toNat, iv[2].toNat, iv[3].toNat,
     counter_low, counter_high, block_len, flags
   ]
 

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -165,23 +165,9 @@ lemma fromUInt32_normalized (x : UInt32) : (fromUInt32 (p:=p) x).Normalized := b
   simp [h]
 
 theorem value_fromUInt32 (x : UInt32) : value (fromUInt32 (p:=p) x) = x.toNat := by
-  simp only [valueU32, value_horner, fromUInt32, decomposeNat, UInt32.toFin_val]
-  set x := x.toNat
-  have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) = x % 256 := by
-    rw [ZMod.val_cast_of_lt]
-    have : x % 256 < 256 := Nat.mod_lt _ (by norm_num)
-    linarith [p_large_enough.elim]
-  simp only [h]
-  have : 2^8 = 256 := rfl
-  simp only [this]
-  have : x < 256^4 := by simp [x, UInt32.toNat_lt_size]
-  have : x / 256^3 % 256 = x / 256^3 := by rw [Nat.mod_eq_of_lt]; omega
-  rw [this]
-  have div_succ_pow (n : ℕ) : x / 256^(n + 1) = (x / 256^n) / 256 := by rw [Nat.div_div_eq_div_mul]; rfl
-  have mod_add_div (n : ℕ) : x / 256^n % 256 + 256 * (x / 256^(n + 1)) = x / 256^n := by
-    rw [div_succ_pow n, Nat.mod_add_div]
-  simp only [mod_add_div]
-  rw [div_succ_pow 1, Nat.pow_one, Nat.mod_add_div, Nat.mod_add_div]
+  simp only [fromUInt32, UInt32.toFin_val]
+  apply value_of_decomposedNat_of_small
+  simp [UInt32.toNat_lt_size]
 
 def fromByte (x: Fin 256) : U32 (F p) :=
   ⟨ x.val, 0, 0, 0 ⟩

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -133,6 +133,28 @@ def fromUInt32 (x : UInt32) : U32 (F p) :=
 def valueU32 (x : U32 (F p)) (h : x.Normalized) : UInt32 :=
   UInt32.ofNatLT x.value (value_lt_of_normalized h)
 
+lemma value_of_decomposedNat_of_small (x : ℕ) :
+    x < 256^4 ->
+    (decomposeNat (p := p) x).value = x := by
+  intro hx
+  simp only [value, decomposeNat]
+  -- Need to show that ZMod.val of each component equals the component itself
+  have h (y : ℕ) : y < 256 → ZMod.val (n:=p) (y : ℕ) = y := by
+    intro hy
+    rw [ZMod.val_cast_of_lt]
+    linarith [p_large_enough.elim]
+  -- Apply h to each component
+  rw [h (x % 256) (Nat.mod_lt _ (by norm_num : 256 > 0))]
+  rw [h (x / 256 % 256) (Nat.mod_lt _ (by norm_num : 256 > 0))]
+  rw [h (x / 256^2 % 256) (Nat.mod_lt _ (by norm_num : 256 > 0))]
+  rw [h (x / 256^3 % 256) (Nat.mod_lt _ (by norm_num : 256 > 0))]
+
+  have h1 := Nat.div_add_mod x 256
+  have h2 := Nat.div_add_mod (x / 256) 256
+  have h3 := Nat.div_add_mod (x / 256 ^ 2) 256
+  have h4 := Nat.div_add_mod (x / 256 ^ 3) 256
+  omega
+
 lemma fromUInt32_normalized (x : UInt32) : (fromUInt32 (p:=p) x).Normalized := by
   simp only [Normalized, fromUInt32, decomposeNat]
   have h (x : ℕ) : ZMod.val (n:=p) (x % 256 : ℕ) < 256 := by


### PR DESCRIPTION
## Summary

This PR implements a complete BLAKE3 ApplyRounds circuit using new FormalCircuit combinators, with full soundness and completeness proofs.

### Key Contributions

**FormalCircuit Combinators (`Clean/Circuit/StructuralLemmas.lean`)**:
- `FormalCircuit.concat`: Sequential composition combinator for chaining circuits
- `FormalCircuit.weakenSpec`: Specification adaptation combinator  
- Complete soundness and completeness proofs for both combinators

**BLAKE3 ApplyRounds Circuit (`Clean/Gadgets/BLAKE3/ApplyRounds.lean`)**:
- Modular circuit construction using combinators:
  - `roundWithPermute`: Single round + permutation
  - `twoRoundsWithPermute`, `fourRoundsWithPermute`, `sixRoundsWithPermute`: Multi-round compositions
  - `sevenRoundsApplyStyle`: Complete 7-round BLAKE3 compression
- Full soundness & complete proofs

## Test plan

- `lake build` succeeds
- All proofs complete without sorry

🤖 Generated with [Claude Code](https://claude.ai/code)