### PR TITLE
Improve naming of circuit theorems

### DIFF
--- a/Clean/Circomlib/Bitify.lean
+++ b/Clean/Circomlib/Bitify.lean
@@ -72,7 +72,7 @@ def arbitraryBitLengthCircuit (n : ℕ) : GeneralFormalCircuit (F p) field (fiel
 
   subcircuitsConsistent := by simp +arith [circuit_norm, main]
 
-  Assumptions input _ _ := input.val < 2^n
+  ProverAssumptions input _ _ := input.val < 2^n
 
   /- without further assumptions on n, this circuit just tells us that the output bits represent
     _some_ number congruent to the input modulo p -/
@@ -115,7 +115,7 @@ def circuit (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields 
   localLength _ := n
   output _ i := varFromOffset (fields n) i
 
-  Assumptions input _ _ := input.val < 2^n
+  ProverAssumptions input _ _ := input.val < 2^n
 
   Spec input output _ :=
     input.val < 2^n ∧ output = fieldToBits n input

--- a/Clean/Circomlib/Bitify2.lean
+++ b/Clean/Circomlib/Bitify2.lean
@@ -132,40 +132,23 @@ def circuit : GeneralFormalCircuit (F p) (fields 254) field where
   subcircuitsConsistent := by simp +arith [circuit_norm, main,
     Bits2Num.main, AliasCheck.circuit]
 
-  Assumptions input _ _ := (∀ i (_ : i < 254), input[i] = 0 ∨ input[i] = 1) ∧ fromBits (input.map ZMod.val) < p
-
+  ProverAssumptions input _ _ :=
+    (∀ i (_ : i < 254), input[i] = 0 ∨ input[i] = 1) ∧ fromBits (input.map ZMod.val) < p
+  Assumptions input _ :=
+    (∀ i (_ : i < 254), input[i] = 0 ∨ input[i] = 1)
   Spec input output _ :=
-    (∀ i (_ : i < 254), input[i] = 0 ∨ input[i] = 1) → output.val = fromBits (input.map ZMod.val)
+    output.val = fromBits (input.map ZMod.val)
 
   soundness := by
-    intro i0 env input_var input h_input assumptions output h_binary
-    simp only [ElaboratedCircuit.main, main] at assumptions output ⊢
-    simp only [circuit_norm, Bits2Num.main, AliasCheck.circuit] at h_input assumptions output ⊢
-    have : (∀ (i : ℕ) (x : i < 254), Expression.eval env input_var[i] = input[i]) := by
-      intro i hi
-      rw [← h_input]
-      simp only [Vector.getElem_map]
-    have : (∀ (i : ℕ) (x : i < 254), Expression.eval env input_var[i] = 0 ∨ Expression.eval env input_var[i] = 1) := by
-      intro i hi
-      rw [this]
-      apply h_binary
-    simp_all only [implies_true, forall_const]
-    obtain ⟨ h_bits, h_eq ⟩ := assumptions
-    rw [← ZMod.val_natCast_of_lt h_bits]
-    rw [← Vector.mapFinRange_eq_map]
-    rw [← fieldFromBits_eq_mapFinRange_cast]
-    conv =>
-          rhs
-          congr
-          congr
-          congr
-          ext i
-          rw [← h_input]
-          simp only [Fin.getElem_fin, Vector.getElem_map]
-          rw [← Fin.getElem_fin]
-    rw [← Bits2Num.lc_eq]
-    simp only [output, circuit_norm, main, AliasCheck.circuit, Bits2Num.main]
-    rw [h_eq]
+    circuit_proof_start
+    simp only [circuit_norm, Bits2Num.main, AliasCheck.circuit] at h_input h_assumptions h_holds ⊢
+    set output := (env.get (i₀ + (127 + 1 + 135 + 1)))
+    simp_all only [implies_true, forall_const, fields]
+    obtain ⟨ h_bits, h_eq ⟩ := h_holds
+    rw [← ZMod.val_natCast_of_lt h_bits, ← Vector.mapFinRange_eq_map,
+      ← fieldFromBits_eq_mapFinRange_cast]
+    simp only [← h_input, circuit_norm]
+    simp only [← Fin.getElem_fin, Bits2Num.lc_eq]
 
   completeness := by
     simp only [circuit_norm, main]
@@ -227,13 +210,13 @@ def circuit (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields 
   subcircuitsConsistent := by
     simp +arith only [circuit_norm, main, IsZero.circuit]
 
-  Assumptions input _ _ := input.val < 2^n
+  ProverAssumptions input _ _ := input.val < 2^n
 
   Spec input output _ :=
     output = fieldToBits n (if n = 0 then 0 else 2^n - input.val : F p)
 
   soundness := by
-    intro i0 env input_var input h_input h_holds
+    intro i0 env input_var input h_input _ h_holds
     simp only [circuit_norm, main, IsZero.circuit, IsZero.main] at h_holds ⊢
     obtain ⟨ h_bits, h_iszero, h_eq ⟩ := h_holds
 

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -403,7 +403,7 @@ structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F] [Pr
   Spec : Input F → Output F → ProverData F → Prop
 
   /-- the statement to be assumed for completeness -/
-  ProverAssumptions : Input F → ProverData F → ProverHint F → Prop
+  ProverAssumptions : Input F → ProverData F → ProverHint F → Prop  := fun _ _ _ => True
   /-- auxiliary statement to be proved for completeness, alongside the constraints -/
   ProverSpec : Input F → Output F → ProverHint F → Prop := fun _ _ _ => True
 

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -351,11 +351,13 @@ structure FormalAssertion (F : Type) (Input : TypeMap) [Field F] [ProvableType I
 
 @[circuit_norm]
 def GeneralFormalCircuit.Soundness (F : Type) [Field F] (circuit : ElaboratedCircuit F Input Output)
+    (Assumptions : Input F → ProverData F → Prop)
     (Spec : Input F → Output F → ProverData F → Prop) :=
   -- for all environments that determine witness assignments
   ∀ offset : ℕ, ∀ env : Environment F,
-  -- for all inputs
+  -- for all inputs that satisfy the assumptions
   ∀ input_var : Var Input F, ∀ input : Input F, eval env input_var = input →
+  Assumptions input env.data →
   -- if the constraints hold
   ConstraintsHold.Soundness env (circuit.main input_var |>.operations offset) →
   -- the spec holds on the input and output
@@ -365,33 +367,25 @@ def GeneralFormalCircuit.Soundness (F : Type) [Field F] (circuit : ElaboratedCir
 @[circuit_norm]
 def GeneralFormalCircuit.Completeness (F : Type) [Field F]
     (circuit : ElaboratedCircuit F Input Output)
-    (Assumptions : Input F → ProverData F → ProverHint F → Prop) :=
+    (ProverAssumptions : Input F → ProverData F → ProverHint F → Prop)
+    (ProverSpec : Input F → Output F → ProverHint F → Prop) :=
   -- for all prover environments which use the default witness generators for local variables
   ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the "honest prover" assumptions
   ∀ input : Input F, eval env input_var = input →
-  Assumptions input env.data env.hint →
+  ProverAssumptions input env.data env.hint →
   -- the constraints hold
-  ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset)
-
-@[circuit_norm]
-def GeneralFormalCircuit.CompletenessSpecProof (F : Type) [Field F]
-    (circuit : ElaboratedCircuit F Input Output)
-    (Assumptions : Input F → ProverData F → ProverHint F → Prop)
-    (CompletenessSpec : Input F → Output F → ProverHint F → Prop) :=
-  ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
-  env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
-  ∀ input : Input F, eval env input_var = input →
-  Assumptions input env.data env.hint →
-  CompletenessSpec input (eval env (circuit.output input_var offset)) env.hint
+  ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset) ∧
+  -- and, if given, the prover spec holds
+  ProverSpec input (eval env (circuit.output input_var offset)) env.hint
 
 /--
 `GeneralFormalCircuit` is the most general model of formal circuits, needed in cases where the circuit is a
 _mix_ of "assertion-like" and "function-like". It allows you flexibility in specifying separate statements
 to be proved in the soundness and completeness proofs, by
-- only using the `Spec` in the soundness statement
-- only using the `Assumptions` in the completeness statement
+- only using the `Assumptions` and `Spec` in the soundness statement
+- having separate `ProverAssumptions` and `ProverSpec` for the completeness statement
 i.e. the two statements are not "coupled".
 
 For example, take the `toBits n` circuit, which outputs the `n`-bit decomposition of the input.
@@ -403,13 +397,18 @@ add the range assumption to the soundness statement, thus making the circuit har
 -/
 structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F] [ProvableType Input] [ProvableType Output]
     extends elaborated : ElaboratedCircuit F Input Output where
-  Assumptions : Input F → ProverData F → ProverHint F → Prop -- the statement to be assumed for completeness
-  Spec : Input F → Output F → ProverData F → Prop -- the statement to be proved for soundness. (Might have to include `Assumptions` on the inputs, as a hypothesis.)
-  soundness : GeneralFormalCircuit.Soundness F elaborated Spec
-  completeness : GeneralFormalCircuit.Completeness F elaborated Assumptions
-  CompletenessSpec : Input F → Output F → ProverHint F → Prop := fun _ _ _ => True
-  completenessSpec : GeneralFormalCircuit.CompletenessSpecProof F elaborated Assumptions CompletenessSpec
-    := by unfold GeneralFormalCircuit.CompletenessSpecProof; intros; trivial
+  /-- the statement to be assumed for soundness -/
+  Assumptions : Input F → ProverData F → Prop := fun _ _ => True
+  /-- the statement to be proved for soundness. -/
+  Spec : Input F → Output F → ProverData F → Prop
+
+  /-- the statement to be assumed for completeness -/
+  ProverAssumptions : Input F → ProverData F → ProverHint F → Prop
+  /-- auxiliary statement to be proved for completeness, alongside the constraints -/
+  ProverSpec : Input F → Output F → ProverHint F → Prop := fun _ _ _ => True
+
+  soundness : GeneralFormalCircuit.Soundness F elaborated Assumptions Spec
+  completeness : GeneralFormalCircuit.Completeness F elaborated ProverAssumptions ProverSpec
 end
 
 export Circuit (witnessVar witnessField witnessVars witnessVector assertZero lookup)

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -163,7 +163,7 @@ def ConstraintsHold.Soundness (eval : Environment F) : List (Operation F) → Pr
   | .lookup l :: ops =>
     l.Soundness eval ∧ ConstraintsHold.Soundness eval ops
   | .subcircuit s :: ops =>
-    s.Soundness eval ∧ ConstraintsHold.Soundness eval ops
+    s.Spec eval ∧ ConstraintsHold.Soundness eval ops
 
 /--
 Version of `ConstraintsHold` that replaces the statement of subcircuits with their `Completeness`.
@@ -176,7 +176,7 @@ def ConstraintsHold.Completeness (eval : ProverEnvironment F) : List (Operation 
   | .lookup l :: ops =>
     l.Completeness eval ∧ ConstraintsHold.Completeness eval ops
   | .subcircuit s :: ops =>
-    s.Completeness eval ∧ ConstraintsHold.Completeness eval ops
+    s.ProverAssumptions eval ∧ ConstraintsHold.Completeness eval ops
 end Circuit
 
 /--
@@ -198,7 +198,7 @@ def ProverEnvironment.UsesLocalWitnessesCompleteness (env : ProverEnvironment F)
   | .witness m c :: ops => env.ExtendsVector (c env) offset ∧ env.UsesLocalWitnessesCompleteness (offset + m) ops
   | .assert _ :: ops => env.UsesLocalWitnessesCompleteness offset ops
   | .lookup _ :: ops => env.UsesLocalWitnessesCompleteness offset ops
-  | .subcircuit s :: ops => s.UsesLocalWitnesses env ∧ env.UsesLocalWitnessesCompleteness (offset + s.localLength) ops
+  | .subcircuit s :: ops => s.ProverSpec env ∧ env.UsesLocalWitnessesCompleteness (offset + s.localLength) ops
 
 /-- Same as `UsesLocalWitnesses`, but on flat operations -/
 def ProverEnvironment.UsesLocalWitnessesFlat (env : ProverEnvironment F) (n : ℕ) (ops : List (FlatOperation F)) : Prop :=

--- a/Clean/Circuit/Operations.lean
+++ b/Clean/Circuit/Operations.lean
@@ -88,28 +88,25 @@ structure Subcircuit (F : Type) [Field F] (offset : ℕ) where
   ops : NestedOperations F
 
   -- we have a low-level notion of "the constraints hold on these operations".
-  -- for convenience, we allow the framework to transform that into custom `Soundness`,
-  -- `Completeness` and `UsesLocalWitnesses` statements (which may involve inputs/outputs, assumptions on inputs, etc)
-  Soundness : Environment F → Prop
-  -- `Completeness` and `UsesLocalWitnesses` see the full prover `ProverEnvironment`, which carries
-  -- the hint that drives witness generation.
-  Completeness : ProverEnvironment F → Prop
-  UsesLocalWitnesses : ProverEnvironment F → Prop
+  -- for convenience, we allow the framework to transform that into custom `Spec`,
+  -- `ProverAssumptions` and `ProverSpec` statements (which may involve inputs/outputs, assumptions on inputs, etc)
+  Spec : Environment F → Prop
+  ProverAssumptions : ProverEnvironment F → Prop
+  ProverSpec : ProverEnvironment F → Prop
 
   -- for faster simplification, the subcircuit records its local witness length separately
   -- even though it could be derived from the operations
   localLength : ℕ
 
-  -- `Soundness` needs to follow from the constraints for any witness
-  imply_soundness : ∀ env,
-    ConstraintsHoldFlat env ops.toFlat → Soundness env
+  -- soundness: `Spec` needs to follow from the constraints for any witness
+  soundness : ∀ env,
+    ConstraintsHoldFlat env ops.toFlat → Spec env
 
-  -- `Completeness` needs to imply the constraints, when using the locally declared witness generators of this circuit
-  implied_by_completeness : ∀ env, env.ExtendsVector (localWitnesses env ops.toFlat) offset →
-    Completeness env → ConstraintsHoldFlat env ops.toFlat
-  -- `UsesLocalWitnesses` needs to follow from the local witness generator condition
-  imply_usesLocalWitnesses : ∀ env, env.ExtendsVector (localWitnesses env ops.toFlat) offset →
-    UsesLocalWitnesses env
+  -- completeness: `ProverAssumptions` needs to imply the constraints,
+  -- when using the locally declared witness generators of this circuit.
+  -- `ProverSpec` also needs to follow from the local witness generator condition.
+  completeness : ∀ env, env.ExtendsVector (localWitnesses env ops.toFlat) offset →
+    (ProverAssumptions env → ConstraintsHoldFlat env ops.toFlat) ∧ ProverSpec env
 
   -- `localLength` must be consistent with the operations
   localLength_eq : localLength = FlatOperation.localLength ops.toFlat

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -195,7 +195,7 @@ def FormalAssertion.toSubcircuit (circuit : FormalAssertion F β)
   }
 
 /--
-Theorem and implementation that allows us to take a formal circuit and use it as a subcircuit.
+Theorem and implementation that allows us to take a general formal circuit and use it as a subcircuit.
 -/
 def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
     (n : ℕ) (input_var : Var β F) : Subcircuit F n :=
@@ -206,16 +206,19 @@ def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
   have imply_soundness : ∀ env : Environment F,
       let input := eval env input_var
       let output := eval env (circuit.output input_var n)
-      ConstraintsHoldFlat env nestedOps.toFlat → circuit.Spec input output env.data := by
-    intro env input output h_holds
-    rw [ops.toNested_toFlat] at h_holds
-    apply circuit.soundness n env input_var input rfl
+      ConstraintsHoldFlat env nestedOps.toFlat →
+      circuit.Assumptions input env.data →
+      circuit.Spec input output env.data := by
+    intro env input output constraints assumptions
+    rw [ops.toNested_toFlat] at constraints
+    apply circuit.soundness n env input_var input rfl assumptions
     apply can_replace_soundness
-    exact constraintsHold_toFlat_iff.mp h_holds
+    exact constraintsHold_toFlat_iff.mp constraints
 
   have implied_by_completeness : ∀ env : ProverEnvironment F,
       env.ExtendsVector (FlatOperation.localWitnesses env nestedOps.toFlat) n →
-      circuit.Assumptions (eval env input_var) env.data env.hint → ConstraintsHoldFlat env nestedOps.toFlat := by
+      circuit.ProverAssumptions (eval env input_var) env.data env.hint →
+      ConstraintsHoldFlat env nestedOps.toFlat := by
     intro env h_env assumptions
     set input := eval env input_var
     rw [ops.toNested_toFlat] at h_env ⊢
@@ -223,15 +226,22 @@ def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
     rw [constraintsHold_toFlat_iff]
     apply can_replace_completeness h_consistent h_env
     have h_env_completeness := env.can_replace_usesLocalWitnessesCompleteness h_consistent h_env
-    apply circuit.completeness n env input_var h_env_completeness input rfl assumptions
+    apply (circuit.completeness n env input_var h_env_completeness input rfl assumptions).1
 
   {
     ops := nestedOps,
-    Soundness env := circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data,
-    Completeness env := circuit.Assumptions (eval env input_var) env.data env.hint,
-    UsesLocalWitnesses env := circuit.Assumptions (eval env input_var) env.data env.hint →
-      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data
-      ∧ circuit.CompletenessSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint,
+
+    Soundness env := circuit.Assumptions (eval env input_var) env.data →
+      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data,
+
+    Completeness env := circuit.ProverAssumptions (eval env input_var) env.data env.hint,
+
+    UsesLocalWitnesses env :=
+      circuit.ProverAssumptions (eval env input_var) env.data env.hint →
+      (circuit.Assumptions (eval env input_var) env.data →
+        circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data)
+      ∧ circuit.ProverSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint,
+
     localLength := circuit.localLength input_var
 
     imply_soundness
@@ -244,7 +254,7 @@ def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
         rw [ops.toNested_toFlat] at h_env'
         rw [←env.usesLocalWitnessesFlat_iff_extends, ←env.usesLocalWitnesses_iff_flat] at h_env'
         have h_env_completeness := env.can_replace_usesLocalWitnessesCompleteness h_consistent h_env'
-        exact circuit.completenessSpec n env input_var h_env_completeness _ rfl assumptions
+        exact (circuit.completeness n env input_var h_env_completeness _ rfl assumptions).2
 
     localLength_eq := by
       rw [ops.toNested_toFlat, ← circuit.localLength_eq input_var n,
@@ -395,9 +405,10 @@ theorem GeneralFormalCircuit.toSubcircuit_usesLocalWitnesses
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).UsesLocalWitnesses env =
-    (circuit.Assumptions (eval env input_var) env.data env.hint →
-      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data
-      ∧ circuit.CompletenessSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint) := by
+    (circuit.ProverAssumptions (eval env input_var) env.data env.hint →
+      (circuit.Assumptions (eval env input_var) env.data →
+        circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data)
+      ∧ circuit.ProverSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint) := by
   rfl
 
 /--
@@ -463,7 +474,8 @@ theorem GeneralFormalCircuit.toSubcircuit_soundness
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : Environment F) :
     (circuit.toSubcircuit n input_var).Soundness env =
-    circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data := by
+    (circuit.Assumptions (eval env input_var) env.data →
+      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data) := by
   rfl
 
 /--
@@ -498,7 +510,7 @@ theorem GeneralFormalCircuit.toSubcircuit_completeness
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).Completeness env =
-    circuit.Assumptions (eval env input_var) env.data env.hint := by
+    circuit.ProverAssumptions (eval env input_var) env.data env.hint := by
   rfl
 
 /--

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -70,7 +70,7 @@ def FormalCircuit.toSubcircuit (circuit : FormalCircuit F β α)
   let nestedOps : NestedOperations F := .nested ⟨ circuit.name, ops.toNested ⟩
   have h_consistent : ops.SubcircuitsConsistent n := circuit.subcircuitsConsistent input_var n
 
-  have imply_soundness : ∀ env : Environment F,
+  have soundness : ∀ env : Environment F,
     let input := eval env input_var
     let output := eval env (circuit.output input_var n)
     ConstraintsHoldFlat env nestedOps.toFlat → circuit.Assumptions input → circuit.Spec input output := by
@@ -88,7 +88,7 @@ def FormalCircuit.toSubcircuit (circuit : FormalCircuit F β α)
     apply can_replace_soundness
     exact constraintsHold_toFlat_iff.mp h_holds
 
-  have implied_by_completeness : ∀ env : ProverEnvironment F,
+  have completeness : ∀ env : ProverEnvironment F,
       env.ExtendsVector (FlatOperation.localWitnesses env nestedOps.toFlat) n →
       circuit.Assumptions (eval env input_var) → ConstraintsHoldFlat env nestedOps.toFlat := by
     -- we are given that the assumptions are true
@@ -112,21 +112,22 @@ def FormalCircuit.toSubcircuit (circuit : FormalCircuit F β α)
 
   {
     ops := nestedOps,
-    Soundness env := circuit.Assumptions (eval env input_var) →
+    Spec env := circuit.Assumptions (eval env input_var) →
       circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)),
-    Completeness env := circuit.Assumptions (eval env input_var),
-    UsesLocalWitnesses env := circuit.Assumptions (eval env input_var) →
+    ProverAssumptions env := circuit.Assumptions (eval env input_var),
+    ProverSpec env := circuit.Assumptions (eval env input_var) →
       circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)),
     localLength := circuit.localLength input_var
 
-    imply_soundness
-    implied_by_completeness
-    imply_usesLocalWitnesses := by
-      intro env h_env as
+    soundness
+    completeness := by
+      intro env h_env
+      use completeness env h_env
+      intro as
       -- by completeness, the constraints hold
-      have h_holds := implied_by_completeness env h_env as
+      have h_holds := completeness env h_env as
       -- by soundness, this implies the spec
-      exact imply_soundness env h_holds as
+      exact soundness env h_holds as
 
     localLength_eq := by
       rw [ops.toNested_toFlat, ←circuit.localLength_eq input_var n,
@@ -144,12 +145,12 @@ def FormalAssertion.toSubcircuit (circuit : FormalAssertion F β)
 
   {
     ops := nestedOps,
-    Soundness env := circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var),
-    Completeness env := circuit.Assumptions (eval env input_var) ∧ circuit.Spec (eval env input_var),
-    UsesLocalWitnesses _ := True,
+    Spec env := circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var),
+    ProverAssumptions env := circuit.Assumptions (eval env input_var) ∧ circuit.Spec (eval env input_var),
+    ProverSpec _ := True,
     localLength := circuit.localLength input_var
 
-    imply_soundness := by
+    soundness := by
       -- we are given an environment where the constraints hold, and can assume the assumptions are true
       intro env h_holds
       let input : β F := eval env input_var
@@ -166,12 +167,14 @@ def FormalAssertion.toSubcircuit (circuit : FormalAssertion F β)
       apply can_replace_soundness
       exact constraintsHold_toFlat_iff.mp h_holds
 
-    implied_by_completeness := by
+    completeness := by
       -- we are given that the assumptions and the spec are true
-      intro env h_env h_completeness
+      intro env h_env
+      simp only [and_true]
+      intro assumptions
 
       let input := eval env input_var
-      have as : circuit.Assumptions input ∧ circuit.Spec input := h_completeness
+      have as : circuit.Assumptions input ∧ circuit.Spec input := assumptions
       rw [ops.toNested_toFlat] at h_env ⊢
 
       have h_env : env.UsesLocalWitnesses n ops := by
@@ -187,8 +190,6 @@ def FormalAssertion.toSubcircuit (circuit : FormalAssertion F β)
       apply constraintsHold_toFlat_iff.mpr
       exact can_replace_completeness h_consistent h_env h_holds
 
-    imply_usesLocalWitnesses := by intros; exact trivial
-
     localLength_eq := by
       rw [ops.toNested_toFlat, ← circuit.localLength_eq input_var n,
         FlatOperation.localLength_toFlat]
@@ -203,7 +204,7 @@ def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
   let nestedOps : NestedOperations F := .nested ⟨ circuit.name, ops.toNested ⟩
   have h_consistent : ops.SubcircuitsConsistent n := circuit.subcircuitsConsistent input_var n
 
-  have imply_soundness : ∀ env : Environment F,
+  have soundness : ∀ env : Environment F,
       let input := eval env input_var
       let output := eval env (circuit.output input_var n)
       ConstraintsHoldFlat env nestedOps.toFlat →
@@ -215,7 +216,7 @@ def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
     apply can_replace_soundness
     exact constraintsHold_toFlat_iff.mp constraints
 
-  have implied_by_completeness : ∀ env : ProverEnvironment F,
+  have implied_by_assumptions : ∀ env : ProverEnvironment F,
       env.ExtendsVector (FlatOperation.localWitnesses env nestedOps.toFlat) n →
       circuit.ProverAssumptions (eval env input_var) env.data env.hint →
       ConstraintsHoldFlat env nestedOps.toFlat := by
@@ -231,12 +232,12 @@ def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
   {
     ops := nestedOps,
 
-    Soundness env := circuit.Assumptions (eval env input_var) env.data →
+    Spec env := circuit.Assumptions (eval env input_var) env.data →
       circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data,
 
-    Completeness env := circuit.ProverAssumptions (eval env input_var) env.data env.hint,
+    ProverAssumptions env := circuit.ProverAssumptions (eval env input_var) env.data env.hint,
 
-    UsesLocalWitnesses env :=
+    ProverSpec env :=
       circuit.ProverAssumptions (eval env input_var) env.data env.hint →
       (circuit.Assumptions (eval env input_var) env.data →
         circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data)
@@ -244,12 +245,13 @@ def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
 
     localLength := circuit.localLength input_var
 
-    imply_soundness
-    implied_by_completeness
-    imply_usesLocalWitnesses := by
-      intro env h_env assumptions
+    soundness
+    completeness := by
+      intro env h_env
+      use implied_by_assumptions env h_env
+      intro assumptions
       constructor
-      · exact implied_by_completeness env h_env assumptions |> imply_soundness env
+      · exact implied_by_assumptions env h_env assumptions |> soundness env
       · have h_env' := h_env
         rw [ops.toNested_toFlat] at h_env'
         rw [←env.usesLocalWitnessesFlat_iff_extends, ←env.usesLocalWitnesses_iff_flat] at h_env'
@@ -393,7 +395,7 @@ Simplifies UsesLocalWitnesses for FormalCircuit.toSubcircuit to avoid unfolding 
 theorem FormalCircuit.toSubcircuit_usesLocalWitnesses
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : FormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
-    (circuit.toSubcircuit n input_var).UsesLocalWitnesses env =
+    (circuit.toSubcircuit n input_var).ProverSpec env =
     (circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var) (eval env (circuit.output input_var n))) := by
   rfl
 
@@ -404,7 +406,7 @@ Simplifies UsesLocalWitnesses for GeneralFormalCircuit.toSubcircuit to avoid unf
 theorem GeneralFormalCircuit.toSubcircuit_usesLocalWitnesses
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
-    (circuit.toSubcircuit n input_var).UsesLocalWitnesses env =
+    (circuit.toSubcircuit n input_var).ProverSpec env =
     (circuit.ProverAssumptions (eval env input_var) env.data env.hint →
       (circuit.Assumptions (eval env input_var) env.data →
         circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data)
@@ -418,7 +420,7 @@ Simplifies UsesLocalWitnesses for FormalAssertion.toSubcircuit to avoid unfoldin
 theorem FormalAssertion.toSubcircuit_usesLocalWitnesses
     {F : Type} [Field F] {Input : TypeMap} [ProvableType Input]
     (circuit : FormalAssertion F Input) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
-    (circuit.toSubcircuit n input_var).UsesLocalWitnesses env = True := by
+    (circuit.toSubcircuit n input_var).ProverSpec env = True := by
   rfl
 
 -- Simplification lemmas for toSubcircuit.localLength
@@ -462,7 +464,7 @@ Simplifies Soundness for FormalCircuit.toSubcircuit to avoid unfolding the entir
 theorem FormalCircuit.toSubcircuit_soundness
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : FormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : Environment F) :
-    (circuit.toSubcircuit n input_var).Soundness env =
+    (circuit.toSubcircuit n input_var).Spec env =
     (circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var) (eval env (circuit.output input_var n))) := by
   rfl
 
@@ -473,7 +475,7 @@ Simplifies Soundness for GeneralFormalCircuit.toSubcircuit to avoid unfolding th
 theorem GeneralFormalCircuit.toSubcircuit_soundness
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : Environment F) :
-    (circuit.toSubcircuit n input_var).Soundness env =
+    (circuit.toSubcircuit n input_var).Spec env =
     (circuit.Assumptions (eval env input_var) env.data →
       circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data) := by
   rfl
@@ -485,7 +487,7 @@ Simplifies Soundness for FormalAssertion.toSubcircuit to avoid unfolding the ent
 theorem FormalAssertion.toSubcircuit_soundness
     {F : Type} [Field F] {Input : TypeMap} [ProvableType Input]
     (circuit : FormalAssertion F Input) (n : ℕ) (input_var : Var Input F) (env : Environment F) :
-    (circuit.toSubcircuit n input_var).Soundness env =
+    (circuit.toSubcircuit n input_var).Spec env =
     (circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var)) := by
   rfl
 
@@ -498,7 +500,7 @@ Simplifies Completeness for FormalCircuit.toSubcircuit to avoid unfolding the en
 theorem FormalCircuit.toSubcircuit_completeness
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : FormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
-    (circuit.toSubcircuit n input_var).Completeness env =
+    (circuit.toSubcircuit n input_var).ProverAssumptions env =
     circuit.Assumptions (eval env input_var) := by
   rfl
 
@@ -509,7 +511,7 @@ Simplifies Completeness for GeneralFormalCircuit.toSubcircuit to avoid unfolding
 theorem GeneralFormalCircuit.toSubcircuit_completeness
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
-    (circuit.toSubcircuit n input_var).Completeness env =
+    (circuit.toSubcircuit n input_var).ProverAssumptions env =
     circuit.ProverAssumptions (eval env input_var) env.data env.hint := by
   rfl
 
@@ -520,6 +522,6 @@ Simplifies Completeness for FormalAssertion.toSubcircuit to avoid unfolding the 
 theorem FormalAssertion.toSubcircuit_completeness
     {F : Type} [Field F] {Input : TypeMap} [ProvableType Input]
     (circuit : FormalAssertion F Input) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
-    (circuit.toSubcircuit n input_var).Completeness env =
+    (circuit.toSubcircuit n input_var).ProverAssumptions env =
     (circuit.Assumptions (eval env input_var) ∧ circuit.Spec (eval env input_var)) := by
   rfl

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -595,47 +595,41 @@ end FlatOperation
 `FormalCircuit`. The idea is to make `FormalCircuit.Assumption` available in the soundness
 by assuming it within `GeneralFormalCircuit.Spec`.
 -/
-def FormalCircuit.isGeneralFormalCircuit (F : Type) (Input Output : TypeMap)
-    [Field F] [ProvableType Output] [ProvableType Input]
-    (orig : FormalCircuit F Input Output) : GeneralFormalCircuit F Input Output := by
-  let Spec input output := orig.Assumptions input → orig.Spec input output
-  exact {
-    elaborated := orig.elaborated,
-    Assumptions i _ _ := orig.Assumptions i,
-    Spec i o _ := Spec i o,
-    soundness := by
-      simp only [GeneralFormalCircuit.Soundness, forall_eq', Spec]
+@[circuit_norm]
+def FormalCircuit.isGeneralFormalCircuit {F : Type} {Input Output : TypeMap}
+  [Field F] [ProvableType Output] [ProvableType Input]
+    (orig : FormalCircuit F Input Output) : GeneralFormalCircuit F Input Output where
+  elaborated := orig.elaborated
+  Assumptions i _ := orig.Assumptions i
+  Spec i o _ := orig.Spec i o
+  ProverAssumptions i _ _ := orig.Assumptions i
+  soundness := by
+      simp only [circuit_norm, forall_eq']
       intros
       apply orig.soundness <;> trivial
-    ,
-    completeness := by
-      simp only [GeneralFormalCircuit.Completeness, forall_eq']
-      intros
-      apply orig.completeness <;> trivial
-    completenessSpec := fun _ _ _ _ _ _ _ => trivial
-  }
+  completeness := by
+    simp only [circuit_norm, forall_eq']
+    intros
+    apply orig.completeness <;> trivial
 
 /--
 `FormalAssertion.isGeneralFormalCircuit` explains how `GeneralFormalCircuit` is a generalization of
 `FormalAssertion`.  The idea is to make `FormalAssertion.Spec` available in the completeness
 by putting it within `GeneralFormalCircuit.Assumption`.
 -/
-def FormalAssertion.isGeneralFormalCircuit (F : Type) (Input : TypeMap)
-    [Field F] [ProvableType Input] (orig : FormalAssertion F Input) :
-    GeneralFormalCircuit F Input unit := by
-  let Spec input (_ : Unit) := orig.Assumptions input → orig.Spec input
-  exact {
-    elaborated := orig.elaborated,
-    Assumptions input _ _ := orig.Assumptions input ∧ orig.Spec input,
-    Spec i o _ := Spec i o,
-    soundness := by
-      simp only [GeneralFormalCircuit.Soundness, forall_eq', Spec]
-      intros
-      apply orig.soundness <;> trivial
-    ,
-    completeness := by
-      simp only [GeneralFormalCircuit.Completeness, forall_eq']
-      rintro _ _ _ _ ⟨ _, _ ⟩
-      apply orig.completeness <;> trivial
-    completenessSpec := fun _ _ _ _ _ _ _ => trivial
-  }
+@[circuit_norm]
+def FormalAssertion.isGeneralFormalCircuit {F : Type} {Input : TypeMap}
+  [Field F] [ProvableType Input]
+    (orig : FormalAssertion F Input) : GeneralFormalCircuit F Input unit where
+  elaborated := orig.elaborated
+  Assumptions i _ := orig.Assumptions i
+  Spec i _ _ := orig.Spec i
+  ProverAssumptions i _ _ := orig.Assumptions i ∧ orig.Spec i
+  soundness := by
+    simp only [circuit_norm, forall_eq']
+    intros
+    apply orig.soundness <;> trivial
+  completeness := by
+    simp only [circuit_norm, forall_eq']
+    rintro _ _ _ _ ⟨ _, _ ⟩
+    apply orig.completeness <;> trivial

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -140,7 +140,7 @@ theorem can_replace_soundness {ops : Operations F} {env} :
   | subcircuit circuit ops ih =>
     dsimp only [ConstraintsHold.Soundness]
     dsimp only [ConstraintsHold] at h
-    exact ⟨ circuit.imply_soundness env h.left, ih h.right ⟩
+    exact ⟨ circuit.soundness env h.left, ih h.right ⟩
 
 end Circuit
 
@@ -271,14 +271,14 @@ theorem can_replace_usesLocalWitnessesCompleteness {env : ProverEnvironment F} {
     intro h
     rw [add_comm]
     apply And.intro ?_ (ih h.right)
-    apply circuit.imply_usesLocalWitnesses
+    apply (circuit.completeness _ _).2
     rw [← usesLocalWitnessesFlat_iff_extends]
     exact h.left
 
 theorem usesLocalWitnessesCompleteness_iff_forAll (n : ℕ) {env : ProverEnvironment F} {ops : Operations F} :
   env.UsesLocalWitnessesCompleteness n ops ↔ ops.forAll n {
     witness m _ c := env.ExtendsVector (c env) m,
-    subcircuit _ _ s := s.UsesLocalWitnesses env
+    subcircuit _ _ s := s.ProverSpec env
   } := by
   induction ops using Operations.induct generalizing n with
   | empty => trivial
@@ -299,7 +299,7 @@ theorem ConstraintsHold.soundness_iff_forAll (n : ℕ) (env : Environment F) (op
   ConstraintsHold.Soundness env ops ↔ ops.forAll n {
     assert _ e := env e = 0,
     lookup _ l := l.Soundness env,
-    subcircuit _ _ s := s.Soundness env
+    subcircuit _ _ s := s.Spec env
   } := by
   induction ops using Operations.induct generalizing n with
   | empty => trivial
@@ -312,7 +312,7 @@ theorem ConstraintsHold.completeness_iff_forAll (n : ℕ) (env : ProverEnvironme
   ConstraintsHold.Completeness env ops ↔ ops.forAll n {
     assert _ e := env e = 0,
     lookup _ l := l.Completeness env,
-    subcircuit _ _ s := s.Completeness env
+    subcircuit _ _ s := s.ProverAssumptions env
   } := by
   induction ops using Operations.induct generalizing n with
   | empty => trivial
@@ -340,7 +340,7 @@ theorem can_replace_completeness {env} {ops : Operations F} {n : ℕ} (h : ops.S
   | subcircuit n circuit ops ih =>
     simp_all only [ConstraintsHold, ConstraintsHold.Completeness, ProverEnvironment.UsesLocalWitnesses, Operations.forAllFlat, Operations.forAll, and_true]
     intro h_env h_compl
-    apply circuit.implied_by_completeness env ?_ h_compl.left
+    apply (circuit.completeness env ?_).left h_compl.left
     rw [←ProverEnvironment.usesLocalWitnessesFlat_iff_extends]
     exact h_env.left
 end Circuit
@@ -377,7 +377,7 @@ theorem ConstraintsHold.soundness_iff_forAll' {env : Environment F} {circuit : C
   ConstraintsHold.Soundness env (circuit.operations n) ↔ circuit.forAll n {
     assert _ e := env e = 0,
     lookup _ l := l.Soundness env,
-    subcircuit _ _ s := s.Soundness env
+    subcircuit _ _ s := s.Spec env
   } := by
   rw [forAll_def, ConstraintsHold.soundness_iff_forAll n]
 
@@ -385,7 +385,7 @@ theorem ConstraintsHold.completeness_iff_forAll' {env : ProverEnvironment F} {ci
   ConstraintsHold.Completeness env (circuit.operations n) ↔ circuit.forAll n {
     assert _ e := env e = 0,
     lookup _ l := l.Completeness env,
-    subcircuit _ _ s := s.Completeness env
+    subcircuit _ _ s := s.ProverAssumptions env
   } := by
   rw [forAll_def, ConstraintsHold.completeness_iff_forAll n]
 

--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -99,7 +99,7 @@ def decodeInstruction : GeneralFormalCircuit (F p) field DecodedInstruction wher
   main := decodeInstructionMain
   localLength _ := 8
 
-  Assumptions
+  ProverAssumptions
   | instruction, _, _ => instruction.val < 256
 
   Spec
@@ -175,7 +175,7 @@ def fetchInstruction
   localLength _ := 4
   output _ i₀ := varFromOffset RawInstruction i₀
 
-  Assumptions
+  ProverAssumptions
   | pc, _, _ => pc.val + 3 < programSize
 
   Spec
@@ -322,17 +322,19 @@ def readFromMemory :
   localLength _ := 5
   output _ i₀ := var ⟨i₀ + 4⟩
 
-  Assumptions
-  | { state, offset, mode }, env, _ =>
+  ProverAssumptions
+  | { state, offset, mode }, data, _ =>
     mode.isEncodedCorrectly ∧
-    MemoryCompletenessAssumption env ∧
+    MemoryCompletenessAssumption data ∧
     -- for completeness, we assume that the memory access succeeds
-    ∃ hm : NeZero (memorySize env),
-    (Spec.dataMemoryAccess (memory env) offset mode.val state.ap state.fp).isSome
+    ∃ hm : NeZero (memorySize data),
+    (Spec.dataMemoryAccess (memory data) offset mode.val state.ap state.fp).isSome
+
+  Assumptions
+  | { state, offset, mode }, _ => mode.isEncodedCorrectly
 
   Spec
   | {state, offset, mode}, output, env =>
-    mode.isEncodedCorrectly →
     ∃ hm : NeZero (memorySize env),
     match Spec.dataMemoryAccess (memory env) offset mode.val state.ap state.fp with
       | some value => output = value
@@ -342,7 +344,6 @@ def readFromMemory :
     circuit_proof_start [ReadOnlyTableFromFunction, Spec.dataMemoryAccess,
       Spec.memoryAccess, DecodedAddressingMode.val, DecodedAddressingMode.isEncodedCorrectly,
       memorySize, memoryValue, memory, MemoryEntry]
-    intro h_assumptions
     set memoryTable := env.data.getTable MemoryTable with h_memory_table_def
     simp only [MemoryTable] at h_holds
 
@@ -492,13 +493,16 @@ def nextState : GeneralFormalCircuit (F p) StateTransitionInput State where
   output _ i₀ := varFromOffset State i₀
 
   Assumptions
+  | {state, decoded, v1, v2, v3}, _ =>
+    DecodedInstructionType.isEncodedCorrectly decoded.instrType
+
+  ProverAssumptions
   | {state, decoded, v1, v2, v3}, _, _ =>
     DecodedInstructionType.isEncodedCorrectly decoded.instrType ∧
     (Spec.computeNextState (DecodedInstructionType.val decoded.instrType) v1 v2 v3 state).isSome
 
   Spec
   | {state, decoded, v1, v2, v3}, output, _ =>
-    DecodedInstructionType.isEncodedCorrectly decoded.instrType →
     match Spec.computeNextState (DecodedInstructionType.val decoded.instrType) v1 v2 v3 state with
       | some nextState => output = nextState
       | none => False -- impossible, constraints ensure that the transition is valid
@@ -521,7 +525,6 @@ def nextState : GeneralFormalCircuit (F p) StateTransitionInput State where
     set fp_next := env.get (i₀ + 2)
 
     -- case analysis on the instruction type
-    intro h_assumptions
     rcases h_assumptions with isAdd_cases | isMul_cases | isStoreState_cases | isLoadState_cases
     <;> split <;> simp_all [add_eq_zero_iff_eq_neg]
 
@@ -663,7 +666,8 @@ def femtoCairoStepAssumptions
 
 def femtoCairoStepSoundness
     {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p)) (h_programSize : programSize < p)
-    : GeneralFormalCircuit.Soundness (F p) (femtoCairoStepElaboratedCircuit program h_programSize) (femtoCairoStepSpec program) := by
+    : GeneralFormalCircuit.Soundness (F p) (femtoCairoStepElaboratedCircuit program h_programSize) (fun _ _ => True)
+      (femtoCairoStepSpec program) := by
   circuit_proof_start [femtoCairoStepSpec, femtoCairoStepAssumptions, femtoCairoStepElaboratedCircuit,
     Spec.femtoCairoMachineTransition, fetchInstruction, readFromMemory, nextState, decodeInstruction]
 
@@ -752,7 +756,7 @@ def femtoCairoStepSoundness
 def femtoCairoStepCompleteness {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p))
   (h_programSize : programSize < p) :
     GeneralFormalCircuit.Completeness (F p) (femtoCairoStepElaboratedCircuit program h_programSize)
-      (femtoCairoStepAssumptions program) := by
+      (femtoCairoStepAssumptions program) (fun _ _ _ => True) := by
   circuit_proof_start [femtoCairoStepAssumptions, femtoCairoStepElaboratedCircuit,
     fetchInstruction, decodeInstruction, readFromMemory, nextState]
 
@@ -790,10 +794,11 @@ variable (h_program : ValidProgramSize p programSize ∧ ValidProgram program)
 
 def femtoCairoStep : GeneralFormalCircuit (F p) State State where
   __ := femtoCairoStepElaboratedCircuit program h_programSize
-  Assumptions := femtoCairoStepAssumptions program
+  ProverAssumptions := femtoCairoStepAssumptions program
   Spec := femtoCairoStepSpec program
   soundness := femtoCairoStepSoundness program h_programSize
   completeness := femtoCairoStepCompleteness program h_programSize
+
 /--
   The femtoCairo table, which defines the step relation for the femtoCairo VM.
   Given a read-only program memory and a read-only data memory, it defines

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -29,7 +29,7 @@ def toBits (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields n
   subcircuitsConsistent x i0 := by simp +arith only [main, circuit_norm]
     -- TODO arith is needed because forAll passes `localLength + offset` while bind passes `offset + localLength`
 
-  Assumptions (x : F p) _ _ := x.val < 2^n
+  ProverAssumptions (x : F p) _ _ := x.val < 2^n
 
   Spec (x : F p) (bits : Vector (F p) n) _ :=
     x.val < 2^n ∧ bits = fieldToBits n x

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -94,21 +94,21 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
 @[circuit_norm ↓]
 lemma elaborated_eq (α : TypeMap) [ProvableType α] : (circuit α (F:=F)).elaborated = elaborated α := rfl
 
--- rewrite soundness/completeness directly
+-- rewrite spec/proverAssumptions/proverSpec directly
 
 @[circuit_norm]
-theorem soundness (α : TypeMap) [ProvableType α] (n : ℕ) (env : Environment F) (x y : Var α F) :
-    ((circuit α).toSubcircuit n (x, y)).Soundness env = (eval env x = eval env y) := by
+theorem spec (α : TypeMap) [ProvableType α] (n : ℕ) (env : Environment F) (x y : Var α F) :
+    ((circuit α).toSubcircuit n (x, y)).Spec env = (eval env x = eval env y) := by
   simp only [circuit_norm, circuit]
 
 @[circuit_norm]
-theorem completeness (α : TypeMap) [ProvableType α] (n : ℕ) (env : ProverEnvironment F) (x y : Var α F) :
-    ((circuit α).toSubcircuit n (x, y)).Completeness env = (eval env x = eval env y) := by
+theorem proverAssumptions (α : TypeMap) [ProvableType α] (n : ℕ) (env : ProverEnvironment F) (x y : Var α F) :
+    ((circuit α).toSubcircuit n (x, y)).ProverAssumptions env = (eval env x = eval env y) := by
   simp only [circuit_norm, circuit]
 
 @[circuit_norm]
-theorem usesLocalWitnesses (α : TypeMap) [ProvableType α] (n : ℕ) (env : ProverEnvironment F) (x y : Var α F) :
-    ((circuit α).toSubcircuit n (x, y)).UsesLocalWitnesses env = True := by
+theorem proverSpec (α : TypeMap) [ProvableType α] (n : ℕ) (env : ProverEnvironment F) (x y : Var α F) :
+    ((circuit α).toSubcircuit n (x, y)).ProverSpec env = True := by
   simp only [FormalAssertion.toSubcircuit, circuit]
 
 end Equality

--- a/Clean/Utils/Tactics/CircuitProofStart.lean
+++ b/Clean/Utils/Tactics/CircuitProofStart.lean
@@ -21,8 +21,7 @@ partial def circuitProofStartCore : TacticM Unit := do
                        headConst? == some ``GeneralFormalCircuit.Soundness
     let isCompleteness := headConst? == some ``Completeness ||
                           headConst? == some ``FormalAssertion.Completeness ||
-                          headConst? == some ``GeneralFormalCircuit.Completeness ||
-                          headConst? == some ``GeneralFormalCircuit.CompletenessSpecProof
+                          headConst? == some ``GeneralFormalCircuit.Completeness
 
     if isSoundness then
       match headConst? with
@@ -38,7 +37,7 @@ partial def circuitProofStartCore : TacticM Unit := do
           evalTactic (← `(tactic| intro $(mkIdent name):ident))
       | some ``GeneralFormalCircuit.Soundness =>
         evalTactic (← `(tactic| unfold GeneralFormalCircuit.Soundness))
-        let names := [`i₀, `env, `input_var, `input, `h_input, `h_holds]
+        let names := [`i₀, `env, `input_var, `input, `h_input, `h_assumptions, `h_holds]
         for name in names do
           evalTactic (← `(tactic| intro $(mkIdent name):ident))
       | _ => pure ()
@@ -61,16 +60,11 @@ partial def circuitProofStartCore : TacticM Unit := do
         let names := [`i₀, `env, `input_var, `h_env, `input, `h_input, `h_assumptions]
         for name in names do
           evalTactic (← `(tactic| intro $(mkIdent name):ident))
-      | some ``GeneralFormalCircuit.CompletenessSpecProof =>
-        evalTactic (← `(tactic| unfold GeneralFormalCircuit.CompletenessSpecProof))
-        let names := [`i₀, `env, `input_var, `h_env, `input, `h_input, `h_assumptions]
-        for name in names do
-          evalTactic (← `(tactic| intro $(mkIdent name):ident))
       | _ => pure ()
       return
     else
       -- Goal is not a supported Soundness or Completeness type
-      throwError "circuitProofStartCore can only be used on Soundness, Completeness, FormalAssertion.Soundness, FormalAssertion.Completeness, GeneralFormalCircuit.Soundness, GeneralFormalCircuit.Completeness, or GeneralFormalCircuit.CompletenessSpecProof goals"
+      throwError "circuit_proof_start can only be used on Soundness, Completeness and variants"
 
 /--
   Standard tactic for starting soundness and completeness proofs.
@@ -146,5 +140,5 @@ elab_rules : tactic
   | `(tactic| circuit_proof_all $[[$terms:term,*]]?) => do
   let lemmas := terms.getD (.mk #[])
   evalTactic (← `(tactic| circuit_proof_start [$lemmas,*]))
-  evalTactic (← `(tactic| simp_all))
+  evalTactic (← `(tactic| try simp_all))
   evalTactic (← `(tactic| done))


### PR DESCRIPTION
* make names of theorems on `GeneralFormalCircuit` more consistent
  - add `Assumptions`, rename `Assumptions` to `ProverAssumptions`
  - `CompletenessSpec` -> `ProverSpec`
* make names of properties/theorems on `Subcircuit` more consistent
  - `Soundness` -> `Spec`, `Completeness` -> `ProverAssumptions`, `UsesLocalWitnesses` -> `ProverSpec`
* combine `completeness` and `completenessSpecProof` into a single theorem, on both `GeneralFormalCircuit` and `Subcircuit`
