### PR TITLE
chore: Remove consecutive empty lines

### DIFF
--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -767,7 +767,6 @@ def femtoCairoTable
 
   completeness := by sorry
 
-
 /--
   The formal table for the femtoCairo VM, which ensures that the execution starts with
   the default initial state (pc=0, ap=0, fp=0)

--- a/Clean/Examples/FemtoCairo/Spec.lean
+++ b/Clean/Examples/FemtoCairo/Spec.lean
@@ -129,5 +129,4 @@ def femtoCairoMachineBoundedExecution
     let reachedState ← femtoCairoMachineBoundedExecution program memory state i
     femtoCairoMachineTransition program memory reachedState
 
-
 end Examples.FemtoCairo.Spec

--- a/Clean/Examples/FemtoCairo/Types.lean
+++ b/Clean/Examples/FemtoCairo/Types.lean
@@ -59,7 +59,6 @@ structure DecodedInstruction (F : Type) where
   addr2 : DecodedAddressingMode F
   addr3 : DecodedAddressingMode F
 
-
 /--
   Input structure for the memory read circuit.
   Contains the current machine state, the offset operand, and the addressing mode.
@@ -79,8 +78,6 @@ structure StateTransitionInput (F : Type) where
   v1 : F
   v2 : F
   v3 : F
-
-
 
 instance : ProvableType State where
   size := 3


### PR DESCRIPTION
`doc/conventions.md` says one empty line is enough so this PR removes consecutive empty lines.