### PR TITLE
Move general utility lemmas to appropriate files

### DIFF
--- a/Clean/Circomlib/Bitify2.lean
+++ b/Clean/Circomlib/Bitify2.lean
@@ -122,21 +122,6 @@ def main (input : Vector (Expression (F p)) 254) := do
   -- Convert bits to number
   Bits2Num.main 254 input
 
-lemma mapFinRange_eq_map {α β : Type} {n : ℕ} (v : Vector α n) (f : α → β) :
-    Vector.mapFinRange n (fun i => f v[i]) = v.map f := by
-  ext i
-  simp only [Vector.getElem_mapFinRange, Vector.getElem_map]
-  simp
-
-omit [Fact (p < 2 ^ 254)] [Fact (p > 2 ^ 253)] in
-lemma fieldFromBits_eq_mapFinRange_cast {n} {f : Fin n → F p} :
-    fieldFromBits (Vector.mapFinRange n f) = (fromBits (Vector.mapFinRange n fun i => (f i).val) : F p) := by
-  unfold fieldFromBits
-  apply congrArg (Nat.cast : ℕ → F p)
-  apply congrArg fromBits
-  ext i
-  simp only [Vector.getElem_map, Vector.getElem_mapFinRange]
-
 set_option linter.constructorNameAsVariable false
 
 def circuit : GeneralFormalCircuit (F p) (fields 254) field where
@@ -167,7 +152,7 @@ def circuit : GeneralFormalCircuit (F p) (fields 254) field where
     simp_all only [implies_true, forall_const]
     obtain ⟨ h_bits, h_eq ⟩ := assumptions
     rw [← ZMod.val_natCast_of_lt h_bits]
-    rw [← mapFinRange_eq_map]
+    rw [← Vector.mapFinRange_eq_map]
     rw [← fieldFromBits_eq_mapFinRange_cast]
     conv =>
           rhs

--- a/Clean/Utils/Bits.lean
+++ b/Clean/Utils/Bits.lean
@@ -291,4 +291,12 @@ lemma fieldFromBits_eq {n : ℕ} {xs ys : Vector (F p) n} (h: ∀ (i : Fin n), x
     exact h fi
   rw [h_vec_eq]
 
+lemma fieldFromBits_eq_mapFinRange_cast {n} {f : Fin n → F p} :
+    fieldFromBits (Vector.mapFinRange n f) = (fromBits (Vector.mapFinRange n fun i => (f i).val) : F p) := by
+  unfold fieldFromBits
+  apply congrArg (Nat.cast : ℕ → F p)
+  apply congrArg fromBits
+  ext i
+  simp only [Vector.getElem_map, Vector.getElem_mapFinRange]
+
 end Utils.Bits

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -178,6 +178,12 @@ theorem getElem_mapFinRange {n} {create : Fin n → α} :
     ∀ (i : ℕ) (hi : i < n), (mapFinRange n create)[i] = create ⟨ i, hi ⟩ := by
   simp [mapFinRange, finRange]
 
+lemma mapFinRange_eq_map {n : ℕ} (v : Vector α n) (f : α → β) :
+    Vector.mapFinRange n (fun i => f v[i]) = v.map f := by
+  ext i
+  simp only [Vector.getElem_mapFinRange, Vector.getElem_map]
+  simp
+
 def mapRange (n : ℕ) (create : ℕ → α) : Vector α n :=
   match n with
   | 0 => #v[]


### PR DESCRIPTION
## Summary
- Move `mapFinRange_eq_map` from `Bitify2.lean` to `Utils/Vector.lean`
- Move `fieldFromBits_eq_mapFinRange_cast` from `Bitify2.lean` to `Utils/Bits.lean`

These lemmas are general-purpose utilities that were incorrectly placed in a circuit-specific file. Moving them to the appropriate utility modules improves code organization and makes them more discoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)