### PR TITLE
Soundness Proof for `Num2BitsNeg`

### DIFF
--- a/Clean/Circomlib/Bitify2.lean
+++ b/Clean/Circomlib/Bitify2.lean
@@ -279,7 +279,7 @@ def circuit (n : ℕ) (hn : 2^n < p) : FormalCircuit (F p) field (fields n) wher
           convert h_input
         rw [this] at h_eq
         simp_all only [Nat.reducePow, gt_iff_lt, id_eq, mul_zero, dite_eq_ite, ite_self, add_zero,
-          ↓reduceIte, zero_mul, ne_eq, not_false_eq_true, ZMod.natCast_val]
+          ↓reduceIte, zero_mul, ZMod.natCast_val]
         have : (2 ^ n - ZMod.cast input) = fieldFromBits bits := by
           rw [sub_eq_add_neg, ZMod.cast_id, ← h_eq]
           let bits_vars := Vector.mapRange n fun i => var (F := F p) { index := i0 + i }


### PR DESCRIPTION
This PR completes the soundness proof for the `Num2BitsNeg` circuit in Clean/Circomlib/Bitify2.lean.

*Proof sketch*

1. Extract bit constraints and the zero-test invariant from h_holds.
2. Split on n = 0 and discharge the trivial case by simplification.
3. For n > 0:
   - Define the evaluated bit vector from the environment.
   - Show the folded linear combination equals fieldFromBits.
   - Split on whether input = 0:
      - If input = 0, show the output bits encode 0.
      - Otherwise, show the output bits encode 2^n - input.