### PR TITLE
Use circuit_proof_start optional arguments where applicable

### DIFF
--- a/Clean/Gadgets/BLAKE3/BLAKE3G.lean
+++ b/Clean/Gadgets/BLAKE3/BLAKE3G.lean
@@ -77,7 +77,7 @@ def Spec (a b c d : Fin 16) (input : Inputs (F p)) (out : BLAKE3State (F p)) :=
   out.value = g state.value a b c d x.value y.value ∧ out.Normalized
 
 theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) Assumptions (Spec a b c d) := by
-  circuit_proof_start [Assumptions, BLAKE3State.Normalized, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated, and_imp,
+  circuit_proof_start [BLAKE3State.Normalized, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated, and_imp,
     Addition32.Assumptions, Addition32.Spec, Rotation32.Assumptions, Rotation32.Spec,
     Xor32.Assumptions, Xor32.Spec, getElem_eval_vector]
 
@@ -115,7 +115,7 @@ theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) Assu
     · simp only [Vector.getElem_map, getElem_eval_vector, h_input, h_assumptions]
 
 theorem completeness (a b c d : Fin 16) : Completeness (F p) (elaborated a b c d) Assumptions := by
-  circuit_proof_start [Assumptions, BLAKE3State.Normalized]
+  circuit_proof_start [BLAKE3State.Normalized]
 
   dsimp only [main, circuit_norm, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated] at h_env ⊢
   simp only [circuit_norm, and_imp,

--- a/Clean/Gadgets/BLAKE3/BLAKE3G.lean
+++ b/Clean/Gadgets/BLAKE3/BLAKE3G.lean
@@ -115,9 +115,7 @@ theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) Assu
     · simp only [Vector.getElem_map, getElem_eval_vector, h_input, h_assumptions]
 
 theorem completeness (a b c d : Fin 16) : Completeness (F p) (elaborated a b c d) Assumptions := by
-  circuit_proof_start
-
-  dsimp only [Assumptions, BLAKE3State.Normalized] at h_assumptions
+  circuit_proof_start [Assumptions, BLAKE3State.Normalized]
 
   dsimp only [main, circuit_norm, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated] at h_env ⊢
   simp only [circuit_norm, and_imp,

--- a/Clean/Gadgets/BLAKE3/BLAKE3G.lean
+++ b/Clean/Gadgets/BLAKE3/BLAKE3G.lean
@@ -77,7 +77,7 @@ def Spec (a b c d : Fin 16) (input : Inputs (F p)) (out : BLAKE3State (F p)) :=
   out.value = g state.value a b c d x.value y.value ∧ out.Normalized
 
 theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) Assumptions (Spec a b c d) := by
-  circuit_proof_start [BLAKE3State.Normalized, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated, and_imp,
+  circuit_proof_start [Assumptions, BLAKE3State.Normalized, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated, and_imp,
     Addition32.Assumptions, Addition32.Spec, Rotation32.Assumptions, Rotation32.Spec,
     Xor32.Assumptions, Xor32.Spec, getElem_eval_vector]
 

--- a/Clean/Gadgets/BLAKE3/Round.lean
+++ b/Clean/Gadgets/BLAKE3/Round.lean
@@ -101,11 +101,8 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   · exact c8.right
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start
-
-  simp only [circuit_norm, G.circuit, G.Assumptions, G.Spec] at ⊢ h_env h_input
-  simp only [circuit_norm, Environment.UsesLocalWitnessesCompleteness,
-    getElem_eval_vector, Fin.isValue, and_imp, and_true] at h_input h_env ⊢
+  circuit_proof_start [G.circuit, G.Assumptions, G.Spec, Environment.UsesLocalWitnessesCompleteness,
+    getElem_eval_vector, Fin.isValue, and_imp, and_true]
 
   simp only [h_input] at *
   obtain ⟨c1, c2, c3, c4, c5, c6, c7, c8⟩ := h_env


### PR DESCRIPTION
## Summary
Applied the new `circuit_proof_start [lemma1, lemma2, ...]` syntax introduced in PR #246 to simplify proof initialization in multiple files.

🤖 Generated with [Claude Code](https://claude.ai/code)