### PR TITLE
Add missing DecidableEq instances

### DIFF
--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -17,6 +17,7 @@ structure U32 (T : Type) where
   x1 : T
   x2 : T
   x3 : T
+deriving DecidableEq
 
 instance : ProvableType U32 where
   size := 4

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -20,6 +20,7 @@ structure U64 (T : Type) where
   x5 : T
   x6 : T
   x7 : T
+deriving DecidableEq
 
 instance : ProvableType U64 where
   size := 8


### PR DESCRIPTION
To use `IsZero` gadget #257 on U32 or U64, we need `DecidableEq` instances on `U32 F` and `U64 F`.

This PR adds those instances using `deriving DecidableEq` after `structure` definitions.

An alternative is to prove `DecidableEq` on all `ProvableType`s. That would create a path in the type class search space where "to figure out if something is `DecidableEq`, try to figure out if it's a `ProvableType`". This will create duplicate instances on `ProvableVector`s because vectors already preserve `DecidableEq`. And the typeclass search will be slower in case of failure.