### PR TITLE
Fix issue #218: Add specialized eval_pair lemmas for Expression F

### DIFF
--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -202,7 +202,7 @@ def circuit : FormalCircuit (F p) Inputs field where
     rw [h_subcircuit_sound]
     -- Now we need to show the RHS equals our spec
     -- First, simplify the evaluation of the vector
-    simp only [eval_vector, Vector.getElem_map, id_eq, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero, eval_pair]
+    simp only [eval_vector, Vector.getElem_map, id_eq, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero, circuit_norm]
     rfl
 
   completeness := by

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -565,6 +565,25 @@ theorem eval_pair_both_expr (env : Environment F)
     eval (α:=ProvablePair field field) env (a, b) = (Expression.eval env a, Expression.eval env b) :=
   eval_pair (α := field) (β := field) env a b
 
+-- Specialized lemmas for Vector (Expression F) to handle type inference issues with vectors
+@[circuit_norm ↓ high]
+theorem eval_pair_left_vector_expr {n : ℕ} {β: TypeMap} [ProvableType β] (env : Environment F)
+  (a : Vector (Expression F) n) (b : Var β F) :
+    eval (α:=ProvablePair (fields n) β) env (a, b) = (eval env a, eval env b) :=
+  eval_pair (α := fields n) env a b
+
+@[circuit_norm ↓ high]
+theorem eval_pair_right_vector_expr {n : ℕ} {α: TypeMap} [ProvableType α] (env : Environment F)
+  (a : Var α F) (b : Vector (Expression F) n) :
+    eval (α:=ProvablePair α (fields n)) env (a, b) = (eval env a, eval env b) :=
+  eval_pair (β := fields n) env a b
+
+@[circuit_norm ↓ high]
+theorem eval_pair_both_vector_expr {n m : ℕ} (env : Environment F)
+  (a : Vector (Expression F) n) (b : Vector (Expression F) m) :
+    eval (α:=ProvablePair (fields n) (fields m)) env (a, b) = (eval env a, eval env b) :=
+  eval_pair (α := fields n) (β := fields m) env a b
+
 omit [Field F] in
 @[circuit_norm ↓ high]
 theorem varFromOffset_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (offset : ℕ) :

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -546,6 +546,25 @@ theorem eval_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (env : En
   simp only [eval, toVars, toElements, fromElements, Vector.map_append]
   rw [Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
 
+-- Specialized lemmas for Expression F to handle type inference issues
+@[circuit_norm ↓ high]
+theorem eval_pair_left_expr {β: TypeMap} [ProvableType β] (env : Environment F)
+  (a : Expression F) (b : Var β F) :
+    eval (α:=ProvablePair field β) env (a, b) = (Expression.eval env a, eval env b) :=
+  eval_pair (α := field) env a b
+
+@[circuit_norm ↓ high]
+theorem eval_pair_right_expr {α: TypeMap} [ProvableType α] (env : Environment F)
+  (a : Var α F) (b : Expression F) :
+    eval (α:=ProvablePair α field) env (a, b) = (eval env a, Expression.eval env b) :=
+  eval_pair (β := field) env a b
+
+@[circuit_norm ↓ high]
+theorem eval_pair_both_expr (env : Environment F)
+  (a b : Expression F) :
+    eval (α:=ProvablePair field field) env (a, b) = (Expression.eval env a, Expression.eval env b) :=
+  eval_pair (α := field) (β := field) env a b
+
 omit [Field F] in
 @[circuit_norm ↓ high]
 theorem varFromOffset_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (offset : ℕ) :


### PR DESCRIPTION
## Summary
- Adds specialized eval_pair lemmas to handle Expression F type inference issues
- Removes explicit eval_pair usage in favor of circuit_norm

## Context
Fixes #218 - `eval_pair` sometimes requires type annotations when used with `Expression F` values. This PR adds three specialized lemmas that handle the common cases where one or both components of a pair are `Expression F` values.

## Changes
1. Added three new lemmas in `Clean/Circuit/Provable.lean`:
   - `eval_pair_left_expr`: When the left component is `Expression F`
   - `eval_pair_right_expr`: When the right component is `Expression F`
   - `eval_pair_both_expr`: When both components are `Expression F`

2. Updated `Clean/Circomlib/Mux1.lean` to use `circuit_norm` instead of explicit `eval_pair`

## Test plan
✅ lake build succeeds
✅ Experimentally verified that the issue #218 scenario no longer requires type annotations

🤖 Generated with [Claude Code](https://claude.ai/code)