### PR TITLE
ProvablePair is nonempty when either element is nonempty

### DIFF
--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -525,11 +525,17 @@ instance ProvablePair.instance {α β: TypeMap} [ProvableType α] [ProvableType 
   toElements_fromElements v := by
     simp [ProvableType.toElements_fromElements, Vector.cast]
 
-instance {α β: TypeMap} [NonEmptyProvableType α] [NonEmptyProvableType β] :
+instance {α β: TypeMap} [NonEmptyProvableType α] [ProvableType β] :
   NonEmptyProvableType (ProvablePair α β) where
   nonempty := by
     simp only [ProvablePair.instance, size]
     have h1 := NonEmptyProvableType.nonempty (M := α)
+    omega
+
+instance {α β: TypeMap} [ProvableType α] [NonEmptyProvableType β] :
+  NonEmptyProvableType (ProvablePair α β) where
+  nonempty := by
+    simp only [ProvablePair.instance, size]
     have h2 := NonEmptyProvableType.nonempty (M := β)
     omega
 


### PR DESCRIPTION
Before this PR, `ProvablePair` was proven to be non-empty when both elements are non-empty.

This PR introduces more flexibility. If either element is non-empty, the pair is non-empty.