### PR TITLE
Fix double spaces in type annotations

### DIFF
--- a/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
@@ -23,7 +23,7 @@ instance : ProvableStruct Outputs where
   The low part is the least significant `offset` bits,
   and the high part is the most significant `8 - offset` bits.
 -/
-def main (offset : Fin 8) (x :  Expression (F p)) : Circuit (F p) (Var Outputs (F p)) := do
+def main (offset : Fin 8) (x : Expression (F p)) : Circuit (F p) (Var Outputs (F p)) := do
   let low ← witness fun env => mod (env x) (2^offset.val) (by simp [two_pow_lt])
   let high ← witness fun env => floorDiv (env x) (2^offset.val)
 

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -191,13 +191,13 @@ namespace CellOffset
   Current row offset
 -/
 @[table_assignment_norm]
-def curr {W : ℕ+} (j : Fin (size S)) :  CellOffset W S := ⟨0, j⟩
+def curr {W : ℕ+} (j : Fin (size S)) : CellOffset W S := ⟨0, j⟩
 
 /--
   Next row offset
 -/
 @[table_assignment_norm]
-def next {W : ℕ+} (j : Fin (size S)) :  CellOffset W S := ⟨1, j⟩
+def next {W : ℕ+} (j : Fin (size S)) : CellOffset W S := ⟨1, j⟩
 
 end CellOffset
 


### PR DESCRIPTION
## Summary
- Fixed double spaces after colons in type annotations for consistency
- Affected files:
  - `Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean`
  - `Clean/Table/Basic.lean`

## Test plan
- [x] `lake build` succeeds
- [x] No diagnostic errors reported by Lean LSP

🤖 Generated with [Claude Code](https://claude.ai/code)