### PR TITLE
Remove redundant Assumptions _ := True from FormalCircuit instances

### DIFF
--- a/Clean/Circomlib/Comparators.lean
+++ b/Clean/Circomlib/Comparators.lean
@@ -38,8 +38,6 @@ def circuit : FormalCircuit (F p) field field where
   main
   localLength _ := 2
 
-  Assumptions _ := True
-
   Spec input output :=
     output = (if input = 0 then 1 else 0)
 
@@ -90,8 +88,6 @@ def main (input : Expression (F p) × Expression (F p)) := do
 def circuit : FormalCircuit (F p) fieldPair field where
   main
   localLength _ := 2
-
-  Assumptions _ := True
 
   Spec input output :=
     output = (if input.1 = input.2 then 1 else 0)

--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -96,8 +96,6 @@ def decodeInstructionCircuit : FormalCircuit (F p) field DecodedInstruction wher
     }
   localLength _ := 8
 
-  Assumptions | instruction => True
-
   Spec
   | instruction, output =>
     match Spec.decodeInstruction instruction with
@@ -323,7 +321,6 @@ def fetchInstructionCircuit
     return { rawInstrType, op1, op2, op3 }
 
   localLength _ := 4
-  Assumptions | pc => True
   Spec
   | pc, output =>
     match Spec.fetchInstruction program pc with


### PR DESCRIPTION
## Summary
Removes redundant `Assumptions _ := True` field specifications from `FormalCircuit` instances, since `FormalCircuit` already provides this as a default value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)