### PR TITLE
Remove redundant empty brackets in simp only tactic

### DIFF
--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -102,7 +102,7 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
     -- IsBool means s = 0 ∨ s = 1
     simp only [eval_vector]
     simp only [Vector.getElem_map]
-    simp only [] at h_assumptions
+    simp only at h_assumptions
 
     cases h_assumptions with
       | inl h0 =>


### PR DESCRIPTION
## Summary
- Removed redundant `[]` from `simp only []` tactic as per review feedback

## Test plan
- [x] `lake build` succeeds
- [x] No diagnostic errors reported by Lean LSP

🤖 Generated with [Claude Code](https://claude.ai/code)