### PR TITLE
Completeness Proof for Bits2Num_strict

### DIFF
--- a/Clean/Circomlib/Bitify2.lean
+++ b/Clean/Circomlib/Bitify2.lean
@@ -154,16 +154,14 @@ def circuit : GeneralFormalCircuit (F p) (fields 254) field where
     intro i0 env input_var input h_input assumptions output h_binary
     simp only [ElaboratedCircuit.main, main] at assumptions output ⊢
     simp only [circuit_norm, Bits2Num.main, AliasCheck.circuit] at h_input assumptions output ⊢
-    have : (∀ (i : ℕ) (x : i < 254), Expression.eval env input_var[i] = input[i]) := by {
+    have : (∀ (i : ℕ) (x : i < 254), Expression.eval env input_var[i] = input[i]) := by
       intro i hi
       rw [← h_input]
       simp only [Vector.getElem_map]
-    }
-    have : (∀ (i : ℕ) (x : i < 254), Expression.eval env input_var[i] = 0 ∨ Expression.eval env input_var[i] = 1) := by {
+    have : (∀ (i : ℕ) (x : i < 254), Expression.eval env input_var[i] = 0 ∨ Expression.eval env input_var[i] = 1) := by
       intro i hi
       rw [this]
       apply h_binary
-    }
     simp_all only [implies_true, forall_const]
     obtain ⟨ h_bits, h_eq ⟩ := assumptions
     rw [← ZMod.val_natCast_of_lt h_bits]
@@ -188,7 +186,7 @@ def circuit : GeneralFormalCircuit (F p) (fields 254) field where
     simp only [circuit_norm, Bits2Num.main] at h_env h_input ⊢
     simp only [h_input, circuit_norm] at h_env ⊢
     obtain ⟨assumption₁, assumption₂⟩ := assumptions
-    simp only [circuit_norm, AliasCheck.circuit, assumption₁,assumption₂] at ⊢
+    simp only [circuit_norm, AliasCheck.circuit, assumption₁, assumption₂] at ⊢
     rw [← h_env]
     rfl
 end Bits2Num_strict


### PR DESCRIPTION
This PR establishes a completeness proof for the `Bit2Num_strict` circuit.

The `AliasCheck` component used in `Bit2Num_strict` is designed to reject witnesses that violate the constraint
`fromBits (input.map ZMod.val) < p`.
To reflect this behavior in the proof, we extend the `Assumptions` to include this condition.

However, the soundness theorem for `FormalCircuitP` is parameterized by the `Assumptions`. Strengthening the assumptions, therefore, weakens the resulting soundness guarantee. To avoid this degradation, this PR replaces `FormalCircuitP` with `GeneralFormalCircuit`, whose soundness property is independent of the `Assumptions`.

The soundness of the resulting circuit still relies on the bitness condition
`∀ i (_ : i < 254), input[i] = 0 ∨ input[i] = 1`.
Accordingly, we move this condition from the circuit assumptions into the precondition of the `Spec`, making it explicit at the specification level and allowing it to be used directly in the soundness proof.

Overall, this refactoring preserves the original soundness guarantees while enabling a faithful completeness proof that aligns with the operational behavior of `AliasCheck`.
