### PR TITLE
feat: add completeness to FormalTable (#349)

### DIFF
--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -349,6 +349,10 @@ namespace TableConstraint
 def finalOffset (table : TableConstraint W S F α) : ℕ :=
   (table .empty).snd.offset
 
+@[reducible, table_norm, table_assignment_norm]
+def finalInputSize (table : TableConstraint W S F α) : ℕ :=
+  (table .empty).snd.inputSize
+
 @[table_norm]
 def operations (table : TableConstraint W S F α) : Operations F :=
   table .empty |>.snd.circuit
@@ -379,6 +383,12 @@ def windowEnv (table : TableConstraint W S F Unit)
   In particular, we construct the environment by taking directly the result of the assignment function
   so that every variable evaluate to the trace cell value which is assigned to
 -/
+@[table_norm]
+def UsesLocalWitnessesOnWindow (table : TableConstraint W S F Unit)
+  (window : TraceOfLength F S W) (aux_env : Environment F) : Prop :=
+  let env := windowEnv table window aux_env
+  env.UsesLocalWitnesses table.finalInputSize table.operations
+
 @[table_norm]
 def ConstraintsHoldOnWindow (table : TableConstraint W S F Unit)
   (window : TraceOfLength F S W) (aux_env : Environment F) : Prop :=
@@ -589,12 +599,50 @@ def TableConstraintsHold {N : ℕ} (constraints : List (TableOperation S F))
     -- if the trace is empty, we are done
     | <+>, _ => True
 
+@[table_norm]
+def TableUsesLocalWitnesses {N : ℕ} (constraints : List (TableOperation S F))
+  (trace : TraceOfLength F S N) (env : TableEnvironments F) : Prop :=
+  let constraints_and_envs := constraints.mapIdx (fun i cs => (cs, env.toEnvironment i))
+  foldl N constraints_and_envs trace.val constraints_and_envs
+  where
+  @[table_norm]
+  foldl (N : ℕ) (cs : List (TableOperation S F × (ℕ → (Environment F)))) :
+    Trace F S → (cs_iterator : List (TableOperation S F × (ℕ → (Environment F)))) → Prop
+    | trace +> curr +> next, (⟨.everyRowExceptLast constraint, env⟩) :: rest =>
+        let others := foldl N cs (trace +> curr +> next) rest
+        let window : TraceOfLength F S 2 := ⟨<+> +> curr +> next, rfl ⟩
+        constraint.UsesLocalWitnessesOnWindow window (env (trace.len + 1)) ∧ others
+
+    | trace +> row, (⟨.boundary idx constraint, env⟩) :: rest =>
+        let others := foldl N cs (trace +> row) rest
+        let window : TraceOfLength F S 1 := ⟨<+> +> row, rfl⟩
+        let targetIdx := match idx with
+          | .fromStart i => i
+          | .fromEnd i => N - 1 - i
+        (if trace.len = targetIdx then constraint.UsesLocalWitnessesOnWindow window (env trace.len) else True) ∧ others
+
+    | trace +> row, (⟨.everyRow constraint, env⟩) :: rest =>
+        let others := foldl N cs (trace +> row) rest
+        let window : TraceOfLength F S 1 := ⟨<+> +> row, rfl⟩
+        constraint.UsesLocalWitnessesOnWindow window (env trace.len) ∧ others
+
+    | trace, (⟨.everyRowExceptLast _, _⟩) :: rest =>
+        foldl N cs trace rest
+
+    | trace +> _, [] =>
+        foldl N cs trace cs
+
+    | <+>, _ => True
+
 structure FormalTable (F : Type) [Field F] (S : Type → Type) [ProvableType S] where
   /-- list of constraints that are applied over the table -/
   constraints : List (TableOperation S F)
 
   /-- optional assumption on the table length and other tables in the environment -/
   Assumption : ℕ → ProverData F → Prop := fun _ _ => True
+
+  /-- assumptions on the trace and environments needed for completeness -/
+  CompletenessAssumption {N : ℕ} : TraceOfLength F S N → TableEnvironments F → Prop := fun _ _ => True
 
   /-- specification for the table -/
   Spec {N : ℕ}  : TraceOfLength F S N → ProverData F → Prop
@@ -606,6 +654,14 @@ structure FormalTable (F : Type) [Field F] (S : Type → Type) [ProvableType S] 
     Assumption N env.data →
     TableConstraintsHold constraints trace env →
     Spec trace env.data
+
+  /-- the completeness states that if the environments use local witnesses
+      and the completeness assumptions hold, then the constraints hold. -/
+  completeness :
+    ∀ (N : ℕ) (trace : TraceOfLength F S N) (env : TableEnvironments F),
+    TableUsesLocalWitnesses constraints trace env →
+    CompletenessAssumption trace env →
+    TableConstraintsHold constraints trace env
 
   /-- this property tells us that that the number of variables contained in the `assignment` of each
       constraint is consistent with the number of variables introduced in the circuit. -/

--- a/Clean/Table/Inductive.lean
+++ b/Clean/Table/Inductive.lean
@@ -298,10 +298,21 @@ theorem table_soundness (table : InductiveTable F State Input) (input output : S
 def toFormal (table : InductiveTable F State Input) (input output : State F) : FormalTable F (ProvablePair State Input) where
   constraints := table.tableConstraints input output
   Assumption N env := N > 0 ∧ table.Spec input [] 0 rfl input env
+
+  CompletenessAssumption {N} trace env :=
+    (hN : N > 0) →
+    table.InitialStateAssumptions input env.data ∧
+    trace.ForAllRowsWithPrevious (fun row i rest =>
+      table.Spec input (traceInputs rest) i (traceInputs_length rest) row.1 env.data ∧
+      table.InputAssumptions i row.2 env.data) ∧
+    (trace.val.lastRow (by rw [trace.property]; exact hN)).1 = output
+
   Spec {N} trace env := table.Spec input (traceInputs trace.tail) (N-1) (traceInputs_length trace.tail) output env
 
   soundness N trace env assumption constraints :=
     table.table_soundness input output ⟨N, assumption.left⟩ trace env assumption.right constraints
+
+  completeness := by sorry
 
   offset_consistent := by
     simp +arith [List.Forall, tableConstraints, inductiveConstraint, equalityConstraint,

--- a/Clean/Tables/Addition8.lean
+++ b/Clean/Tables/Addition8.lean
@@ -37,6 +37,7 @@ def Spec_add8 {N : ℕ} (trace : TraceOfLength (F p) RowType N) : Prop :=
 def formalAdd8Table : FormalTable (F p) RowType := {
   constraints := add8Table,
   Spec := Spec_add8,
+
   soundness := by
     intro N trace envs _
     simp [table_norm, add8Table, Spec_add8]
@@ -71,6 +72,8 @@ def formalAdd8Table : FormalTable (F p) RowType := {
         -- now we prove a local property about the current row, from the constraints
         obtain ⟨ lookup_x, lookup_y, h_add⟩ := h_holds
         exact h_add lookup_x lookup_y
+
+  completeness := by sorry
 }
 
 end Tables.Addition8

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -225,6 +225,8 @@ def formalFib32Table : FormalTable (F p) RowType := {
       simp only [fib32]
       rw [←curr_fib0, ←curr_fib1, ←eq_spec]
       simp only [curr_fib1, add_spec, Nat.reducePow, and_self, curr_normalized_y]
+
+  completeness := by sorry
 }
 
 end Tables.Fibonacci32

--- a/Clean/Tables/Fibonacci8.lean
+++ b/Clean/Tables/Fibonacci8.lean
@@ -97,6 +97,7 @@ lemma boundary_step (first_row : Row (F p) RowType) (aux_env : Environment (F p)
 def formalFibTable : FormalTable (F p) RowType := {
   constraints := fibTable
   Spec
+  completeness := by sorry
 
   soundness := by
     intro N trace envs _


### PR DESCRIPTION
## Summary

Adds a `completeness` field to `FormalTable`, resolving #349. This mirrors the circuit-level pattern where completeness = `UsesLocalWitnesses + domain assumptions → constraints hold`.

**New definitions in `Clean/Table/Basic.lean`:**
- `TableConstraint.finalInputSize` — input variable count for a table constraint
- `TableConstraint.UsesLocalWitnessesOnWindow` — per-window honest witness condition
- `TableUsesLocalWitnesses` — fold over trace, parallel to `TableConstraintsHold`
- `FormalTable.CompletenessAssumption` — domain-specific assumptions (defaults to `True`)
- `FormalTable.completeness` — `TableUsesLocalWitnesses → CompletenessAssumption → TableConstraintsHold`

**`InductiveTable.toFormal` (`Clean/Table/Inductive.lean`):**
- `CompletenessAssumption` instantiated with `InitialStateAssumptions`, per-row `Spec + InputAssumptions`, and output boundary match
- Completeness proof is `sorry` (to be filled in follow-up)

**Existing tables** (`Fibonacci8`, `Fibonacci32`, `Addition8`) get `completeness := by sorry` placeholders.

## Test plan
- [x] `lake build` passes (only expected sorry warnings)
- [ ] Fill in completeness proof for `InductiveTable.toFormal`
- [ ] Fill in completeness proofs for direct `FormalTable` constructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)