### PR TITLE
IsZero gadget for ProvableType in general

### DIFF
--- a/Clean.lean
+++ b/Clean.lean
@@ -18,6 +18,8 @@ import Clean.Tables.Fibonacci32Inductive
 import Clean.Tables.KeccakInductive
 import Clean.Gadgets.Bits
 import Clean.Gadgets.Conditional
+import Clean.Gadgets.IsZeroField
+import Clean.Gadgets.IsZero
 import Clean.Gadgets.BLAKE3.ApplyRounds
 import Clean.Gadgets.BLAKE3.BLAKE3G
 import Clean.Gadgets.BLAKE3.Compress

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -407,6 +407,17 @@ lemma fromElements_comp_toElements {F} :
   funext x
   simp [fromElements_toElements]
 
+lemma fromElements_eq_iff {M : TypeMap} [ProvableType M] {F : Type} {A : Vector F (size M)} {B : M F} :
+    fromElements A = B ↔ A = toElements B := by
+  constructor
+  · intro h
+    rw [← h, toElements_fromElements]
+  · intro h
+    rw [h, fromElements_toElements]
+
+-- basic simp lemmas
+
+
 @[circuit_norm]
 theorem eval_const {F : Type} [Field F] {α : TypeMap} [ProvableType α] {env : Environment F} {x : α F} :
     eval env (const x) = x := by

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -5,8 +5,28 @@ For more complicated interconnected theorems, we have separate files,
 such as `Circuit.Subcircuit` which focuses on establishing the foundation for subcircuit composition.
 -/
 import Clean.Circuit.Basic
+import Clean.Circuit.Provable
 
 variable {F : Type} [Field F] {α β : Type}
+
+-- ProvableType lemmas
+
+namespace ProvableType
+
+/--
+A useful lemma for proving equality via `fromElements`.
+States that `fromElements A = B` is equivalent to `A = toElements B`.
+This forms one direction of the Galois connection between `Vector F (size M)` and `M F`.
+-/
+theorem fromElements_eq_iff {M : TypeMap} [ProvableType M] {F : Type} {A : Vector F (size M)} {B : M F} :
+    fromElements A = B ↔ A = toElements B := by
+  constructor
+  · intro h
+    rw [← h, toElements_fromElements]
+  · intro h
+    rw [h, fromElements_toElements]
+
+end ProvableType
 
 -- basic simp lemmas
 

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -9,27 +9,6 @@ import Clean.Circuit.Provable
 
 variable {F : Type} [Field F] {α β : Type}
 
--- ProvableType lemmas
-
-namespace ProvableType
-
-/--
-A useful lemma for proving equality via `fromElements`.
-States that `fromElements A = B` is equivalent to `A = toElements B`.
-This forms one direction of the Galois connection between `Vector F (size M)` and `M F`.
--/
-theorem fromElements_eq_iff {M : TypeMap} [ProvableType M] {F : Type} {A : Vector F (size M)} {B : M F} :
-    fromElements A = B ↔ A = toElements B := by
-  constructor
-  · intro h
-    rw [← h, toElements_fromElements]
-  · intro h
-    rw [h, fromElements_toElements]
-
-end ProvableType
-
--- basic simp lemmas
-
 namespace Operations
 @[circuit_norm]
 theorem append_localLength {a b: Operations F} :

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -62,13 +62,24 @@ lemma foldl_isZero_eq_one_iff {n : ℕ} {vars : Vector (Expression (F p)) n} {va
     simp only [Expression.eval]
     let vars_pre := vars.take pre |>.cast (by simp : min pre (pre + 1) = pre)
     let vals_pre := vals.take pre |>.cast (by simp : min pre (pre + 1) = pre)
-    have h_eval_pre : Vector.map (Expression.eval env) vars_pre = vals_pre := by sorry
+    have h_eval_pre : Vector.map (Expression.eval env) vars_pre = vals_pre := by
+      simp only [vars_pre, vals_pre]
+      simp only [Vector.take_eq_extract, add_tsub_cancel_right, Vector.extract_eq_pop,
+        Nat.add_one_sub_one, Nat.sub_zero, Vector.cast_cast, Vector.cast_rfl, Vector.map_pop,
+        vals_pre, vars_pre]
+      simp only [h_eval]
     specialize h_ih h_eval_pre (i₀:=i₀)
     simp only [vars_pre, vals_pre] at h_ih
     simp only [Nat.add_one_sub_one, Vector.drop_eq_cast_extract, Vector.cast_rfl, Fin.getElem_fin,
       Vector.getElem_cast, Vector.getElem_extract, forall_const, id_eq, vals_pre, vars_pre] at h_ih
     simp only [id_eq, Fin.getElem_fin, Fin.coe_castSucc, Fin.val_last, vals_pre, vars_pre]
-    specialize h_ih (by sorry)
+    specialize h_ih (by
+      intro i
+      specialize h_isZero i
+      norm_num at h_isZero ⊢
+      simp only [Nat.add_one_sub_one, Nat.sub_zero, Vector.getElem_cast, Vector.getElem_pop',
+        vals_pre, vars_pre]
+      simp only [h_isZero])
     simp only [Vector.getElem_take] at h_ih
     rw [h_ih]
     specialize h_isZero pre trivial

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -1,0 +1,53 @@
+import Clean.Circuit.Basic
+import Clean.Circuit.Provable
+import Clean.Circuit.Loops
+import Clean.Gadgets.IsZeroField
+import Clean.Utils.Field
+import Clean.Utils.Tactics
+
+namespace Gadgets.IsZero
+
+variable {p : ℕ} [Fact p.Prime]
+variable {M : TypeMap} [ProvableType M]
+
+/--
+Main circuit that checks if all components of a ProvableType are zero.
+Returns 1 if all components are 0, otherwise returns 0.
+-/
+def main (input : Var M (F p)) : Circuit (F p) (Var field (F p)) := do
+  let elemVars := toVars input
+  -- Use foldl to multiply all IsZero results together
+  -- Start with 1, and for each element, multiply by its IsZero result
+  let result ← Circuit.foldl (_const_out := by sorry) elemVars (1 : Expression (F p)) fun acc elem => do
+    let isZeroElem ← IsZeroField.circuit elem
+    return acc * isZeroElem
+  return result
+
+instance elaborated : ElaboratedCircuit (F p) M field where
+  main := main
+  localLength _ := 2 * size M  -- Each IsZeroField uses 2 witnesses
+  localLength_eq := by
+    simp only [main, circuit_norm]
+    sorry
+  subcircuitsConsistent := by
+    simp only [main, circuit_norm]
+    sorry
+
+def Assumptions (_ : M (F p)) : Prop := True
+
+def Spec (input : M (F p)) (output : F p) : Prop :=
+  output = if (∀ i : Fin (size M), (toElements input)[i] = 0) then 1 else 0
+
+theorem soundness : Soundness (F p) (elaborated (M := M)) Assumptions Spec := by
+  circuit_proof_start
+  sorry
+
+theorem completeness : Completeness (F p) (elaborated (M := M)) Assumptions := by
+  circuit_proof_start
+  sorry
+
+def circuit : FormalCircuit (F p) M field := {
+  elaborated with Assumptions, Spec, soundness, completeness
+}
+
+end Gadgets.IsZero

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -25,12 +25,11 @@ def main (input : Var M (F p)) : Circuit (F p) (Var field (F p)) := do
 
 instance elaborated : ElaboratedCircuit (F p) M field where
   main := main
-  localLength _ := 2 * size M  -- Each IsZeroField uses 2 witnesses
+  localLength _ := 2 * size M
   localLength_eq := by
     simp +arith [circuit_norm, main, IsZeroField.circuit.localLength_eq, IsZeroField.circuit]
   subcircuitsConsistent := by
-    intros
-    sorry
+    simp +arith [circuit_norm, main, IsZeroField.circuit.localLength_eq, IsZeroField.circuit]
 
 def Assumptions (_ : M (F p)) : Prop := True
 

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -38,6 +38,20 @@ def Spec (input : M (F p)) (output : F p) : Prop :=
 
 theorem soundness : Soundness (F p) (elaborated (M := M)) Assumptions Spec := by
   circuit_proof_start
+  let s := size M
+  let vars : Vector (Expression (F p)) s := toElements (M:=M) input_var
+  let vals : Vector (F p) s := toElements (M:=M) input
+  -- need to change h_ionput into an element-wise condition
+  suffices (
+    Expression.eval env
+    (Fin.foldl s
+      (fun acc i ↦
+        acc *
+          (IsZeroField.circuit.output (vars[↑i] : Expression (F p))
+            (i₀ + ↑i * IsZeroField.circuit.localLength (vars[↑i] : Expression (F p))) : Var field (F p)))
+      1) =
+  if ∀ (i : Fin (size M)), vals[↑i] = 0 then 1 else 0
+  ) by apply this
   sorry
 
 theorem completeness : Completeness (F p) (elaborated (M := M)) Assumptions := by

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -92,7 +92,7 @@ lemma foldl_isZero_eq_one_iff {n : ℕ} {vars : Vector (Expression F) n} {vals :
 
 theorem soundness : Soundness F (elaborated (M := M)) Assumptions Spec := by
   circuit_proof_start
-  simp only [Parser.Attr.explicit_provable_type, ProvableType.eval, ProvableType.fromElements_eq_iff] at h_input
+  simp only [explicit_provable_type, ProvableType.fromElements_eq_iff] at h_input
   apply foldl_isZero_eq_one_iff <;> assumption
 
 theorem completeness : Completeness F (elaborated (M := M)) Assumptions := by

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -16,10 +16,10 @@ Returns 1 if all components are 0, otherwise returns 0.
 -/
 def main (input : Var M (F p)) : Circuit (F p) (Var field (F p)) := do
   let elemVars := toVars input
-  -- Use foldl to multiply all IsZero results together
+  -- Use foldlRange to multiply all IsZero results together
   -- Start with 1, and for each element, multiply by its IsZero result
-  let result ← Circuit.foldl (_const_out := by sorry) elemVars (1 : Expression (F p)) fun acc elem => do
-    let isZeroElem ← IsZeroField.circuit elem
+  let result ← Circuit.foldlRange (size M) (1 : Expression (F p)) fun acc i => do
+    let isZeroElem ← IsZeroField.circuit elemVars[i]
     return acc * isZeroElem
   return result
 
@@ -30,7 +30,7 @@ instance elaborated : ElaboratedCircuit (F p) M field where
     simp only [main, circuit_norm]
     sorry
   subcircuitsConsistent := by
-    simp only [main, circuit_norm]
+    intros
     sorry
 
 def Assumptions (_ : M (F p)) : Prop := True

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -41,8 +41,7 @@ theorem soundness : Soundness (F p) (elaborated (M := M)) Assumptions Spec := by
   sorry
 
 theorem completeness : Completeness (F p) (elaborated (M := M)) Assumptions := by
-  circuit_proof_start
-  sorry
+  circuit_proof_start [IsZeroField.circuit, IsZeroField.Assumptions]
 
 def circuit : FormalCircuit (F p) M field := {
   elaborated with Assumptions, Spec, soundness, completeness

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -42,6 +42,7 @@ theorem soundness : Soundness (F p) (elaborated (M := M)) Assumptions Spec := by
   let vars : Vector (Expression (F p)) s := toElements (M:=M) input_var
   let vals : Vector (F p) s := toElements (M:=M) input
   -- need to change h_ionput into an element-wise condition
+  simp only [Parser.Attr.explicit_provable_type, ProvableType.eval] at h_input
   suffices (
     Expression.eval env
     (Fin.foldl s

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -92,9 +92,6 @@ lemma foldl_isZero_eq_one_iff {n : ℕ} {vars : Vector (Expression F) n} {vals :
 
 theorem soundness : Soundness F (elaborated (M := M)) Assumptions Spec := by
   circuit_proof_start
-  let s := size M
-  let vars : Vector (Expression F) s := toElements (M:=M) input_var
-  let vals : Vector F s := toElements (M:=M) input
   simp only [Parser.Attr.explicit_provable_type, ProvableType.eval, ProvableType.fromElements_eq_iff] at h_input
   apply foldl_isZero_eq_one_iff <;> assumption
 

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -24,7 +24,7 @@ def main (input : Var M (F p)) : Circuit (F p) (Var field (F p)) := do
   return result
 
 instance elaborated : ElaboratedCircuit (F p) M field where
-  main := main
+  main
   localLength _ := 2 * size M
   localLength_eq := by
     simp +arith [circuit_norm, main, IsZeroField.circuit.localLength_eq, IsZeroField.circuit]

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -12,8 +12,8 @@ variable {F : Type} [Field F] [DecidableEq F]
 variable {M : TypeMap} [ProvableType M]
 
 /--
-Main circuit that checks if all components of a ProvableType are zero.
-Returns 1 if all components are 0, otherwise returns 0.
+Main circuit that checks if all elements of a ProvableType are zero.
+Returns 1 if all elementts are 0, otherwise returns 0.
 -/
 def main (input : Var M F) : Circuit F (Var field F) := do
   let elemVars := toVars input
@@ -95,12 +95,8 @@ theorem soundness : Soundness F (elaborated (M := M)) Assumptions Spec := by
   let s := size M
   let vars : Vector (Expression F) s := toElements (M:=M) input_var
   let vals : Vector F s := toElements (M:=M) input
-  -- need to change h_ionput into an element-wise condition
-  simp only [Parser.Attr.explicit_provable_type, ProvableType.eval] at h_input
-  simp only [ProvableType.fromElements_eq_iff] at h_input
-  apply foldl_isZero_eq_one_iff
-  · assumption
-  · assumption
+  simp only [Parser.Attr.explicit_provable_type, ProvableType.eval, ProvableType.fromElements_eq_iff] at h_input
+  apply foldl_isZero_eq_one_iff <;> assumption
 
 theorem completeness : Completeness F (elaborated (M := M)) Assumptions := by
   circuit_proof_start [IsZeroField.circuit, IsZeroField.Assumptions]

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -27,8 +27,7 @@ instance elaborated : ElaboratedCircuit (F p) M field where
   main := main
   localLength _ := 2 * size M  -- Each IsZeroField uses 2 witnesses
   localLength_eq := by
-    simp only [main, circuit_norm]
-    sorry
+    simp +arith [circuit_norm, main, IsZeroField.circuit.localLength_eq, IsZeroField.circuit]
   subcircuitsConsistent := by
     intros
     sorry

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -38,7 +38,7 @@ def Spec (input : M (F p)) (output : F p) : Prop :=
   output = if (∀ i : Fin (size M), (toElements input)[i] = 0) then 1 else 0
 
 /--
-Lemma for the soundness proof: folding multiplication of IsZero results gives 1 iff all elements are 0.
+lemma for soundness. Separate because the statement is optimized for induction.
 -/
 lemma foldl_isZero_eq_one_iff {n : ℕ} {vars : Vector (Expression (F p)) n} {vals : Vector (F p) n}
     {env : Environment (F p)} {i₀ : ℕ}
@@ -58,44 +58,37 @@ lemma foldl_isZero_eq_one_iff {n : ℕ} {vars : Vector (Expression (F p)) n} {va
   induction n generalizing i₀
   · simp only [id_eq, Fin.getElem_fin, Fin.foldl_zero, IsEmpty.forall_iff, ↓reduceIte, Expression.eval]
   · rename_i pre h_ih
-    simp only [Fin.foldl_succ_last]
-    simp only [Expression.eval]
+    simp only [Fin.foldl_succ_last, Expression.eval]
     let vars_pre := vars.take pre |>.cast (by simp : min pre (pre + 1) = pre)
     let vals_pre := vals.take pre |>.cast (by simp : min pre (pre + 1) = pre)
     have h_eval_pre : Vector.map (Expression.eval env) vars_pre = vals_pre := by
-      simp only [vars_pre, vals_pre]
       simp only [Vector.take_eq_extract, add_tsub_cancel_right, Vector.extract_eq_pop,
         Nat.add_one_sub_one, Nat.sub_zero, Vector.cast_cast, Vector.cast_rfl, Vector.map_pop,
-        vals_pre, vars_pre]
-      simp only [h_eval]
+        vals_pre, vars_pre, h_eval]
     specialize h_ih h_eval_pre (i₀:=i₀)
-    simp only [vars_pre, vals_pre] at h_ih
+    simp only [vars_pre, vals_pre] at *
     simp only [Nat.add_one_sub_one, Vector.drop_eq_cast_extract, Vector.cast_rfl, Fin.getElem_fin,
-      Vector.getElem_cast, Vector.getElem_extract, forall_const, id_eq, vals_pre, vars_pre] at h_ih
-    simp only [id_eq, Fin.getElem_fin, Fin.coe_castSucc, Fin.val_last, vals_pre, vars_pre]
+      Vector.getElem_cast, Vector.getElem_extract, forall_const, id_eq] at h_ih
+    simp only [id_eq, Fin.getElem_fin, Fin.coe_castSucc, Fin.val_last]
     specialize h_ih (by
       intro i
       specialize h_isZero i
       norm_num at h_isZero ⊢
       simp only [Nat.add_one_sub_one, Nat.sub_zero, Vector.getElem_cast, Vector.getElem_pop',
-        vals_pre, vars_pre]
-      simp only [h_isZero])
+        h_isZero])
     simp only [Vector.getElem_take] at h_ih
     rw [h_ih]
     specialize h_isZero pre trivial
     norm_num at h_isZero ⊢
-    simp only [h_isZero]
-    simp only [Fin.forall_fin_succ']
+    simp only [h_isZero, Fin.forall_fin_succ']
     norm_num
     split
     · rename_i h
       simp only [h]
-      simp only [implies_true, true_and, vals_pre, vars_pre]
-      simp only [← h_eval]
-      simp only [Vector.getElem_map]
+      simp only [implies_true, true_and, ← h_eval, Vector.getElem_map]
     · rename_i h
       simp only [h]
-      simp only [false_and, ↓reduceIte, vals_pre, vars_pre]
+      simp only [false_and, ↓reduceIte]
 
 theorem soundness : Soundness (F p) (elaborated (M := M)) Assumptions Spec := by
   circuit_proof_start

--- a/Clean/Gadgets/IsZeroField.lean
+++ b/Clean/Gadgets/IsZeroField.lean
@@ -29,7 +29,7 @@ def main (x : Var field (F p)) : Circuit (F p) (Var field (F p)) := do
   return isZero
 
 instance elaborated : ElaboratedCircuit (F p) field field where
-  main := main
+  main
   localLength _ := 2  -- 2 witnesses: isZero and x_inv
 
 def Assumptions (_ : F p) : Prop := True
@@ -45,9 +45,9 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     norm_num at *
     rcases h_holds with ⟨ _, h_one ⟩
     symm
+    ring_nf at h_one
     apply sub_eq_zero.mp
     simp only [h_one]
-    ring_nf
   · aesop
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by

--- a/Clean/Gadgets/IsZeroField.lean
+++ b/Clean/Gadgets/IsZeroField.lean
@@ -1,0 +1,61 @@
+import Clean.Circuit.Basic
+import Clean.Circuit.Provable
+import Clean.Gadgets.Equality
+import Clean.Utils.Field
+import Clean.Utils.Tactics
+
+namespace Gadgets.IsZeroField
+
+variable {p : ℕ} [Fact p.Prime]
+
+/--
+Main circuit that checks if a field element is zero.
+Returns 1 if the input is 0, otherwise returns 0.
+-/
+def main (x : Var field (F p)) : Circuit (F p) (Var field (F p)) := do
+  let isZero ← witness fun env => if x.eval env = 0 then (1 : F p) else 0
+
+  -- When x ≠ 0, we need x_inv such that x * x_inv = 1
+  -- When x = 0, x_inv can be anything (we use 0)
+  let x_inv ← witness fun env =>
+    if x.eval env = 0 then 0 else (x.eval env : F p)⁻¹
+
+  isZero * x === 0  -- If isZero = 1, then x must be 0
+  isZero * (isZero - 1) === 0  -- isZero must be boolean (0 or 1)
+
+  -- If isZero = 0 (i.e., x ≠ 0), then x * x_inv = 1, so x is non-zero
+  (1 - isZero) * x * x_inv === (1 - isZero)
+
+  return isZero
+
+instance elaborated : ElaboratedCircuit (F p) field field where
+  main := main
+  localLength _ := 2  -- 2 witnesses: isZero and x_inv
+
+def Assumptions (_ : F p) : Prop := True
+
+def Spec (x : F p) (output : F p) : Prop :=
+  output = if x = 0 then 1 else 0
+
+theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
+  circuit_proof_start
+  split
+  · rename_i h_input
+    simp only [h_input] at *
+    norm_num at *
+    rcases h_holds with ⟨ _, h_one ⟩
+    symm
+    apply sub_eq_zero.mp
+    simp only [h_one]
+    ring_nf
+  · aesop
+
+theorem completeness : Completeness (F p) elaborated Assumptions := by
+  circuit_proof_start
+  aesop
+
+def circuit : FormalCircuit (F p) field field := {
+  elaborated with Assumptions, Spec, soundness, completeness
+}
+
+end Gadgets.IsZeroField

--- a/Clean/Gadgets/IsZeroField.lean
+++ b/Clean/Gadgets/IsZeroField.lean
@@ -13,18 +13,13 @@ Main circuit that checks if a field element is zero.
 Returns 1 if the input is 0, otherwise returns 0.
 -/
 def main (x : Var field F) : Circuit F (Var field F) := do
-  let isZero ← witness fun env => if x.eval env = 0 then (1 : F) else 0
-
   -- When x ≠ 0, we need x_inv such that x * x_inv = 1
   -- When x = 0, x_inv can be anything (we use 0)
-  let x_inv ← witness fun env =>
+  let xInv ← witness fun env =>
     if x.eval env = 0 then 0 else (x.eval env : F)⁻¹
 
-  isZero * x === 0  -- If isZero = 1, then x must be 0
-  isZero * (isZero - 1) === 0  -- isZero must be boolean (0 or 1)
-
-  -- If isZero = 0 (i.e., x ≠ 0), then x * x_inv = 1, so x is non-zero
-  (1 - isZero) * x * x_inv === (1 - isZero)
+  let isZero <== 1 - x*xInv -- If x is zero, isZero is one
+  isZero * x === 0  -- If x is not zero, isZero is zero
 
   return isZero
 
@@ -43,11 +38,7 @@ theorem soundness : Soundness F elaborated Assumptions (Spec (F:=F)) := by
   · rename_i h_input
     simp only [h_input] at *
     norm_num at *
-    rcases h_holds with ⟨ _, h_one ⟩
-    symm
-    ring_nf at h_one
-    apply sub_eq_zero.mp
-    simp only [h_one]
+    assumption
   · aesop
 
 theorem completeness : Completeness F elaborated Assumptions := by


### PR DESCRIPTION
This will be useful in #229 because `IsZeroU32` can be replaced with the general version in this PR.