### PR TITLE
Counting tuples

### DIFF
--- a/Clean/Circuit/Count.lean
+++ b/Clean/Circuit/Count.lean
@@ -2,20 +2,28 @@
 
 For permutation argument, it's necessary to count the occurrences of values.
 
-This module defines an operation for counting occurrences.
+This module defines an operation for counting occurrences of field tuples.
+
+The business of `ProvableTypes` can be encoded into field tuples.
 -/
 
 import Clean.Circuit.Provable
 
 /--
-An instance of `Accouunt` associates a label to a size of the tuple to be counted.
-The multiplicity counting occurs separately on each label.
--/
-class Account (label : String) (arity : outParam ℕ) (F : Type)
+An `Accouunt` associates a label to the size of tuples to be counted. No runtime information
+is contained in an `Account`. The actual counting will happen during the witness generation time.
 
-structure Count (label : String) {arity : ℕ} (F : Type) [Account label arity F] where
-  entry : Vector (Expression F) arity
+The multiplicity counting occurs separately on each (label, arity).
+`Account`s with different arities are treated separate even if they share the same label.
+-/
+structure Account where
+  label : String
+  arity : ℕ -- exact number of field elements of tuples to be counted
+
+structure Count (F : Type) where
+  account : Account
+  entry : Vector (Expression F) account.arity
   multiplicity : Expression F -- summed up on each different value of entry
 
-instance {label : String} {arity : ℕ} {F : Type} [Repr F] [Account label arity F] : Repr (Count label F) where
-  reprPrec c _ := "(Count " ++ label ++ " " ++ reprStr c.entry ++ ")"
+instance {F : Type} [Repr F] : Repr (Count F) where
+  reprPrec c _ := "(Count " ++ c.account.label ++ " " ++ reprStr c.entry ++ ")"

--- a/Clean/Circuit/Count.lean
+++ b/Clean/Circuit/Count.lean
@@ -8,16 +8,14 @@ This module defines an operation for counting occurrences.
 import Clean.Circuit.Provable
 
 /--
-An instance of `Accouunt` associates a label to a `ProvableType` that's counted.
-There can be multiple labels associated with the same `ProvableType`.
+An instance of `Accouunt` associates a label to a size of the tuple to be counted.
 The multiplicity counting occurs separately on each label.
-Don't use the same label in multiple accounts.
 -/
-class Account (label : String) (M : outParam TypeMap) (F : Type) extends ProvableType M, Repr (Var M F)
+class Account (label : String) (arity : outParam ℕ) (F : Type)
 
-structure Count (label : String) {M : TypeMap} (F : Type) [Account label M F] where
-  entry : Var M F
-  multiplicity : Expression F
+structure Count (label : String) {arity : ℕ} (F : Type) [Account label arity F] where
+  entry : Vector (Expression F) arity
+  multiplicity : Expression F -- summed up on each different value of entry
 
-instance {label : String} {M : TypeMap} {F : Type} [Account label M F] : Repr (Count label (M:=M) F) where
+instance {label : String} {arity : ℕ} {F : Type} [Repr F] [Account label arity F] : Repr (Count label F) where
   reprPrec c _ := "(Count " ++ label ++ " " ++ reprStr c.entry ++ ")"

--- a/Clean/Circuit/Count.lean
+++ b/Clean/Circuit/Count.lean
@@ -13,12 +13,11 @@ There can be multiple labels associated with the same `ProvableType`.
 The multiplicity counting occurs separately on each label.
 Don't use the same label in multiple accounts.
 -/
-class Account (label : String) where
-  M : TypeMap
-  [inst : ProvableType M]
+class Account (label : String) (M : outParam TypeMap) (F : Type) extends ProvableType M, Repr (Var M F)
 
-structure Count (F : Type) where
-  label : String
-  [account : Account label]
-  entry : Var account.M F
+structure Count (label : String) {M : TypeMap} (F : Type) [Account label M F] where
+  entry : Var M F
   multiplicity : Expression F
+
+instance {label : String} {M : TypeMap} {F : Type} [Account label M F] : Repr (Count label (M:=M) F) where
+  reprPrec c _ := "(Count " ++ label ++ " " ++ reprStr c.entry ++ ")"

--- a/Clean/Circuit/Count.lean
+++ b/Clean/Circuit/Count.lean
@@ -1,0 +1,24 @@
+/- Counting occurrences of ProvableType values
+
+For permutation argument, it's necessary to count the occurrences of values.
+
+This module defines an operation for counting occurrences.
+-/
+
+import Clean.Circuit.Provable
+
+/--
+An instance of `Accouunt` associates a label to a `ProvableType` that's counted.
+There can be multiple labels associated with the same `ProvableType`.
+The multiplicity counting occurs separately on each label.
+Don't use the same label in multiple accounts.
+-/
+class Account (label : String) where
+  M : TypeMap
+  [inst : ProvableType M]
+
+structure Count (F : Type) where
+  label : String
+  [account : Account label]
+  entry : Var account.M F
+  multiplicity : Expression F

--- a/Clean/Circuit/Operations.lean
+++ b/Clean/Circuit/Operations.lean
@@ -17,6 +17,7 @@ inductive FlatOperation (F : Type) where
   | witness : (m : ℕ) → (Environment F → Vector F m) → FlatOperation F
   | assert : Expression F → FlatOperation F
   | lookup : Lookup F → FlatOperation F
+  | count : Count F → FlatOperation F
 
 namespace FlatOperation
 instance [Repr F] : Repr (FlatOperation F) where
@@ -24,6 +25,7 @@ instance [Repr F] : Repr (FlatOperation F) where
   | witness m _, _ => "(Witness " ++ reprStr m ++ ")"
   | assert e, _ => "(Assert " ++ reprStr e ++ " == 0)"
   | lookup l, _ => reprStr l
+  | count c, _ => reprStr c
 
 /--
 What it means that "constraints hold" on a list of flat operations:

--- a/Clean/Circuit/Operations.lean
+++ b/Clean/Circuit/Operations.lean
@@ -1,4 +1,5 @@
 import Clean.Circuit.Expression
+import Clean.Circuit.Count
 import Clean.Circuit.Lookup
 import Clean.Circuit.Provable
 import Clean.Circuit.SimpGadget


### PR DESCRIPTION
This is one candidate solution to https://github.com/Verified-zkEVM/clean/issues/252

The implementation is based on @mitschabaude 's idea. A new operation `count` is introduced. At the witness generation time, tuples of field elements (usually encoding a `ProvableType`) will be counted.

At the moment, the accounting is based on a pair of `label, arity` (called `Account`).