### PR TITLE
feat: add CompletenessSpec to GeneralFormalCircuit

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -373,6 +373,17 @@ def GeneralFormalCircuit.Completeness (F : Type) [Field F] (circuit : Elaborated
   -- the constraints hold
   ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset)
 
+@[circuit_norm]
+def GeneralFormalCircuit.CompletenessSpecProof (F : Type) [Field F]
+    (circuit : ElaboratedCircuit F Input Output)
+    (Assumptions : Input F → ProverData F → Prop)
+    (CompletenessSpec : Input F → Output F → ProverData F → Prop) :=
+  ∀ offset : ℕ, ∀ env, ∀ input_var : Var Input F,
+  env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
+  ∀ input : Input F, eval env input_var = input →
+  Assumptions input env.data →
+  CompletenessSpec input (eval env (circuit.output input_var offset)) env.data
+
 /--
 `GeneralFormalCircuit` is the most general model of formal circuits, needed in cases where the circuit is a
 _mix_ of "assertion-like" and "function-like". It allows you flexibility in specifying separate statements
@@ -394,6 +405,9 @@ structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F] [Pr
   Spec : Input F → Output F → ProverData F → Prop -- the statement to be proved for soundness. (Might have to include `Assumptions` on the inputs, as a hypothesis.)
   soundness : GeneralFormalCircuit.Soundness F elaborated Spec
   completeness : GeneralFormalCircuit.Completeness F elaborated Assumptions
+  CompletenessSpec : Input F → Output F → ProverData F → Prop := fun _ _ _ => True
+  completenessSpec : GeneralFormalCircuit.CompletenessSpecProof F elaborated Assumptions CompletenessSpec
+    := by unfold GeneralFormalCircuit.CompletenessSpecProof; intros; trivial
 end
 
 export Circuit (witnessVar witnessField witnessVars witnessVector assertZero lookup)

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -230,14 +230,21 @@ def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
     Soundness env := circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data,
     Completeness env := circuit.Assumptions (eval env input_var) env.data,
     UsesLocalWitnesses env := circuit.Assumptions (eval env input_var) env.data →
-      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data,
+      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data
+      ∧ circuit.CompletenessSpec (eval env input_var) (eval env (circuit.output input_var n)) env.data,
     localLength := circuit.localLength input_var
 
     imply_soundness
     implied_by_completeness
-    imply_usesLocalWitnesses env h_env assumptions :=
-      -- constraints hold by completeness, which implies the spec by soundness
-      implied_by_completeness env h_env assumptions |> imply_soundness env
+    imply_usesLocalWitnesses := by
+      intro env h_env assumptions
+      constructor
+      · exact implied_by_completeness env h_env assumptions |> imply_soundness env
+      · have h_env' := h_env
+        rw [ops.toNested_toFlat] at h_env'
+        rw [←env.usesLocalWitnessesFlat_iff_extends, ←env.usesLocalWitnesses_iff_flat] at h_env'
+        have h_env_completeness := env.can_replace_usesLocalWitnessesCompleteness h_consistent h_env'
+        exact circuit.completenessSpec n env input_var h_env_completeness _ rfl assumptions
 
     localLength_eq := by
       rw [ops.toNested_toFlat, ← circuit.localLength_eq input_var n,
@@ -388,7 +395,8 @@ theorem GeneralFormalCircuit.toSubcircuit_usesLocalWitnesses
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : Environment F) :
     (circuit.toSubcircuit n input_var).UsesLocalWitnesses env =
     (circuit.Assumptions (eval env input_var) env.data →
-      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data) := by
+      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data
+      ∧ circuit.CompletenessSpec (eval env input_var) (eval env (circuit.output input_var n)) env.data) := by
   rfl
 
 /--

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -606,6 +606,7 @@ def FormalCircuit.isGeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Fi
       simp only [GeneralFormalCircuit.Completeness, forall_eq']
       intros
       apply orig.completeness <;> trivial
+    completenessSpec := fun _ _ _ _ _ _ _ => trivial
   }
 
 /--
@@ -629,4 +630,5 @@ def FormalAssertion.isGeneralFormalCircuit (F : Type) (Input : TypeMap) [Field F
       simp only [GeneralFormalCircuit.Completeness, forall_eq']
       rintro _ _ _ _ ⟨ _, _ ⟩
       apply orig.completeness <;> trivial
+    completenessSpec := fun _ _ _ _ _ _ _ => trivial
   }

--- a/Clean/Utils/Tactics/CircuitProofStart.lean
+++ b/Clean/Utils/Tactics/CircuitProofStart.lean
@@ -21,7 +21,8 @@ partial def circuitProofStartCore : TacticM Unit := do
                        headConst? == some ``GeneralFormalCircuit.Soundness
     let isCompleteness := headConst? == some ``Completeness ||
                           headConst? == some ``FormalAssertion.Completeness ||
-                          headConst? == some ``GeneralFormalCircuit.Completeness
+                          headConst? == some ``GeneralFormalCircuit.Completeness ||
+                          headConst? == some ``GeneralFormalCircuit.CompletenessSpecProof
 
     if isSoundness then
       match headConst? with
@@ -60,11 +61,16 @@ partial def circuitProofStartCore : TacticM Unit := do
         let names := [`i₀, `env, `input_var, `h_env, `input, `h_input, `h_assumptions]
         for name in names do
           evalTactic (← `(tactic| intro $(mkIdent name):ident))
+      | some ``GeneralFormalCircuit.CompletenessSpecProof =>
+        evalTactic (← `(tactic| unfold GeneralFormalCircuit.CompletenessSpecProof))
+        let names := [`i₀, `env, `input_var, `h_env, `input, `h_input, `h_assumptions]
+        for name in names do
+          evalTactic (← `(tactic| intro $(mkIdent name):ident))
       | _ => pure ()
       return
     else
       -- Goal is not a supported Soundness or Completeness type
-      throwError "circuitProofStartCore can only be used on Soundness, Completeness, FormalAssertion.Soundness, FormalAssertion.Completeness, GeneralFormalCircuit.Soundness, or GeneralFormalCircuit.Completeness goals"
+      throwError "circuitProofStartCore can only be used on Soundness, Completeness, FormalAssertion.Soundness, FormalAssertion.Completeness, GeneralFormalCircuit.Soundness, GeneralFormalCircuit.Completeness, or GeneralFormalCircuit.CompletenessSpecProof goals"
 
 /--
   Standard tactic for starting soundness and completeness proofs.


### PR DESCRIPTION
Add a CompletenessSpec field to GeneralFormalCircuit that is available during completeness proofs (via UsesLocalWitnesses) but not used during soundness. This allows subcircuit parents to reason about how the output is computed using ProverData, eliminating the need to inline subcircuit logic in completeness proofs.

This is useful when 
(1) a circuit uses outputs from sub-circuits to construct a bigger output using `ProverData`
(2) the outputs from sub-circuits need to satisfy an assertion
(3) the nice property comes from how the output is computed using `ProverData`.
(4) we don't want to inline sub-circuits.

Before this PR, although `Spec` had access to `ProverData`, `Spec` was not useful for describing any nontrivial relationship between the `Output` and `ProverData`. The soundness proof doesn't have any access to witness computation so the soundness could not prove any nontrivial relationship between `Output` and `ProverData`.

After this PR, `CompletenessSpec` can state nontrivial relationship between `Output` and `ProverDaata`. Moreover, `CompletenessSpec` only gets proven in the context of completeness where the specific witness computation is available. This allows subcircuit to inform the supercircuit about the specific choice of `Output` based on `ProverData`.