### PR TITLE
Fix #230: Make circuit_proof_start work with FormalAssertion and GeneralFormalCircuit

### DIFF
--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -1,6 +1,7 @@
 import Clean.Gadgets.Equality
 import Clean.Gadgets.Boolean
 import Clean.Utils.Bits
+import Clean.Utils.Tactics.CircuitProofStart
 
 namespace Gadgets.ToBits
 open Utils.Bits
@@ -34,27 +35,25 @@ def toBits (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields n
     x.val < 2^n ∧ bits = fieldToBits n x
 
   soundness := by
-    intro k eval x_var x h_input h_holds
+    circuit_proof_start [main]
     simp only [main, circuit_norm] at *
     simp only [h_input, circuit_norm] at h_holds
-    clear h_input
 
     obtain ⟨ h_bits, h_eq ⟩ := h_holds
 
-    let bit_vars : Vector (Expression (F p)) n := .mapRange n (var ⟨k + ·⟩)
-    let bits : Vector (F p) n := bit_vars.map eval
+    let bit_vars : Vector (Expression (F p)) n := .mapRange n (var ⟨i₀ + ·⟩)
+    let bits : Vector (F p) n := bit_vars.map env
 
     replace h_bits (i : ℕ) (hi : i < n) : IsBool bits[i] := by
       simp only [circuit_norm, bits, bit_vars]
       exact h_bits ⟨ i, hi ⟩
 
-    change x = eval (fieldFromBitsExpr bit_vars) at h_eq
+    change input = env (fieldFromBitsExpr bit_vars) at h_eq
     rw [h_eq, fieldFromBits_eval bit_vars, fieldToBits_fieldFromBits hn bits h_bits]
     use fieldFromBits_lt _ h_bits
 
   completeness := by
-    intro k eval x_var h_env x h_input h_assumptions
-    simp only [main, circuit_norm] at *
+    circuit_proof_start [main]
     simp only [h_input, circuit_norm] at h_env ⊢
 
     constructor
@@ -62,15 +61,15 @@ def toBits (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields n
       rw [h_env i]
       simp [fieldToBits, Utils.Bits.toBits, Vector.getElem_mapRange, IsBool]
 
-    let bit_vars : Vector (Expression (F p)) n := .mapRange n (var ⟨k + ·⟩)
+    let bit_vars : Vector (Expression (F p)) n := .mapRange n (var ⟨i₀ + ·⟩)
 
-    have h_bits_eq : bit_vars.map eval = fieldToBits n x := by
+    have h_bits_eq : bit_vars.map env = fieldToBits n input := by
       rw [Vector.ext_iff]
       intro i hi
       simp only [circuit_norm, bit_vars]
       exact h_env ⟨ i, hi ⟩
 
-    show x = eval (fieldFromBitsExpr bit_vars)
+    show input = env (fieldFromBitsExpr bit_vars)
     rw [fieldFromBits_eval bit_vars, h_bits_eq, fieldFromBits_fieldToBits h_assumptions]
 
 -- formal assertion that uses the same circuit to implement a range check. without input assumption

--- a/Clean/Gadgets/Boolean.lean
+++ b/Clean/Gadgets/Boolean.lean
@@ -1,5 +1,6 @@
 import Clean.Circuit.Basic
 import Clean.Utils.Field
+import Clean.Utils.Tactics.CircuitProofStart
 import Mathlib.Data.Nat.Bitwise
 
 /-- A predicate stating that an element is boolean (0 or 1) for any type with 0 and 1 -/
@@ -203,8 +204,13 @@ def assertBool : FormalAssertion (F p) field where
   Assumptions _ := True
   Spec (x : F p) := IsBool x
 
-  soundness := by simp_all only [circuit_norm, IsBool.iff_mul_sub_one, sub_eq_add_neg]
-  completeness := by simp_all only [circuit_norm, IsBool.iff_mul_sub_one, sub_eq_add_neg]
+  soundness := by 
+    circuit_proof_start [IsBool.iff_mul_sub_one, sub_eq_add_neg]
+    exact h_holds
+  completeness := by 
+    circuit_proof_start [IsBool.iff_mul_sub_one, sub_eq_add_neg]
+    rw [h_input]
+    exact h_spec
 end Boolean
 
 export Boolean (assertBool)


### PR DESCRIPTION
## Summary
- Extended `circuitProofStartCore` to handle `FormalAssertion.Soundness/Completeness` and `GeneralFormalCircuit.Soundness/Completeness` types
- Each variant now correctly introduces its specific parameters
- Updated example proofs in `Boolean.lean` and `Bits.lean` to demonstrate usage

## Details
The `circuit_proof_start` tactic now properly handles all six variants:

| Type | Parameters introduced |
|------|----------------------|
| `Soundness` | `i₀`, `env`, `input_var`, `input`, `h_input`, `h_assumptions`, `h_holds` |
| `FormalAssertion.Soundness` | Same as `Soundness` |
| `GeneralFormalCircuit.Soundness` | `i₀`, `env`, `input_var`, `input`, `h_input`, `h_holds` (no `h_assumptions`) |
| `Completeness` | `i₀`, `env`, `input_var`, `h_env`, `input`, `h_input`, `h_assumptions` |
| `FormalAssertion.Completeness` | Same as `Completeness` + `h_spec` |
| `GeneralFormalCircuit.Completeness` | Same as `Completeness` |

## Test plan
- [x] `lake build` succeeds
- [x] Updated proofs in `Boolean.lean` and `Bits.lean` work correctly

Fixes #230

🤖 Generated with [Claude Code](https://claude.ai/code)