### PR TITLE
Standardize natural number notation from Nat to ℕ

### DIFF
--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -121,7 +121,7 @@ This follows the same pattern as applyRounds but for only 2 rounds:
 - Second round, permute message
 Returns the final state and permuted message.
 -/
-def applyTwoRounds (state : Vector Nat 16) (message : Vector Nat 16) : Vector Nat 16 × Vector Nat 16 :=
+def applyTwoRounds (state : Vector ℕ 16) (message : Vector ℕ 16) : Vector ℕ 16 × Vector ℕ 16 :=
   let state1 := round state message
   let msg1 := permute message
   let state2 := round state1 msg1
@@ -182,7 +182,7 @@ This follows the same pattern as applyRounds but for only 4 rounds:
 - Fourth round, permute message
 Returns the final state and permuted message.
 -/
-def applyFourRounds (state : Vector Nat 16) (message : Vector Nat 16) : Vector Nat 16 × Vector Nat 16 :=
+def applyFourRounds (state : Vector ℕ 16) (message : Vector ℕ 16) : Vector ℕ 16 × Vector ℕ 16 :=
   let state1 := round state message
   let msg1 := permute message
   let state2 := round state1 msg1
@@ -248,7 +248,7 @@ This follows the same pattern as applyRounds but for only 6 rounds:
 - First through sixth rounds, each followed by permute message
 Returns the final state and permuted message.
 -/
-def applySixRounds (state : Vector Nat 16) (message : Vector Nat 16) : Vector Nat 16 × Vector Nat 16 :=
+def applySixRounds (state : Vector ℕ 16) (message : Vector ℕ 16) : Vector ℕ 16 × Vector ℕ 16 :=
   let state1 := round state message
   let msg1 := permute message
   let state2 := round state1 msg1
@@ -313,7 +313,7 @@ This follows the same pattern as applyRounds but for 7 rounds:
 - Seventh round (final, no permutation)
 Returns the final BLAKE3State.
 -/
-def applySevenRounds (state : Vector Nat 16) (message : Vector Nat 16) : Vector Nat 16 :=
+def applySevenRounds (state : Vector ℕ 16) (message : Vector ℕ 16) : Vector ℕ 16 :=
   let state1 := round state message
   let msg1 := permute message
   let state2 := round state1 msg1
@@ -354,11 +354,11 @@ Lemma showing that applyRounds can be expressed using applySevenRounds.
 This connects the spec-level function with our circuit implementation.
 -/
 lemma applyRounds_eq_applySevenRounds
-    (chaining_value : Vector Nat 8)
-    (block_words : Vector Nat 16)
-    (counter : Nat)
-    (block_len : Nat)
-    (flags : Nat) :
+    (chaining_value : Vector ℕ 8)
+    (block_words : Vector ℕ 16)
+    (counter : ℕ)
+    (block_len : ℕ)
+    (flags : ℕ) :
     applyRounds chaining_value block_words counter block_len flags =
     applySevenRounds
       (#v[

--- a/Clean/Gadgets/Rotation32/Rotation32.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32.lean
@@ -32,7 +32,7 @@ def Spec (offset : Fin 32) (x : U32 (F p)) (y: U32 (F p)) :=
   y.value = rotRight32 x.value offset.val
   ∧ y.Normalized
 
-def output (offset : Fin 32) (i0 : Nat) : U32 (Expression (F p)) :=
+def output (offset : Fin 32) (i0 : ℕ) : U32 (Expression (F p)) :=
   Rotation32Bits.output (offset % 8).val i0
 
 -- #eval! (rot32 (p:=p_babybear) 0) default |>.localLength

--- a/Clean/Gadgets/Rotation32/Rotation32Bits.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32Bits.lean
@@ -36,7 +36,7 @@ def Spec (offset : Fin 8) (x : U32 (F p)) (y: U32 (F p)) :=
   y.value = rotRight32 x.value offset.val
   ∧ y.Normalized
 
-def output (offset : Fin 8) (i0 : Nat) : U32 (Expression (F p)) :=
+def output (offset : Fin 8) (i0 : ℕ) : U32 (Expression (F p)) :=
   U32.fromLimbs (.ofFn fun ⟨i,_⟩ =>
     (var ⟨i0 + i*2 + 1⟩) + var ⟨i0 + (i + 1) % 4 * 2⟩ * .const ((2^(8 - offset.val) : ℕ) : F p))
 

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -33,7 +33,7 @@ def Spec (offset : Fin 64) (x : U64 (F p)) (y: U64 (F p)) :=
   y.value = rotRight64 x.value offset.val
   ∧ y.Normalized
 
-def output (offset : Fin 64) (i0 : Nat) : U64 (Expression (F p)) :=
+def output (offset : Fin 64) (i0 : ℕ) : U64 (Expression (F p)) :=
   Rotation64Bits.output (offset % 8).val i0
 
 -- #eval! (main (p:=p_babybear) 0) default |>.localLength

--- a/Clean/Gadgets/Rotation64/Rotation64Bits.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bits.lean
@@ -34,7 +34,7 @@ def Spec (offset : Fin 8) (x : U64 (F p)) (y: U64 (F p)) :=
   y.value = rotRight64 x.value offset.val
   ∧ y.Normalized
 
-def output (offset : Fin 8) (i0 : Nat) : U64 (Expression (F p)) :=
+def output (offset : Fin 8) (i0 : ℕ) : U64 (Expression (F p)) :=
   U64.fromLimbs (.ofFn fun ⟨i,_⟩ =>
     (var ⟨i0 + i*2 + 1⟩) + var ⟨i0 + (i + 1) % 8 * 2⟩ * .const ((2^(8 - offset.val) : ℕ) : F p))
 

--- a/Clean/Specs/Keccak256.lean
+++ b/Clean/Specs/Keccak256.lean
@@ -16,7 +16,7 @@ def roundConstants : Vector UInt64 24 := #v[
   0x0000000080000001, 0x8000000080008008
 ]
 
-def bits2bytes (x : Nat) : Nat :=
+def bits2bytes (x : ℕ) : ℕ :=
   (x + 7) / 8
 
 def thetaC (state : Vector ℕ 25) : Vector ℕ 5 :=

--- a/Clean/Table/WitnessGeneration.lean
+++ b/Clean/Table/WitnessGeneration.lean
@@ -7,7 +7,7 @@ variable {F : Type} {S : Type → Type} {W: ℕ+} [ProvableType S] [Field F]
   The rule is that the auxiliary cells are appended to the end of the row in order.
   For example: [input<0>, aux<0>, input<1>, input<2>, aux<1>] => {1: 3, 4: 4}
 -/
-def buildAuxMap (as : CellAssignment W S) : Std.HashMap Nat Nat := Id.run do
+def buildAuxMap (as : CellAssignment W S) : Std.HashMap ℕ ℕ := Id.run do
   let (_, _, map) :=
     as.vars.foldl
       fun (idx, offset, m) cell =>

--- a/Clean/Utils/Bitwise.lean
+++ b/Clean/Utils/Bitwise.lean
@@ -52,11 +52,11 @@ theorem xor_eq_add {x : ℕ} (n : ℕ) (hx : x < 2^n) (y : ℕ) : x + 2^n * y = 
     rw [Nat.testBit_lt_two_pow hx]
     simp [this]
 
-theorem and_mul_two_pow {x y n : Nat} : 2 ^ n * (x &&& y) =  2 ^ n * x &&&  2 ^ n * y := by
+theorem and_mul_two_pow {x y n : ℕ} : 2 ^ n * (x &&& y) =  2 ^ n * x &&&  2 ^ n * y := by
   simp only [mul_comm]
   exact Nat.bitwise_mul_two_pow
 
-theorem xor_mul_two_pow {x y n : Nat} : 2 ^ n * (x ^^^ y) =  2 ^ n * x ^^^  2 ^ n * y := by
+theorem xor_mul_two_pow {x y n : ℕ} : 2 ^ n * (x ^^^ y) =  2 ^ n * x ^^^  2 ^ n * y := by
   simp only [mul_comm]
   exact Nat.bitwise_mul_two_pow
 

--- a/backends/plonky3/tests/TraceGen.lean
+++ b/backends/plonky3/tests/TraceGen.lean
@@ -8,7 +8,7 @@ import Clean.Table.Json
 open Tables.Fibonacci8Table
 
 -- Generate trace with specified steps and output path
-def generateTrace (steps : Nat) (output_path : String) : IO Unit := do
+def generateTrace (steps : ℕ) (output_path : String) : IO Unit := do
   let fib_relation_babybear := fib_relation (p := p_babybear)
   let init_row : RowType (F p_babybear) := { x := 0, y := 1 }
 


### PR DESCRIPTION
## Summary
- Standardize natural number type notation across the codebase
- Replace ASCII `Nat` with Unicode `ℕ` in type annotations
- Maintain consistency with recent development trends

## Changes
This PR updates 9 files with 18 type annotation changes, replacing `Nat` with `ℕ` in:
- Type annotations (e.g., `(x : Nat)` → `(x : ℕ)`)
- Generic type parameters (e.g., `{n : Nat}` → `{n : ℕ}`)
- Return types (e.g., `HashMap Nat Nat` → `HashMap ℕ ℕ`)

Note: Standard library API calls (e.g., `Nat.add`, `Nat.zero`) remain unchanged as they are part of Lean's core library.

## Test plan
- [x] `lake build` succeeds
- [x] All existing tests pass
- [x] No functional changes, only notation updates

🤖 Generated with [Claude Code](https://claude.ai/code)