### PR TITLE
Pass full prover environment where useful

### DIFF
--- a/Clean/Circomlib/Bitify.lean
+++ b/Clean/Circomlib/Bitify.lean
@@ -72,7 +72,7 @@ def arbitraryBitLengthCircuit (n : ℕ) : GeneralFormalCircuit (F p) field (fiel
 
   subcircuitsConsistent := by simp +arith [circuit_norm, main]
 
-  Assumptions input _ _ := input.val < 2^n
+  Assumptions input _ := input.val < 2^n
 
   /- without further assumptions on n, this circuit just tells us that the output bits represent
     _some_ number congruent to the input modulo p -/
@@ -115,7 +115,7 @@ def circuit (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields 
   localLength _ := n
   output _ i := varFromOffset (fields n) i
 
-  Assumptions input _ _ := input.val < 2^n
+  Assumptions input _ := input.val < 2^n
 
   Spec input output _ :=
     input.val < 2^n ∧ output = fieldToBits n input

--- a/Clean/Circomlib/Bitify2.lean
+++ b/Clean/Circomlib/Bitify2.lean
@@ -132,7 +132,7 @@ def circuit : GeneralFormalCircuit (F p) (fields 254) field where
   subcircuitsConsistent := by simp +arith [circuit_norm, main,
     Bits2Num.main, AliasCheck.circuit]
 
-  Assumptions input _ _ := (∀ i (_ : i < 254), input[i] = 0 ∨ input[i] = 1) ∧ fromBits (input.map ZMod.val) < p
+  Assumptions input _ := (∀ i (_ : i < 254), input[i] = 0 ∨ input[i] = 1) ∧ fromBits (input.map ZMod.val) < p
 
   Spec input output _ :=
     (∀ i (_ : i < 254), input[i] = 0 ∨ input[i] = 1) → output.val = fromBits (input.map ZMod.val)
@@ -227,7 +227,7 @@ def circuit (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields 
   subcircuitsConsistent := by
     simp +arith only [circuit_norm, main, IsZero.circuit]
 
-  Assumptions input _ _ := input.val < 2^n
+  Assumptions input _ := input.val < 2^n
 
   Spec input output _ :=
     output = fieldToBits n (if n = 0 then 0 else 2^n - input.val : F p)

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -365,26 +365,26 @@ def GeneralFormalCircuit.Soundness (F : Type) [Field F] (circuit : ElaboratedCir
 @[circuit_norm]
 def GeneralFormalCircuit.Completeness (F : Type) [Field F]
     (circuit : ElaboratedCircuit F Input Output)
-    (Assumptions : Input F → ProverData F → ProverHint F → Prop) :=
+    (Assumptions : Input F → ProverEnvironment F → Prop) :=
   -- for all prover environments which use the default witness generators for local variables
   ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the "honest prover" assumptions
   ∀ input : Input F, eval env input_var = input →
-  Assumptions input env.data env.hint →
+  Assumptions input env →
   -- the constraints hold
   ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset)
 
 @[circuit_norm]
 def GeneralFormalCircuit.CompletenessSpecProof (F : Type) [Field F]
     (circuit : ElaboratedCircuit F Input Output)
-    (Assumptions : Input F → ProverData F → ProverHint F → Prop)
-    (CompletenessSpec : Input F → Output F → ProverHint F → Prop) :=
+    (Assumptions : Input F → ProverEnvironment F → Prop)
+    (CompletenessSpec : Input F → Output F → ProverEnvironment F → Prop) :=
   ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   ∀ input : Input F, eval env input_var = input →
-  Assumptions input env.data env.hint →
-  CompletenessSpec input (eval env (circuit.output input_var offset)) env.hint
+  Assumptions input env →
+  CompletenessSpec input (eval env (circuit.output input_var offset)) env
 
 /--
 `GeneralFormalCircuit` is the most general model of formal circuits, needed in cases where the circuit is a
@@ -403,11 +403,15 @@ add the range assumption to the soundness statement, thus making the circuit har
 -/
 structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F] [ProvableType Input] [ProvableType Output]
     extends elaborated : ElaboratedCircuit F Input Output where
-  Assumptions : Input F → ProverData F → ProverHint F → Prop -- the statement to be assumed for completeness
-  Spec : Input F → Output F → ProverData F → Prop -- the statement to be proved for soundness. (Might have to include `Assumptions` on the inputs, as a hypothesis.)
+  /-- the statement to be proved for soundness. (Might have to include `Assumptions` on the inputs, as a hypothesis.) -/
+  Spec : Input F → Output F → ProverData F → Prop
+  /-- the statement to be assumed for completeness -/
+  Assumptions : Input F → ProverEnvironment F → Prop
+  /-- auxiliary statement to be proved for completeness, alongside the constraints -/
+  CompletenessSpec : Input F → Output F → ProverEnvironment F → Prop := fun _ _ _ => True
+
   soundness : GeneralFormalCircuit.Soundness F elaborated Spec
   completeness : GeneralFormalCircuit.Completeness F elaborated Assumptions
-  CompletenessSpec : Input F → Output F → ProverHint F → Prop := fun _ _ _ => True
   completenessSpec : GeneralFormalCircuit.CompletenessSpecProof F elaborated Assumptions CompletenessSpec
     := by unfold GeneralFormalCircuit.CompletenessSpecProof; intros; trivial
 end

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -215,7 +215,7 @@ def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
 
   have implied_by_completeness : ∀ env : ProverEnvironment F,
       env.ExtendsVector (FlatOperation.localWitnesses env nestedOps.toFlat) n →
-      circuit.Assumptions (eval env input_var) env.data env.hint → ConstraintsHoldFlat env nestedOps.toFlat := by
+      circuit.Assumptions (eval env input_var) env → ConstraintsHoldFlat env nestedOps.toFlat := by
     intro env h_env assumptions
     set input := eval env input_var
     rw [ops.toNested_toFlat] at h_env ⊢
@@ -228,10 +228,10 @@ def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
   {
     ops := nestedOps,
     Soundness env := circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data,
-    Completeness env := circuit.Assumptions (eval env input_var) env.data env.hint,
-    UsesLocalWitnesses env := circuit.Assumptions (eval env input_var) env.data env.hint →
+    Completeness env := circuit.Assumptions (eval env input_var) env,
+    UsesLocalWitnesses env := circuit.Assumptions (eval env input_var) env →
       circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data
-      ∧ circuit.CompletenessSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint,
+      ∧ circuit.CompletenessSpec (eval env input_var) (eval env (circuit.output input_var n)) env,
     localLength := circuit.localLength input_var
 
     imply_soundness
@@ -395,9 +395,9 @@ theorem GeneralFormalCircuit.toSubcircuit_usesLocalWitnesses
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).UsesLocalWitnesses env =
-    (circuit.Assumptions (eval env input_var) env.data env.hint →
+    (circuit.Assumptions (eval env input_var) env →
       circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data
-      ∧ circuit.CompletenessSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint) := by
+      ∧ circuit.CompletenessSpec (eval env input_var) (eval env (circuit.output input_var n)) env) := by
   rfl
 
 /--
@@ -498,7 +498,7 @@ theorem GeneralFormalCircuit.toSubcircuit_completeness
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).Completeness env =
-    circuit.Assumptions (eval env input_var) env.data env.hint := by
+    circuit.Assumptions (eval env input_var) env := by
   rfl
 
 /--

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -601,7 +601,7 @@ def FormalCircuit.isGeneralFormalCircuit (F : Type) (Input Output : TypeMap)
   let Spec input output := orig.Assumptions input → orig.Spec input output
   exact {
     elaborated := orig.elaborated,
-    Assumptions i _ _ := orig.Assumptions i,
+    Assumptions i _ := orig.Assumptions i,
     Spec i o _ := Spec i o,
     soundness := by
       simp only [GeneralFormalCircuit.Soundness, forall_eq', Spec]
@@ -626,7 +626,7 @@ def FormalAssertion.isGeneralFormalCircuit (F : Type) (Input : TypeMap)
   let Spec input (_ : Unit) := orig.Assumptions input → orig.Spec input
   exact {
     elaborated := orig.elaborated,
-    Assumptions input _ _ := orig.Assumptions input ∧ orig.Spec input,
+    Assumptions input _ := orig.Assumptions input ∧ orig.Spec input,
     Spec i o _ := Spec i o,
     soundness := by
       simp only [GeneralFormalCircuit.Soundness, forall_eq', Spec]

--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -100,7 +100,7 @@ def decodeInstruction : GeneralFormalCircuit (F p) field DecodedInstruction wher
   localLength _ := 8
 
   Assumptions
-  | instruction, _, _ => instruction.val < 256
+  | instruction, _ => instruction.val < 256
 
   Spec
   | instruction, output, _ =>
@@ -176,7 +176,7 @@ def fetchInstruction
   output _ i₀ := varFromOffset RawInstruction i₀
 
   Assumptions
-  | pc, _, _ => pc.val + 3 < programSize
+  | pc, _ => pc.val + 3 < programSize
 
   Spec
   | pc, output, _ =>
@@ -284,8 +284,7 @@ def MemoryCompletenessAssumption (env : ProverData (F p)) : Prop :=
   The circuit uses lookups into a read-only table representing the memory.
   This circuit is not satisfiable if the memory access is out of bounds.
 -/
-def readFromMemory :
-    GeneralFormalCircuit (F p) MemoryReadInput field where
+def readFromMemory : GeneralFormalCircuit (F p) MemoryReadInput field where
   main := fun { state, offset, mode } => do
     /-
       read into memory for all cases of addressing mode.
@@ -323,18 +322,18 @@ def readFromMemory :
   output _ i₀ := var ⟨i₀ + 4⟩
 
   Assumptions
-  | { state, offset, mode }, env, _ =>
+  | { state, offset, mode }, env =>
     mode.isEncodedCorrectly ∧
-    MemoryCompletenessAssumption env ∧
+    MemoryCompletenessAssumption env.data ∧
     -- for completeness, we assume that the memory access succeeds
-    ∃ hm : NeZero (memorySize env),
-    (Spec.dataMemoryAccess (memory env) offset mode.val state.ap state.fp).isSome
+    ∃ hm : NeZero (memorySize env.data),
+    (Spec.dataMemoryAccess (memory env.data) offset mode.val state.ap state.fp).isSome
 
   Spec
-  | {state, offset, mode}, output, env =>
+  | {state, offset, mode}, output, data =>
     mode.isEncodedCorrectly →
-    ∃ hm : NeZero (memorySize env),
-    match Spec.dataMemoryAccess (memory env) offset mode.val state.ap state.fp with
+    ∃ hm : NeZero (memorySize data),
+    match Spec.dataMemoryAccess (memory data) offset mode.val state.ap state.fp with
       | some value => output = value
       | none => False -- impossible, constraints ensure that memory accesses are valid
 
@@ -492,7 +491,7 @@ def nextState : GeneralFormalCircuit (F p) StateTransitionInput State where
   output _ i₀ := varFromOffset State i₀
 
   Assumptions
-  | {state, decoded, v1, v2, v3}, _, _ =>
+  | {state, decoded, v1, v2, v3}, _ =>
     DecodedInstructionType.isEncodedCorrectly decoded.instrType ∧
     (Spec.computeNextState (DecodedInstructionType.val decoded.instrType) v1 v2 v3 state).isSome
 
@@ -654,12 +653,12 @@ def femtoCairoStepSpec
 -/
 def femtoCairoStepAssumptions
     {programSize : ℕ} [NeZero programSize] (program : Fin programSize → F p)
-    (state : State (F p)) (data : ProverData (F p)) (_hint : ProverHint (F p)) : Prop :=
+    (state : State (F p)) (env : ProverEnvironment (F p)) : Prop :=
   ValidProgramSize p programSize ∧
   ValidProgram program ∧
-  MemoryCompletenessAssumption data ∧
-  ∃ _hm : NeZero (memorySize data),
-  (Spec.femtoCairoMachineTransition program (memory data) state).isSome
+  MemoryCompletenessAssumption env.data ∧
+  ∃ _hm : NeZero (memorySize env.data),
+  (Spec.femtoCairoMachineTransition program (memory env.data) state).isSome
 
 def femtoCairoStepSoundness
     {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p)) (h_programSize : programSize < p)

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -29,7 +29,7 @@ def toBits (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields n
   subcircuitsConsistent x i0 := by simp +arith only [main, circuit_norm]
     -- TODO arith is needed because forAll passes `localLength + offset` while bind passes `offset + localLength`
 
-  Assumptions (x : F p) _ _ := x.val < 2^n
+  Assumptions (x : F p) _ := x.val < 2^n
 
   Spec (x : F p) (bits : Vector (F p) n) _ :=
     x.val < 2^n ∧ bits = fieldToBits n x


### PR DESCRIPTION
Instead of prover data + prover hint separately, this just passes the full `ProverEnvironment` to a circuit's completeness-related statements (`Assumptions`, `CompletenessSpec`).

This increases the flexibility of the general formal circuits API: in particular, it enables passing callbacks of the form
```lean
ProverEnvironment F -> \alpha
```
to general formal circuits, and allow `Assumptions` and `CompletenessSpec` to access its return value.