### PR TITLE
Remove remaining redundant simp arguments

### DIFF
--- a/Clean/Gadgets/BLAKE3/Compress.lean
+++ b/Clean/Gadgets/BLAKE3/Compress.lean
@@ -58,10 +58,9 @@ lemma ApplyRouunds.circuit_spec_is :
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
   circuit_proof_start
-  simp_all only [circuit_norm, ApplyRounds.circuit_assumptions_is,
-    ApplyRouunds.circuit_spec_is,
+  simp_all only [circuit_norm, ApplyRounds.circuit_assumptions_is, ApplyRouunds.circuit_spec_is,
     ApplyRounds.Spec, FinalStateUpdate.circuit, FinalStateUpdate.Assumptions,
-    compress, ApplyRounds.Assumptions, FinalStateUpdate.Spec]
+    ApplyRounds.Assumptions, FinalStateUpdate.Spec]
 
 def circuit : FormalCircuit (F p) ApplyRounds.Inputs BLAKE3State := {
   elaborated with Assumptions, Spec, soundness, completeness

--- a/Clean/Gadgets/Keccak/AbsorbBlock.lean
+++ b/Clean/Gadgets/Keccak/AbsorbBlock.lean
@@ -82,10 +82,8 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
   intro i0 env ⟨ state_var, block_var ⟩ h_env ⟨ state, block ⟩ h_input h_assumptions
 
   -- simplify goal and witnesses
-  simp only [circuit_norm, RATE, main, Spec, Assumptions, absorbBlock,
-    Xor64.circuit, Xor64.Assumptions, Xor64.Spec,
-    Permutation.circuit, Permutation.Assumptions, Permutation.Spec,
-    Input.mk.injEq] at *
+  simp only [circuit_norm, RATE, main, Assumptions, Xor64.circuit, Xor64.Assumptions, Xor64.Spec,
+    Permutation.circuit, Permutation.Assumptions, Permutation.Spec, Input.mk.injEq] at *
   simp only [getElem_eval_vector, h_input] at h_env ⊢
 
   have assumptions' (i : Fin 17) : state[i.val].Normalized ∧ block[i.val].Normalized := by

--- a/Clean/Gadgets/Keccak/KeccakRound.lean
+++ b/Clean/Gadgets/Keccak/KeccakRound.lean
@@ -37,7 +37,7 @@ theorem soundness (rc : UInt64) : Soundness (F p) (elaborated rc) Assumptions (S
 
   -- simplify goal
   apply KeccakState.normalized_value_ext
-  simp only [circuit_norm, elaborated, eval_vector, keccakRound, iota]
+  simp only [circuit_norm, eval_vector, keccakRound, iota]
 
   -- simplify constraints
   simp only [Assumptions] at state_norm

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -44,7 +44,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   simp only [main, circuit_norm, Spec,
     KeccakRound.circuit, KeccakRound.elaborated,
     KeccakRound.Spec, KeccakRound.Assumptions] at h_holds ⊢
-  simp only [zero_add, h_input] at h_holds
+  simp only [h_input] at h_holds
   obtain ⟨ h_init, h_succ ⟩ := h_holds
   specialize h_init h_assumptions
 
@@ -79,11 +79,10 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
 
   -- simplify
   dsimp only [Assumptions] at h_assumptions
-  simp only [main, h_input, h_assumptions, circuit_norm, Spec,
-    KeccakRound.circuit, KeccakRound.elaborated,
-    KeccakRound.Spec, KeccakRound.Assumptions] at h_env ⊢
+  simp only [main, h_input, h_assumptions, circuit_norm, KeccakRound.circuit,
+    KeccakRound.elaborated, KeccakRound.Spec,
+    KeccakRound.Assumptions] at h_env ⊢
 
-  -- only keep the statements about normalization
   obtain ⟨ h_init, h_succ ⟩ := h_env
   replace h_init := h_init.left
   replace h_succ := fun i hi ih => (h_succ i hi ih).left

--- a/Clean/Gadgets/Keccak/Theta.lean
+++ b/Clean/Gadgets/Keccak/Theta.lean
@@ -30,10 +30,9 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     ThetaC.Spec, ThetaD.Spec, ThetaXor.Spec, Specs.Keccak256.theta]
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  simp_all [circuit_norm, main, Assumptions, Spec,
-    ThetaC.circuit, ThetaD.circuit, ThetaXor.circuit,
-    ThetaC.Assumptions, ThetaD.Assumptions, ThetaXor.Assumptions,
-    ThetaC.Spec, ThetaD.Spec, ThetaXor.Spec, Specs.Keccak256.theta]
+  simp_all [circuit_norm, main, Assumptions, ThetaC.circuit, ThetaD.circuit, ThetaXor.circuit,
+    ThetaC.Assumptions, ThetaD.Assumptions, ThetaXor.Assumptions, ThetaC.Spec, ThetaD.Spec,
+    ThetaXor.Spec]
 
 def circuit : FormalCircuit (F p) KeccakState KeccakState :=
  { elaborated with Assumptions, Spec, soundness, completeness }

--- a/Clean/Tables/BLAKE3/ProcessBlocksInductive.lean
+++ b/Clean/Tables/BLAKE3/ProcessBlocksInductive.lean
@@ -339,7 +339,7 @@ lemma soundness : InductiveTable.Soundness (F p) ProcessBlocksState BlockInput S
       | inr _ => contradiction
     simp only [x_block_exists_zero] at *
     simp only [Conditional.circuit, Conditional.Assumptions, Conditional.Spec, h_eval, step, circuit_norm] at h_holds ⊢
-    simp only [step, circuit_norm, h_holds, h_eval, ProcessBlocksState.toChunkState] at ⊢ spec_previous
+    simp only [circuit_norm, h_holds, ProcessBlocksState.toChunkState] at ⊢ spec_previous
     norm_num at h_holds ⊢
     simp_all only [circuit_norm]
     omega


### PR DESCRIPTION
This PR removes all the remaining warnings about unused simp arguments.

(I came across a comment that didn't make sense and removed it.)