### PR TITLE
Replace 'by rfl' with 'rfl' where possible

### DIFF
--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -364,11 +364,11 @@ variable {α: TypeMap} [ProvableType α]
 
 @[circuit_norm ↓ high]
 theorem eval_field {F : Type} [Field F] (env : Environment F) (x : Var field F) :
-  ProvableType.eval env x = Expression.eval env x := by rfl
+  ProvableType.eval env x = Expression.eval env x := rfl
 
 @[circuit_norm ↓]
 theorem varFromOffset_field {F} (offset : ℕ) :
-  varFromOffset (F:=F) field offset = var ⟨offset⟩ := by rfl
+  varFromOffset (F:=F) field offset = var ⟨offset⟩ := rfl
 
 @[circuit_norm ↓]
 theorem eval_fields {F : Type} [Field F] (env : Environment F) (x : Var (fields n) F) :
@@ -513,7 +513,7 @@ theorem varFromOffset_vector {F : Type} [Field F] {α: TypeMap} [NonEmptyProvabl
     congr
     conv => rhs; congr; rhs; congr; intro i; rw [mul_comm, add_assoc]
     let create (i : ℕ) : Expression F := var ⟨ offset + i ⟩
-    have h_create : (fun i => var ⟨ offset + (n * size α + i) ⟩) = (fun i ↦ create (n * size α + i)) := by rfl
+    have h_create : (fun i => var ⟨ offset + (n * size α + i) ⟩) = (fun i ↦ create (n * size α + i)) := rfl
     rw [h_create, ←Vector.mapRange_add_eq_append]
     have h_size_succ : (n + 1) * size α = n * size α + size α := by rw [add_mul]; ac_rfl
     rw [←Vector.cast_mapRange h_size_succ]

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -266,13 +266,13 @@ variable {α β: TypeMap} [ProvableType α] [ProvableType β]
 
 /-- The local length of a subcircuit is derived from the original formal circuit -/
 lemma subcircuit_localLength_eq (circuit: FormalCircuit F β α) (input: Var β F) (offset: ℕ) :
-  (circuit.toSubcircuit offset input).localLength = circuit.localLength input := by rfl
+  (circuit.toSubcircuit offset input).localLength = circuit.localLength input := rfl
 
 lemma assertion_localLength_eq (circuit: FormalAssertion F β) (input: Var β F) (offset: ℕ) :
-  (circuit.toSubcircuit offset input).localLength = circuit.localLength input := by rfl
+  (circuit.toSubcircuit offset input).localLength = circuit.localLength input := rfl
 
 lemma subcircuitWithAssertion_localLength_eq (circuit: GeneralFormalCircuit F β α) (input: Var β F) (offset: ℕ) :
-  (circuit.toSubcircuit offset input).localLength = circuit.localLength input := by rfl
+  (circuit.toSubcircuit offset input).localLength = circuit.localLength input := rfl
 end Circuit
 
 -- subcircuit composability for `ComputableWitnesses`

--- a/Clean/Table/Theorems.lean
+++ b/Clean/Table/Theorems.lean
@@ -130,7 +130,7 @@ def pushVarInput_offset (assignment: CellAssignment W S) (off: CellOffset W S) :
   simp [pushVarInput, Vector.push]
 
 lemma pushRow_offset (assignment: CellAssignment W S) (row: Fin W) :
-  (assignment.pushRow row).offset = assignment.offset + size S := by rfl
+  (assignment.pushRow row).offset = assignment.offset + size S := rfl
 
 theorem assignmentFromCircuit_offset (as: CellAssignment W S) (ops: Operations F) :
     (assignmentFromCircuit as ops).offset = as.offset + ops.localLength := by

--- a/Clean/Tables/Addition8.lean
+++ b/Clean/Tables/Addition8.lean
@@ -63,9 +63,9 @@ def formalAdd8Table : FormalTable (F p) RowType := {
         change _ ∧ _ ∧ (_ → _) at h_holds
 
         -- resolve assignment
-        have h_x_env : env.get 0 = row.x := by rfl
-        have h_y_env : env.get 1 = row.y := by rfl
-        have h_z_env : env.get 3 = row.z := by rfl
+        have h_x_env : env.get 0 = row.x := rfl
+        have h_y_env : env.get 1 = row.y := rfl
+        have h_z_env : env.get 3 = row.z := rfl
         simp only [h_x_env, h_y_env, h_z_env] at h_holds
 
         -- now we prove a local property about the current row, from the constraints

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -149,8 +149,8 @@ lemma boundary_constraints (first_row : Row (F p) RowType) (aux_env : Environmen
   set env := boundary.windowEnv ⟨<+> +> first_row, rfl⟩ aux_env
   simp only [table_norm, boundary, circuit_norm]
   simp only [and_imp]
-  have hx : eval env (varFromOffset U32 0) = first_row.x := by rfl
-  have hy : eval env (varFromOffset U32 4) = first_row.y := by rfl
+  have hx : eval env (varFromOffset U32 0) = first_row.x := rfl
+  have hy : eval env (varFromOffset U32 4) = first_row.y := rfl
   rw [hx, hy]
   clear hx hy
   intro x_zero y_one


### PR DESCRIPTION
## Summary
- Replaced `by rfl` with `rfl` in simple equality proofs (12 instances)
- This follows Mathlib's preference

## Rationale

`:= rfl` is more common.

```
clean (simplify-by-rfl-to-rfl) $ grep ":= by rfl" -r . --include="*.lean" | wc -l
129
clean (simplify-by-rfl-to-rfl) $ grep ":= rfl" -r . --include="*.lean" | wc -l
7901
```

This ~56:1 ratio indicates a strong preference for the direct `rfl` syntax. Note that these counts include all dependencies (mathlib, std, etc.), which reflects both the community standard and this project's inherited style.

## Changes
Modified 5 files:
- `Clean/Circuit/Provable.lean` (3 replacements)
- `Clean/Circuit/Subcircuit.lean` (3 replacements)  
- `Clean/Table/Theorems.lean` (1 replacement)
- `Clean/Tables/Addition8.lean` (3 replacements)
- `Clean/Tables/Fibonacci32.lean` (2 replacements)

## Exclusions
- **Fibonacci8.lean**: Excluded due to timeout issues when changed
- **2 instances kept as `by rfl`**: In class definitions where additional context is needed

## Test plan
- [x] `lake build` succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)