### PR TITLE
Remove default argument values that were never used

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -67,11 +67,11 @@ theorem bind_normalize {α β} (f : Circuit F α) (g : α → Circuit F β) : f.
 -- the results of a circuit: operations, output value and local length (which determines the next offset)
 
 @[reducible, circuit_norm]
-def operations (circuit : Circuit F α) (offset := 0) : Operations F :=
+def operations (circuit : Circuit F α) (offset : ℕ) : Operations F :=
   (circuit offset).2
 
 @[reducible, circuit_norm]
-def output (circuit : Circuit F α) (offset := 0) : α :=
+def output (circuit : Circuit F α) (offset : ℕ) : α :=
   (circuit offset).1
 
 @[reducible, circuit_norm]


### PR DESCRIPTION
This PR removes default argument values that were never used.

I hit a problem where type-check succeeded though I forgot an argument. This doesn't happen if default argument values don't exist.

This PR leaves the default argument value of `localLength` untouched. The default value `offset := 0` is used often because the `localLength` usually stays the same regardless of the `offset` argument.