### PR TITLE
Update Plonky3 dependencies to latest main

### DIFF
--- a/backends/plonky3/Cargo.lock
+++ b/backends/plonky3/Cargo.lock
@@ -3,22 +3,39 @@
 version = 4
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
+name = "anyhow"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
 
 [[package]]
 name = "clean_backend"
@@ -48,10 +65,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.3"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "either"
@@ -60,15 +86,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "getrandom"
-version = "0.3.3"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "rand_core",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -91,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "lazy_static"
@@ -102,31 +181,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.172"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -164,25 +257,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "p3-air"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "p3-field",
  "p3-matrix",
+ "serde",
 ]
 
 [[package]]
 name = "p3-baby-bear"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
+ "p3-challenger",
  "p3-field",
  "p3-mds",
  "p3-monty-31",
@@ -193,11 +282,12 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
+ "p3-monty-31",
  "p3-symmetric",
  "p3-util",
  "tracing",
@@ -205,8 +295,8 @@ dependencies = [
 
 [[package]]
 name = "p3-commit"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -219,21 +309,22 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-util",
+ "spin",
  "tracing",
 ]
 
 [[package]]
 name = "p3-field"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -247,8 +338,8 @@ dependencies = [
 
 [[package]]
 name = "p3-fri"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -261,13 +352,14 @@ dependencies = [
  "p3-util",
  "rand",
  "serde",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "p3-interpolation"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -277,8 +369,8 @@ dependencies = [
 
 [[package]]
 name = "p3-keccak"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "p3-field",
  "p3-symmetric",
@@ -288,8 +380,8 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -298,18 +390,17 @@ dependencies = [
  "rand",
  "serde",
  "tracing",
- "transpose",
 ]
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 
 [[package]]
 name = "p3-mds"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "p3-dft",
  "p3-field",
@@ -320,8 +411,8 @@ dependencies = [
 
 [[package]]
 name = "p3-merkle-tree"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "itertools 0.14.0",
  "p3-commit",
@@ -332,13 +423,14 @@ dependencies = [
  "p3-util",
  "rand",
  "serde",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "p3-monty-31"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -353,14 +445,14 @@ dependencies = [
  "paste",
  "rand",
  "serde",
+ "spin",
  "tracing",
- "transpose",
 ]
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -371,8 +463,8 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -381,8 +473,8 @@ dependencies = [
 
 [[package]]
 name = "p3-uni-stark"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "itertools 0.14.0",
  "p3-air",
@@ -394,15 +486,17 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-util",
  "serde",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "p3-util"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e784f44#e784f44924e12a5a6799f3b03c18d1fa6b1a111e"
+version = "0.4.2"
+source = "git+https://github.com/Plonky3/Plonky3?rev=47e442f#47e442ffb5ad5f6c86f845e48283867f348243ba"
 dependencies = [
  "serde",
+ "transpose",
 ]
 
 [[package]]
@@ -418,87 +512,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
- "zerocopy",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom",
-]
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
+name = "scopeguard"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -507,14 +606,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -528,9 +628,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "strength_reduce"
@@ -540,9 +649,9 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -550,13 +659,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.8"
+name = "thiserror"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -570,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -581,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -592,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -613,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -637,9 +765,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "valuable"
@@ -648,61 +782,162 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "wit-bindgen",
 ]
 
 [[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "wasm-metadata"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wasmparser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.25"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "zerocopy-derive",
+ "windows-link",
 ]
 
 [[package]]
-name = "zerocopy-derive"
-version = "0.8.25"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
 ]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/backends/plonky3/Cargo.toml
+++ b/backends/plonky3/Cargo.toml
@@ -11,19 +11,19 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 
 # Plonky3 dependencies - using git for latest versions
-p3-air = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-challenger = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-commit = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-dft = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-field = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-fri = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-keccak = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-matrix = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-symmetric = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-util = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3", rev="e784f44" }
-rand = { version = "0.9", features = ["small_rng"] }
+p3-air = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-challenger = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-commit = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-dft = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-field = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-fri = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-keccak = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-matrix = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-symmetric = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-util = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3", rev = "47e442f" }
+rand = "0.10"

--- a/backends/plonky3/src/check_constraints.rs
+++ b/backends/plonky3/src/check_constraints.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, PairBuilder};
+use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues};
 use p3_field::Field;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 use p3_matrix::stack::VerticalPair;
@@ -146,6 +146,10 @@ where
             self.row_index, x, y
         );
     }
+
+    fn preprocessed(&self) -> Option<Self::M> {
+        Some(self.preprocessed)
+    }
 }
 
 impl<F: Field> AirBuilderWithPublicValues for DebugConstraintBuilder<'_, F> {
@@ -153,12 +157,6 @@ impl<F: Field> AirBuilderWithPublicValues for DebugConstraintBuilder<'_, F> {
 
     fn public_values(&self) -> &[Self::F] {
         self.public_values
-    }
-}
-
-impl<F: Field> PairBuilder for DebugConstraintBuilder<'_, F> {
-    fn preprocessed(&self) -> Self::M {
-        self.preprocessed
     }
 }
 

--- a/backends/plonky3/src/clean_air.rs
+++ b/backends/plonky3/src/clean_air.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, PairBuilder};
+use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
@@ -29,7 +29,7 @@ impl<F: Field> BaseAir<F> for MainAir<F> {
     }
 }
 
-impl<AB: AirBuilderWithPublicValues + PairBuilder + BaseMessageBuilder> Air<AB> for MainAir<AB::F>
+impl<AB: AirBuilderWithPublicValues + BaseMessageBuilder> Air<AB> for MainAir<AB::F>
 where
     AB::F: Field + PrimeCharacteristicRing,
 {
@@ -51,7 +51,7 @@ where
                         let var: VarLocation = context.assignment.vars[var_idx].clone();
                         match var {
                             VarLocation::Cell { row, column } => match row {
-                                0 => local[column],
+                                0 => local[column].clone(),
                                 _ => panic!("Invalid row index: {}", row),
                             },
                             VarLocation::Aux { .. } => {
@@ -81,8 +81,8 @@ where
                         let var: VarLocation = context.assignment.vars[var_idx].clone();
                         match var {
                             VarLocation::Cell { row, column } => match row {
-                                0 => local[column],
-                                1 => next[column],
+                                0 => local[column].clone(),
+                                1 => next[column].clone(),
                                 _ => panic!("Invalid row index: {}", row),
                             },
                             VarLocation::Aux { .. } => {
@@ -164,7 +164,7 @@ impl<F: Field> MainAir<F> {
 
         // For now, assume these lookups are for byte range
         for &c in &lookup_cols {
-            let v = local[c].into();
+            let v = local[c].clone().into();
             let mul = AB::F::ONE.into();
             let l = Lookup::new(crate::LookupType::ByteRange, v, mul);
             builder.send(l);
@@ -179,7 +179,7 @@ impl<F: Field> MainAir<F> {
         load_pi: &dyn Fn(usize) -> AB::Expr,
         constraint_builder: &mut dyn FnMut(AB::Expr),
     ) where
-        AB: AirBuilder + AirBuilderWithPublicValues + PairBuilder + BaseMessageBuilder,
+        AB: AirBuilder + AirBuilderWithPublicValues + BaseMessageBuilder,
         AB::F: Field + PrimeCharacteristicRing,
     {
         for op in ops {
@@ -244,7 +244,7 @@ impl<F: Field> BaseAir<F> for CleanAirInstance<F> {
 
 impl<AB> Air<AB> for CleanAirInstance<AB::F>
 where
-    AB: AirBuilder + AirBuilderWithPublicValues + PairBuilder + BaseMessageBuilder,
+    AB: AirBuilder + AirBuilderWithPublicValues + BaseMessageBuilder,
     AB::F: Field,
 {
     fn eval(&self, builder: &mut AB) {

--- a/backends/plonky3/src/folder.rs
+++ b/backends/plonky3/src/folder.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 
 use p3_air::{
-    AirBuilder, AirBuilderWithPublicValues, ExtensionBuilder, PairBuilder, PermutationAirBuilder,
+    AirBuilder, AirBuilderWithPublicValues, ExtensionBuilder, PermutationAirBuilder,
 };
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
@@ -84,6 +84,10 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
         self.accumulator += Into::<PackedChallenge<SC>>::into(alpha_power) * x;
         self.constraint_index += 1;
     }
+
+    fn preprocessed(&self) -> Option<Self::M> {
+        Some(self.preprocessed)
+    }
 }
 
 impl<SC: StarkGenericConfig> AirBuilderWithPublicValues for ProverConstraintFolder<'_, SC> {
@@ -92,12 +96,6 @@ impl<SC: StarkGenericConfig> AirBuilderWithPublicValues for ProverConstraintFold
     #[inline]
     fn public_values(&self) -> &[Self::F] {
         self.public_values
-    }
-}
-
-impl<SC: StarkGenericConfig> PairBuilder for ProverConstraintFolder<'_, SC> {
-    fn preprocessed(&self) -> Self::M {
-        self.preprocessed
     }
 }
 
@@ -175,6 +173,10 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC>
         self.accumulator *= self.alpha;
         self.accumulator += x;
     }
+
+    fn preprocessed(&self) -> Option<Self::M> {
+        Some(self.preprocessed)
+    }
 }
 
 impl<SC: StarkGenericConfig> AirBuilderWithPublicValues for VerifierConstraintFolder<'_, SC> {
@@ -182,12 +184,6 @@ impl<SC: StarkGenericConfig> AirBuilderWithPublicValues for VerifierConstraintFo
 
     fn public_values(&self) -> &[Self::F] {
         self.public_values
-    }
-}
-
-impl<SC: StarkGenericConfig> PairBuilder for VerifierConstraintFolder<'_, SC> {
-    fn preprocessed(&self) -> Self::M {
-        self.preprocessed
     }
 }
 

--- a/backends/plonky3/src/key.rs
+++ b/backends/plonky3/src/key.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use p3_air::{
-    Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, PairBuilder, PermutationAirBuilder,
+    Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, PermutationAirBuilder,
     VirtualPairCol,
 };
 use p3_commit::{Pcs, PolynomialSpace};
@@ -27,7 +27,7 @@ type PcsData<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
     <SC as StarkGenericConfig>::Challenger,
 >>::ProverData;
 
-pub trait VerifyingKey<F> {
+pub trait VerifyingKey<F: Field> {
     fn lookups(&self) -> &Vec<(Lookup<VirtualPairCol<F>>, bool)>
     where
         F: Field;
@@ -45,8 +45,8 @@ pub trait VerifyingKey<F> {
             + PermutationAirBuilder
             + MultiTableBuilder
             + AirBuilderWithPublicValues
-            + PairBuilder
-            + BaseMessageBuilder;
+            + BaseMessageBuilder,
+        AB::Var: Copy;
 }
 
 pub struct VK<SC: StarkGenericConfig> {
@@ -201,8 +201,8 @@ impl<F: Field> VerifyingKey<F> for AirInfo<F> {
             + PermutationAirBuilder
             + MultiTableBuilder
             + AirBuilderWithPublicValues
-            + PairBuilder
             + BaseMessageBuilder,
+        AB::Var: Copy,
     {
         self.air.eval(builder);
         eval_permutation_constraints(self.lookups(), builder);
@@ -225,7 +225,7 @@ impl<F: Field> BaseAir<F> for AirInfo<F> {
 
 impl<AB> Air<AB> for AirInfo<AB::F>
 where
-    AB: AirBuilder + AirBuilderWithPublicValues + PairBuilder + BaseMessageBuilder,
+    AB: AirBuilder + AirBuilderWithPublicValues + BaseMessageBuilder,
     AB::F: Field,
 {
     fn eval(&self, builder: &mut AB) {

--- a/backends/plonky3/src/lookup.rs
+++ b/backends/plonky3/src/lookup.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use p3_air::{
-    Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, PairBuilder, PairCol, VirtualPairCol,
+    Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, PairCol, VirtualPairCol,
 };
 use p3_field::Field;
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
@@ -114,11 +114,9 @@ impl<F: Field> AirBuilder for LookupBuilder<F> {
     }
 
     fn assert_zero<I: Into<Self::Expr>>(&mut self, _x: I) {}
-}
 
-impl<F: Field> PairBuilder for LookupBuilder<F> {
-    fn preprocessed(&self) -> Self::M {
-        self.preprocessed.clone()
+    fn preprocessed(&self) -> Option<Self::M> {
+        Some(self.preprocessed.clone())
     }
 }
 
@@ -244,14 +242,14 @@ impl<F: Field> BaseAir<F> for ByteRangeAir<F> {
     }
 }
 
-impl<AB: PairBuilder + BaseMessageBuilder> Air<AB> for ByteRangeAir<AB::F>
+impl<AB: AirBuilder + BaseMessageBuilder> Air<AB> for ByteRangeAir<AB::F>
 where
     AB::F: Field,
 {
     fn eval(&self, builder: &mut AB) {
         // generate receive lookups
         let main = builder.main();
-        let preprocessed = builder.preprocessed();
+        let preprocessed = builder.preprocessed().expect("ByteRangeAir requires preprocessed trace");
 
         let local_mul = main.get(0, 0).unwrap().into();
         let local_preprocessed_val = preprocessed.get(0, 0).unwrap().into();

--- a/backends/plonky3/src/permutation.rs
+++ b/backends/plonky3/src/permutation.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use p3_air::{AirBuilder, ExtensionBuilder, PairBuilder, PermutationAirBuilder, VirtualPairCol};
+use p3_air::{AirBuilder, ExtensionBuilder, PermutationAirBuilder, VirtualPairCol};
 use p3_field::{ExtensionField, Field, PrimeField32};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
 
@@ -192,7 +192,8 @@ pub fn eval_permutation_constraints<AB>(
     lookups: &[(Lookup<VirtualPairCol<AB::F>>, bool)],
     builder: &mut AB,
 ) where
-    AB: AirBuilder + PairBuilder + PermutationAirBuilder + MultiTableBuilder,
+    AB: AirBuilder + PermutationAirBuilder + MultiTableBuilder,
+    AB::Var: Copy,
 {
     let main = builder.main();
     let preprocessed = builder.preprocessed();
@@ -211,7 +212,7 @@ pub fn eval_permutation_constraints<AB>(
         let entry: AB::ExprEF = (*entry).into();
 
         // Get preprocessed row once or use empty slice
-        let preprocessed_row = preprocessed.row_slice(0);
+        let preprocessed_row = preprocessed.as_ref().and_then(|p| p.row_slice(0));
         let empty_preprocessed: &[AB::Var] = &[];
         let preprocessed_ref = preprocessed_row.as_deref().unwrap_or(empty_preprocessed);
 

--- a/backends/plonky3/tests/clean_air.rs
+++ b/backends/plonky3/tests/clean_air.rs
@@ -8,7 +8,7 @@ use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
-use p3_fri::{create_test_fri_config, TwoAdicFriPcs};
+use p3_fri::{create_test_fri_params, TwoAdicFriPcs};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_merkle_tree::MerkleTreeMmcs;
@@ -91,7 +91,7 @@ fn test_clean_fib() {
     let val_mmcs = ValMmcs::new(hash, compress);
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
     let dft = Dft::default();
-    let config = create_test_fri_config(challenge_mmcs, 2);
+    let config = create_test_fri_params(challenge_mmcs, 2);
     let pcs = Pcs::new(dft, val_mmcs, config);
 
     let challenger = Challenger::new(perm);


### PR DESCRIPTION
## Summary
- Update all 15 Plonky3 crate dependencies from commit `e784f44` (v0.1.0) to `47e442f` (v0.4.2+)
- Adapt to upstream API changes: `PairBuilder` removal, `AB::Var` no longer `Copy`, `rand` 0.9 → 0.10
- Fix renamed `create_test_fri_config` → `create_test_fri_params`

🤖 Generated with [Claude Code](https://claude.com/claude-code)