### PR TITLE
Prover Hints as Callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.lake
 .vscode
+.codex
 backends/plonky3/target
 backends/plonky3/tests/fixtures/output

--- a/Clean.lean
+++ b/Clean.lean
@@ -18,6 +18,7 @@ import Clean.Circomlib.Sign
 import Clean.Examples.AddOperations
 import Clean.Examples.Add32Explicit
 import Clean.Examples.ToJson
+import Clean.Examples.HintExample
 import Clean.Examples.FemtoCairo.FemtoCairo
 import Clean.Tables.Fibonacci8
 import Clean.Tables.Fibonacci32

--- a/Clean/Circomlib/BinSub.lean
+++ b/Clean/Circomlib/BinSub.lean
@@ -35,7 +35,8 @@ def inputLinearSub (n : ℕ) (inp : BinSubInput n (Expression (F p))) : Expressi
   Fin.foldl n (fun lin k => lin + inp[0][k] * (2^k.val : F p) - (inp[1][k] * (2^k.val : F p))) (2^n : F p)
 
 -- Lemma: evaluating `inputLinearSub` corresponds to the circuit's desired output
-lemma inputLinearSub_eval_eq_sub {n : ℕ} [hn : NeZero n] (env : Environment (F p)) (input : Var (BinSubInput n) (F p)) (input_val : BinSubInput n (F p)) (h_eval : ProvableType.eval' env input = input_val) :
+lemma inputLinearSub_eval_eq_sub {n : ℕ} [hn : NeZero n] (env : Environment (F p))
+  (input : Var (BinSubInput n) (F p)) (input_val : BinSubInput n (F p)) (h_eval : eval env input = input_val) :
     Expression.eval env (inputLinearSub n input) =
       fieldFromBits input_val[0] + 2^n - fieldFromBits input_val[1] := by
   simp only [inputLinearSub, circuit_norm, eval_foldl]
@@ -83,7 +84,7 @@ lemma lin_bound {p : ℕ} [Fact p.Prime] {n : ℕ} (in0 in1 : F p)  (h0 : in0.va
 
 -- Lemma: Simplified LHS evaluation for soundness proof
 lemma soundness_lhs_eval {n : ℕ} [NeZero n] (env : Environment (F p)) (input_var : Var (BinSubInput n) (F p)) (input : BinSubInput n (F p))
-    (h_input : ProvableType.eval' env input_var = input) :
+    (h_input : eval env input_var = input) :
     Expression.eval env (inputLinearSub n input_var) = fieldFromBits input[0] + 2^n - fieldFromBits input[1] := by
   apply inputLinearSub_eval_eq_sub; assumption
 
@@ -135,7 +136,7 @@ lemma completeness_sum_mod {n : ℕ} [NeZero n] (hnout : 2^(n+1) < p) (env : Env
 -- Lemma: Aux bit equals lin divided by 2^n
 lemma completeness_aux_div {n : ℕ} [NeZero n] (hnout : 2^(n+1) < p) (env : Environment (F p)) (i₀ : ℕ)
     (input : BinSubInput n (F p)) (h_assumptions : ∀ j i (hj : j < 2) (hi : i < n), IsBool input[j][i])
-    (input_var : Var (BinSubInput n) (F p)) (h_input : ProvableType.eval' env input_var = input)
+    (input_var : Var (BinSubInput n) (F p)) (h_input : eval env input_var = input)
     (h_env_aux : env.get (i₀ + n) = if (Expression.eval env (inputLinearSub n input_var)).val / 2 ^ n % 2 = 1 then 1 else 0) :
     (env.get (i₀ + n)).val = (Expression.eval env (inputLinearSub n input_var)).val / 2^n := by
   rw [h_env_aux]
@@ -170,7 +171,7 @@ lemma completeness_aux_div {n : ℕ} [NeZero n] (hnout : 2^(n+1) < p) (env : Env
 -- Lemma: Main reconstruction equation for completeness
 lemma completeness_reconstruction {n : ℕ} [NeZero n] (hnout : 2^(n+1) < p) (env : Environment (F p)) (i₀ : ℕ)
     (input : BinSubInput n (F p)) (input_var : Var (BinSubInput n) (F p))
-    (h_input : ProvableType.eval' env input_var = input)
+    (h_input : eval env input_var = input)
     (h_assumptions : ∀ j i (hj : j < 2) (hi : i < n), IsBool input[j][i])
     (h_out_binary : ∀ (i : Fin n), IsBool (env.get (i₀ + ↑i)))
     (h_env_out : ∀ (i : Fin n), env.get (i₀ + ↑i) = (fieldToBits n (Expression.eval env (inputLinearSub n input_var)))[i])

--- a/Clean/Circomlib/BinSub.lean
+++ b/Clean/Circomlib/BinSub.lean
@@ -35,7 +35,7 @@ def inputLinearSub (n : ℕ) (inp : BinSubInput n (Expression (F p))) : Expressi
   Fin.foldl n (fun lin k => lin + inp[0][k] * (2^k.val : F p) - (inp[1][k] * (2^k.val : F p))) (2^n : F p)
 
 -- Lemma: evaluating `inputLinearSub` corresponds to the circuit's desired output
-lemma inputLinearSub_eval_eq_sub {n : ℕ} [hn : NeZero n] (env : Environment (F p)) (input : Var (BinSubInput n) (F p)) (input_val : BinSubInput n (F p)) (h_eval : ProvableType.eval env input = input_val) :
+lemma inputLinearSub_eval_eq_sub {n : ℕ} [hn : NeZero n] (env : Environment (F p)) (input : Var (BinSubInput n) (F p)) (input_val : BinSubInput n (F p)) (h_eval : ProvableType.eval' env input = input_val) :
     Expression.eval env (inputLinearSub n input) =
       fieldFromBits input_val[0] + 2^n - fieldFromBits input_val[1] := by
   simp only [inputLinearSub, circuit_norm, eval_foldl]
@@ -83,7 +83,7 @@ lemma lin_bound {p : ℕ} [Fact p.Prime] {n : ℕ} (in0 in1 : F p)  (h0 : in0.va
 
 -- Lemma: Simplified LHS evaluation for soundness proof
 lemma soundness_lhs_eval {n : ℕ} [NeZero n] (env : Environment (F p)) (input_var : Var (BinSubInput n) (F p)) (input : BinSubInput n (F p))
-    (h_input : ProvableType.eval env input_var = input) :
+    (h_input : ProvableType.eval' env input_var = input) :
     Expression.eval env (inputLinearSub n input_var) = fieldFromBits input[0] + 2^n - fieldFromBits input[1] := by
   apply inputLinearSub_eval_eq_sub; assumption
 
@@ -135,7 +135,7 @@ lemma completeness_sum_mod {n : ℕ} [NeZero n] (hnout : 2^(n+1) < p) (env : Env
 -- Lemma: Aux bit equals lin divided by 2^n
 lemma completeness_aux_div {n : ℕ} [NeZero n] (hnout : 2^(n+1) < p) (env : Environment (F p)) (i₀ : ℕ)
     (input : BinSubInput n (F p)) (h_assumptions : ∀ j i (hj : j < 2) (hi : i < n), IsBool input[j][i])
-    (input_var : Var (BinSubInput n) (F p)) (h_input : ProvableType.eval env input_var = input)
+    (input_var : Var (BinSubInput n) (F p)) (h_input : ProvableType.eval' env input_var = input)
     (h_env_aux : env.get (i₀ + n) = if (Expression.eval env (inputLinearSub n input_var)).val / 2 ^ n % 2 = 1 then 1 else 0) :
     (env.get (i₀ + n)).val = (Expression.eval env (inputLinearSub n input_var)).val / 2^n := by
   rw [h_env_aux]
@@ -170,7 +170,7 @@ lemma completeness_aux_div {n : ℕ} [NeZero n] (hnout : 2^(n+1) < p) (env : Env
 -- Lemma: Main reconstruction equation for completeness
 lemma completeness_reconstruction {n : ℕ} [NeZero n] (hnout : 2^(n+1) < p) (env : Environment (F p)) (i₀ : ℕ)
     (input : BinSubInput n (F p)) (input_var : Var (BinSubInput n) (F p))
-    (h_input : ProvableType.eval env input_var = input)
+    (h_input : ProvableType.eval' env input_var = input)
     (h_assumptions : ∀ j i (hj : j < 2) (hi : i < n), IsBool input[j][i])
     (h_out_binary : ∀ (i : Fin n), IsBool (env.get (i₀ + ↑i)))
     (h_env_out : ∀ (i : Fin n), env.get (i₀ + ↑i) = (fieldToBits n (Expression.eval env (inputLinearSub n input_var)))[i])

--- a/Clean/Circomlib/BinSum.lean
+++ b/Clean/Circomlib/BinSum.lean
@@ -85,7 +85,7 @@ lemma inputLinearSum_eval_eq_sum {n ops : ℕ} [hn : NeZero n]
   (env : Environment (F p))
   (input : Var (BinSumInput n ops) (F p))
   (input_val : BinSumInput n ops (F p))
-  (h_eval : ProvableType.eval env input = input_val) :
+  (h_eval : ProvableType.eval' env input = input_val) :
     Expression.eval env (inputLinearSum n ops input) =
     Fin.foldl ops (fun acc j => acc + fieldFromBits input_val[j.val]) 0 := by
   -- The main function uses input[j][k] which evaluates to input_val[j][k]

--- a/Clean/Circomlib/BinSum.lean
+++ b/Clean/Circomlib/BinSum.lean
@@ -85,7 +85,7 @@ lemma inputLinearSum_eval_eq_sum {n ops : ℕ} [hn : NeZero n]
   (env : Environment (F p))
   (input : Var (BinSumInput n ops) (F p))
   (input_val : BinSumInput n ops (F p))
-  (h_eval : ProvableType.eval' env input = input_val) :
+  (h_eval : eval env input = input_val) :
     Expression.eval env (inputLinearSum n ops input) =
     Fin.foldl ops (fun acc j => acc + fieldFromBits input_val[j.val]) 0 := by
   -- The main function uses input[j][k] which evaluates to input_val[j][k]
@@ -207,7 +207,9 @@ def circuit (n ops : ℕ) [hn : NeZero n] (hnout : 2^(nbits ((2^n - 1) * ops)) <
     intros witness_offset env inputs_var h_witness_extends inputs h_inputs_eval h_inputs_binary
     simp only [circuit_norm, main, Num2Bits.arbitraryBitLengthCircuit]
     convert sum_bound_of_binary_inputs hnout inputs h_inputs_binary
-    exact inputLinearSum_eval_eq_sum _ _ _ h_inputs_eval
+    have h_inputs_eval' : eval env.toEnvironment inputs_var = inputs := by
+      simpa only [CircuitType.eval_var_prover_to_verifier] using h_inputs_eval
+    exact inputLinearSum_eval_eq_sum _ _ _ h_inputs_eval'
 
 end BinSum
 

--- a/Clean/Circomlib/BinSum.lean
+++ b/Clean/Circomlib/BinSum.lean
@@ -205,11 +205,9 @@ def circuit (n ops : ℕ) [hn : NeZero n] (hnout : 2^(nbits ((2^n - 1) * ops)) <
 
   completeness := by
     intros witness_offset env inputs_var h_witness_extends inputs h_inputs_eval h_inputs_binary
-    simp only [circuit_norm, main, Num2Bits.arbitraryBitLengthCircuit]
+    simp only [circuit_norm, main, Num2Bits.arbitraryBitLengthCircuit] at ⊢ h_inputs_eval
     convert sum_bound_of_binary_inputs hnout inputs h_inputs_binary
-    have h_inputs_eval' : eval env.toEnvironment inputs_var = inputs := by
-      simpa only [CircuitType.eval_var_prover_to_verifier] using h_inputs_eval
-    exact inputLinearSum_eval_eq_sum _ _ _ h_inputs_eval'
+    exact inputLinearSum_eval_eq_sum _ _ _ h_inputs_eval
 
 end BinSum
 

--- a/Clean/Circomlib/BinSum.lean
+++ b/Clean/Circomlib/BinSum.lean
@@ -85,7 +85,7 @@ lemma inputLinearSum_eval_eq_sum {n ops : ℕ} [hn : NeZero n]
   (env : Environment (F p))
   (input : Var (BinSumInput n ops) (F p))
   (input_val : BinSumInput n ops (F p))
-  (h_eval : eval env input = input_val) :
+  (h_eval : ProvableType.eval env input = input_val) :
     Expression.eval env (inputLinearSum n ops input) =
     Fin.foldl ops (fun acc j => acc + fieldFromBits input_val[j.val]) 0 := by
   -- The main function uses input[j][k] which evaluates to input_val[j][k]

--- a/Clean/Circomlib/Bitify.lean
+++ b/Clean/Circomlib/Bitify.lean
@@ -50,9 +50,8 @@ lemma lc_eq {i0} {env} {n : ℕ} :
   (Expression.eval env <| Prod.fst <|
     Fin.foldl n (fun (lc1, e2) i => (lc1 + (var (F:=F p) ⟨ i0 + ↑i ⟩) * e2, e2 + e2)) (0, 1))
     = fieldFromBits (Vector.mapRange n fun i => env.get (i0 + i)) := by
-  suffices ((eval env
-    (Fin.foldl n (fun (lc1, e2) i => (lc1 + (var (F:=F p) ⟨ i0 + ↑i ⟩) * e2, e2 + e2)) (0, 1) :
-      fieldPair (Expression (F p)))) : fieldPair (F p))
+  suffices (eval (Var:=Var fieldPair (F p)) env <|
+    Fin.foldl n (fun (lc1, e2) i => (lc1 + (var (F:=F p) ⟨ i0 + ↑i ⟩) * e2, e2 + e2)) (0, 1))
     = (fieldFromBits (Vector.mapRange n fun i => env.get (i0 + i)), 2^n) by
     simp_all [circuit_norm]
   simp only [fieldFromBits, fromBits, Vector.getElem_map]
@@ -77,7 +76,7 @@ def arbitraryBitLengthCircuit (n : ℕ) : GeneralFormalCircuit (F p) field (fiel
 
   /- without further assumptions on n, this circuit just tells us that the output bits represent
     _some_ number congruent to the input modulo p -/
-  Spec (input : F p) (bits : Vector (F p) n) _ :=
+  Spec input bits _ :=
     input.val < 2^n
     ∧ (∀ i (_ : i < n), bits[i] = 0 ∨ bits[i] = 1)
     ∧ fieldFromBits bits = input
@@ -164,9 +163,8 @@ lemma lc_eq {env} {n : ℕ} {v : Vector (Expression (F p)) n} :
     Fin.foldl n (fun ((lc1, e2) : Expression (F p) × Expression (F p)) i =>
       (lc1 + v[↑i] * e2, e2 + e2)) (0, 1))
     = fieldFromBits (Vector.mapFinRange n fun i => v[↑i].eval env) := by
-  suffices ((eval env
-    (Fin.foldl n (fun (lc1, e2) i => (lc1 + v[↑i] * e2, e2 + e2)) (0, 1) :
-      fieldPair (Expression (F p)))) : fieldPair (F p))
+  suffices (eval (Var:=Var fieldPair (F p)) env <|
+    Fin.foldl n (fun (lc1, e2) i => (lc1 + v[↑i] * e2, e2 + e2)) (0, 1))
     = (fieldFromBits (Vector.mapFinRange n fun i => v[↑i].eval env), 2^n) by
     simp_all [circuit_norm]
   simp only [fieldFromBits, fromBits, Vector.getElem_map, Vector.getElem_mapFinRange]

--- a/Clean/Circomlib/Bitify.lean
+++ b/Clean/Circomlib/Bitify.lean
@@ -50,7 +50,7 @@ lemma lc_eq {i0} {env} {n : ℕ} :
   (Expression.eval env <| Prod.fst <|
     Fin.foldl n (fun (lc1, e2) i => (lc1 + (var (F:=F p) ⟨ i0 + ↑i ⟩) * e2, e2 + e2)) (0, 1))
     = fieldFromBits (Vector.mapRange n fun i => env.get (i0 + i)) := by
-  suffices (eval (α:=fieldPair) env <|
+  suffices (ProvableType.eval (α:=fieldPair) env <|
     Fin.foldl n (fun (lc1, e2) i => (lc1 + (var (F:=F p) ⟨ i0 + ↑i ⟩) * e2, e2 + e2)) (0, 1))
     = (fieldFromBits (Vector.mapRange n fun i => env.get (i0 + i)), 2^n) by
     simp_all [circuit_norm]
@@ -76,7 +76,7 @@ def arbitraryBitLengthCircuit (n : ℕ) : GeneralFormalCircuit (F p) field (fiel
 
   /- without further assumptions on n, this circuit just tells us that the output bits represent
     _some_ number congruent to the input modulo p -/
-  Spec input bits _ :=
+  Spec (input : F p) (bits : Vector (F p) n) _ :=
     input.val < 2^n
     ∧ (∀ i (_ : i < n), bits[i] = 0 ∨ bits[i] = 1)
     ∧ fieldFromBits bits = input
@@ -163,7 +163,7 @@ lemma lc_eq {env} {n : ℕ} {v : Vector (Expression (F p)) n} :
     Fin.foldl n (fun ((lc1, e2) : Expression (F p) × Expression (F p)) i =>
       (lc1 + v[↑i] * e2, e2 + e2)) (0, 1))
     = fieldFromBits (Vector.mapFinRange n fun i => v[↑i].eval env) := by
-  suffices (eval (α:=fieldPair) env <|
+  suffices (ProvableType.eval (α:=fieldPair) env <|
     Fin.foldl n (fun (lc1, e2) i => (lc1 + v[↑i] * e2, e2 + e2)) (0, 1))
     = (fieldFromBits (Vector.mapFinRange n fun i => v[↑i].eval env), 2^n) by
     simp_all [circuit_norm]

--- a/Clean/Circomlib/Bitify.lean
+++ b/Clean/Circomlib/Bitify.lean
@@ -50,8 +50,9 @@ lemma lc_eq {i0} {env} {n : ℕ} :
   (Expression.eval env <| Prod.fst <|
     Fin.foldl n (fun (lc1, e2) i => (lc1 + (var (F:=F p) ⟨ i0 + ↑i ⟩) * e2, e2 + e2)) (0, 1))
     = fieldFromBits (Vector.mapRange n fun i => env.get (i0 + i)) := by
-  suffices (ProvableType.eval' (α:=fieldPair) env <|
-    Fin.foldl n (fun (lc1, e2) i => (lc1 + (var (F:=F p) ⟨ i0 + ↑i ⟩) * e2, e2 + e2)) (0, 1))
+  suffices ((eval env
+    (Fin.foldl n (fun (lc1, e2) i => (lc1 + (var (F:=F p) ⟨ i0 + ↑i ⟩) * e2, e2 + e2)) (0, 1) :
+      fieldPair (Expression (F p)))) : fieldPair (F p))
     = (fieldFromBits (Vector.mapRange n fun i => env.get (i0 + i)), 2^n) by
     simp_all [circuit_norm]
   simp only [fieldFromBits, fromBits, Vector.getElem_map]
@@ -163,8 +164,9 @@ lemma lc_eq {env} {n : ℕ} {v : Vector (Expression (F p)) n} :
     Fin.foldl n (fun ((lc1, e2) : Expression (F p) × Expression (F p)) i =>
       (lc1 + v[↑i] * e2, e2 + e2)) (0, 1))
     = fieldFromBits (Vector.mapFinRange n fun i => v[↑i].eval env) := by
-  suffices (ProvableType.eval' (α:=fieldPair) env <|
-    Fin.foldl n (fun (lc1, e2) i => (lc1 + v[↑i] * e2, e2 + e2)) (0, 1))
+  suffices ((eval env
+    (Fin.foldl n (fun (lc1, e2) i => (lc1 + v[↑i] * e2, e2 + e2)) (0, 1) :
+      fieldPair (Expression (F p)))) : fieldPair (F p))
     = (fieldFromBits (Vector.mapFinRange n fun i => v[↑i].eval env), 2^n) by
     simp_all [circuit_norm]
   simp only [fieldFromBits, fromBits, Vector.getElem_map, Vector.getElem_mapFinRange]

--- a/Clean/Circomlib/Bitify.lean
+++ b/Clean/Circomlib/Bitify.lean
@@ -50,7 +50,7 @@ lemma lc_eq {i0} {env} {n : ℕ} :
   (Expression.eval env <| Prod.fst <|
     Fin.foldl n (fun (lc1, e2) i => (lc1 + (var (F:=F p) ⟨ i0 + ↑i ⟩) * e2, e2 + e2)) (0, 1))
     = fieldFromBits (Vector.mapRange n fun i => env.get (i0 + i)) := by
-  suffices (ProvableType.eval (α:=fieldPair) env <|
+  suffices (ProvableType.eval' (α:=fieldPair) env <|
     Fin.foldl n (fun (lc1, e2) i => (lc1 + (var (F:=F p) ⟨ i0 + ↑i ⟩) * e2, e2 + e2)) (0, 1))
     = (fieldFromBits (Vector.mapRange n fun i => env.get (i0 + i)), 2^n) by
     simp_all [circuit_norm]
@@ -163,7 +163,7 @@ lemma lc_eq {env} {n : ℕ} {v : Vector (Expression (F p)) n} :
     Fin.foldl n (fun ((lc1, e2) : Expression (F p) × Expression (F p)) i =>
       (lc1 + v[↑i] * e2, e2 + e2)) (0, 1))
     = fieldFromBits (Vector.mapFinRange n fun i => v[↑i].eval env) := by
-  suffices (ProvableType.eval (α:=fieldPair) env <|
+  suffices (ProvableType.eval' (α:=fieldPair) env <|
     Fin.foldl n (fun (lc1, e2) i => (lc1 + v[↑i] * e2, e2 + e2)) (0, 1))
     = (fieldFromBits (Vector.mapFinRange n fun i => v[↑i].eval env), 2^n) by
     simp_all [circuit_norm]

--- a/Clean/Circomlib/Bitify2.lean
+++ b/Clean/Circomlib/Bitify2.lean
@@ -132,11 +132,11 @@ def circuit : GeneralFormalCircuit (F p) (fields 254) field where
   subcircuitsConsistent := by simp +arith [circuit_norm, main,
     Bits2Num.main, AliasCheck.circuit]
 
-  ProverAssumptions input _ _ :=
+  ProverAssumptions (input : fields 254 (F p)) _ _ :=
     (∀ i (_ : i < 254), input[i] = 0 ∨ input[i] = 1) ∧ fromBits (input.map ZMod.val) < p
-  Assumptions input _ :=
+  Assumptions (input : fields 254 (F p)) _ :=
     (∀ i (_ : i < 254), input[i] = 0 ∨ input[i] = 1)
-  Spec input output _ :=
+  Spec (input : fields 254 (F p)) output _ :=
     output.val = fromBits (input.map ZMod.val)
 
   soundness := by
@@ -216,7 +216,7 @@ def circuit (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields 
     output = fieldToBits n (if n = 0 then 0 else 2^n - input.val : F p)
 
   soundness := by
-    intro i0 env input_var input h_input _ h_holds
+    intro i0 env input_var (input : F p) h_input _ h_holds
     simp only [circuit_norm, main, IsZero.circuit, IsZero.main] at h_holds ⊢
     obtain ⟨ h_bits, h_iszero, h_eq ⟩ := h_holds
 
@@ -241,9 +241,8 @@ def circuit (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields 
       by_cases h_input_zero : input = 0
       · simp_rw [h_input_zero] at h_input ⊢
         have : Expression.eval env input_var = 0 := by
-          simp only [eval, fromElements, toVars, toElements] at h_input
+          simp only [circuit_norm] at h_input
           convert h_input
-          simp
         rw [this] at h_eq
         simp only [id_eq, mul_zero, dite_eq_ite, ite_self, add_zero, neg_zero, ZMod.val_zero,
           Nat.cast_zero, sub_zero] at h_eq ⊢

--- a/Clean/Circomlib/Bitify2.lean
+++ b/Clean/Circomlib/Bitify2.lean
@@ -69,9 +69,8 @@ def circuit : FormalCircuit (F p) field (fields 254) where
     rw [Nat.mod_eq_of_lt h_alias, toBits_fromBits, Vector.ext_iff]
     simp only [circuit_norm]
     intro i hi
-    rw [ZMod.natCast_zmod_val]
-    intro i hi; specialize h_bits i hi
     simp only [circuit_norm]
+    specialize h_bits i hi
     rcases h_bits with h_bits | h_bits
       <;> simp [h_bits, ZMod.val_one]
 
@@ -217,7 +216,8 @@ def circuit (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields 
 
   soundness := by
     intro i0 env input_var (input : F p) h_input _ h_holds
-    simp only [circuit_norm, main, IsZero.circuit, IsZero.main] at h_holds ⊢
+    simp only [circuit_norm] at h_input
+    simp only [circuit_norm, main, IsZero.circuit, IsZero.main, h_input] at h_holds ⊢
     obtain ⟨ h_bits, h_iszero, h_eq ⟩ := h_holds
 
     by_cases h_n : n = 0
@@ -239,13 +239,8 @@ def circuit (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields 
         simp [fieldFromBitsExpr, bits_vars, Vector.getElem_mapRange]
 
       by_cases h_input_zero : input = 0
-      · simp_rw [h_input_zero] at h_input ⊢
-        have : Expression.eval env input_var = 0 := by
-          simp only [circuit_norm] at h_input
-          convert h_input
-        rw [this] at h_eq
-        simp only [id_eq, mul_zero, dite_eq_ite, ite_self, add_zero, neg_zero, ZMod.val_zero,
-          Nat.cast_zero, sub_zero] at h_eq ⊢
+      · subst h_input_zero
+        simp only [id_eq, mul_zero, dite_eq_ite, ite_self, add_zero, neg_zero, sub_zero] at h_eq ⊢
         rw [← h_eq]
         have h_f := fieldToBits_fieldFromBits hn bits h_bits'
         simp_all only [Nat.reducePow, gt_iff_lt, id_eq, mul_zero, dite_eq_ite, ite_self, add_zero,
@@ -264,22 +259,10 @@ def circuit (n : ℕ) (hn : 2^n < p) : GeneralFormalCircuit (F p) field (fields 
           exact h_eq
         rw [h_val_zero]
         simp [fieldToBits, toBits, Vector.getElem_mapRange]
-      · have : Expression.eval env input_var = input := by
-          rw [← h_input]
-          simp [circuit_norm]
-        rw [this] at h_eq
-        simp_all only [Nat.reducePow, gt_iff_lt, id_eq, mul_zero, dite_eq_ite, ite_self, add_zero,
-          ↓reduceIte, zero_mul, ZMod.natCast_val]
-        have : (2 ^ n - ZMod.cast input) = fieldFromBits bits := by
-          rw [sub_eq_add_neg, ZMod.cast_id, ← h_eq]
-          let bits_vars := Vector.mapRange n fun i => var (F := F p) { index := i0 + i }
-          have h_expr_fold : (Fin.foldl n (fun acc i ↦ acc + var { index := i0 + ↑i } * Expression.const (2 ^ (Fin.val i))) 0)
-              = fieldFromBitsExpr bits_vars := by
-            simp only [fieldFromBitsExpr, bits_vars, Vector.getElem_mapRange]
-          rw [← fieldFromBits_eval]
-        rw [this]
-        symm
-        apply fieldToBits_fieldFromBits hn
+      · simp_all only [↓reduceIte, mul_zero, dite_eq_ite, ite_self, add_zero, zero_mul]
+        rw [sub_eq_add_neg, ← h_eq]
+        simp only [fieldFromBits_eval]
+        rw [fieldToBits_fieldFromBits hn]
         exact h_bits'
 
   completeness := by

--- a/Clean/Circomlib/CompConstant.lean
+++ b/Clean/Circomlib/CompConstant.lean
@@ -90,12 +90,11 @@ def main (ct : ℕ) (input : Vector (Expression (F p)) 254) := do
 
   -- Convert sum to bits
   have hp : p > 2^135 := by linarith [‹Fact (p > 2^253)›.elim]
-  let bits : Var (fields 135) (F p) ← Num2Bits.circuit 135 hp sout
+  let bits ← Num2Bits.circuit 135 hp sout
 
   let out <== bits[127]
   return out
 
-set_option maxRecDepth 2000 in
 def circuit (c : ℕ) (h_c : c < 2^254) : FormalCircuit (F p) (fields 254) field where
   main := main c
   localLength _ := 127 + 1 + 135 + 1  -- parts witness + sout witness + Num2Bits + out witness

--- a/Clean/Circomlib/CompConstant.lean
+++ b/Clean/Circomlib/CompConstant.lean
@@ -90,7 +90,7 @@ def main (ct : ℕ) (input : Vector (Expression (F p)) 254) := do
 
   -- Convert sum to bits
   have hp : p > 2^135 := by linarith [‹Fact (p > 2^253)›.elim]
-  let bits ← Num2Bits.circuit 135 hp sout
+  let bits : Var (fields 135) (F p) ← Num2Bits.circuit 135 hp sout
 
   let out <== bits[127]
   return out

--- a/Clean/Circomlib/Comparators.lean
+++ b/Clean/Circomlib/Comparators.lean
@@ -157,7 +157,7 @@ def circuit : FormalAssertion (F p) Inputs where
     enabled = 1 → inp.1 = inp.2
 
   soundness := by
-    circuit_proof_start [Inputs.mk.injEq]
+    circuit_proof_start
     intro h_ie
     simp_all only [one_ne_zero, or_true, id_eq, one_mul]
     cases h_input with
@@ -179,7 +179,7 @@ def circuit : FormalAssertion (F p) Inputs where
         trivial
 
   completeness := by
-    circuit_proof_start [Inputs.mk.injEq]
+    circuit_proof_start
     simp_all only [id_eq]
     constructor
     trivial

--- a/Clean/Circomlib/Comparators.lean
+++ b/Clean/Circomlib/Comparators.lean
@@ -213,7 +213,7 @@ template LessThan(n) {
 -/
 def main (n : ℕ) (hn : 2^(n+1) < p) (input : Expression (F p) × Expression (F p)) := do
   let diff := input.1 + (2^n : F p) - input.2
-  let bits : Var (fields (n + 1)) (F p) ← Num2Bits.circuit (n + 1) hn diff
+  let bits ← Num2Bits.circuit (n + 1) hn diff
   let out <== 1 - bits[n]
   return out
 

--- a/Clean/Circomlib/Comparators.lean
+++ b/Clean/Circomlib/Comparators.lean
@@ -157,7 +157,7 @@ def circuit : FormalAssertion (F p) Inputs where
     enabled = 1 → inp.1 = inp.2
 
   soundness := by
-    circuit_proof_start
+    circuit_proof_start [Inputs.mk.injEq]
     intro h_ie
     simp_all only [one_ne_zero, or_true, id_eq, one_mul]
     cases h_input with
@@ -179,7 +179,7 @@ def circuit : FormalAssertion (F p) Inputs where
         trivial
 
   completeness := by
-    circuit_proof_start
+    circuit_proof_start [Inputs.mk.injEq]
     simp_all only [id_eq]
     constructor
     trivial
@@ -213,7 +213,7 @@ template LessThan(n) {
 -/
 def main (n : ℕ) (hn : 2^(n+1) < p) (input : Expression (F p) × Expression (F p)) := do
   let diff := input.1 + (2^n : F p) - input.2
-  let bits ← Num2Bits.circuit (n + 1) hn diff
+  let bits : Var (fields (n + 1)) (F p) ← Num2Bits.circuit (n + 1) hn diff
   let out <== 1 - bits[n]
   return out
 

--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -874,7 +874,7 @@ lemma main_output_binary_from_completeness (n : ℕ) (offset : ℕ) (env : Prove
     let output := env ((main input_var).output offset)
     IsBool output := by
   apply main_output_binary
-  · simpa only [CircuitType.eval_var_fields_prover, CircuitType.eval_var_fields] using h_eval
+  · simpa only [circuit_norm] using h_eval
   · assumption
   apply Circuit.can_replace_completeness (n := offset)
   · apply subcircuitsConsistent

--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -524,9 +524,9 @@ lemma eval_toArray_extract_eq {n : ℕ} (start finish : ℕ) {env : ProverEnviro
     show (w.toArray.extract start finish)[i]'(size_proof2 ▸ hi) = w.toArray[start + i]'(by simp [w.size_toArray]; exact h_idx)
     rw [Array.getElem_extract]
   rw [rhs]
-  have h_eval' := h_eval
-  simp only [ProvableType.eval_fields] at h_eval'
-  rw [h_eval', Vector.getElem_map]
+  have h_eval_simp := h_eval
+  simp only [ProvableType.eval_fields] at h_eval_simp
+  rw [h_eval_simp, Vector.getElem_map]
 
 /-- Helper to show that extracting a subvector preserves element access -/
 lemma extract_preserves_element {p n n1 : ℕ} (input : fields n (F p)) (i : ℕ) (hi : i < n1) (h_n1_lt : n1 ≤ n) :

--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -497,7 +497,7 @@ def Spec (n : ℕ) (input : fields n (F p)) (output : F p) : Prop :=
 /-- If eval env v = w for vectors v and w, then evaluating extracted subvectors preserves equality -/
 lemma eval_toArray_extract_eq {n : ℕ} (start finish : ℕ) {env : ProverEnvironment (F p)}
     {v : Var (fields n) (F p)} {w : fields n (F p)}
-    (h_eval : w = eval env v)
+    (h_eval : w = ProvableType.eval env v)
     (h_bounds : finish ≤ n) (h_start : start ≤ finish) :
     ProvableType.eval (α := fields (finish - start)) env
       ⟨v.toArray.extract start finish, by simp [Array.size_extract]; omega⟩ =
@@ -600,7 +600,7 @@ lemma Vector.foldl_and_split {n1 n2 n3 : ℕ} (v : Vector ℕ n3)
 /-- Soundness for n = 0 case -/
 lemma soundness_zero {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : Environment (F p)) (input_var : Var (fields 0) (F p))
-    (input : fields 0 (F p)) (_h_env : input = eval env input_var)
+    (input : fields 0 (F p)) (_h_env : input = ProvableType.eval env input_var)
     (_h_assumptions : Assumptions 0 input)
     (_h_hold : Circuit.ConstraintsHold.Soundness env ((main input_var).operations offset)) :
     Spec 0 input (env ((main input_var).output offset)) := by
@@ -614,7 +614,7 @@ lemma soundness_zero {p : ℕ} [Fact p.Prime]
 /-- Soundness for n = 1 case -/
 lemma soundness_one {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : Environment (F p)) (input_var : Var (fields 1) (F p))
-    (input : fields 1 (F p)) (h_env : input = eval env input_var)
+    (input : fields 1 (F p)) (h_env : input = ProvableType.eval env input_var)
     (h_assumptions : Assumptions 1 input)
     (_h_hold : Circuit.ConstraintsHold.Soundness env ((main input_var).operations offset)) :
     Spec 1 input (env ((main input_var).output offset)) := by
@@ -644,7 +644,7 @@ lemma soundness_one {p : ℕ} [Fact p.Prime]
 /-- Soundness for n = 2 case -/
 lemma soundness_two {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : Environment (F p)) (input_var : Var (fields 2) (F p))
-    (input : fields 2 (F p)) (h_env : input = eval env input_var)
+    (input : fields 2 (F p)) (h_env : input = ProvableType.eval env input_var)
     (h_assumptions : Assumptions 2 input)
     (h_hold : Circuit.ConstraintsHold.Soundness env ((main input_var).operations offset)) :
     Spec 2 input (env ((main input_var).output offset)) := by
@@ -680,7 +680,7 @@ lemma completeness_zero {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : ProverEnvironment (F p)) (input_var : Var (fields 0) (F p))
     (input : fields 0 (F p))
     (_h_local_witnesses : env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset))
-    (_h_env : input = eval env input_var)
+    (_h_env : input = ProvableType.eval env input_var)
     (_h_assumptions : Assumptions 0 input) :
     Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset) := by
   simp [main, Circuit.ConstraintsHold.Completeness]
@@ -690,7 +690,7 @@ lemma completeness_one {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : ProverEnvironment (F p)) (input_var : Var (fields 1) (F p))
     (input : fields 1 (F p))
     (_h_local_witnesses : env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset))
-    (_h_env : input = eval env input_var)
+    (_h_env : input = ProvableType.eval env input_var)
     (_h_assumptions : Assumptions 1 input) :
     Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset) := by
   simp [main, Circuit.ConstraintsHold.Completeness]
@@ -700,7 +700,7 @@ lemma completeness_two {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : ProverEnvironment (F p)) (input_var : Var (fields 2) (F p))
     (input : fields 2 (F p))
     (h_local_witnesses : env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset))
-    (h_env : input = eval env input_var)
+    (h_env : input = ProvableType.eval env input_var)
     (h_assumptions : Assumptions 2 input) :
     Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset) := by
   simp only [main, circuit_norm] at h_local_witnesses ⊢
@@ -726,7 +726,7 @@ lemma completeness_two {p : ℕ} [Fact p.Prime]
 theorem soundness {p : ℕ} [Fact p.Prime] (n : ℕ) :
     ∀ (offset : ℕ) (env : Environment (F p)) (input_var : Var (fields n) (F p))
       (input : fields n (F p)),
-    input = eval env input_var →
+    input = ProvableType.eval env input_var →
     Assumptions n input →
     Circuit.ConstraintsHold.Soundness env ((main input_var).operations offset) →
     Spec n input (env ((main input_var).output offset)) := by
@@ -749,13 +749,13 @@ theorem soundness {p : ℕ} [Fact p.Prime] (n : ℕ) :
       let input2 : fields n2 (F p) := input.drop n1 |>.cast (by omega)
       let input_var1 : Var (fields n1) (F p) := input_var.take n1 |>.cast (by simp only [Nat.min_def, n1]; split <;> omega)
       let input_var2 : Var (fields n2) (F p) := input_var.drop n1 |>.cast (by omega)
-      have h_eval1 : input1 = eval env input_var1 := by
+      have h_eval1 : input1 = ProvableType.eval env input_var1 := by
         simp only [input_var1, input1]
         apply Vector.ext
         intro i hi
         simp only [h_env, ProvableType.eval_fields, Vector.getElem_map, Vector.getElem_cast, Vector.getElem_take]
 
-      have h_eval2 : input2 = eval env input_var2 := by
+      have h_eval2 : input2 = ProvableType.eval env input_var2 := by
         simp only [input_var2, input2]
         apply Vector.ext
         intro i hi
@@ -856,7 +856,7 @@ theorem soundness {p : ℕ} [Fact p.Prime] (n : ℕ) :
 
 lemma main_output_binary (n : ℕ) (offset : ℕ) (env : Environment (F p))
     (input_var : Var (fields n) (F p)) (input : fields n (F p))
-    (h_eval : input = eval env input_var)
+    (h_eval : input = ProvableType.eval env input_var)
     (h_assumptions : Assumptions n input)
     (h_constraints : Circuit.ConstraintsHold env ((main input_var).operations offset)) :
     let output := env ((main input_var).output offset)
@@ -866,7 +866,7 @@ lemma main_output_binary (n : ℕ) (offset : ℕ) (env : Environment (F p))
 
 lemma main_output_binary_from_completeness (n : ℕ) (offset : ℕ) (env : ProverEnvironment (F p))
     (input_var : Var (fields n) (F p)) (input : fields n (F p))
-    (h_eval : input = eval env input_var)
+    (h_eval : input = ProvableType.eval env input_var)
     (h_assumptions : Assumptions n input)
     (h_local_witnesses : env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset))
     (h_completeness : Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset)) :
@@ -886,7 +886,7 @@ theorem completeness {p : ℕ} [Fact p.Prime] (n : ℕ) :
     ∀ (offset : ℕ) (env : ProverEnvironment (F p)) (input_var : Var (fields n) (F p))
       (input : fields n (F p)),
     env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset) →
-    input = eval env input_var →
+    input = ProvableType.eval env input_var →
     Assumptions n input →
     Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset) := by
   induction n using Nat.strong_induction_on with
@@ -906,14 +906,14 @@ theorem completeness {p : ℕ} [Fact p.Prime] (n : ℕ) :
       let input1 : fields n1 (F p) := input.take n1 |>.cast (by simp only [Nat.min_def, n1]; split <;> omega)
       let input2 : fields n2 (F p) := input.drop n1 |>.cast (by omega)
 
-      have h_eval1 : input1 = eval env input_var1 := by
+      have h_eval1 : input1 = ProvableType.eval env input_var1 := by
         simp only [input_var1, input1]
         apply Vector.ext
         intro i hi
         -- Need to show: input[i] = (eval env (Vector.cast _ (Vector.take input_var n1)))[i]
         simp only [h_env, ProvableType.eval_fields, Vector.getElem_map, Vector.getElem_cast, Vector.getElem_take]
 
-      have h_eval2 : input2 = eval env input_var2 := by
+      have h_eval2 : input2 = ProvableType.eval env input_var2 := by
         simp only [input_var2, input2]
         apply Vector.ext
         intro i hi

--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -497,12 +497,13 @@ def Spec (n : ℕ) (input : fields n (F p)) (output : F p) : Prop :=
 /-- If eval env v = w for vectors v and w, then evaluating extracted subvectors preserves equality -/
 lemma eval_toArray_extract_eq {n : ℕ} (start finish : ℕ) {env : ProverEnvironment (F p)}
     {v : Var (fields n) (F p)} {w : fields n (F p)}
-    (h_eval : w = ProvableType.eval' env v)
+    (h_eval : w = eval env v)
     (h_bounds : finish ≤ n) (h_start : start ≤ finish) :
-    ProvableType.eval' (α := fields (finish - start)) env
-      ⟨v.toArray.extract start finish, by simp [Array.size_extract]; omega⟩ =
+    eval env
+      (⟨v.toArray.extract start finish, by simp [Array.size_extract]; omega⟩ :
+        fields (finish - start) (Expression (F p))) =
     ⟨w.toArray.extract start finish, by simp [Array.size_extract]; omega⟩ := by
-  simp only [ProvableType.eval_fields]
+  simp only [CircuitType.eval_fields_dispatch_prover]
   apply Vector.ext
   intro i hi
   simp only [Vector.getElem_map]
@@ -525,7 +526,7 @@ lemma eval_toArray_extract_eq {n : ℕ} (start finish : ℕ) {env : ProverEnviro
     rw [Array.getElem_extract]
   rw [rhs]
   have h_eval_simp := h_eval
-  simp only [ProvableType.eval_fields] at h_eval_simp
+  simp only [CircuitType.eval_var_fields_prover] at h_eval_simp
   rw [h_eval_simp, Vector.getElem_map]
 
 /-- Helper to show that extracting a subvector preserves element access -/
@@ -600,7 +601,7 @@ lemma Vector.foldl_and_split {n1 n2 n3 : ℕ} (v : Vector ℕ n3)
 /-- Soundness for n = 0 case -/
 lemma soundness_zero {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : Environment (F p)) (input_var : Var (fields 0) (F p))
-    (input : fields 0 (F p)) (_h_env : input = ProvableType.eval' env input_var)
+    (input : fields 0 (F p)) (_h_env : input = eval env input_var)
     (_h_assumptions : Assumptions 0 input)
     (_h_hold : Circuit.ConstraintsHold.Soundness env ((main input_var).operations offset)) :
     Spec 0 input (env ((main input_var).output offset)) := by
@@ -614,7 +615,7 @@ lemma soundness_zero {p : ℕ} [Fact p.Prime]
 /-- Soundness for n = 1 case -/
 lemma soundness_one {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : Environment (F p)) (input_var : Var (fields 1) (F p))
-    (input : fields 1 (F p)) (h_env : input = ProvableType.eval' env input_var)
+    (input : fields 1 (F p)) (h_env : input = eval env input_var)
     (h_assumptions : Assumptions 1 input)
     (_h_hold : Circuit.ConstraintsHold.Soundness env ((main input_var).operations offset)) :
     Spec 1 input (env ((main input_var).output offset)) := by
@@ -644,7 +645,7 @@ lemma soundness_one {p : ℕ} [Fact p.Prime]
 /-- Soundness for n = 2 case -/
 lemma soundness_two {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : Environment (F p)) (input_var : Var (fields 2) (F p))
-    (input : fields 2 (F p)) (h_env : input = ProvableType.eval' env input_var)
+    (input : fields 2 (F p)) (h_env : input = eval env input_var)
     (h_assumptions : Assumptions 2 input)
     (h_hold : Circuit.ConstraintsHold.Soundness env ((main input_var).operations offset)) :
     Spec 2 input (env ((main input_var).output offset)) := by
@@ -656,7 +657,7 @@ lemma soundness_two {p : ℕ} [Fact p.Prime]
   have h_eval1 : env input_var[1] = input[1] := by simp [h_env, circuit_norm]
   have h_and_spec := AND.circuit.soundness offset env (input_var[0], input_var[1])
     (input[0], input[1])
-    (by simp only [circuit_norm, ProvableType.eval_fieldPair, h_eval0, h_eval1])
+    (by simp only [circuit_norm, h_eval0, h_eval1])
     ⟨h_input0, h_input1⟩ h_hold
 
   rcases h_and_spec with ⟨h_val, h_binary⟩
@@ -680,7 +681,7 @@ lemma completeness_zero {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : ProverEnvironment (F p)) (input_var : Var (fields 0) (F p))
     (input : fields 0 (F p))
     (_h_local_witnesses : env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset))
-    (_h_env : input = ProvableType.eval' env input_var)
+    (_h_env : input = eval env input_var)
     (_h_assumptions : Assumptions 0 input) :
     Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset) := by
   simp [main, Circuit.ConstraintsHold.Completeness]
@@ -690,7 +691,7 @@ lemma completeness_one {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : ProverEnvironment (F p)) (input_var : Var (fields 1) (F p))
     (input : fields 1 (F p))
     (_h_local_witnesses : env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset))
-    (_h_env : input = ProvableType.eval' env input_var)
+    (_h_env : input = eval env input_var)
     (_h_assumptions : Assumptions 1 input) :
     Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset) := by
   simp [main, Circuit.ConstraintsHold.Completeness]
@@ -700,7 +701,7 @@ lemma completeness_two {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : ProverEnvironment (F p)) (input_var : Var (fields 2) (F p))
     (input : fields 2 (F p))
     (h_local_witnesses : env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset))
-    (h_env : input = ProvableType.eval' env input_var)
+    (h_env : input = eval env input_var)
     (h_assumptions : Assumptions 2 input) :
     Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset) := by
   simp only [main, circuit_norm] at h_local_witnesses ⊢
@@ -716,17 +717,17 @@ lemma completeness_two {p : ℕ} [Fact p.Prime]
     constructor
     · have h_eval0 : Expression.eval env input_var[0] = input[0] :=
         by simp[h_env, circuit_norm]
-      simp only [circuit_norm, ProvableType.eval_fieldPair, h_eval0]
+      simp only [circuit_norm, h_eval0]
       exact h_binary0
     · have h_eval1 : Expression.eval env input_var[1] = input[1] :=
         by simp[h_env, circuit_norm]
-      simp only [circuit_norm, ProvableType.eval_fieldPair, h_eval1]
+      simp only [circuit_norm, h_eval1]
       exact h_binary1
 
 theorem soundness {p : ℕ} [Fact p.Prime] (n : ℕ) :
     ∀ (offset : ℕ) (env : Environment (F p)) (input_var : Var (fields n) (F p))
       (input : fields n (F p)),
-    input = ProvableType.eval' env input_var →
+    input = eval env input_var →
     Assumptions n input →
     Circuit.ConstraintsHold.Soundness env ((main input_var).operations offset) →
     Spec n input (env ((main input_var).output offset)) := by
@@ -749,17 +750,17 @@ theorem soundness {p : ℕ} [Fact p.Prime] (n : ℕ) :
       let input2 : fields n2 (F p) := input.drop n1 |>.cast (by omega)
       let input_var1 : Var (fields n1) (F p) := input_var.take n1 |>.cast (by simp only [Nat.min_def, n1]; split <;> omega)
       let input_var2 : Var (fields n2) (F p) := input_var.drop n1 |>.cast (by omega)
-      have h_eval1 : input1 = ProvableType.eval' env input_var1 := by
+      have h_eval1 : input1 = eval env input_var1 := by
         simp only [input_var1, input1]
         apply Vector.ext
         intro i hi
-        simp only [h_env, ProvableType.eval_fields, Vector.getElem_map, Vector.getElem_cast, Vector.getElem_take]
+        simp only [h_env, CircuitType.eval_var_fields, Vector.getElem_map, Vector.getElem_cast, Vector.getElem_take]
 
-      have h_eval2 : input2 = ProvableType.eval' env input_var2 := by
+      have h_eval2 : input2 = eval env input_var2 := by
         simp only [input_var2, input2]
         apply Vector.ext
         intro i hi
-        simp only [h_env, ProvableType.eval_fields, Vector.getElem_map, Vector.getElem_cast, Vector.getElem_drop]
+        simp only [h_env, CircuitType.eval_var_fields, Vector.getElem_map, Vector.getElem_cast, Vector.getElem_drop]
 
       have h_assumptions1 : Assumptions n1 input1 := by
         intro i hi
@@ -796,7 +797,7 @@ theorem soundness {p : ℕ} [Fact p.Prime] (n : ℕ) :
         env
         (out1, out2)
         (env out1, env out2)
-        (by simp only [circuit_norm, ProvableType.eval_fieldPair])
+        (by simp only [circuit_norm])
         ⟨by rcases h_spec1 with ⟨_, h_binary1⟩; exact h_binary1,
          by rcases h_spec2 with ⟨_, h_binary2⟩; exact h_binary2⟩
         h_hold'.2.2
@@ -856,7 +857,7 @@ theorem soundness {p : ℕ} [Fact p.Prime] (n : ℕ) :
 
 lemma main_output_binary (n : ℕ) (offset : ℕ) (env : Environment (F p))
     (input_var : Var (fields n) (F p)) (input : fields n (F p))
-    (h_eval : input = ProvableType.eval' env input_var)
+    (h_eval : input = eval env input_var)
     (h_assumptions : Assumptions n input)
     (h_constraints : Circuit.ConstraintsHold env ((main input_var).operations offset)) :
     let output := env ((main input_var).output offset)
@@ -866,14 +867,14 @@ lemma main_output_binary (n : ℕ) (offset : ℕ) (env : Environment (F p))
 
 lemma main_output_binary_from_completeness (n : ℕ) (offset : ℕ) (env : ProverEnvironment (F p))
     (input_var : Var (fields n) (F p)) (input : fields n (F p))
-    (h_eval : input = ProvableType.eval' env input_var)
+    (h_eval : input = eval env input_var)
     (h_assumptions : Assumptions n input)
     (h_local_witnesses : env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset))
     (h_completeness : Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset)) :
     let output := env ((main input_var).output offset)
     IsBool output := by
   apply main_output_binary
-  · assumption
+  · simpa only [CircuitType.eval_var_fields_prover, CircuitType.eval_var_fields] using h_eval
   · assumption
   apply Circuit.can_replace_completeness (n := offset)
   · apply subcircuitsConsistent
@@ -886,7 +887,7 @@ theorem completeness {p : ℕ} [Fact p.Prime] (n : ℕ) :
     ∀ (offset : ℕ) (env : ProverEnvironment (F p)) (input_var : Var (fields n) (F p))
       (input : fields n (F p)),
     env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset) →
-    input = ProvableType.eval' env input_var →
+    input = eval env input_var →
     Assumptions n input →
     Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset) := by
   induction n using Nat.strong_induction_on with
@@ -906,18 +907,18 @@ theorem completeness {p : ℕ} [Fact p.Prime] (n : ℕ) :
       let input1 : fields n1 (F p) := input.take n1 |>.cast (by simp only [Nat.min_def, n1]; split <;> omega)
       let input2 : fields n2 (F p) := input.drop n1 |>.cast (by omega)
 
-      have h_eval1 : input1 = ProvableType.eval' env input_var1 := by
+      have h_eval1 : input1 = eval env input_var1 := by
         simp only [input_var1, input1]
         apply Vector.ext
         intro i hi
         -- Need to show: input[i] = (eval env (Vector.cast _ (Vector.take input_var n1)))[i]
-        simp only [h_env, ProvableType.eval_fields, Vector.getElem_map, Vector.getElem_cast, Vector.getElem_take]
+        simp only [h_env, CircuitType.eval_var_fields_prover, Vector.getElem_map, Vector.getElem_cast, Vector.getElem_take]
 
-      have h_eval2 : input2 = ProvableType.eval' env input_var2 := by
+      have h_eval2 : input2 = eval env input_var2 := by
         simp only [input_var2, input2]
         apply Vector.ext
         intro i hi
-        simp only [h_env, ProvableType.eval_fields, Vector.getElem_map, Vector.getElem_cast, Vector.getElem_drop]
+        simp only [h_env, CircuitType.eval_var_fields_prover, Vector.getElem_map, Vector.getElem_cast, Vector.getElem_drop]
       have h_assumptions1 : Assumptions n1 input1 := by
         intro i hi
         -- input1[i] = input[i] since input1 is take of input
@@ -1005,14 +1006,14 @@ theorem completeness {p : ℕ} [Fact p.Prime] (n : ℕ) :
               · exact h_assumptions2
 
             constructor
-            · simp only [circuit_norm, ProvableType.eval_fieldPair]
+            · simp only [circuit_norm]
               apply main_output_binary_from_completeness n1 offset env input_var1 input1
               · exact h_eval1
               · exact h_assumptions1
               · exact h_local_witnesses.1
               · exact h_comp1
 
-            · simp only [circuit_norm, ProvableType.eval_fieldPair]
+            · simp only [circuit_norm]
               have h_rest := h_local_witnesses.2
               rw [Circuit.ConstraintsHold.bind_usesLocalWitnesses] at h_rest
               apply main_output_binary_from_completeness n2 (offset + (main input_var1).localLength offset) env input_var2 input2

--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -497,9 +497,9 @@ def Spec (n : ℕ) (input : fields n (F p)) (output : F p) : Prop :=
 /-- If eval env v = w for vectors v and w, then evaluating extracted subvectors preserves equality -/
 lemma eval_toArray_extract_eq {n : ℕ} (start finish : ℕ) {env : ProverEnvironment (F p)}
     {v : Var (fields n) (F p)} {w : fields n (F p)}
-    (h_eval : w = ProvableType.eval env v)
+    (h_eval : w = ProvableType.eval' env v)
     (h_bounds : finish ≤ n) (h_start : start ≤ finish) :
-    ProvableType.eval (α := fields (finish - start)) env
+    ProvableType.eval' (α := fields (finish - start)) env
       ⟨v.toArray.extract start finish, by simp [Array.size_extract]; omega⟩ =
     ⟨w.toArray.extract start finish, by simp [Array.size_extract]; omega⟩ := by
   simp only [ProvableType.eval_fields]
@@ -600,7 +600,7 @@ lemma Vector.foldl_and_split {n1 n2 n3 : ℕ} (v : Vector ℕ n3)
 /-- Soundness for n = 0 case -/
 lemma soundness_zero {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : Environment (F p)) (input_var : Var (fields 0) (F p))
-    (input : fields 0 (F p)) (_h_env : input = ProvableType.eval env input_var)
+    (input : fields 0 (F p)) (_h_env : input = ProvableType.eval' env input_var)
     (_h_assumptions : Assumptions 0 input)
     (_h_hold : Circuit.ConstraintsHold.Soundness env ((main input_var).operations offset)) :
     Spec 0 input (env ((main input_var).output offset)) := by
@@ -614,7 +614,7 @@ lemma soundness_zero {p : ℕ} [Fact p.Prime]
 /-- Soundness for n = 1 case -/
 lemma soundness_one {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : Environment (F p)) (input_var : Var (fields 1) (F p))
-    (input : fields 1 (F p)) (h_env : input = ProvableType.eval env input_var)
+    (input : fields 1 (F p)) (h_env : input = ProvableType.eval' env input_var)
     (h_assumptions : Assumptions 1 input)
     (_h_hold : Circuit.ConstraintsHold.Soundness env ((main input_var).operations offset)) :
     Spec 1 input (env ((main input_var).output offset)) := by
@@ -644,7 +644,7 @@ lemma soundness_one {p : ℕ} [Fact p.Prime]
 /-- Soundness for n = 2 case -/
 lemma soundness_two {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : Environment (F p)) (input_var : Var (fields 2) (F p))
-    (input : fields 2 (F p)) (h_env : input = ProvableType.eval env input_var)
+    (input : fields 2 (F p)) (h_env : input = ProvableType.eval' env input_var)
     (h_assumptions : Assumptions 2 input)
     (h_hold : Circuit.ConstraintsHold.Soundness env ((main input_var).operations offset)) :
     Spec 2 input (env ((main input_var).output offset)) := by
@@ -680,7 +680,7 @@ lemma completeness_zero {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : ProverEnvironment (F p)) (input_var : Var (fields 0) (F p))
     (input : fields 0 (F p))
     (_h_local_witnesses : env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset))
-    (_h_env : input = ProvableType.eval env input_var)
+    (_h_env : input = ProvableType.eval' env input_var)
     (_h_assumptions : Assumptions 0 input) :
     Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset) := by
   simp [main, Circuit.ConstraintsHold.Completeness]
@@ -690,7 +690,7 @@ lemma completeness_one {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : ProverEnvironment (F p)) (input_var : Var (fields 1) (F p))
     (input : fields 1 (F p))
     (_h_local_witnesses : env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset))
-    (_h_env : input = ProvableType.eval env input_var)
+    (_h_env : input = ProvableType.eval' env input_var)
     (_h_assumptions : Assumptions 1 input) :
     Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset) := by
   simp [main, Circuit.ConstraintsHold.Completeness]
@@ -700,7 +700,7 @@ lemma completeness_two {p : ℕ} [Fact p.Prime]
     (offset : ℕ) (env : ProverEnvironment (F p)) (input_var : Var (fields 2) (F p))
     (input : fields 2 (F p))
     (h_local_witnesses : env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset))
-    (h_env : input = ProvableType.eval env input_var)
+    (h_env : input = ProvableType.eval' env input_var)
     (h_assumptions : Assumptions 2 input) :
     Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset) := by
   simp only [main, circuit_norm] at h_local_witnesses ⊢
@@ -726,7 +726,7 @@ lemma completeness_two {p : ℕ} [Fact p.Prime]
 theorem soundness {p : ℕ} [Fact p.Prime] (n : ℕ) :
     ∀ (offset : ℕ) (env : Environment (F p)) (input_var : Var (fields n) (F p))
       (input : fields n (F p)),
-    input = ProvableType.eval env input_var →
+    input = ProvableType.eval' env input_var →
     Assumptions n input →
     Circuit.ConstraintsHold.Soundness env ((main input_var).operations offset) →
     Spec n input (env ((main input_var).output offset)) := by
@@ -749,13 +749,13 @@ theorem soundness {p : ℕ} [Fact p.Prime] (n : ℕ) :
       let input2 : fields n2 (F p) := input.drop n1 |>.cast (by omega)
       let input_var1 : Var (fields n1) (F p) := input_var.take n1 |>.cast (by simp only [Nat.min_def, n1]; split <;> omega)
       let input_var2 : Var (fields n2) (F p) := input_var.drop n1 |>.cast (by omega)
-      have h_eval1 : input1 = ProvableType.eval env input_var1 := by
+      have h_eval1 : input1 = ProvableType.eval' env input_var1 := by
         simp only [input_var1, input1]
         apply Vector.ext
         intro i hi
         simp only [h_env, ProvableType.eval_fields, Vector.getElem_map, Vector.getElem_cast, Vector.getElem_take]
 
-      have h_eval2 : input2 = ProvableType.eval env input_var2 := by
+      have h_eval2 : input2 = ProvableType.eval' env input_var2 := by
         simp only [input_var2, input2]
         apply Vector.ext
         intro i hi
@@ -856,7 +856,7 @@ theorem soundness {p : ℕ} [Fact p.Prime] (n : ℕ) :
 
 lemma main_output_binary (n : ℕ) (offset : ℕ) (env : Environment (F p))
     (input_var : Var (fields n) (F p)) (input : fields n (F p))
-    (h_eval : input = ProvableType.eval env input_var)
+    (h_eval : input = ProvableType.eval' env input_var)
     (h_assumptions : Assumptions n input)
     (h_constraints : Circuit.ConstraintsHold env ((main input_var).operations offset)) :
     let output := env ((main input_var).output offset)
@@ -866,7 +866,7 @@ lemma main_output_binary (n : ℕ) (offset : ℕ) (env : Environment (F p))
 
 lemma main_output_binary_from_completeness (n : ℕ) (offset : ℕ) (env : ProverEnvironment (F p))
     (input_var : Var (fields n) (F p)) (input : fields n (F p))
-    (h_eval : input = ProvableType.eval env input_var)
+    (h_eval : input = ProvableType.eval' env input_var)
     (h_assumptions : Assumptions n input)
     (h_local_witnesses : env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset))
     (h_completeness : Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset)) :
@@ -886,7 +886,7 @@ theorem completeness {p : ℕ} [Fact p.Prime] (n : ℕ) :
     ∀ (offset : ℕ) (env : ProverEnvironment (F p)) (input_var : Var (fields n) (F p))
       (input : fields n (F p)),
     env.UsesLocalWitnessesCompleteness offset ((main input_var).operations offset) →
-    input = ProvableType.eval env input_var →
+    input = ProvableType.eval' env input_var →
     Assumptions n input →
     Circuit.ConstraintsHold.Completeness env ((main input_var).operations offset) := by
   induction n using Nat.strong_induction_on with
@@ -906,14 +906,14 @@ theorem completeness {p : ℕ} [Fact p.Prime] (n : ℕ) :
       let input1 : fields n1 (F p) := input.take n1 |>.cast (by simp only [Nat.min_def, n1]; split <;> omega)
       let input2 : fields n2 (F p) := input.drop n1 |>.cast (by omega)
 
-      have h_eval1 : input1 = ProvableType.eval env input_var1 := by
+      have h_eval1 : input1 = ProvableType.eval' env input_var1 := by
         simp only [input_var1, input1]
         apply Vector.ext
         intro i hi
         -- Need to show: input[i] = (eval env (Vector.cast _ (Vector.take input_var n1)))[i]
         simp only [h_env, ProvableType.eval_fields, Vector.getElem_map, Vector.getElem_cast, Vector.getElem_take]
 
-      have h_eval2 : input2 = ProvableType.eval env input_var2 := by
+      have h_eval2 : input2 = ProvableType.eval' env input_var2 := by
         simp only [input_var2, input2]
         apply Vector.ext
         intro i hi

--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -656,7 +656,7 @@ lemma soundness_two {p : ℕ} [Fact p.Prime]
   have h_eval1 : env input_var[1] = input[1] := by simp [h_env, circuit_norm]
   have h_and_spec := AND.circuit.soundness offset env (input_var[0], input_var[1])
     (input[0], input[1])
-    (by simp only [ProvableType.eval_fieldPair, h_eval0, h_eval1])
+    (by simp only [circuit_norm, ProvableType.eval_fieldPair, h_eval0, h_eval1])
     ⟨h_input0, h_input1⟩ h_hold
 
   rcases h_and_spec with ⟨h_val, h_binary⟩
@@ -716,11 +716,11 @@ lemma completeness_two {p : ℕ} [Fact p.Prime]
     constructor
     · have h_eval0 : Expression.eval env input_var[0] = input[0] :=
         by simp[h_env, circuit_norm]
-      simp only [ProvableType.eval_fieldPair, h_eval0]
+      simp only [circuit_norm, ProvableType.eval_fieldPair, h_eval0]
       exact h_binary0
     · have h_eval1 : Expression.eval env input_var[1] = input[1] :=
         by simp[h_env, circuit_norm]
-      simp only [ProvableType.eval_fieldPair, h_eval1]
+      simp only [circuit_norm, ProvableType.eval_fieldPair, h_eval1]
       exact h_binary1
 
 theorem soundness {p : ℕ} [Fact p.Prime] (n : ℕ) :
@@ -796,7 +796,7 @@ theorem soundness {p : ℕ} [Fact p.Prime] (n : ℕ) :
         env
         (out1, out2)
         (env out1, env out2)
-        (by simp only [ProvableType.eval_fieldPair])
+        (by simp only [circuit_norm, ProvableType.eval_fieldPair])
         ⟨by rcases h_spec1 with ⟨_, h_binary1⟩; exact h_binary1,
          by rcases h_spec2 with ⟨_, h_binary2⟩; exact h_binary2⟩
         h_hold'.2.2
@@ -1005,14 +1005,14 @@ theorem completeness {p : ℕ} [Fact p.Prime] (n : ℕ) :
               · exact h_assumptions2
 
             constructor
-            · simp only [ProvableType.eval_fieldPair]
+            · simp only [circuit_norm, ProvableType.eval_fieldPair]
               apply main_output_binary_from_completeness n1 offset env input_var1 input1
               · exact h_eval1
               · exact h_assumptions1
               · exact h_local_witnesses.1
               · exact h_comp1
 
-            · simp only [ProvableType.eval_fieldPair]
+            · simp only [circuit_norm, ProvableType.eval_fieldPair]
               have h_rest := h_local_witnesses.2
               rw [Circuit.ConstraintsHold.bind_usesLocalWitnesses] at h_rest
               apply main_output_binary_from_completeness n2 (offset + (main input_var1).localLength offset) env input_var2 input2

--- a/Clean/Circomlib/Mux2.lean
+++ b/Clean/Circomlib/Mux2.lean
@@ -126,8 +126,7 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
       -- Now simplify the left side: Expression.eval env (var { index := offset + 1 * i })
       simp only [Expression.eval]
       -- Right side: eval of the computed expression
-      have h_env_i := h_env ⟨i, hi⟩
-      rw [h_env_i]
+      rw [h_env ⟨i, hi⟩]
       norm_num
 
 end MultiMux2

--- a/Clean/Circomlib/Mux2.lean
+++ b/Clean/Circomlib/Mux2.lean
@@ -33,7 +33,7 @@ template MultiMux2(n) {
     signal  s10;
     s10 <== s[1] * s[0];
 
-    for (var i=0; i<n; i++) {
+    for (var i=0; i < n; i++) {
           a10[i] <==  ( c[i][ 3]-c[i][ 2]-c[i][ 1]+c[i][ 0] ) * s10;
            a1[i] <==  ( c[i][ 2]-c[i][ 0] ) * s[1];
            a0[i] <==  ( c[i][ 1]-c[i][ 0] ) * s[0];
@@ -126,7 +126,8 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
       -- Now simplify the left side: Expression.eval env (var { index := offset + 1 * i })
       simp only [Expression.eval]
       -- Right side: eval of the computed expression
-      rw [h_env ⟨i, hi⟩]
+      have h_env_i := h_env ⟨i, hi⟩
+      rw [h_env_i]
       norm_num
 
 end MultiMux2

--- a/Clean/Circomlib/Mux3.lean
+++ b/Clean/Circomlib/Mux3.lean
@@ -147,8 +147,7 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
       -- Now simplify the left side: Expression.eval env (var { index := offset + 1 * i })
       simp only [Expression.eval]
       -- Right side: eval of the computed expression
-      have h_env_i := h_env ⟨i, hi⟩
-      rw [h_env_i]
+      rw [h_env ⟨i, hi⟩]
       norm_num
 
 end MultiMux3

--- a/Clean/Circomlib/Mux3.lean
+++ b/Clean/Circomlib/Mux3.lean
@@ -39,7 +39,7 @@ template MultiMux3(n) {
     signal  s10;
     s10 <== s[1] * s[0];
 
-    for (var i=0; i<n; i++) {
+    for (var i=0; i < n; i++) {
 
          a210[i] <==  ( c[i][ 7]-c[i][ 6]-c[i][ 5]+c[i][ 4] - c[i][ 3]+c[i][ 2]+c[i][ 1]-c[i][ 0] ) * s10;
           a21[i] <==  ( c[i][ 6]-c[i][ 4]-c[i][ 2]+c[i][ 0] ) * s[1];
@@ -147,7 +147,8 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
       -- Now simplify the left side: Expression.eval env (var { index := offset + 1 * i })
       simp only [Expression.eval]
       -- Right side: eval of the computed expression
-      rw [h_env ⟨i, hi⟩]
+      have h_env_i := h_env ⟨i, hi⟩
+      rw [h_env_i]
       norm_num
 
 end MultiMux3

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -349,14 +349,72 @@ structure FormalAssertion (F : Type) (Input : TypeMap) [Field F] [ProvableType I
   -- the output has to be unit
   output _ _ := ()
 
+/-
+GFC-specific variant of `ElaboratedCircuit` that uses `CircuitType` to describe
+input/output schemas. This allows GFC to support schemas with prover hints, where
+the verifier- and prover-value forms differ.
+
+`FormalCircuit` / `FormalAssertion` continue to use the pure-provable
+`ElaboratedCircuit` above.
+-/
+class GeneralElaboratedCircuit (F : Type) (Input Output : TypeMap) [Field F]
+    [CircuitType Input] [CircuitType Output] where
+  name : String := "anonymous"
+  main : CircuitType.Var Input F → Circuit F (CircuitType.Var Output F)
+
+  /-- how many local witnesses this circuit introduces -/
+  localLength : CircuitType.Var Input F → ℕ
+
+  /-- the local length must not depend on the offset. usually automatically proved by `rfl` -/
+  localLength_eq : ∀ input offset, (main input).localLength offset = localLength input
+    := by intros; rfl
+
+  /-- a direct way of computing the output of this circuit (i.e. without having to unfold `main`) -/
+  output : CircuitType.Var Input F → ℕ → CircuitType.Var Output F :=
+    fun input offset => (main input).output offset
+
+  /-- correctness of `output` -/
+  output_eq : ∀ input offset, (main input).output offset = output input offset
+    := by intros; rfl
+
+  /-- technical condition: all subcircuits must be consistent with the current offset -/
+  subcircuitsConsistent : ∀ input offset, ((main input).operations offset).SubcircuitsConsistent offset
+    := by intros; and_intros <;> (
+      try simp only [circuit_norm]
+      try first | ac_rfl | trivial
+    )
+
+attribute [circuit_norm] GeneralElaboratedCircuit.main GeneralElaboratedCircuit.localLength
+  GeneralElaboratedCircuit.output
+
+/--
+Lift an `ElaboratedCircuit` (pure-provable) to a `GeneralElaboratedCircuit`.
+`CircuitType.Var Input F` / `CircuitType.Var Output F` coincide with `Var Input F` /
+`Var Output F` for the default `ProvableType → CircuitType` instance, so the field
+copies are definitionally typed.
+-/
+def ElaboratedCircuit.toGeneral {F : Type} [Field F] {Input Output : TypeMap}
+    [ProvableType Input] [ProvableType Output]
+    (circuit : ElaboratedCircuit F Input Output) : GeneralElaboratedCircuit F Input Output where
+  name := circuit.name
+  main := circuit.main
+  localLength := circuit.localLength
+  localLength_eq := circuit.localLength_eq
+  output := circuit.output
+  output_eq := circuit.output_eq
+  subcircuitsConsistent := circuit.subcircuitsConsistent
+
 @[circuit_norm]
-def GeneralFormalCircuit.Soundness (F : Type) [Field F] (circuit : ElaboratedCircuit F Input Output)
-    (Assumptions : Input F → ProverData F → Prop)
-    (Spec : Input F → Output F → ProverData F → Prop) :=
+def GeneralFormalCircuit.Soundness (F : Type) [Field F]
+    [CircuitType Input] [CircuitType Output]
+    (circuit : GeneralElaboratedCircuit F Input Output)
+    (Assumptions : CircuitType.VerifierValue Input F → ProverData F → Prop)
+    (Spec : CircuitType.VerifierValue Input F → CircuitType.VerifierValue Output F → ProverData F → Prop) :=
   -- for all environments that determine witness assignments
   ∀ offset : ℕ, ∀ env : Environment F,
-  -- for all inputs that satisfy the assumptions
-  ∀ input_var : Var Input F, ∀ input : Input F, eval env input_var = input →
+  -- for all inputs that satisfy the assumptions (verifier view — hints erased)
+  ∀ input_var : CircuitType.Var Input F, ∀ input : CircuitType.VerifierValue Input F,
+  eval env input_var = input →
   Assumptions input env.data →
   -- if the constraints hold
   ConstraintsHold.Soundness env (circuit.main input_var |>.operations offset) →
@@ -366,14 +424,15 @@ def GeneralFormalCircuit.Soundness (F : Type) [Field F] (circuit : ElaboratedCir
 
 @[circuit_norm]
 def GeneralFormalCircuit.Completeness (F : Type) [Field F]
-    (circuit : ElaboratedCircuit F Input Output)
-    (ProverAssumptions : Input F → ProverData F → ProverHints F → Prop)
-    (ProverSpec : Input F → Output F → ProverHints F → Prop) :=
+    [CircuitType Input] [CircuitType Output]
+    (circuit : GeneralElaboratedCircuit F Input Output)
+    (ProverAssumptions : CircuitType.Value Input F → ProverData F → ProverHints F → Prop)
+    (ProverSpec : CircuitType.Value Input F → CircuitType.Value Output F → ProverHints F → Prop) :=
   -- for all prover environments which use the default witness generators for local variables
-  ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
+  ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : CircuitType.Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
-  -- for all inputs that satisfy the "honest prover" assumptions
-  ∀ input : Input F, eval env input_var = input →
+  -- for all inputs that satisfy the "honest prover" assumptions (prover view — hints visible)
+  ∀ input : CircuitType.Value Input F, eval env input_var = input →
   ProverAssumptions input env.data env.hint →
   -- the constraints hold
   ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset) ∧
@@ -395,17 +454,18 @@ this assumption is not needed as the circuit adds that constraint itself. Using 
 add the range assumption to the soundness statement, thus making the circuit hard to use
 (in particular, not usable as a bit range check, because it already _requires_ the bit range assumption).
 -/
-structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F] [ProvableType Input] [ProvableType Output]
-    extends elaborated : ElaboratedCircuit F Input Output where
-  /-- the statement to be assumed for soundness -/
-  Assumptions : Input F → ProverData F → Prop := fun _ _ => True
-  /-- the statement to be proved for soundness. -/
-  Spec : Input F → Output F → ProverData F → Prop
+structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F]
+    [CircuitType Input] [CircuitType Output]
+    extends elaborated : GeneralElaboratedCircuit F Input Output where
+  /-- the statement to be assumed for soundness (verifier view — hints erased) -/
+  Assumptions : CircuitType.VerifierValue Input F → ProverData F → Prop := fun _ _ => True
+  /-- the statement to be proved for soundness (verifier view). -/
+  Spec : CircuitType.VerifierValue Input F → CircuitType.VerifierValue Output F → ProverData F → Prop
 
-  /-- the statement to be assumed for completeness -/
-  ProverAssumptions : Input F → ProverData F → ProverHints F → Prop  := fun _ _ _ => True
-  /-- auxiliary statement to be proved for completeness, alongside the constraints -/
-  ProverSpec : Input F → Output F → ProverHints F → Prop := fun _ _ _ => True
+  /-- the statement to be assumed for completeness (prover view — hints visible) -/
+  ProverAssumptions : CircuitType.Value Input F → ProverData F → ProverHints F → Prop := fun _ _ _ => True
+  /-- auxiliary statement to be proved for completeness, alongside the constraints (prover view) -/
+  ProverSpec : CircuitType.Value Input F → CircuitType.Value Output F → ProverHints F → Prop := fun _ _ _ => True
 
   soundness : GeneralFormalCircuit.Soundness F elaborated Assumptions Spec
   completeness : GeneralFormalCircuit.Completeness F elaborated ProverAssumptions ProverSpec

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -249,12 +249,12 @@ def Soundness (F : Type) [Field F] (circuit : ElaboratedCircuit F Input Output)
   -- for all environments that determine witness assignments
   ∀ offset : ℕ, ∀ env : Environment F,
   -- for all inputs that satisfy the assumptions
-  ∀ input_var : Var Input F, ∀ input : Input F, eval' env input_var = input →
+  ∀ input_var : Var Input F, ∀ input : Input F, eval env input_var = input →
   Assumptions input →
   -- if the constraints hold
   ConstraintsHold.Soundness env (circuit.main input_var |>.operations offset) →
   -- the spec holds on the input and output
-  let output := eval' env (circuit.output input_var offset)
+  let output := eval env (circuit.output input_var offset)
   Spec input output
 
 @[circuit_norm]
@@ -264,7 +264,7 @@ def Completeness (F : Type) [Field F] (circuit : ElaboratedCircuit F Input Outpu
   ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the assumptions
-  ∀ input : Input F, eval' env input_var = input →
+  ∀ input : Input F, eval env input_var = input →
   Assumptions input →
   -- the constraints hold
   ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset)
@@ -306,7 +306,7 @@ def FormalAssertion.Soundness (F : Type) [Field F] (circuit : ElaboratedCircuit 
   -- for all environments that determine witness assignments
   ∀ offset : ℕ, ∀ env : Environment F,
   -- for all inputs that satisfy the assumptions
-  ∀ input_var : Var Input F, ∀ input : Input F, eval' env input_var = input →
+  ∀ input_var : Var Input F, ∀ input : Input F, eval env input_var = input →
   Assumptions input →
   -- if the constraints hold
   ConstraintsHold.Soundness env (circuit.main input_var |>.operations offset) →
@@ -320,7 +320,7 @@ def FormalAssertion.Completeness (F : Type) [Field F] (circuit : ElaboratedCircu
   ∀ offset, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the assumptions AND the spec
-  ∀ input : Input F, eval' env input_var = input →
+  ∀ input : Input F, eval env input_var = input →
   Assumptions input → Spec input →
   -- the constraints hold
   ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset)
@@ -358,12 +358,12 @@ def GeneralFormalCircuit.Soundness (F : Type) [Field F] (circuit : ElaboratedCir
   -- for all environments that determine witness assignments
   ∀ offset : ℕ, ∀ env : Environment F,
   -- for all inputs that satisfy the assumptions
-  ∀ input_var : Var Input F, ∀ input : Input F, eval' env input_var = input →
+  ∀ input_var : Var Input F, ∀ input : Input F, eval env input_var = input →
   Assumptions input env.data →
   -- if the constraints hold
   ConstraintsHold.Soundness env (circuit.main input_var |>.operations offset) →
   -- the spec holds on the input and output
-  let output := eval' env (circuit.output input_var offset)
+  let output := eval env (circuit.output input_var offset)
   Spec input output env.data
 
 @[circuit_norm]
@@ -375,12 +375,12 @@ def GeneralFormalCircuit.Completeness (F : Type) [Field F]
   ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the "honest prover" assumptions
-  ∀ input : Input F, eval' env input_var = input →
+  ∀ input : Input F, eval env input_var = input →
   ProverAssumptions input env.data env.hint →
   -- the constraints hold
   ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset) ∧
   -- and, if given, the prover spec holds
-  ProverSpec input (eval' env (circuit.output input_var offset)) env.hint
+  ProverSpec input (eval env (circuit.output input_var offset)) env.hint
 
 /--
 `GeneralFormalCircuit` is the most general model of formal circuits, needed in cases where the circuit is a
@@ -423,12 +423,12 @@ def GeneralFormalCircuit.WithHint.Soundness (F : Type) [Field F]
   ∀ offset : ℕ, ∀ env : Environment F,
   -- for all inputs that satisfy the assumptions (verifier view — hints erased)
   ∀ input_var : Var Input F, ∀ input : Value Input F,
-  eval' env input_var = input →
+  eval env input_var = input →
   Assumptions input env.data →
   -- if the constraints hold
   ConstraintsHold.Soundness env (circuit.main input_var |>.operations offset) →
   -- the spec holds on the input and output
-  let output := eval' env (circuit.output input_var offset)
+  let output := eval env (circuit.output input_var offset)
   Spec input output env.data
 
 @[circuit_norm]
@@ -441,12 +441,12 @@ def GeneralFormalCircuit.WithHint.Completeness (F : Type) [Field F]
   ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the "honest prover" assumptions (prover view — hints visible)
-  ∀ input : ProverValue Input F, eval' env input_var = input →
+  ∀ input : ProverValue Input F, eval env input_var = input →
   ProverAssumptions input env.data env.hint →
   -- the constraints hold
   ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset) ∧
   -- and, if given, the prover spec holds
-  ProverSpec input (eval' env (circuit.output input_var offset)) env.hint
+  ProverSpec input (eval env (circuit.output input_var offset)) env.hint
 
 /--
 Hint-aware variant of `GeneralFormalCircuit` for schemas whose prover and

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -367,8 +367,8 @@ def GeneralFormalCircuit.Soundness (F : Type) [Field F] (circuit : ElaboratedCir
 @[circuit_norm]
 def GeneralFormalCircuit.Completeness (F : Type) [Field F]
     (circuit : ElaboratedCircuit F Input Output)
-    (ProverAssumptions : Input F → ProverData F → ProverHint F → Prop)
-    (ProverSpec : Input F → Output F → ProverHint F → Prop) :=
+    (ProverAssumptions : Input F → ProverData F → ProverHints F → Prop)
+    (ProverSpec : Input F → Output F → ProverHints F → Prop) :=
   -- for all prover environments which use the default witness generators for local variables
   ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
@@ -403,9 +403,9 @@ structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F] [Pr
   Spec : Input F → Output F → ProverData F → Prop
 
   /-- the statement to be assumed for completeness -/
-  ProverAssumptions : Input F → ProverData F → ProverHint F → Prop  := fun _ _ _ => True
+  ProverAssumptions : Input F → ProverData F → ProverHints F → Prop  := fun _ _ _ => True
   /-- auxiliary statement to be proved for completeness, alongside the constraints -/
-  ProverSpec : Input F → Output F → ProverHint F → Prop := fun _ _ _ => True
+  ProverSpec : Input F → Output F → ProverHints F → Prop := fun _ _ _ => True
 
   soundness : GeneralFormalCircuit.Soundness F elaborated Assumptions Spec
   completeness : GeneralFormalCircuit.Completeness F elaborated ProverAssumptions ProverSpec
@@ -439,22 +439,22 @@ instance {m : ℕ} (α : TypeMap) [NonEmptyProvableType α] :
 -- witness generation
 
 /-- Build a `ProverEnvironment` from a witness list and a specific prover hint. -/
-def ProverEnvironment.fromList (witnesses : List F) (hint : ProverHint F) : ProverEnvironment F where
+def ProverEnvironment.fromList (witnesses : List F) (hint : ProverHints F) : ProverEnvironment F where
   get i := witnesses[i]?.getD 0
   data _ _ := #[]
   hint
 
-def FlatOperation.dynamicWitness (hint : ProverHint F) (op : FlatOperation F) (acc : List F) : List F := match op with
+def FlatOperation.dynamicWitness (hint : ProverHints F) (op : FlatOperation F) (acc : List F) : List F := match op with
   | .witness _ compute => (compute (.fromList acc hint)).toList
   | .assert _ => []
   | .lookup _ => []
 
-def FlatOperation.dynamicWitnesses (ops : List (FlatOperation F)) (hint : ProverHint F) (init : List F) : List F :=
+def FlatOperation.dynamicWitnesses (ops : List (FlatOperation F)) (hint : ProverHints F) (init : List F) : List F :=
   ops.foldl (fun (acc : List F) (op : FlatOperation F) =>
     acc ++ op.dynamicWitness hint acc
   ) init
 
-def FlatOperation.proverEnvironment (ops : List (FlatOperation F)) (hint : ProverHint F) (init : List F) :=
+def FlatOperation.proverEnvironment (ops : List (FlatOperation F)) (hint : ProverHints F) (init : List F) :=
   ProverEnvironment.fromList (FlatOperation.dynamicWitnesses ops hint init) hint
 
 def ProverEnvironment.AgreesBelow (n : ℕ) (env env' : ProverEnvironment F) :=
@@ -477,7 +477,7 @@ def Circuit.ComputableWitnesses (circuit : Circuit F α) (n : ℕ) :=
 If a circuit satisfies `computableWitnesses`, we can construct a concrete environment
 that satisfies `UsesLocalWitnesses`. (Proof in `Theorems`.)
 -/
-def Circuit.proverEnvironment (circuit : Circuit F α) (hint : ProverHint F) (init : List F := []) : ProverEnvironment F :=
+def Circuit.proverEnvironment (circuit : Circuit F α) (hint : ProverHints F) (init : List F := []) : ProverEnvironment F :=
   .fromList (FlatOperation.dynamicWitnesses (circuit.operations init.length).toFlat hint init) hint
 
 -- witness generators used for AIR trace export

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -360,17 +360,17 @@ the verifier- and prover-value forms differ.
 class GeneralElaboratedCircuit (F : Type) (Input Output : TypeMap) [Field F]
     [CircuitType Input] [CircuitType Output] where
   name : String := "anonymous"
-  main : CircuitType.Var Input F → Circuit F (CircuitType.Var Output F)
+  main : Var Input F → Circuit F (Var Output F)
 
   /-- how many local witnesses this circuit introduces -/
-  localLength : CircuitType.Var Input F → ℕ
+  localLength : Var Input F → ℕ
 
   /-- the local length must not depend on the offset. usually automatically proved by `rfl` -/
   localLength_eq : ∀ input offset, (main input).localLength offset = localLength input
     := by intros; rfl
 
   /-- a direct way of computing the output of this circuit (i.e. without having to unfold `main`) -/
-  output : CircuitType.Var Input F → ℕ → CircuitType.Var Output F :=
+  output : Var Input F → ℕ → Var Output F :=
     fun input offset => (main input).output offset
 
   /-- correctness of `output` -/
@@ -389,9 +389,8 @@ attribute [circuit_norm] GeneralElaboratedCircuit.main GeneralElaboratedCircuit.
 
 /--
 Lift an `ElaboratedCircuit` (pure-provable) to a `GeneralElaboratedCircuit`.
-`CircuitType.Var Input F` / `CircuitType.Var Output F` coincide with `Var Input F` /
-`Var Output F` for the default `ProvableType → CircuitType` instance, so the field
-copies are definitionally typed.
+`Var Input F` / `Var Output F` are the default `ProvableType → CircuitType` variable
+forms, so the field copies are definitionally typed.
 -/
 def ElaboratedCircuit.toGeneral {F : Type} [Field F] {Input Output : TypeMap}
     [ProvableType Input] [ProvableType Output]
@@ -475,7 +474,7 @@ def GeneralFormalCircuit.WithHint.Soundness (F : Type) [Field F]
   -- for all environments that determine witness assignments
   ∀ offset : ℕ, ∀ env : Environment F,
   -- for all inputs that satisfy the assumptions (verifier view — hints erased)
-  ∀ input_var : CircuitType.Var Input F, ∀ input : CircuitType.Value Input F,
+  ∀ input_var : Var Input F, ∀ input : CircuitType.Value Input F,
   eval' env input_var = input →
   Assumptions input env.data →
   -- if the constraints hold
@@ -491,7 +490,7 @@ def GeneralFormalCircuit.WithHint.Completeness (F : Type) [Field F]
     (ProverAssumptions : CircuitType.ProverValue Input F → ProverData F → ProverHints F → Prop)
     (ProverSpec : CircuitType.ProverValue Input F → CircuitType.ProverValue Output F → ProverHints F → Prop) :=
   -- for all prover environments which use the default witness generators for local variables
-  ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : CircuitType.Var Input F,
+  ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the "honest prover" assumptions (prover view — hints visible)
   ∀ input : CircuitType.ProverValue Input F, eval' env input_var = input →

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -405,16 +405,13 @@ def ElaboratedCircuit.toGeneral {F : Type} [Field F] {Input Output : TypeMap}
   subcircuitsConsistent := circuit.subcircuitsConsistent
 
 @[circuit_norm]
-def GeneralFormalCircuit.Soundness (F : Type) [Field F]
-    [CircuitType Input] [CircuitType Output]
-    (circuit : GeneralElaboratedCircuit F Input Output)
-    (Assumptions : CircuitType.Value Input F → ProverData F → Prop)
-    (Spec : CircuitType.Value Input F → CircuitType.Value Output F → ProverData F → Prop) :=
+def GeneralFormalCircuit.Soundness (F : Type) [Field F] (circuit : ElaboratedCircuit F Input Output)
+    (Assumptions : Input F → ProverData F → Prop)
+    (Spec : Input F → Output F → ProverData F → Prop) :=
   -- for all environments that determine witness assignments
   ∀ offset : ℕ, ∀ env : Environment F,
-  -- for all inputs that satisfy the assumptions (verifier view — hints erased)
-  ∀ input_var : CircuitType.Var Input F, ∀ input : CircuitType.Value Input F,
-  eval' env input_var = input →
+  -- for all inputs that satisfy the assumptions
+  ∀ input_var : Var Input F, ∀ input : Input F, eval' env input_var = input →
   Assumptions input env.data →
   -- if the constraints hold
   ConstraintsHold.Soundness env (circuit.main input_var |>.operations offset) →
@@ -424,15 +421,14 @@ def GeneralFormalCircuit.Soundness (F : Type) [Field F]
 
 @[circuit_norm]
 def GeneralFormalCircuit.Completeness (F : Type) [Field F]
-    [CircuitType Input] [CircuitType Output]
-    (circuit : GeneralElaboratedCircuit F Input Output)
-    (ProverAssumptions : CircuitType.ProverValue Input F → ProverData F → ProverHints F → Prop)
-    (ProverSpec : CircuitType.ProverValue Input F → CircuitType.ProverValue Output F → ProverHints F → Prop) :=
+    (circuit : ElaboratedCircuit F Input Output)
+    (ProverAssumptions : Input F → ProverData F → ProverHints F → Prop)
+    (ProverSpec : Input F → Output F → ProverHints F → Prop) :=
   -- for all prover environments which use the default witness generators for local variables
-  ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : CircuitType.Var Input F,
+  ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
-  -- for all inputs that satisfy the "honest prover" assumptions (prover view — hints visible)
-  ∀ input : CircuitType.ProverValue Input F, eval' env input_var = input →
+  -- for all inputs that satisfy the "honest prover" assumptions
+  ∀ input : Input F, eval' env input_var = input →
   ProverAssumptions input env.data env.hint →
   -- the constraints hold
   ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset) ∧
@@ -455,6 +451,61 @@ add the range assumption to the soundness statement, thus making the circuit har
 (in particular, not usable as a bit range check, because it already _requires_ the bit range assumption).
 -/
 structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F]
+    [ProvableType Input] [ProvableType Output]
+    extends elaborated : ElaboratedCircuit F Input Output where
+  /-- the statement to be assumed for soundness -/
+  Assumptions : Input F → ProverData F → Prop := fun _ _ => True
+  /-- the statement to be proved for soundness. -/
+  Spec : Input F → Output F → ProverData F → Prop
+
+  /-- the statement to be assumed for completeness -/
+  ProverAssumptions : Input F → ProverData F → ProverHints F → Prop := fun _ _ _ => True
+  /-- auxiliary statement to be proved for completeness, alongside the constraints -/
+  ProverSpec : Input F → Output F → ProverHints F → Prop := fun _ _ _ => True
+
+  soundness : GeneralFormalCircuit.Soundness F elaborated Assumptions Spec
+  completeness : GeneralFormalCircuit.Completeness F elaborated ProverAssumptions ProverSpec
+
+@[circuit_norm]
+def GeneralFormalCircuit.WithHint.Soundness (F : Type) [Field F]
+    [CircuitType Input] [CircuitType Output]
+    (circuit : GeneralElaboratedCircuit F Input Output)
+    (Assumptions : CircuitType.Value Input F → ProverData F → Prop)
+    (Spec : CircuitType.Value Input F → CircuitType.Value Output F → ProverData F → Prop) :=
+  -- for all environments that determine witness assignments
+  ∀ offset : ℕ, ∀ env : Environment F,
+  -- for all inputs that satisfy the assumptions (verifier view — hints erased)
+  ∀ input_var : CircuitType.Var Input F, ∀ input : CircuitType.Value Input F,
+  eval' env input_var = input →
+  Assumptions input env.data →
+  -- if the constraints hold
+  ConstraintsHold.Soundness env (circuit.main input_var |>.operations offset) →
+  -- the spec holds on the input and output
+  let output := eval' env (circuit.output input_var offset)
+  Spec input output env.data
+
+@[circuit_norm]
+def GeneralFormalCircuit.WithHint.Completeness (F : Type) [Field F]
+    [CircuitType Input] [CircuitType Output]
+    (circuit : GeneralElaboratedCircuit F Input Output)
+    (ProverAssumptions : CircuitType.ProverValue Input F → ProverData F → ProverHints F → Prop)
+    (ProverSpec : CircuitType.ProverValue Input F → CircuitType.ProverValue Output F → ProverHints F → Prop) :=
+  -- for all prover environments which use the default witness generators for local variables
+  ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : CircuitType.Var Input F,
+  env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
+  -- for all inputs that satisfy the "honest prover" assumptions (prover view — hints visible)
+  ∀ input : CircuitType.ProverValue Input F, eval' env input_var = input →
+  ProverAssumptions input env.data env.hint →
+  -- the constraints hold
+  ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset) ∧
+  -- and, if given, the prover spec holds
+  ProverSpec input (eval' env (circuit.output input_var offset)) env.hint
+
+/--
+Hint-aware variant of `GeneralFormalCircuit` for schemas whose prover and
+verifier views differ.
+-/
+structure GeneralFormalCircuit.WithHint (F : Type) (Input Output : TypeMap) [Field F]
     [CircuitType Input] [CircuitType Output]
     extends elaborated : GeneralElaboratedCircuit F Input Output where
   /-- the statement to be assumed for soundness (verifier view — hints erased) -/
@@ -467,8 +518,27 @@ structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F]
   /-- auxiliary statement to be proved for completeness, alongside the constraints (prover view) -/
   ProverSpec : CircuitType.ProverValue Input F → CircuitType.ProverValue Output F → ProverHints F → Prop := fun _ _ _ => True
 
-  soundness : GeneralFormalCircuit.Soundness F elaborated Assumptions Spec
-  completeness : GeneralFormalCircuit.Completeness F elaborated ProverAssumptions ProverSpec
+  soundness : GeneralFormalCircuit.WithHint.Soundness F elaborated Assumptions Spec
+  completeness : GeneralFormalCircuit.WithHint.Completeness F elaborated ProverAssumptions ProverSpec
+
+@[circuit_norm]
+def GeneralFormalCircuit.toWithHint {F : Type} [Field F] {Input Output : TypeMap}
+    [ProvableType Input] [ProvableType Output]
+    (circuit : GeneralFormalCircuit F Input Output) :
+    GeneralFormalCircuit.WithHint F Input Output where
+  elaborated := circuit.elaborated.toGeneral
+  Assumptions input data := circuit.Assumptions input data
+  Spec input output data := circuit.Spec input output data
+  ProverAssumptions input data hint := circuit.ProverAssumptions input data hint
+  ProverSpec input output hint := circuit.ProverSpec input output hint
+  soundness := by
+    simpa only [GeneralFormalCircuit.WithHint.Soundness, ElaboratedCircuit.toGeneral,
+      CircuitType.eval_verifier, CircuitType.eval_var, CircuitType.value_of_provableType]
+      using circuit.soundness
+  completeness := by
+    simpa only [GeneralFormalCircuit.WithHint.Completeness, ElaboratedCircuit.toGeneral,
+      CircuitType.eval_prover, CircuitType.eval_var_prover, CircuitType.proverValue_of_provableType]
+      using circuit.completeness
 end
 
 export Circuit (witnessVar witnessField witnessVars witnessVector assertZero lookup)

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -480,11 +480,11 @@ def GeneralFormalCircuit.toWithHint {F : Type} [Field F] {Input Output : TypeMap
   ProverSpec input output hint := circuit.ProverSpec input output hint
   soundness := by
     simpa only [GeneralFormalCircuit.WithHint.Soundness,
-      CircuitType.eval_verifier, CircuitType.eval_var, CircuitType.value_of_provableType]
+      CircuitType.eval_verifier, CircuitType.value_of_provableType]
       using circuit.soundness
   completeness := by
     simpa only [GeneralFormalCircuit.WithHint.Completeness,
-      CircuitType.eval_prover, CircuitType.eval_var_prover, CircuitType.proverValue_of_provableType]
+      CircuitType.eval_prover, CircuitType.proverValue_of_provableType]
       using circuit.completeness
 end
 

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -397,8 +397,7 @@ this assumption is not needed as the circuit adds that constraint itself. Using 
 add the range assumption to the soundness statement, thus making the circuit hard to use
 (in particular, not usable as a bit range check, because it already _requires_ the bit range assumption).
 -/
-structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F]
-    [ProvableType Input] [ProvableType Output]
+structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F] [ProvableType Input] [ProvableType Output]
     extends elaborated : ElaboratedCircuit F Input Output where
   /-- the statement to be assumed for soundness -/
   Assumptions : Input F → ProverData F → Prop := fun _ _ => True
@@ -453,7 +452,7 @@ Hint-aware variant of `GeneralFormalCircuit` for schemas whose prover and
 verifier views differ.
 -/
 structure GeneralFormalCircuit.WithHint (F : Type) (Input Output : TypeMap) [Field F]
-    [CircuitType Input] [CircuitType Output]
+  [CircuitType Input] [CircuitType Output]
     extends elaborated : ElaboratedCircuit F Input Output where
   /-- the statement to be assumed for soundness (verifier view — hints erased) -/
   Assumptions : Value Input F → ProverData F → Prop := fun _ _ => True

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -247,12 +247,12 @@ def Soundness (F : Type) [Field F] (circuit : ElaboratedCircuit F Input Output)
   -- for all environments that determine witness assignments
   ∀ offset : ℕ, ∀ env : Environment F,
   -- for all inputs that satisfy the assumptions
-  ∀ input_var : Var Input F, ∀ input : Input F, eval env input_var = input →
+  ∀ input_var : Var Input F, ∀ input : Input F, eval' env input_var = input →
   Assumptions input →
   -- if the constraints hold
   ConstraintsHold.Soundness env (circuit.main input_var |>.operations offset) →
   -- the spec holds on the input and output
-  let output := eval env (circuit.output input_var offset)
+  let output := eval' env (circuit.output input_var offset)
   Spec input output
 
 @[circuit_norm]
@@ -262,7 +262,7 @@ def Completeness (F : Type) [Field F] (circuit : ElaboratedCircuit F Input Outpu
   ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the assumptions
-  ∀ input : Input F, eval env input_var = input →
+  ∀ input : Input F, eval' env input_var = input →
   Assumptions input →
   -- the constraints hold
   ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset)
@@ -304,7 +304,7 @@ def FormalAssertion.Soundness (F : Type) [Field F] (circuit : ElaboratedCircuit 
   -- for all environments that determine witness assignments
   ∀ offset : ℕ, ∀ env : Environment F,
   -- for all inputs that satisfy the assumptions
-  ∀ input_var : Var Input F, ∀ input : Input F, eval env input_var = input →
+  ∀ input_var : Var Input F, ∀ input : Input F, eval' env input_var = input →
   Assumptions input →
   -- if the constraints hold
   ConstraintsHold.Soundness env (circuit.main input_var |>.operations offset) →
@@ -318,7 +318,7 @@ def FormalAssertion.Completeness (F : Type) [Field F] (circuit : ElaboratedCircu
   ∀ offset, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the assumptions AND the spec
-  ∀ input : Input F, eval env input_var = input →
+  ∀ input : Input F, eval' env input_var = input →
   Assumptions input → Spec input →
   -- the constraints hold
   ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset)
@@ -414,12 +414,12 @@ def GeneralFormalCircuit.Soundness (F : Type) [Field F]
   ∀ offset : ℕ, ∀ env : Environment F,
   -- for all inputs that satisfy the assumptions (verifier view — hints erased)
   ∀ input_var : CircuitType.Var Input F, ∀ input : CircuitType.VerifierValue Input F,
-  eval env input_var = input →
+  eval' env input_var = input →
   Assumptions input env.data →
   -- if the constraints hold
   ConstraintsHold.Soundness env (circuit.main input_var |>.operations offset) →
   -- the spec holds on the input and output
-  let output := eval env (circuit.output input_var offset)
+  let output := eval' env (circuit.output input_var offset)
   Spec input output env.data
 
 @[circuit_norm]
@@ -432,12 +432,12 @@ def GeneralFormalCircuit.Completeness (F : Type) [Field F]
   ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : CircuitType.Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the "honest prover" assumptions (prover view — hints visible)
-  ∀ input : CircuitType.Value Input F, eval env input_var = input →
+  ∀ input : CircuitType.Value Input F, eval' env input_var = input →
   ProverAssumptions input env.data env.hint →
   -- the constraints hold
   ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset) ∧
   -- and, if given, the prover spec holds
-  ProverSpec input (eval env (circuit.output input_var offset)) env.hint
+  ProverSpec input (eval' env (circuit.output input_var offset)) env.hint
 
 /--
 `GeneralFormalCircuit` is the most general model of formal circuits, needed in cases where the circuit is a

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -469,12 +469,12 @@ structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F]
 def GeneralFormalCircuit.WithHint.Soundness (F : Type) [Field F]
     [CircuitType Input] [CircuitType Output]
     (circuit : GeneralElaboratedCircuit F Input Output)
-    (Assumptions : CircuitType.Value Input F → ProverData F → Prop)
-    (Spec : CircuitType.Value Input F → CircuitType.Value Output F → ProverData F → Prop) :=
+    (Assumptions : Value Input F → ProverData F → Prop)
+    (Spec : Value Input F → Value Output F → ProverData F → Prop) :=
   -- for all environments that determine witness assignments
   ∀ offset : ℕ, ∀ env : Environment F,
   -- for all inputs that satisfy the assumptions (verifier view — hints erased)
-  ∀ input_var : Var Input F, ∀ input : CircuitType.Value Input F,
+  ∀ input_var : Var Input F, ∀ input : Value Input F,
   eval' env input_var = input →
   Assumptions input env.data →
   -- if the constraints hold
@@ -487,13 +487,13 @@ def GeneralFormalCircuit.WithHint.Soundness (F : Type) [Field F]
 def GeneralFormalCircuit.WithHint.Completeness (F : Type) [Field F]
     [CircuitType Input] [CircuitType Output]
     (circuit : GeneralElaboratedCircuit F Input Output)
-    (ProverAssumptions : CircuitType.ProverValue Input F → ProverData F → ProverHints F → Prop)
-    (ProverSpec : CircuitType.ProverValue Input F → CircuitType.ProverValue Output F → ProverHints F → Prop) :=
+    (ProverAssumptions : ProverValue Input F → ProverData F → ProverHints F → Prop)
+    (ProverSpec : ProverValue Input F → ProverValue Output F → ProverHints F → Prop) :=
   -- for all prover environments which use the default witness generators for local variables
   ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the "honest prover" assumptions (prover view — hints visible)
-  ∀ input : CircuitType.ProverValue Input F, eval' env input_var = input →
+  ∀ input : ProverValue Input F, eval' env input_var = input →
   ProverAssumptions input env.data env.hint →
   -- the constraints hold
   ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset) ∧
@@ -508,14 +508,14 @@ structure GeneralFormalCircuit.WithHint (F : Type) (Input Output : TypeMap) [Fie
     [CircuitType Input] [CircuitType Output]
     extends elaborated : GeneralElaboratedCircuit F Input Output where
   /-- the statement to be assumed for soundness (verifier view — hints erased) -/
-  Assumptions : CircuitType.Value Input F → ProverData F → Prop := fun _ _ => True
+  Assumptions : Value Input F → ProverData F → Prop := fun _ _ => True
   /-- the statement to be proved for soundness (verifier view). -/
-  Spec : CircuitType.Value Input F → CircuitType.Value Output F → ProverData F → Prop
+  Spec : Value Input F → Value Output F → ProverData F → Prop
 
   /-- the statement to be assumed for completeness (prover view — hints visible) -/
-  ProverAssumptions : CircuitType.ProverValue Input F → ProverData F → ProverHints F → Prop := fun _ _ _ => True
+  ProverAssumptions : ProverValue Input F → ProverData F → ProverHints F → Prop := fun _ _ _ => True
   /-- auxiliary statement to be proved for completeness, alongside the constraints (prover view) -/
-  ProverSpec : CircuitType.ProverValue Input F → CircuitType.ProverValue Output F → ProverHints F → Prop := fun _ _ _ => True
+  ProverSpec : ProverValue Input F → ProverValue Output F → ProverHints F → Prop := fun _ _ _ => True
 
   soundness : GeneralFormalCircuit.WithHint.Soundness F elaborated Assumptions Spec
   completeness : GeneralFormalCircuit.WithHint.Completeness F elaborated ProverAssumptions ProverSpec

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -206,7 +206,7 @@ def ProverEnvironment.UsesLocalWitnessesFlat (env : ProverEnvironment F) (n : �
 
 section
 open Circuit (ConstraintsHold)
-variable {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
+variable {Input Output : TypeMap}
 
 /-
 Common base type for circuits that are to be used in formal proofs.
@@ -214,7 +214,7 @@ Common base type for circuits that are to be used in formal proofs.
 It contains the main circuit plus some of its properties in elaborated form, to make it
 faster to reason about them in proofs.
 -/
-class ElaboratedCircuit (F : Type) (Input Output : TypeMap) [Field F] [ProvableType Input] [ProvableType Output] where
+class ElaboratedCircuit (F : Type) (Input Output : TypeMap) [Field F] [CircuitType Input] [CircuitType Output] where
   name : String := "anonymous"
   main : Var Input F → Circuit F (Var Output F)
 
@@ -240,6 +240,8 @@ class ElaboratedCircuit (F : Type) (Input Output : TypeMap) [Field F] [ProvableT
     )
 
 attribute [circuit_norm] ElaboratedCircuit.main ElaboratedCircuit.localLength ElaboratedCircuit.output
+
+variable [ProvableType Input] [ProvableType Output]
 
 @[circuit_norm]
 def Soundness (F : Type) [Field F] (circuit : ElaboratedCircuit F Input Output)
@@ -349,60 +351,6 @@ structure FormalAssertion (F : Type) (Input : TypeMap) [Field F] [ProvableType I
   -- the output has to be unit
   output _ _ := ()
 
-/-
-GFC-specific variant of `ElaboratedCircuit` that uses `CircuitType` to describe
-input/output schemas. This allows GFC to support schemas with prover hints, where
-the verifier- and prover-value forms differ.
-
-`FormalCircuit` / `FormalAssertion` continue to use the pure-provable
-`ElaboratedCircuit` above.
--/
-class GeneralElaboratedCircuit (F : Type) (Input Output : TypeMap) [Field F]
-    [CircuitType Input] [CircuitType Output] where
-  name : String := "anonymous"
-  main : Var Input F → Circuit F (Var Output F)
-
-  /-- how many local witnesses this circuit introduces -/
-  localLength : Var Input F → ℕ
-
-  /-- the local length must not depend on the offset. usually automatically proved by `rfl` -/
-  localLength_eq : ∀ input offset, (main input).localLength offset = localLength input
-    := by intros; rfl
-
-  /-- a direct way of computing the output of this circuit (i.e. without having to unfold `main`) -/
-  output : Var Input F → ℕ → Var Output F :=
-    fun input offset => (main input).output offset
-
-  /-- correctness of `output` -/
-  output_eq : ∀ input offset, (main input).output offset = output input offset
-    := by intros; rfl
-
-  /-- technical condition: all subcircuits must be consistent with the current offset -/
-  subcircuitsConsistent : ∀ input offset, ((main input).operations offset).SubcircuitsConsistent offset
-    := by intros; and_intros <;> (
-      try simp only [circuit_norm]
-      try first | ac_rfl | trivial
-    )
-
-attribute [circuit_norm] GeneralElaboratedCircuit.main GeneralElaboratedCircuit.localLength
-  GeneralElaboratedCircuit.output
-
-/--
-Lift an `ElaboratedCircuit` (pure-provable) to a `GeneralElaboratedCircuit`.
-`Var Input F` / `Var Output F` are the default `ProvableType → CircuitType` variable
-forms, so the field copies are definitionally typed.
--/
-def ElaboratedCircuit.toGeneral {F : Type} [Field F] {Input Output : TypeMap}
-    [ProvableType Input] [ProvableType Output]
-    (circuit : ElaboratedCircuit F Input Output) : GeneralElaboratedCircuit F Input Output where
-  name := circuit.name
-  main := circuit.main
-  localLength := circuit.localLength
-  localLength_eq := circuit.localLength_eq
-  output := circuit.output
-  output_eq := circuit.output_eq
-  subcircuitsConsistent := circuit.subcircuitsConsistent
-
 @[circuit_norm]
 def GeneralFormalCircuit.Soundness (F : Type) [Field F] (circuit : ElaboratedCircuit F Input Output)
     (Assumptions : Input F → ProverData F → Prop)
@@ -468,7 +416,7 @@ structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F]
 @[circuit_norm]
 def GeneralFormalCircuit.WithHint.Soundness (F : Type) [Field F]
     [CircuitType Input] [CircuitType Output]
-    (circuit : GeneralElaboratedCircuit F Input Output)
+    (circuit : ElaboratedCircuit F Input Output)
     (Assumptions : Value Input F → ProverData F → Prop)
     (Spec : Value Input F → Value Output F → ProverData F → Prop) :=
   -- for all environments that determine witness assignments
@@ -486,7 +434,7 @@ def GeneralFormalCircuit.WithHint.Soundness (F : Type) [Field F]
 @[circuit_norm]
 def GeneralFormalCircuit.WithHint.Completeness (F : Type) [Field F]
     [CircuitType Input] [CircuitType Output]
-    (circuit : GeneralElaboratedCircuit F Input Output)
+    (circuit : ElaboratedCircuit F Input Output)
     (ProverAssumptions : ProverValue Input F → ProverData F → ProverHints F → Prop)
     (ProverSpec : ProverValue Input F → ProverValue Output F → ProverHints F → Prop) :=
   -- for all prover environments which use the default witness generators for local variables
@@ -506,7 +454,7 @@ verifier views differ.
 -/
 structure GeneralFormalCircuit.WithHint (F : Type) (Input Output : TypeMap) [Field F]
     [CircuitType Input] [CircuitType Output]
-    extends elaborated : GeneralElaboratedCircuit F Input Output where
+    extends elaborated : ElaboratedCircuit F Input Output where
   /-- the statement to be assumed for soundness (verifier view — hints erased) -/
   Assumptions : Value Input F → ProverData F → Prop := fun _ _ => True
   /-- the statement to be proved for soundness (verifier view). -/
@@ -525,17 +473,17 @@ def GeneralFormalCircuit.toWithHint {F : Type} [Field F] {Input Output : TypeMap
     [ProvableType Input] [ProvableType Output]
     (circuit : GeneralFormalCircuit F Input Output) :
     GeneralFormalCircuit.WithHint F Input Output where
-  elaborated := circuit.elaborated.toGeneral
+  elaborated := circuit.elaborated
   Assumptions input data := circuit.Assumptions input data
   Spec input output data := circuit.Spec input output data
   ProverAssumptions input data hint := circuit.ProverAssumptions input data hint
   ProverSpec input output hint := circuit.ProverSpec input output hint
   soundness := by
-    simpa only [GeneralFormalCircuit.WithHint.Soundness, ElaboratedCircuit.toGeneral,
+    simpa only [GeneralFormalCircuit.WithHint.Soundness,
       CircuitType.eval_verifier, CircuitType.eval_var, CircuitType.value_of_provableType]
       using circuit.soundness
   completeness := by
-    simpa only [GeneralFormalCircuit.WithHint.Completeness, ElaboratedCircuit.toGeneral,
+    simpa only [GeneralFormalCircuit.WithHint.Completeness,
       CircuitType.eval_prover, CircuitType.eval_var_prover, CircuitType.proverValue_of_provableType]
       using circuit.completeness
 end

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -369,8 +369,8 @@ def GeneralFormalCircuit.Soundness (F : Type) [Field F] (circuit : ElaboratedCir
 @[circuit_norm]
 def GeneralFormalCircuit.Completeness (F : Type) [Field F]
     (circuit : ElaboratedCircuit F Input Output)
-    (ProverAssumptions : Input F → ProverData F → ProverHints F → Prop)
-    (ProverSpec : Input F → Output F → ProverHints F → Prop) :=
+    (ProverAssumptions : Input F → ProverData F → ProverHint F → Prop)
+    (ProverSpec : Input F → Output F → ProverHint F → Prop) :=
   -- for all prover environments which use the default witness generators for local variables
   ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
@@ -405,9 +405,9 @@ structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F] [Pr
   Spec : Input F → Output F → ProverData F → Prop
 
   /-- the statement to be assumed for completeness -/
-  ProverAssumptions : Input F → ProverData F → ProverHints F → Prop := fun _ _ _ => True
+  ProverAssumptions : Input F → ProverData F → ProverHint F → Prop := fun _ _ _ => True
   /-- auxiliary statement to be proved for completeness, alongside the constraints -/
-  ProverSpec : Input F → Output F → ProverHints F → Prop := fun _ _ _ => True
+  ProverSpec : Input F → Output F → ProverHint F → Prop := fun _ _ _ => True
 
   soundness : GeneralFormalCircuit.Soundness F elaborated Assumptions Spec
   completeness : GeneralFormalCircuit.Completeness F elaborated ProverAssumptions ProverSpec
@@ -434,8 +434,8 @@ def GeneralFormalCircuit.WithHint.Soundness (F : Type) [Field F]
 def GeneralFormalCircuit.WithHint.Completeness (F : Type) [Field F]
     [CircuitType Input] [CircuitType Output]
     (circuit : ElaboratedCircuit F Input Output)
-    (ProverAssumptions : ProverValue Input F → ProverData F → ProverHints F → Prop)
-    (ProverSpec : ProverValue Input F → ProverValue Output F → ProverHints F → Prop) :=
+    (ProverAssumptions : ProverValue Input F → ProverData F → ProverHint F → Prop)
+    (ProverSpec : ProverValue Input F → ProverValue Output F → ProverHint F → Prop) :=
   -- for all prover environments which use the default witness generators for local variables
   ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
@@ -460,9 +460,9 @@ structure GeneralFormalCircuit.WithHint (F : Type) (Input Output : TypeMap) [Fie
   Spec : Value Input F → Value Output F → ProverData F → Prop
 
   /-- the statement to be assumed for completeness (prover view — hints visible) -/
-  ProverAssumptions : ProverValue Input F → ProverData F → ProverHints F → Prop := fun _ _ _ => True
+  ProverAssumptions : ProverValue Input F → ProverData F → ProverHint F → Prop := fun _ _ _ => True
   /-- auxiliary statement to be proved for completeness, alongside the constraints (prover view) -/
-  ProverSpec : ProverValue Input F → ProverValue Output F → ProverHints F → Prop := fun _ _ _ => True
+  ProverSpec : ProverValue Input F → ProverValue Output F → ProverHint F → Prop := fun _ _ _ => True
 
   soundness : GeneralFormalCircuit.WithHint.Soundness F elaborated Assumptions Spec
   completeness : GeneralFormalCircuit.WithHint.Completeness F elaborated ProverAssumptions ProverSpec
@@ -515,22 +515,22 @@ instance {m : ℕ} (α : TypeMap) [NonEmptyProvableType α] :
 -- witness generation
 
 /-- Build a `ProverEnvironment` from a witness list and a specific prover hint. -/
-def ProverEnvironment.fromList (witnesses : List F) (hint : ProverHints F) : ProverEnvironment F where
+def ProverEnvironment.fromList (witnesses : List F) (hint : ProverHint F) : ProverEnvironment F where
   get i := witnesses[i]?.getD 0
   data _ _ := #[]
   hint
 
-def FlatOperation.dynamicWitness (hint : ProverHints F) (op : FlatOperation F) (acc : List F) : List F := match op with
+def FlatOperation.dynamicWitness (hint : ProverHint F) (op : FlatOperation F) (acc : List F) : List F := match op with
   | .witness _ compute => (compute (.fromList acc hint)).toList
   | .assert _ => []
   | .lookup _ => []
 
-def FlatOperation.dynamicWitnesses (ops : List (FlatOperation F)) (hint : ProverHints F) (init : List F) : List F :=
+def FlatOperation.dynamicWitnesses (ops : List (FlatOperation F)) (hint : ProverHint F) (init : List F) : List F :=
   ops.foldl (fun (acc : List F) (op : FlatOperation F) =>
     acc ++ op.dynamicWitness hint acc
   ) init
 
-def FlatOperation.proverEnvironment (ops : List (FlatOperation F)) (hint : ProverHints F) (init : List F) :=
+def FlatOperation.proverEnvironment (ops : List (FlatOperation F)) (hint : ProverHint F) (init : List F) :=
   ProverEnvironment.fromList (FlatOperation.dynamicWitnesses ops hint init) hint
 
 def ProverEnvironment.AgreesBelow (n : ℕ) (env env' : ProverEnvironment F) :=
@@ -553,7 +553,7 @@ def Circuit.ComputableWitnesses (circuit : Circuit F α) (n : ℕ) :=
 If a circuit satisfies `computableWitnesses`, we can construct a concrete environment
 that satisfies `UsesLocalWitnesses`. (Proof in `Theorems`.)
 -/
-def Circuit.proverEnvironment (circuit : Circuit F α) (hint : ProverHints F) (init : List F := []) : ProverEnvironment F :=
+def Circuit.proverEnvironment (circuit : Circuit F α) (hint : ProverHint F) (init : List F := []) : ProverEnvironment F :=
   .fromList (FlatOperation.dynamicWitnesses (circuit.operations init.length).toFlat hint init) hint
 
 -- witness generators used for AIR trace export

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -426,13 +426,13 @@ def GeneralFormalCircuit.Soundness (F : Type) [Field F]
 def GeneralFormalCircuit.Completeness (F : Type) [Field F]
     [CircuitType Input] [CircuitType Output]
     (circuit : GeneralElaboratedCircuit F Input Output)
-    (ProverAssumptions : CircuitType.Value Input F → ProverData F → ProverHints F → Prop)
-    (ProverSpec : CircuitType.Value Input F → CircuitType.Value Output F → ProverHints F → Prop) :=
+    (ProverAssumptions : CircuitType.ProverValue Input F → ProverData F → ProverHints F → Prop)
+    (ProverSpec : CircuitType.ProverValue Input F → CircuitType.ProverValue Output F → ProverHints F → Prop) :=
   -- for all prover environments which use the default witness generators for local variables
   ∀ offset : ℕ, ∀ env : ProverEnvironment F, ∀ input_var : CircuitType.Var Input F,
   env.UsesLocalWitnessesCompleteness offset (circuit.main input_var |>.operations offset) →
   -- for all inputs that satisfy the "honest prover" assumptions (prover view — hints visible)
-  ∀ input : CircuitType.Value Input F, eval' env input_var = input →
+  ∀ input : CircuitType.ProverValue Input F, eval' env input_var = input →
   ProverAssumptions input env.data env.hint →
   -- the constraints hold
   ConstraintsHold.Completeness env (circuit.main input_var |>.operations offset) ∧
@@ -463,9 +463,9 @@ structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F]
   Spec : CircuitType.VerifierValue Input F → CircuitType.VerifierValue Output F → ProverData F → Prop
 
   /-- the statement to be assumed for completeness (prover view — hints visible) -/
-  ProverAssumptions : CircuitType.Value Input F → ProverData F → ProverHints F → Prop := fun _ _ _ => True
+  ProverAssumptions : CircuitType.ProverValue Input F → ProverData F → ProverHints F → Prop := fun _ _ _ => True
   /-- auxiliary statement to be proved for completeness, alongside the constraints (prover view) -/
-  ProverSpec : CircuitType.Value Input F → CircuitType.Value Output F → ProverHints F → Prop := fun _ _ _ => True
+  ProverSpec : CircuitType.ProverValue Input F → CircuitType.ProverValue Output F → ProverHints F → Prop := fun _ _ _ => True
 
   soundness : GeneralFormalCircuit.Soundness F elaborated Assumptions Spec
   completeness : GeneralFormalCircuit.Completeness F elaborated ProverAssumptions ProverSpec

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -408,12 +408,12 @@ def ElaboratedCircuit.toGeneral {F : Type} [Field F] {Input Output : TypeMap}
 def GeneralFormalCircuit.Soundness (F : Type) [Field F]
     [CircuitType Input] [CircuitType Output]
     (circuit : GeneralElaboratedCircuit F Input Output)
-    (Assumptions : CircuitType.VerifierValue Input F → ProverData F → Prop)
-    (Spec : CircuitType.VerifierValue Input F → CircuitType.VerifierValue Output F → ProverData F → Prop) :=
+    (Assumptions : CircuitType.Value Input F → ProverData F → Prop)
+    (Spec : CircuitType.Value Input F → CircuitType.Value Output F → ProverData F → Prop) :=
   -- for all environments that determine witness assignments
   ∀ offset : ℕ, ∀ env : Environment F,
   -- for all inputs that satisfy the assumptions (verifier view — hints erased)
-  ∀ input_var : CircuitType.Var Input F, ∀ input : CircuitType.VerifierValue Input F,
+  ∀ input_var : CircuitType.Var Input F, ∀ input : CircuitType.Value Input F,
   eval' env input_var = input →
   Assumptions input env.data →
   -- if the constraints hold
@@ -458,9 +458,9 @@ structure GeneralFormalCircuit (F : Type) (Input Output : TypeMap) [Field F]
     [CircuitType Input] [CircuitType Output]
     extends elaborated : GeneralElaboratedCircuit F Input Output where
   /-- the statement to be assumed for soundness (verifier view — hints erased) -/
-  Assumptions : CircuitType.VerifierValue Input F → ProverData F → Prop := fun _ _ => True
+  Assumptions : CircuitType.Value Input F → ProverData F → Prop := fun _ _ => True
   /-- the statement to be proved for soundness (verifier view). -/
-  Spec : CircuitType.VerifierValue Input F → CircuitType.VerifierValue Output F → ProverData F → Prop
+  Spec : CircuitType.Value Input F → CircuitType.Value Output F → ProverData F → Prop
 
   /-- the statement to be assumed for completeness (prover view — hints visible) -/
   ProverAssumptions : CircuitType.ProverValue Input F → ProverData F → ProverHints F → Prop := fun _ _ _ => True

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -1,10 +1,13 @@
 import Clean.Circuit.Provable
 
+structure Unconstrained (Hint : Type) where
+  value : Hint
+
 /-
   Prover hints: additional data that can be passed to a circuit's witness generation
   but does not affect the circuit's constraints or spec.
 -/
-def ProverHint (Hint : Type) (F : Type) := Environment F → Hint
+def ProverHint (Hint : Type) (F : Type) := ProverEnvironment F → Hint
 
 /--
 `CircuitType` is a joint generalization of `ProvableType` and `ProverHint`.
@@ -18,23 +21,35 @@ class CircuitType (F : Type) (Var : Type) (Value : outParam Type) where
 class ProverType (F : Type) (Var : Type) (Value : outParam Type) where
   evalProver [Field F] : ProverEnvironment F → Var → Value
 
-class Eval (Env : Type) (Var : Type) (Value : outParam Type) where
+class Eval (Env : Type) where
+  Var : Type
+  Value : Type
   eval : Env → Var → Value
 
 export CircuitType (evalVerifier)
 export ProverType (evalProver)
 export Eval (eval)
 
+variable {F : Type} [Field F] {M : TypeMap} [ProvableType M] {Hint : Type}
 variable {Variable : Type} {Value : Type}
-variable {F : Type} {M : TypeMap} [ProvableType M] {Hint : Type}
 
-instance Eval.verifier [Field F] [CircuitType F Variable Value] :
-    Eval (Environment F) Variable Value where
-  eval env v := evalVerifier env v
+instance Eval.verifier [CircuitType F Variable Value] : Eval (Environment F) where
+  Var := Variable
+  Value := Value
+  eval := evalVerifier
 
-instance Eval.prover [Field F] [ProverType F Variable Value] :
-    Eval (ProverEnvironment F) Variable Value where
-  eval env v := evalProver env v
+instance Eval.prover [ProverType F Variable Value] : Eval (ProverEnvironment F) where
+  Var := Variable
+  Value := Value
+  eval := evalProver
+
+@[circuit_norm] lemma eval_eq_evalVerifier [CircuitType F Variable Value]
+ {env : Environment F} (var : Variable) :
+  eval env var = evalVerifier env var := rfl
+
+@[circuit_norm] lemma eval_eq_evalProver [ProverType F Variable Value]
+ {env : ProverEnvironment F} (var : Variable) :
+  eval env var = evalProver env var := rfl
 
 instance {F : Type} : CircuitType F (ProverHint Hint F) Unit where
   evalVerifier _ _ := ()

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -25,10 +25,12 @@ class Eval (Env : Type) (Var : Type) (Value : outParam Type) where
 export Eval (eval)
 
 /-- Verifier evaluation is `Eval` specialized to `Environment F`. -/
+@[circuit_norm]
 abbrev CircuitType (F : Type) (Var : Type) (Value : outParam Type) :=
   Eval (Environment F) Var Value
 
 /-- Prover evaluation is `Eval` specialized to `ProverEnvironment F`. -/
+@[circuit_norm]
 abbrev ProverType (F : Type) (Var : Type) (Value : outParam Type) :=
   Eval (ProverEnvironment F) Var Value
 
@@ -43,7 +45,7 @@ abbrev evalVerifier {F Var Value} [CircuitType F Var Value]
 abbrev evalProver {F Var Value} [ProverType F Var Value]
   (env : ProverEnvironment F) (v : Var) : Value := eval env v
 
-variable {F : Type} [Field F] {M : TypeMap} [ProvableType M] {Hint : Type}
+variable {F : Type} [Field F] {M N : TypeMap} [ProvableType M] [ProvableType N] {Hint : Type}
 
 instance : CircuitType F (ProverHint Hint F) Unit where
   eval _ _ := ()
@@ -93,13 +95,13 @@ All are `rfl` thanks to the corresponding `Eval` instance.
     eval env v = Expression.eval env v := rfl
 
 @[circuit_norm] theorem eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
-    eval env v = Expression.eval env.toEnvironment v := rfl
+    eval env v = Expression.eval env v := rfl
 
 @[circuit_norm] theorem eval_var (env : Environment F) (v : Var M F) :
     eval env v = ProvableType.eval env v := rfl
 
 @[circuit_norm] theorem eval_var_prover (env : ProverEnvironment F) (v : Var M F) :
-    eval env v = ProvableType.eval env.toEnvironment v := rfl
+    eval env v = ProvableType.eval env v := rfl
 
 omit [Field F] in
 @[circuit_norm] theorem eval_hint (env : Environment F) (v : ProverHint Hint F) :
@@ -109,7 +111,23 @@ omit [Field F] in
 @[circuit_norm] theorem eval_hint_prover (env : ProverEnvironment F) (v : ProverHint Hint F) :
     eval env v = v env := rfl
 
+@[circuit_norm] theorem eval_var_field (env : Environment F) (v : Var field F) :
+  eval env v = Expression.eval env v := by simp only [circuit_norm]
+
+@[circuit_norm] theorem eval_var_field_prover (env : ProverEnvironment F) (v : Var field F) :
+  eval env v = Expression.eval env v := by simp only [circuit_norm]
+
 /-- Product unfolds pointwise via the generic `Eval _ (A × B) _` instance. -/
 @[circuit_norm] theorem eval_prod {Env A B A' B'} [Eval Env A A'] [Eval Env B B']
     (env : Env) (p : A × B) :
     eval env p = (eval env p.1, eval env p.2) := rfl
+
+@[circuit_norm] theorem eval_var_pair (env : Environment F) (p1 : Var M F) (p2 : Var N F) :
+    eval (Var := Var (ProvablePair M N) F) env (p1, p2) = (eval env p1, eval env p2) := by
+  rw [eval_var (M := (ProvablePair M N))]
+  simp only [circuit_norm]
+
+@[circuit_norm] theorem eval_var_pair_prover (env : ProverEnvironment F) (p1 : Var M F) (p2 : Var N F) :
+    eval (Var := Var (ProvablePair M N) F) env (p1, p2) = (eval env p1, eval env p2) := by
+  rw [eval_var_prover (M := (ProvablePair M N))]
+  simp only [circuit_norm]

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -48,7 +48,7 @@ abbrev evalProver {F Var Value} [ProverEval F Var Value]
 /-!
 ## `CircuitType`: the schema-level class for circuit I/O
 
-`CircuitType Input` bundles the three derived types (`Var`, `ProverValue`, `VerifierValue`)
+`CircuitType Input` bundles the three derived types (`Var`, `ProverValue`, `Value`)
 and the two eval functions that map the variable form to the two value forms
 (verifier-view, prover-view).
 
@@ -66,8 +66,8 @@ class CircuitType (Input : TypeMap) where
   /-- Prover value — hint fields carry their underlying type. -/
   ProverValue : TypeMap
   /-- Verifier value — hint fields are erased to `Unit`. -/
-  VerifierValue : TypeMap
-  evalVerifier : ∀ {F : Type} [Field F], Environment F → Var F → VerifierValue F
+  Value : TypeMap
+  evalVerifier : ∀ {F : Type} [Field F], Environment F → Var F → Value F
   evalProver   : ∀ {F : Type} [Field F], ProverEnvironment F → Var F → ProverValue F
 
 variable {Input : TypeMap} [CircuitType Input]
@@ -79,14 +79,14 @@ with the input type, and `Var` is the usual `α ∘ Expression`.
 instance ProvableType.toCircuitType {α : TypeMap} [ProvableType α] : CircuitType α where
   Var := Var α
   ProverValue := α
-  VerifierValue := α
+  Value := α
   evalVerifier env v := ProvableType.eval env v
   evalProver env v := ProvableType.eval env v
 
 instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained Hint) where
   Var := ProverHint Hint
   ProverValue _ := Hint
-  VerifierValue _ := Unit
+  Value _ := Unit
   evalVerifier _ _ := ()
   evalProver env v := v env
 
@@ -95,15 +95,15 @@ namespace CircuitType
   Var M F = _root_.Var M F := rfl
 @[circuit_norm] lemma proverValue_of_provableType (F) :
   ProverValue M F = M F := rfl
-@[circuit_norm] lemma verifierValue_of_provableType (F) :
-  VerifierValue M F = M F := rfl
+@[circuit_norm] lemma value_of_provableType (F) :
+  Value M F = M F := rfl
 
 @[circuit_norm] lemma var_of_unconstrained (Hint F) :
   Var (Unconstrained Hint) F = ProverHint Hint F := rfl
 @[circuit_norm] lemma proverValue_of_unconstrained (Hint F) :
   ProverValue (Unconstrained Hint) F = Hint := rfl
-@[circuit_norm] lemma verifierValue_of_unconstrained (Hint F) :
-  VerifierValue (Unconstrained Hint) F = Unit := rfl
+@[circuit_norm] lemma value_of_unconstrained (Hint F) :
+  Value (Unconstrained Hint) F = Unit := rfl
 
 /--
 A `CircuitType Input` instance induces a verifier-side `Eval` on `CircuitType.Var Input F`.
@@ -112,7 +112,7 @@ instance or a hand-written one.
 -/
 @[circuit_norm]
 instance verifierEval (M : TypeMap) [CircuitType M] :
-  VerifierEval F (Var M F) (VerifierValue M F) := ⟨ evalVerifier ⟩
+  VerifierEval F (Var M F) (Value M F) := ⟨ evalVerifier ⟩
 
 /- `CircuitType` induces a prover-side `Eval` on `CircuitType.Var Input F`. -/
 @[circuit_norm]

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -114,32 +114,29 @@ A `CircuitType Input` instance induces a verifier-side `Eval` on `Var Input F`.
 This lets `eval env var` work uniformly whether the Var came from a `ProvableType`-derived
 instance or a hand-written one.
 -/
-@[circuit_norm]
 instance verifierEval (M : TypeMap) [CircuitType M] :
   VerifierEval F (Var M F) (Value M F) := ⟨ evalVerifier ⟩
 
 /- `CircuitType` induces a prover-side `Eval` on `Var Input F`. -/
-@[circuit_norm]
 instance proverEval (M : TypeMap) [CircuitType M] :
   ProverEval F (Var M F) (ProverValue M F) := ⟨ evalProver ⟩
 
-@[circuit_norm] lemma eval_verifier [CircuitType M] (env : Environment F) (v : Var M F) :
+lemma eval_verifier [CircuitType M] (env : Environment F) (v : Var M F) :
   eval env v = evalVerifier env v := rfl
-@[circuit_norm] lemma eval_prover [CircuitType M] (env : ProverEnvironment F) (v : Var M F) :
+lemma eval_prover [CircuitType M] (env : ProverEnvironment F) (v : Var M F) :
   eval env v = evalProver env v := rfl
 
 /- forwarding instances to help instance search get through defeq -/
 
-@[circuit_norm] instance : VerifierEval F (ProverHint Hint F) Unit := verifierEval (Unconstrained Hint)
-@[circuit_norm] instance : ProverEval F (ProverHint Hint F) Hint := proverEval (Unconstrained Hint)
+instance : VerifierEval F (ProverHint Hint F) Unit := verifierEval (Unconstrained Hint)
+instance : ProverEval F (ProverHint Hint F) Hint := proverEval (Unconstrained Hint)
 
 /-!
 ## Simp bridges
 
-`circuit_norm` should normalize a dispatched evaluation `eval` to a concrete one
-(`Expression.eval` / `ProvableType.eval'` / the underlying hint computation), so that
-the existing `circuit_norm` lemma library — which speaks `ProvableType.eval'` and
-`Expression.eval` — continues to fire.
+`circuit_norm` should normalize a dispatched evaluation `eval` to public concrete
+forms (`Expression.eval`, evaluated tuples/vectors, or the underlying hint computation),
+without generally exposing implementation-specific evaluation definitions.
 
 Lemmas are stated on `eval` (the primary API); goals or hypotheses written with
 `evalVerifier` / `evalProver` (which are `abbrev`s over `eval`) match by reducibility.
@@ -149,15 +146,15 @@ All are `rfl` thanks to the corresponding `Eval` instance.
 ProvableType-specific bridges live in `Provable.lean`.
 -/
 
-attribute [circuit_norm] eval evalVerifier evalProver
+attribute [circuit_norm] evalVerifier evalProver
 
 -- TODO we also need to simp toElements and fromElements to their ProvableType versions
 -- all the lemmas that prove using `simp only [circuit_norm]` might actually not be needed
 
 @[circuit_norm] lemma eval_hint (env : Environment F) (v : ProverHint Hint F) :
-  eval env v = () := by simp only [circuit_norm]
+  eval env v = () := rfl
 
 @[circuit_norm] lemma eval_hint_prover (env : ProverEnvironment F) (v : ProverHint Hint F) :
-  eval env v = v env := by simp only [circuit_norm]
+  eval env v = v env := rfl
 
 end CircuitType

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -33,16 +33,15 @@ disagree: e.g. a `ProverHint Hint F` evaluates to `Unit` under `Environment F` b
 class Eval (Env : Type) (Var : Type) (Value : outParam Type) where
   eval : Env → Var → Value
 
-/--
-Public evaluator.
-
-Keep this wrapper irreducible so ordinary reduction cannot expose a particular
-`Eval` instance implementation. Normalization should go through explicit simp
-lemmas (`circuit_norm`, `explicit_provable_type`) instead.
+/-
+`eval` is designed to be the normal form of evaluation statements across instances.
+It is marked irreducible so it stays intact instead of being replaced by particular
+`Eval` instance implementations on specialization/unfolding/whnf.
+Normalization should go through explicit simp lemmas (`circuit_norm`, `explicit_provable_type`) instead.
 -/
-@[irreducible]
-def eval {Env Var Value : Type} [Eval Env Var Value] : Env → Var → Value :=
-  Eval.eval
+attribute [irreducible] Eval.eval
+
+export Eval (eval)
 
 /-- Verifier evaluation is `Eval` specialized to `Environment F`. -/
 @[circuit_norm]
@@ -92,32 +91,16 @@ class CircuitType (Input : TypeMap) where
   to a `M F` (see `eval` below).
   -/
   Var : TypeMap
-  /-- Prover value — hint fields carry their underlying type. -/
-  ProverValue : TypeMap
   /-- Verifier value — hint fields are erased to `Unit`. -/
   Value : TypeMap
+  /-- Prover value — hint fields carry their underlying type. -/
+  ProverValue : TypeMap
   evalVerifier : ∀ {F : Type} [Field F], Environment F → Var F → Value F
   evalProver   : ∀ {F : Type} [Field F], ProverEnvironment F → Var F → ProverValue F
 
 export CircuitType (Var Value ProverValue)
 
-variable {Input : TypeMap} [CircuitType Input]
-
-instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained Hint) where
-  Var := ProverHint Hint
-  ProverValue _ := Hint
-  Value _ := Unit
-  evalVerifier _ _ := ()
-  evalProver env v := v env
-
 namespace CircuitType
-@[circuit_norm] lemma var_of_unconstrained (Hint F) :
-  Var (Unconstrained Hint) F = ProverHint Hint F := rfl
-@[circuit_norm] lemma proverValue_of_unconstrained (Hint F) :
-  ProverValue (Unconstrained Hint) F = Hint := rfl
-@[circuit_norm] lemma value_of_unconstrained (Hint F) :
-  Value (Unconstrained Hint) F = Unit := rfl
-
 /--
 A `CircuitType Input` instance induces a verifier-side `Eval` on `Var Input F`.
 This lets `eval env var` work uniformly whether the Var came from a `ProvableType`-derived
@@ -134,46 +117,44 @@ lemma eval_verifier [CircuitType M] (env : Environment F) (v : Var M F) :
   eval env v = evalVerifier env v := by
   unfold eval
   rfl
+
 lemma eval_prover [CircuitType M] (env : ProverEnvironment F) (v : Var M F) :
   eval env v = evalProver env v := by
   unfold eval
   rfl
+end CircuitType
+
+variable {Input : TypeMap} [CircuitType Input]
+
+instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained Hint) where
+  Var F := ProverEnvironment F → Hint
+  ProverValue _ := Hint
+  Value _ := Unit
+  evalVerifier _ _ := ()
+  evalProver env v := v env
+
+namespace CircuitType
+@[circuit_norm] lemma var_of_unconstrained (Hint F) :
+  Var (Unconstrained Hint) F = ProverHint Hint F := rfl
+@[circuit_norm] lemma proverValue_of_unconstrained (Hint F) :
+  ProverValue (Unconstrained Hint) F = Hint := rfl
+@[circuit_norm] lemma value_of_unconstrained (Hint F) :
+  Value (Unconstrained Hint) F = Unit := rfl
+
 
 /- forwarding instances to help instance search get through defeq -/
 
 instance : VerifierEval F (ProverHint Hint F) Unit := verifierEval (Unconstrained Hint)
 instance : ProverEval F (ProverHint Hint F) Hint := proverEval (Unconstrained Hint)
 
-/-!
-## Simp bridges
-
-`circuit_norm` should normalize a dispatched evaluation `eval` to public concrete
-forms (`Expression.eval`, evaluated tuples/vectors, or the underlying hint computation),
-without generally exposing implementation-specific evaluation definitions.
-
-Lemmas are stated on `eval` (the primary API); goals or hypotheses written with
-`evalVerifier` / `evalProver` (which are `abbrev`s over `eval`) match by reducibility.
-
-All are `rfl` thanks to the corresponding `Eval` instance.
-
-ProvableType-specific bridges live in `Provable.lean`.
--/
-
 attribute [circuit_norm] evalVerifier evalProver
 
--- TODO we also need to simp toElements and fromElements to their ProvableType versions
--- all the lemmas that prove using `simp only [circuit_norm]` might actually not be needed
-
 @[circuit_norm] lemma eval_hint (env : Environment F) (v : ProverHint Hint F) :
-  eval env v = () := by
-  unfold eval
-  change (verifierEval (Unconstrained Hint)).eval env v = ()
-  rfl
+  eval env v = () := by rfl
 
 @[circuit_norm] lemma eval_hint_prover (env : ProverEnvironment F) (v : ProverHint Hint F) :
-  eval env v = v env := by
-  unfold eval
-  change (proverEval (Unconstrained Hint)).eval env v = v env
+    eval env v = v env := by
+  rw [eval_prover (M := Unconstrained Hint)]
   rfl
 
 end CircuitType

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -1,5 +1,7 @@
 import Clean.Circuit.Provable
 
+variable {F : Type} [Field F] {M N : TypeMap} [ProvableType M] [ProvableType N] {Hint : Type}
+
 structure Unconstrained (Hint : Type) (F : Type) where
   value : Hint
 
@@ -68,6 +70,8 @@ class CircuitType (Input : TypeMap) where
   evalVerifier : ∀ {F : Type} [Field F], Environment F → Var F → VerifierValue F
   evalProver   : ∀ {F : Type} [Field F], ProverEnvironment F → Var F → Value F
 
+variable {Input : TypeMap} [CircuitType Input]
+
 /--
 Default `CircuitType` for any `ProvableType`: verifier- and prover-value coincide
 with the input type, and `Var` is the usual `α ∘ Expression`.
@@ -85,9 +89,6 @@ instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained 
   VerifierValue _ := Unit
   evalVerifier _ _ := ()
   evalProver env v := v env
-
-variable {F : Type} [Field F] {M N : TypeMap} [ProvableType M] [ProvableType N] {Hint : Type}
-variable {Input : TypeMap} [CircuitType Input]
 
 namespace CircuitType
 @[circuit_norm] lemma var_of_provableType (F) :
@@ -109,10 +110,12 @@ A `CircuitType Input` instance induces a verifier-side `Eval` on `CircuitType.Va
 This lets `eval env var` work uniformly whether the Var came from a `ProvableType`-derived
 instance or a hand-written one.
 -/
+@[circuit_norm]
 instance verifierEval (M : TypeMap) [CircuitType M] :
   VerifierEval F (Var M F) (VerifierValue M F) := ⟨ evalVerifier ⟩
 
 /- `CircuitType` induces a prover-side `Eval` on `CircuitType.Var Input F`. -/
+@[circuit_norm]
 instance proverEval (M : TypeMap) [CircuitType M] :
   ProverEval F (Var M F) (Value M F) := ⟨ evalProver ⟩
 
@@ -123,30 +126,18 @@ instance proverEval (M : TypeMap) [CircuitType M] :
 
 /- forwarding instances to help instance search get through defeq -/
 
--- @[circuit_norm]
-instance : VerifierEval F (ProverHint Hint F) Unit := verifierEval (Unconstrained Hint)
--- @[circuit_norm]
-instance : ProverEval F (ProverHint Hint F) Hint := proverEval (Unconstrained Hint)
--- @[circuit_norm]
-instance : VerifierEval F (_root_.Var M F) (VerifierValue M F) := verifierEval M
--- @[circuit_norm]
-instance : ProverEval F (_root_.Var M F) (Value M F) := proverEval M
--- @[circuit_norm]
-instance : VerifierEval F (Expression F) F := verifierEval field
--- @[circuit_norm]
-instance : ProverEval F (Expression F) F := proverEval field
--- @[circuit_norm]
-instance : VerifierEval F (_root_.Var M F × _root_.Var N F) (M F × N F) := verifierEval (ProvablePair M N)
--- @[circuit_norm]
-instance : ProverEval F (_root_.Var M F × _root_.Var N F) (M F × N F) := proverEval (ProvablePair M N)
--- @[circuit_norm]
-instance : VerifierEval F (_root_.Var field F × _root_.Var field F) (F × F) := verifierEval (ProvablePair field field)
--- @[circuit_norm]
-instance : ProverEval F (_root_.Var field F × _root_.Var field F) (F × F) := proverEval (ProvablePair field field)
--- @[circuit_norm]
-instance {n : ℕ} : VerifierEval F (_root_.Var (fields n) F) (fields n F) := verifierEval (fields n)
--- @[circuit_norm]
-instance {n : ℕ} : ProverEval F (_root_.Var (fields n) F) (fields n F) := proverEval (fields n)
+@[circuit_norm] instance : VerifierEval F (ProverHint Hint F) Unit := verifierEval (Unconstrained Hint)
+@[circuit_norm] instance : ProverEval F (ProverHint Hint F) Hint := proverEval (Unconstrained Hint)
+@[circuit_norm] instance : VerifierEval F (_root_.Var M F) (M F) := verifierEval M
+@[circuit_norm] instance : ProverEval F (_root_.Var M F) (M F) := proverEval M
+@[circuit_norm] instance : VerifierEval F (Expression F) F := verifierEval field
+@[circuit_norm] instance : ProverEval F (Expression F) F := proverEval field
+@[circuit_norm] instance : VerifierEval F (_root_.Var M F × _root_.Var N F) (M F × N F) := verifierEval (ProvablePair M N)
+@[circuit_norm] instance : ProverEval F (_root_.Var M F × _root_.Var N F) (M F × N F) := proverEval (ProvablePair M N)
+@[circuit_norm] instance : VerifierEval F (_root_.Var field F × _root_.Var field F) (F × F) := verifierEval (ProvablePair field field)
+@[circuit_norm] instance : ProverEval F (_root_.Var field F × _root_.Var field F) (F × F) := proverEval (ProvablePair field field)
+@[circuit_norm] instance {n : ℕ} : VerifierEval F (_root_.Var (fields n) F) (fields n F) := verifierEval (fields n)
+@[circuit_norm] instance {n : ℕ} : ProverEval F (_root_.Var (fields n) F) (fields n F) := proverEval (fields n)
 
 /-!
 ## Simp bridges

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -1,0 +1,63 @@
+import Clean.Circuit.Provable
+
+/-
+  Prover hints: additional data that can be passed to a circuit's witness generation
+  but does not affect the circuit's constraints or spec.
+-/
+def ProverHint (Hint : Type) (F : Type) := Environment F → Hint
+
+/--
+`CircuitType` is a joint generalization of `ProvableType` and `ProverHint`.
+It allows us to pass both committed witnesses and unconstrained prover hints to a circuit.
+
+The only thing we require of a `CircuitType` is that we can evaluate it given an `Environment`.
+-/
+class CircuitType (F : Type) (Var : Type) (Value : outParam Type) where
+  evalVerifier [Field F] : Environment F → Var → Value
+
+class ProverType (F : Type) (Var : Type) (Value : outParam Type) where
+  evalProver [Field F] : ProverEnvironment F → Var → Value
+
+class Eval (Env : Type) (Var : Type) (Value : outParam Type) where
+  eval : Env → Var → Value
+
+export CircuitType (evalVerifier)
+export ProverType (evalProver)
+export Eval (eval)
+
+variable {Variable : Type} {Value : Type}
+variable {F : Type} {M : TypeMap} [ProvableType M] {Hint : Type}
+
+instance Eval.verifier [Field F] [CircuitType F Variable Value] :
+    Eval (Environment F) Variable Value where
+  eval env v := evalVerifier env v
+
+instance Eval.prover [Field F] [ProverType F Variable Value] :
+    Eval (ProverEnvironment F) Variable Value where
+  eval env v := evalProver env v
+
+instance {F : Type} : CircuitType F (ProverHint Hint F) Unit where
+  evalVerifier _ _ := ()
+
+instance {F : Type} : ProverType F (ProverHint Hint F) Hint where
+  evalProver env h := h env
+
+instance {F : Type} : CircuitType F (Var M F) (M F) where
+  evalVerifier env v := ProvableType.eval env v
+
+instance {F : Type} : ProverType F (Var M F) (M F) where
+  evalProver env v := ProvableType.eval env v
+
+instance {F : Type} : CircuitType F (M (Expression F)) (M F) where
+  evalVerifier env v := ProvableType.eval env v
+
+instance {F : Type} : ProverType F (M (Expression F)) (M F) where
+  evalProver env v := ProvableType.eval env v
+
+instance {F : Type} : CircuitType F (Expression F) F where
+  evalVerifier env v := Expression.eval env v
+
+instance {F : Type} : ProverType F (Expression F) F where
+  evalProver env v := Expression.eval env v
+
+-- TODO need simp lemmas!!

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -48,7 +48,7 @@ abbrev evalProver {F Var Value} [ProverEval F Var Value]
 /-!
 ## `CircuitType`: the schema-level class for circuit I/O
 
-`CircuitType Input` bundles the three derived types (`Var`, `Value`, `VerifierValue`)
+`CircuitType Input` bundles the three derived types (`Var`, `ProverValue`, `VerifierValue`)
 and the two eval functions that map the variable form to the two value forms
 (verifier-view, prover-view).
 
@@ -64,11 +64,11 @@ class CircuitType (Input : TypeMap) where
   /-- Variable form used in `main` (what circuits operate on). -/
   Var : TypeMap
   /-- Prover value — hint fields carry their underlying type. -/
-  Value : TypeMap
+  ProverValue : TypeMap
   /-- Verifier value — hint fields are erased to `Unit`. -/
   VerifierValue : TypeMap
   evalVerifier : ∀ {F : Type} [Field F], Environment F → Var F → VerifierValue F
-  evalProver   : ∀ {F : Type} [Field F], ProverEnvironment F → Var F → Value F
+  evalProver   : ∀ {F : Type} [Field F], ProverEnvironment F → Var F → ProverValue F
 
 variable {Input : TypeMap} [CircuitType Input]
 
@@ -78,14 +78,14 @@ with the input type, and `Var` is the usual `α ∘ Expression`.
 -/
 instance ProvableType.toCircuitType {α : TypeMap} [ProvableType α] : CircuitType α where
   Var := Var α
-  Value := α
+  ProverValue := α
   VerifierValue := α
   evalVerifier env v := ProvableType.eval env v
   evalProver env v := ProvableType.eval env v
 
 instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained Hint) where
   Var := ProverHint Hint
-  Value _ := Hint
+  ProverValue _ := Hint
   VerifierValue _ := Unit
   evalVerifier _ _ := ()
   evalProver env v := v env
@@ -93,15 +93,15 @@ instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained 
 namespace CircuitType
 @[circuit_norm] lemma var_of_provableType (F) :
   Var M F = _root_.Var M F := rfl
-@[circuit_norm] lemma value_of_provableType (F) :
-  Value M F = M F := rfl
+@[circuit_norm] lemma proverValue_of_provableType (F) :
+  ProverValue M F = M F := rfl
 @[circuit_norm] lemma verifierValue_of_provableType (F) :
   VerifierValue M F = M F := rfl
 
 @[circuit_norm] lemma var_of_unconstrained (Hint F) :
   Var (Unconstrained Hint) F = ProverHint Hint F := rfl
-@[circuit_norm] lemma value_of_unconstrained (Hint F) :
-  Value (Unconstrained Hint) F = Hint := rfl
+@[circuit_norm] lemma proverValue_of_unconstrained (Hint F) :
+  ProverValue (Unconstrained Hint) F = Hint := rfl
 @[circuit_norm] lemma verifierValue_of_unconstrained (Hint F) :
   VerifierValue (Unconstrained Hint) F = Unit := rfl
 
@@ -117,7 +117,7 @@ instance verifierEval (M : TypeMap) [CircuitType M] :
 /- `CircuitType` induces a prover-side `Eval` on `CircuitType.Var Input F`. -/
 @[circuit_norm]
 instance proverEval (M : TypeMap) [CircuitType M] :
-  ProverEval F (Var M F) (Value M F) := ⟨ evalProver ⟩
+  ProverEval F (Var M F) (ProverValue M F) := ⟨ evalProver ⟩
 
 @[circuit_norm] lemma eval_verifier (env : Environment F) (v : Var M F) :
   eval' env v = evalVerifier env v := rfl

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -26,13 +26,11 @@ export Eval (eval)
 
 /-- Verifier evaluation is `Eval` specialized to `Environment F`. -/
 @[circuit_norm]
-abbrev VerifierEval (F : Type) (Var : Type) (Value : outParam Type) :=
-  Eval (Environment F) Var Value
+abbrev VerifierEval (F : Type) Var (Value : outParam Type) := Eval (Environment F) Var Value
 
 /-- Prover evaluation is `Eval` specialized to `ProverEnvironment F`. -/
 @[circuit_norm]
-abbrev ProverEval (F : Type) (Var : Type) (Value : outParam Type) :=
-  Eval (ProverEnvironment F) Var Value
+abbrev ProverEval (F : Type) Var (Value : outParam Type) := Eval (ProverEnvironment F) Var Value
 
 /--
 Explicit "verifier view" — even on a `ProverEnvironment`, this forces the verifier
@@ -44,115 +42,6 @@ abbrev evalVerifier {F Var Value} [VerifierEval F Var Value]
 /-- Explicit "prover view" — only applies where a `ProverEnvironment` is available. -/
 abbrev evalProver {F Var Value} [ProverEval F Var Value]
   (env : ProverEnvironment F) (v : Var) : Value := eval env v
-
-variable {F : Type} [Field F] {M N : TypeMap} [ProvableType M] [ProvableType N] {Hint : Type}
-
-instance : VerifierEval F (ProverHint Hint F) Unit where
-  eval _ _ := ()
-
-instance : ProverEval F (ProverHint Hint F) Hint where
-  eval env h := h env
-
-instance : VerifierEval F (Var M F) (M F) where
-  eval env v := ProvableType.eval env v
-
-instance : ProverEval F (Var M F) (M F) where
-  eval env v := ProvableType.eval env v
-
-instance : VerifierEval F (M (Expression F)) (M F) where
-  eval env v := ProvableType.eval env v
-
-instance : ProverEval F (M (Expression F)) (M F) where
-  eval env v := ProvableType.eval env v
-
-instance : VerifierEval F (Expression F) F where
-  eval env v := Expression.eval env v
-
-instance : ProverEval F (Expression F) F where
-  eval env v := Expression.eval env v
-
-/--
-Generic product instance: given component-wise evaluators, evaluate a pair pointwise.
--/
-instance {Env A B A' B'} [Eval Env A A'] [Eval Env B B'] : Eval Env (A × B) (A' × B') where
-  eval env p := (eval env p.1, eval env p.2)
-
-/-!
-## Simp bridges
-
-`circuit_norm` should normalize a dispatched evaluation `eval` to a concrete one
-(`Expression.eval` / `ProvableType.eval` / the underlying hint computation), so that
-the existing `circuit_norm` lemma library — which speaks `ProvableType.eval` and
-`Expression.eval` — continues to fire.
-
-Lemmas are stated on `eval` (the primary API); goals or hypotheses written with
-`evalVerifier` / `evalProver` (which are `abbrev`s over `eval`) match by reducibility.
-
-All are `rfl` thanks to the corresponding `Eval` instance.
--/
-
-@[circuit_norm] theorem eval_expr (env : Environment F) (v : Expression F) :
-    eval env v = Expression.eval env v := rfl
-
-@[circuit_norm] theorem eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
-    eval env v = Expression.eval env v := rfl
-
-@[circuit_norm] theorem eval_var (env : Environment F) (v : Var M F) :
-    eval env v = ProvableType.eval env v := rfl
-
-@[circuit_norm] theorem eval_var_prover (env : ProverEnvironment F) (v : Var M F) :
-    eval env v = ProvableType.eval env v := rfl
-
-omit [Field F] in
-@[circuit_norm] theorem eval_hint (env : Environment F) (v : ProverHint Hint F) :
-    eval env v = () := rfl
-
-omit [Field F] in
-@[circuit_norm] theorem eval_hint_prover (env : ProverEnvironment F) (v : ProverHint Hint F) :
-    eval env v = v env := rfl
-
-@[circuit_norm] theorem eval_var_field (env : Environment F) (v : Var field F) :
-  eval env v = Expression.eval env v := by simp only [circuit_norm]
-
-@[circuit_norm] theorem eval_var_field_prover (env : ProverEnvironment F) (v : Var field F) :
-  eval env v = Expression.eval env v := by simp only [circuit_norm]
-
-/-- Product unfolds pointwise via the generic `Eval _ (A × B) _` instance. -/
-@[circuit_norm] theorem eval_prod {Env A B A' B'} [Eval Env A A'] [Eval Env B B']
-    (env : Env) (p : A × B) :
-    eval env p = (eval env p.1, eval env p.2) := rfl
-
-@[circuit_norm] theorem eval_var_pair (env : Environment F) (p1 : Var M F) (p2 : Var N F) :
-    eval (Var := Var (ProvablePair M N) F) env (p1, p2) = (eval env p1, eval env p2) := by
-  rw [eval_var (M := (ProvablePair M N))]
-  simp only [circuit_norm]
-
-@[circuit_norm] theorem eval_var_pair_prover (env : ProverEnvironment F) (p1 : Var M F) (p2 : Var N F) :
-    eval (Var := Var (ProvablePair M N) F) env (p1, p2) = (eval env p1, eval env p2) := by
-  rw [eval_var_prover (M := (ProvablePair M N))]
-  simp only [circuit_norm]
-
-@[circuit_norm] theorem eval_field_pair (F : Type) [Field F]
-  (env : Environment F) (p1 : Var field F) (p2 : Var field F) :
-    eval (Var := Var (ProvablePair field field) F) env (p1, p2) = (eval env p1, eval env p2) := by
-  rw [eval_var (M := (ProvablePair field field))]
-  simp only [circuit_norm]
-
-@[circuit_norm] theorem eval_field_pair_prover (F : Type) [Field F]
-  (env : ProverEnvironment F) (p1 : Var field F) (p2 : Var field F) :
-    eval (Var := Var (ProvablePair field field) F) env (p1, p2) = (eval env p1, eval env p2) := by
-  rw [eval_var_prover (M := (ProvablePair field field))]
-  simp only [circuit_norm]
-
-@[circuit_norm] theorem eval_fields (F : Type) [Field F] {n : ℕ}
-  (env : Environment F) (xs : Var (fields n) F) :
-    eval (Var := Var (fields n) F) env xs = ProvableType.eval env xs := by
-  rw [eval_var (M := (fields n))]
-
-@[circuit_norm] theorem eval_fields_prover (F : Type) [Field F] {n : ℕ}
-  (env : ProverEnvironment F) (xs : Var (fields n) F) :
-    eval (Var := Var (fields n) F) env xs = ProvableType.eval env xs := by
-  rw [eval_var_prover (M := (fields n))]
 
 /-!
 ## `CircuitType`: the schema-level class for circuit I/O
@@ -197,35 +86,137 @@ instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained 
   evalVerifier _ _ := ()
   evalProver env v := v env
 
-namespace CircuitType
+variable {F : Type} [Field F] {M N : TypeMap} [ProvableType M] [ProvableType N] {Hint : Type}
+variable {Input : TypeMap} [CircuitType Input]
 
+namespace CircuitType
 @[circuit_norm] lemma var_of_provableType (F) :
-  CircuitType.Var M F = _root_.Var M F := rfl
+  Var M F = _root_.Var M F := rfl
 @[circuit_norm] lemma value_of_provableType (F) :
-  CircuitType.Value M F = M F := rfl
+  Value M F = M F := rfl
 @[circuit_norm] lemma verifierValue_of_provableType (F) :
-  CircuitType.VerifierValue M F = M F := rfl
+  VerifierValue M F = M F := rfl
 
 @[circuit_norm] lemma var_of_unconstrained (Hint F) :
-  CircuitType.Var (Unconstrained Hint) F = ProverHint Hint F := rfl
+  Var (Unconstrained Hint) F = ProverHint Hint F := rfl
 @[circuit_norm] lemma value_of_unconstrained (Hint F) :
-  CircuitType.Value (Unconstrained Hint) F = Hint := rfl
+  Value (Unconstrained Hint) F = Hint := rfl
 @[circuit_norm] lemma verifierValue_of_unconstrained (Hint F) :
-  CircuitType.VerifierValue (Unconstrained Hint) F = Unit := rfl
+  VerifierValue (Unconstrained Hint) F = Unit := rfl
 
 /--
 A `CircuitType Input` instance induces a verifier-side `Eval` on `CircuitType.Var Input F`.
 This lets `eval env var` work uniformly whether the Var came from a `ProvableType`-derived
 instance or a hand-written one.
 -/
-instance evalVerifierInstance {Input : TypeMap} [c : CircuitType Input]
-    {F : Type} [Field F] :
-    Eval (Environment F) (CircuitType.Var Input F) (CircuitType.VerifierValue Input F) where
-  eval := c.evalVerifier
+instance verifierEval (M : TypeMap) [CircuitType M] :
+  VerifierEval F (Var M F) (VerifierValue M F) := ⟨ evalVerifier ⟩
 
-/-- `CircuitType` induces a prover-side `Eval` on `CircuitType.Var Input F`. -/
-instance evalProverInstance {Input : TypeMap} [c : CircuitType Input]
-    {F : Type} [Field F] :
-    Eval (ProverEnvironment F) (CircuitType.Var Input F) (CircuitType.Value Input F) where
-  eval := c.evalProver
+/- `CircuitType` induces a prover-side `Eval` on `CircuitType.Var Input F`. -/
+instance proverEval (M : TypeMap) [CircuitType M] :
+  ProverEval F (Var M F) (Value M F) := ⟨ evalProver ⟩
+
+@[circuit_norm] lemma eval_verifier (env : Environment F) (v : Var M F) :
+  eval env v = evalVerifier env v := rfl
+@[circuit_norm] lemma eval_prover (env : ProverEnvironment F) (v : Var M F) :
+  eval env v = evalProver env v := rfl
+
+/- forwarding instances to help instance search get through defeq -/
+
+-- @[circuit_norm]
+instance : VerifierEval F (ProverHint Hint F) Unit := verifierEval (Unconstrained Hint)
+-- @[circuit_norm]
+instance : ProverEval F (ProverHint Hint F) Hint := proverEval (Unconstrained Hint)
+-- @[circuit_norm]
+instance : VerifierEval F (_root_.Var M F) (VerifierValue M F) := verifierEval M
+-- @[circuit_norm]
+instance : ProverEval F (_root_.Var M F) (Value M F) := proverEval M
+-- @[circuit_norm]
+instance : VerifierEval F (Expression F) F := verifierEval field
+-- @[circuit_norm]
+instance : ProverEval F (Expression F) F := proverEval field
+-- @[circuit_norm]
+instance : VerifierEval F (_root_.Var M F × _root_.Var N F) (M F × N F) := verifierEval (ProvablePair M N)
+-- @[circuit_norm]
+instance : ProverEval F (_root_.Var M F × _root_.Var N F) (M F × N F) := proverEval (ProvablePair M N)
+-- @[circuit_norm]
+instance : VerifierEval F (_root_.Var field F × _root_.Var field F) (F × F) := verifierEval (ProvablePair field field)
+-- @[circuit_norm]
+instance : ProverEval F (_root_.Var field F × _root_.Var field F) (F × F) := proverEval (ProvablePair field field)
+-- @[circuit_norm]
+instance {n : ℕ} : VerifierEval F (_root_.Var (fields n) F) (fields n F) := verifierEval (fields n)
+-- @[circuit_norm]
+instance {n : ℕ} : ProverEval F (_root_.Var (fields n) F) (fields n F) := proverEval (fields n)
+
+/-!
+## Simp bridges
+
+`circuit_norm` should normalize a dispatched evaluation `eval` to a concrete one
+(`Expression.eval` / `ProvableType.eval` / the underlying hint computation), so that
+the existing `circuit_norm` lemma library — which speaks `ProvableType.eval` and
+`Expression.eval` — continues to fire.
+
+Lemmas are stated on `eval` (the primary API); goals or hypotheses written with
+`evalVerifier` / `evalProver` (which are `abbrev`s over `eval`) match by reducibility.
+
+All are `rfl` thanks to the corresponding `Eval` instance.
+-/
+
+attribute [circuit_norm] eval evalVerifier evalProver
+
+-- TODO we also need to simp toElements and fromElements to their ProvableType versions
+-- all the lemmas that prove using `simp only [circuit_norm]` might actually not be needed
+
+@[circuit_norm] lemma eval_expr (env : Environment F) (v : Expression F) :
+  eval env v = Expression.eval env v := by simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
+  eval env v = Expression.eval env v := by simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_var (env : Environment F) (v : _root_.Var M F) :
+  eval env v = ProvableType.eval env v := by simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_var_prover (env : ProverEnvironment F) (v : _root_.Var M F) :
+  eval env v = ProvableType.eval env v := by simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_hint (env : Environment F) (v : ProverHint Hint F) :
+  eval env v = () := by simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_hint_prover (env : ProverEnvironment F) (v : ProverHint Hint F) :
+  eval env v = v env := by simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_var_field (env : Environment F) (v : _root_.Var field F) :
+  eval env v = Expression.eval env v := by simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_var_field_prover (env : ProverEnvironment F) (v : _root_.Var field F) :
+  eval env v = Expression.eval env v := by simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_var_pair (env : Environment F) (p1 : _root_.Var M F) (p2 : _root_.Var N F) :
+    eval (Var := _root_.Var (ProvablePair M N) F) env (p1, p2) = (eval env p1, eval env p2) := by
+  simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_var_pair_prover (env : ProverEnvironment F) (p1 : _root_.Var M F) (p2 : _root_.Var N F) :
+    eval (Var := _root_.Var (ProvablePair M N) F) env (p1, p2) = (eval env p1, eval env p2) := by
+  simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_field_pair (F : Type) [Field F]
+  (env : Environment F) (p1 : _root_.Var field F) (p2 : _root_.Var field F) :
+    eval (Var := _root_.Var (ProvablePair field field) F) env (p1, p2) = (eval env p1, eval env p2) := by
+  simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_field_pair_prover (F : Type) [Field F]
+  (env : ProverEnvironment F) (p1 : _root_.Var field F) (p2 : _root_.Var field F) :
+    eval (Var := _root_.Var (ProvablePair field field) F) env (p1, p2) = (eval env p1, eval env p2) := by
+  simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_fields (F : Type) [Field F] {n : ℕ}
+  (env : Environment F) (xs : _root_.Var (fields n) F) :
+    eval (Var := _root_.Var (fields n) F) env xs = ProvableType.eval env xs := by
+  simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_fields_prover (F : Type) [Field F] {n : ℕ}
+  (env : ProverEnvironment F) (xs : _root_.Var (fields n) F) :
+    eval (Var := _root_.Var (fields n) F) env xs = ProvableType.eval env xs := by
+  simp only [circuit_norm]
+
 end CircuitType

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -1,6 +1,15 @@
-import Clean.Circuit.Provable
+import Clean.Circuit.Expression
 
-variable {F : Type} [Field F] {M N : TypeMap} [ProvableType M] [ProvableType N] {Hint : Type}
+/--
+'Provable types' are structured collections of field elements.
+
+ We represent them as types generic over a single type argument (the field element),
+ i.e. `Type → Type`.
+-/
+@[reducible]
+def TypeMap := Type → Type
+
+variable {F : Type} [Field F] {M N : TypeMap} {Hint : Type}
 
 structure Unconstrained (Hint : Type) (F : Type) where
   value : Hint
@@ -57,11 +66,22 @@ with the derived types as fields. A `GeneralFormalCircuit` can then be parameter
 as `(Input Output : TypeMap) [CircuitType Input] [CircuitType Output]`.
 
 For pure-provable schemas (no hint fields) the verifier- and prover-value forms
-coincide — see the default instance below.
+coincide — see the default instance in `Provable.lean`.
 -/
 
 class CircuitType (Input : TypeMap) where
-  /-- Variable form used in `main` (what circuits operate on). -/
+  /--
+  `Var M F` is the type of variables that appear in the monadic notation of
+  `Circuit F _`s. Most elements of `Var M F`, especially interesting ones, are not
+  constant values of `M F` because variables in a circuit can depend on contents of
+  the environment.
+
+  An element of `Var M F` represents a `M F` that's polynomially dependent
+  on the environment. More concretely, an element of `Var M F` is a value of `M F`
+  with missing holes, and each hole contains a polynomial that can refer to fixed
+  positions of the environment. Given an environment, `Var M F` can be evaluated
+  to a `M F` (see `eval` below).
+  -/
   Var : TypeMap
   /-- Prover value — hint fields carry their underlying type. -/
   ProverValue : TypeMap
@@ -70,18 +90,9 @@ class CircuitType (Input : TypeMap) where
   evalVerifier : ∀ {F : Type} [Field F], Environment F → Var F → Value F
   evalProver   : ∀ {F : Type} [Field F], ProverEnvironment F → Var F → ProverValue F
 
-variable {Input : TypeMap} [CircuitType Input]
+export CircuitType (Var)
 
-/--
-Default `CircuitType` for any `ProvableType`: verifier- and prover-value coincide
-with the input type, and `Var` is the usual `α ∘ Expression`.
--/
-instance ProvableType.toCircuitType {α : TypeMap} [ProvableType α] : CircuitType α where
-  Var := _root_.Var α
-  ProverValue := α
-  Value := α
-  evalVerifier env v := ProvableType.eval env v
-  evalProver env v := ProvableType.eval env v
+variable {Input : TypeMap} [CircuitType Input]
 
 instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained Hint) where
   Var := ProverHint Hint
@@ -91,13 +102,6 @@ instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained 
   evalProver env v := v env
 
 namespace CircuitType
-@[circuit_norm] lemma var_of_provableType (F) :
-  Var M F = _root_.Var M F := rfl
-@[circuit_norm] lemma proverValue_of_provableType (F) :
-  ProverValue M F = M F := rfl
-@[circuit_norm] lemma value_of_provableType (F) :
-  Value M F = M F := rfl
-
 @[circuit_norm] lemma var_of_unconstrained (Hint F) :
   Var (Unconstrained Hint) F = ProverHint Hint F := rfl
 @[circuit_norm] lemma proverValue_of_unconstrained (Hint F) :
@@ -106,7 +110,7 @@ namespace CircuitType
   Value (Unconstrained Hint) F = Unit := rfl
 
 /--
-A `CircuitType Input` instance induces a verifier-side `Eval` on `CircuitType.Var Input F`.
+A `CircuitType Input` instance induces a verifier-side `Eval` on `Var Input F`.
 This lets `eval env var` work uniformly whether the Var came from a `ProvableType`-derived
 instance or a hand-written one.
 -/
@@ -114,30 +118,20 @@ instance or a hand-written one.
 instance verifierEval (M : TypeMap) [CircuitType M] :
   VerifierEval F (Var M F) (Value M F) := ⟨ evalVerifier ⟩
 
-/- `CircuitType` induces a prover-side `Eval` on `CircuitType.Var Input F`. -/
+/- `CircuitType` induces a prover-side `Eval` on `Var Input F`. -/
 @[circuit_norm]
 instance proverEval (M : TypeMap) [CircuitType M] :
   ProverEval F (Var M F) (ProverValue M F) := ⟨ evalProver ⟩
 
-@[circuit_norm] lemma eval_verifier (env : Environment F) (v : Var M F) :
+@[circuit_norm] lemma eval_verifier [CircuitType M] (env : Environment F) (v : Var M F) :
   eval' env v = evalVerifier env v := rfl
-@[circuit_norm] lemma eval_prover (env : ProverEnvironment F) (v : Var M F) :
+@[circuit_norm] lemma eval_prover [CircuitType M] (env : ProverEnvironment F) (v : Var M F) :
   eval' env v = evalProver env v := rfl
 
 /- forwarding instances to help instance search get through defeq -/
 
 @[circuit_norm] instance : VerifierEval F (ProverHint Hint F) Unit := verifierEval (Unconstrained Hint)
 @[circuit_norm] instance : ProverEval F (ProverHint Hint F) Hint := proverEval (Unconstrained Hint)
-@[circuit_norm] instance : VerifierEval F (_root_.Var M F) (M F) := verifierEval M
-@[circuit_norm] instance : ProverEval F (_root_.Var M F) (M F) := proverEval M
-@[circuit_norm] instance : VerifierEval F (Expression F) F := verifierEval field
-@[circuit_norm] instance : ProverEval F (Expression F) F := proverEval field
-@[circuit_norm] instance : VerifierEval F (_root_.Var M F × _root_.Var N F) (M F × N F) := verifierEval (ProvablePair M N)
-@[circuit_norm] instance : ProverEval F (_root_.Var M F × _root_.Var N F) (M F × N F) := proverEval (ProvablePair M N)
-@[circuit_norm] instance : VerifierEval F (_root_.Var field F × _root_.Var field F) (F × F) := verifierEval (ProvablePair field field)
-@[circuit_norm] instance : ProverEval F (_root_.Var field F × _root_.Var field F) (F × F) := proverEval (ProvablePair field field)
-@[circuit_norm] instance {n : ℕ} : VerifierEval F (_root_.Var (fields n) F) (fields n F) := verifierEval (fields n)
-@[circuit_norm] instance {n : ℕ} : ProverEval F (_root_.Var (fields n) F) (fields n F) := proverEval (fields n)
 
 /-!
 ## Simp bridges
@@ -151,6 +145,8 @@ Lemmas are stated on `eval` (the primary API); goals or hypotheses written with
 `evalVerifier` / `evalProver` (which are `abbrev`s over `eval`) match by reducibility.
 
 All are `rfl` thanks to the corresponding `Eval` instance.
+
+ProvableType-specific bridges live in `Provable.lean`.
 -/
 
 attribute [circuit_norm] eval' evalVerifier evalProver
@@ -158,56 +154,10 @@ attribute [circuit_norm] eval' evalVerifier evalProver
 -- TODO we also need to simp toElements and fromElements to their ProvableType versions
 -- all the lemmas that prove using `simp only [circuit_norm]` might actually not be needed
 
-@[circuit_norm] lemma eval_expr (env : Environment F) (v : Expression F) :
-  eval' env v = Expression.eval env v := by simp only [circuit_norm]
-
-@[circuit_norm] lemma eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
-  eval' env v = Expression.eval env v := by simp only [circuit_norm]
-
-@[circuit_norm] lemma eval_var (env : Environment F) (v : _root_.Var M F) :
-  eval' env v = ProvableType.eval env v := by simp only [circuit_norm]
-
-@[circuit_norm] lemma eval_var_prover (env : ProverEnvironment F) (v : _root_.Var M F) :
-  eval' env v = ProvableType.eval env v := by simp only [circuit_norm]
-
 @[circuit_norm] lemma eval_hint (env : Environment F) (v : ProverHint Hint F) :
   eval' env v = () := by simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_hint_prover (env : ProverEnvironment F) (v : ProverHint Hint F) :
   eval' env v = v env := by simp only [circuit_norm]
-
-@[circuit_norm] lemma eval_var_field (env : Environment F) (v : _root_.Var field F) :
-  eval' env v = Expression.eval env v := by simp only [circuit_norm]
-
-@[circuit_norm] lemma eval_var_field_prover (env : ProverEnvironment F) (v : _root_.Var field F) :
-  eval' env v = Expression.eval env v := by simp only [circuit_norm]
-
-@[circuit_norm] lemma eval_var_pair (env : Environment F) (p1 : _root_.Var M F) (p2 : _root_.Var N F) :
-    eval' (Var := _root_.Var (ProvablePair M N) F) env (p1, p2) = (eval' env p1, eval' env p2) := by
-  simp only [circuit_norm]
-
-@[circuit_norm] lemma eval_var_pair_prover (env : ProverEnvironment F) (p1 : _root_.Var M F) (p2 : _root_.Var N F) :
-    eval' (Var := _root_.Var (ProvablePair M N) F) env (p1, p2) = (eval' env p1, eval' env p2) := by
-  simp only [circuit_norm]
-
-@[circuit_norm] lemma eval_field_pair (F : Type) [Field F]
-  (env : Environment F) (p1 : _root_.Var field F) (p2 : _root_.Var field F) :
-    eval' (Var := _root_.Var (ProvablePair field field) F) env (p1, p2) = (eval' env p1, eval' env p2) := by
-  simp only [circuit_norm]
-
-@[circuit_norm] lemma eval_field_pair_prover (F : Type) [Field F]
-  (env : ProverEnvironment F) (p1 : _root_.Var field F) (p2 : _root_.Var field F) :
-    eval' (Var := _root_.Var (ProvablePair field field) F) env (p1, p2) = (eval' env p1, eval' env p2) := by
-  simp only [circuit_norm]
-
-@[circuit_norm] lemma eval_fields (F : Type) [Field F] {n : ℕ}
-  (env : Environment F) (xs : _root_.Var (fields n) F) :
-    eval' (Var := _root_.Var (fields n) F) env xs = ProvableType.eval env xs := by
-  simp only [circuit_norm]
-
-@[circuit_norm] lemma eval_fields_prover (F : Type) [Field F] {n : ℕ}
-  (env : ProverEnvironment F) (xs : _root_.Var (fields n) F) :
-    eval' (Var := _root_.Var (fields n) F) env xs = ProvableType.eval env xs := by
-  simp only [circuit_norm]
 
 end CircuitType

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -90,7 +90,7 @@ class CircuitType (Input : TypeMap) where
   evalVerifier : ∀ {F : Type} [Field F], Environment F → Var F → Value F
   evalProver   : ∀ {F : Type} [Field F], ProverEnvironment F → Var F → ProverValue F
 
-export CircuitType (Var)
+export CircuitType (Var Value ProverValue)
 
 variable {Input : TypeMap} [CircuitType Input]
 

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -22,9 +22,9 @@ disagree: e.g. a `ProverHint Hint F` evaluates to `Unit` under `Environment F` b
 `Hint` under `ProverEnvironment F`.
 -/
 class Eval (Env : Type) (Var : Type) (Value : outParam Type) where
-  eval : Env → Var → Value
+  eval' : Env → Var → Value
 
-export Eval (eval)
+export Eval (eval')
 
 /-- Verifier evaluation is `Eval` specialized to `Environment F`. -/
 @[circuit_norm]
@@ -39,11 +39,11 @@ Explicit "verifier view" — even on a `ProverEnvironment`, this forces the veri
 instance via the `ProverEnvironment → Environment` projection.
 -/
 abbrev evalVerifier {F Var Value} [VerifierEval F Var Value]
-  (env : Environment F) (v : Var) : Value := eval env v
+  (env : Environment F) (v : Var) : Value := eval' env v
 
 /-- Explicit "prover view" — only applies where a `ProverEnvironment` is available. -/
 abbrev evalProver {F Var Value} [ProverEval F Var Value]
-  (env : ProverEnvironment F) (v : Var) : Value := eval env v
+  (env : ProverEnvironment F) (v : Var) : Value := eval' env v
 
 /-!
 ## `CircuitType`: the schema-level class for circuit I/O
@@ -120,9 +120,9 @@ instance proverEval (M : TypeMap) [CircuitType M] :
   ProverEval F (Var M F) (Value M F) := ⟨ evalProver ⟩
 
 @[circuit_norm] lemma eval_verifier (env : Environment F) (v : Var M F) :
-  eval env v = evalVerifier env v := rfl
+  eval' env v = evalVerifier env v := rfl
 @[circuit_norm] lemma eval_prover (env : ProverEnvironment F) (v : Var M F) :
-  eval env v = evalProver env v := rfl
+  eval' env v = evalProver env v := rfl
 
 /- forwarding instances to help instance search get through defeq -/
 
@@ -153,61 +153,61 @@ Lemmas are stated on `eval` (the primary API); goals or hypotheses written with
 All are `rfl` thanks to the corresponding `Eval` instance.
 -/
 
-attribute [circuit_norm] eval evalVerifier evalProver
+attribute [circuit_norm] eval' evalVerifier evalProver
 
 -- TODO we also need to simp toElements and fromElements to their ProvableType versions
 -- all the lemmas that prove using `simp only [circuit_norm]` might actually not be needed
 
 @[circuit_norm] lemma eval_expr (env : Environment F) (v : Expression F) :
-  eval env v = Expression.eval env v := by simp only [circuit_norm]
+  eval' env v = Expression.eval env v := by simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
-  eval env v = Expression.eval env v := by simp only [circuit_norm]
+  eval' env v = Expression.eval env v := by simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_var (env : Environment F) (v : _root_.Var M F) :
-  eval env v = ProvableType.eval env v := by simp only [circuit_norm]
+  eval' env v = ProvableType.eval env v := by simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_var_prover (env : ProverEnvironment F) (v : _root_.Var M F) :
-  eval env v = ProvableType.eval env v := by simp only [circuit_norm]
+  eval' env v = ProvableType.eval env v := by simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_hint (env : Environment F) (v : ProverHint Hint F) :
-  eval env v = () := by simp only [circuit_norm]
+  eval' env v = () := by simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_hint_prover (env : ProverEnvironment F) (v : ProverHint Hint F) :
-  eval env v = v env := by simp only [circuit_norm]
+  eval' env v = v env := by simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_var_field (env : Environment F) (v : _root_.Var field F) :
-  eval env v = Expression.eval env v := by simp only [circuit_norm]
+  eval' env v = Expression.eval env v := by simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_var_field_prover (env : ProverEnvironment F) (v : _root_.Var field F) :
-  eval env v = Expression.eval env v := by simp only [circuit_norm]
+  eval' env v = Expression.eval env v := by simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_var_pair (env : Environment F) (p1 : _root_.Var M F) (p2 : _root_.Var N F) :
-    eval (Var := _root_.Var (ProvablePair M N) F) env (p1, p2) = (eval env p1, eval env p2) := by
+    eval' (Var := _root_.Var (ProvablePair M N) F) env (p1, p2) = (eval' env p1, eval' env p2) := by
   simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_var_pair_prover (env : ProverEnvironment F) (p1 : _root_.Var M F) (p2 : _root_.Var N F) :
-    eval (Var := _root_.Var (ProvablePair M N) F) env (p1, p2) = (eval env p1, eval env p2) := by
+    eval' (Var := _root_.Var (ProvablePair M N) F) env (p1, p2) = (eval' env p1, eval' env p2) := by
   simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_field_pair (F : Type) [Field F]
   (env : Environment F) (p1 : _root_.Var field F) (p2 : _root_.Var field F) :
-    eval (Var := _root_.Var (ProvablePair field field) F) env (p1, p2) = (eval env p1, eval env p2) := by
+    eval' (Var := _root_.Var (ProvablePair field field) F) env (p1, p2) = (eval' env p1, eval' env p2) := by
   simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_field_pair_prover (F : Type) [Field F]
   (env : ProverEnvironment F) (p1 : _root_.Var field F) (p2 : _root_.Var field F) :
-    eval (Var := _root_.Var (ProvablePair field field) F) env (p1, p2) = (eval env p1, eval env p2) := by
+    eval' (Var := _root_.Var (ProvablePair field field) F) env (p1, p2) = (eval' env p1, eval' env p2) := by
   simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_fields (F : Type) [Field F] {n : ℕ}
   (env : Environment F) (xs : _root_.Var (fields n) F) :
-    eval (Var := _root_.Var (fields n) F) env xs = ProvableType.eval env xs := by
+    eval' (Var := _root_.Var (fields n) F) env xs = ProvableType.eval env xs := by
   simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_fields_prover (F : Type) [Field F] {n : ℕ}
   (env : ProverEnvironment F) (xs : _root_.Var (fields n) F) :
-    eval (Var := _root_.Var (fields n) F) env xs = ProvableType.eval env xs := by
+    eval' (Var := _root_.Var (fields n) F) env xs = ProvableType.eval env xs := by
   simp only [circuit_norm]
 
 end CircuitType

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -1,6 +1,6 @@
 import Clean.Circuit.Provable
 
-structure Unconstrained (Hint : Type) where
+structure Unconstrained (Hint : Type) (F : Type) where
   value : Hint
 
 /-
@@ -12,10 +12,10 @@ def ProverHint (Hint : Type) (F : Type) := ProverEnvironment F → Hint
 /--
 `Eval Env Var Value` says: in environment `Env`, a term `v : Var` evaluates to `Value`.
 
-This is the single joint generalization of verifier evaluation (`Env = Environment F`),
-prover evaluation (`Env = ProverEnvironment F`), `ProvableType`, and prover hints.
+Generalizes verifier evaluation (`Env = Environment F`) and prover evaluation (`Env = ProverEnvironment F`),
+for both `ProvableType` variables and `ProverHint` hints.
 
-The `Var → Value` mapping is per-instance, so verifier- and prover-side can legitimately
+The `Var → Value` mapping is per-instance, so verifier- and prover-side can
 disagree: e.g. a `ProverHint Hint F` evaluates to `Unit` under `Environment F` but to
 `Hint` under `ProverEnvironment F`.
 -/
@@ -26,49 +26,49 @@ export Eval (eval)
 
 /-- Verifier evaluation is `Eval` specialized to `Environment F`. -/
 @[circuit_norm]
-abbrev CircuitType (F : Type) (Var : Type) (Value : outParam Type) :=
+abbrev VerifierEval (F : Type) (Var : Type) (Value : outParam Type) :=
   Eval (Environment F) Var Value
 
 /-- Prover evaluation is `Eval` specialized to `ProverEnvironment F`. -/
 @[circuit_norm]
-abbrev ProverType (F : Type) (Var : Type) (Value : outParam Type) :=
+abbrev ProverEval (F : Type) (Var : Type) (Value : outParam Type) :=
   Eval (ProverEnvironment F) Var Value
 
 /--
 Explicit "verifier view" — even on a `ProverEnvironment`, this forces the verifier
 instance via the `ProverEnvironment → Environment` projection.
 -/
-abbrev evalVerifier {F Var Value} [CircuitType F Var Value]
+abbrev evalVerifier {F Var Value} [VerifierEval F Var Value]
   (env : Environment F) (v : Var) : Value := eval env v
 
 /-- Explicit "prover view" — only applies where a `ProverEnvironment` is available. -/
-abbrev evalProver {F Var Value} [ProverType F Var Value]
+abbrev evalProver {F Var Value} [ProverEval F Var Value]
   (env : ProverEnvironment F) (v : Var) : Value := eval env v
 
 variable {F : Type} [Field F] {M N : TypeMap} [ProvableType M] [ProvableType N] {Hint : Type}
 
-instance : CircuitType F (ProverHint Hint F) Unit where
+instance : VerifierEval F (ProverHint Hint F) Unit where
   eval _ _ := ()
 
-instance : ProverType F (ProverHint Hint F) Hint where
+instance : ProverEval F (ProverHint Hint F) Hint where
   eval env h := h env
 
-instance : CircuitType F (Var M F) (M F) where
+instance : VerifierEval F (Var M F) (M F) where
   eval env v := ProvableType.eval env v
 
-instance : ProverType F (Var M F) (M F) where
+instance : ProverEval F (Var M F) (M F) where
   eval env v := ProvableType.eval env v
 
-instance : CircuitType F (M (Expression F)) (M F) where
+instance : VerifierEval F (M (Expression F)) (M F) where
   eval env v := ProvableType.eval env v
 
-instance : ProverType F (M (Expression F)) (M F) where
+instance : ProverEval F (M (Expression F)) (M F) where
   eval env v := ProvableType.eval env v
 
-instance : CircuitType F (Expression F) F where
+instance : VerifierEval F (Expression F) F where
   eval env v := Expression.eval env v
 
-instance : ProverType F (Expression F) F where
+instance : ProverEval F (Expression F) F where
   eval env v := Expression.eval env v
 
 /--
@@ -131,3 +131,62 @@ omit [Field F] in
     eval (Var := Var (ProvablePair M N) F) env (p1, p2) = (eval env p1, eval env p2) := by
   rw [eval_var_prover (M := (ProvablePair M N))]
   simp only [circuit_norm]
+
+/-!
+## `CircuitType`: the schema-level class for circuit I/O
+
+`CircuitType Input` bundles the three derived types (`Var`, `Value`, `VerifierValue`)
+and the two eval functions that map the variable form to the two value forms
+(verifier-view, prover-view).
+
+Parallel to `ProvableType α`: one class parameterized by a schema `Input : TypeMap`,
+with the derived types as fields. A `GeneralFormalCircuit` can then be parameterized
+as `(Input Output : TypeMap) [CircuitType Input] [CircuitType Output]`.
+
+For pure-provable schemas (no hint fields) the verifier- and prover-value forms
+coincide — see the default instance below.
+-/
+
+class CircuitType (Input : TypeMap) where
+  /-- Variable form used in `main` (what circuits operate on). -/
+  Var : TypeMap
+  /-- Prover value — hint fields carry their underlying type. -/
+  Value : TypeMap
+  /-- Verifier value — hint fields are erased to `Unit`. -/
+  VerifierValue : TypeMap
+  evalVerifier : ∀ {F : Type} [Field F], Environment F → Var F → VerifierValue F
+  evalProver   : ∀ {F : Type} [Field F], ProverEnvironment F → Var F → Value F
+
+/--
+Default `CircuitType` for any `ProvableType`: verifier- and prover-value coincide,
+and `Var` is the usual `α ∘ Expression`.
+-/
+instance ProvableType.toCircuitType {α : TypeMap} [ProvableType α] : CircuitType α where
+  Var := Var α
+  Value := α
+  VerifierValue := α
+  evalVerifier env v := ProvableType.eval env v
+  evalProver env v := ProvableType.eval env v
+
+instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained Hint) where
+  Var := ProverHint Hint
+  Value _ := Hint
+  VerifierValue _ := Unit
+  evalVerifier _ _ := ()
+  evalProver env v := v env
+
+/--
+A `CircuitType Input` instance induces a verifier-side `Eval` on `CircuitType.Var Input F`.
+This lets `eval env var` work uniformly whether the Var came from a `ProvableType`-derived
+instance or a hand-written one.
+-/
+instance CircuitType.evalVerifierInstance {Input : TypeMap} [c : CircuitType Input]
+    {F : Type} [Field F] :
+    Eval (Environment F) (CircuitType.Var Input F) (CircuitType.VerifierValue Input F) where
+  eval := c.evalVerifier
+
+/-- `CircuitType` induces a prover-side `Eval` on `CircuitType.Var Input F`. -/
+instance CircuitType.evalProverInstance {Input : TypeMap} [c : CircuitType Input]
+    {F : Type} [Field F] :
+    Eval (ProverEnvironment F) (CircuitType.Var Input F) (CircuitType.Value Input F) where
+  eval := c.evalProver

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -10,69 +10,106 @@ structure Unconstrained (Hint : Type) where
 def ProverHint (Hint : Type) (F : Type) := ProverEnvironment F → Hint
 
 /--
-`CircuitType` is a joint generalization of `ProvableType` and `ProverHint`.
-It allows us to pass both committed witnesses and unconstrained prover hints to a circuit.
+`Eval Env Var Value` says: in environment `Env`, a term `v : Var` evaluates to `Value`.
 
-The only thing we require of a `CircuitType` is that we can evaluate it given an `Environment`.
+This is the single joint generalization of verifier evaluation (`Env = Environment F`),
+prover evaluation (`Env = ProverEnvironment F`), `ProvableType`, and prover hints.
+
+The `Var → Value` mapping is per-instance, so verifier- and prover-side can legitimately
+disagree: e.g. a `ProverHint Hint F` evaluates to `Unit` under `Environment F` but to
+`Hint` under `ProverEnvironment F`.
 -/
-class CircuitType (F : Type) (Var : Type) (Value : outParam Type) where
-  evalVerifier [Field F] : Environment F → Var → Value
-
-class ProverType (F : Type) (Var : Type) (Value : outParam Type) where
-  evalProver [Field F] : ProverEnvironment F → Var → Value
-
-class Eval (Env : Type) where
-  Var : Type
-  Value : Type
+class Eval (Env : Type) (Var : Type) (Value : outParam Type) where
   eval : Env → Var → Value
 
-export CircuitType (evalVerifier)
-export ProverType (evalProver)
 export Eval (eval)
 
+/-- Verifier evaluation is `Eval` specialized to `Environment F`. -/
+abbrev CircuitType (F : Type) (Var : Type) (Value : outParam Type) :=
+  Eval (Environment F) Var Value
+
+/-- Prover evaluation is `Eval` specialized to `ProverEnvironment F`. -/
+abbrev ProverType (F : Type) (Var : Type) (Value : outParam Type) :=
+  Eval (ProverEnvironment F) Var Value
+
+/--
+Explicit "verifier view" — even on a `ProverEnvironment`, this forces the verifier
+instance via the `ProverEnvironment → Environment` projection.
+-/
+abbrev evalVerifier {F Var Value} [CircuitType F Var Value]
+  (env : Environment F) (v : Var) : Value := eval env v
+
+/-- Explicit "prover view" — only applies where a `ProverEnvironment` is available. -/
+abbrev evalProver {F Var Value} [ProverType F Var Value]
+  (env : ProverEnvironment F) (v : Var) : Value := eval env v
+
 variable {F : Type} [Field F] {M : TypeMap} [ProvableType M] {Hint : Type}
-variable {Variable : Type} {Value : Type}
 
-instance Eval.verifier [CircuitType F Variable Value] : Eval (Environment F) where
-  Var := Variable
-  Value := Value
-  eval := evalVerifier
+instance : CircuitType F (ProverHint Hint F) Unit where
+  eval _ _ := ()
 
-instance Eval.prover [ProverType F Variable Value] : Eval (ProverEnvironment F) where
-  Var := Variable
-  Value := Value
-  eval := evalProver
+instance : ProverType F (ProverHint Hint F) Hint where
+  eval env h := h env
 
-@[circuit_norm] lemma eval_eq_evalVerifier [CircuitType F Variable Value]
- {env : Environment F} (var : Variable) :
-  eval env var = evalVerifier env var := rfl
+instance : CircuitType F (Var M F) (M F) where
+  eval env v := ProvableType.eval env v
 
-@[circuit_norm] lemma eval_eq_evalProver [ProverType F Variable Value]
- {env : ProverEnvironment F} (var : Variable) :
-  eval env var = evalProver env var := rfl
+instance : ProverType F (Var M F) (M F) where
+  eval env v := ProvableType.eval env v
 
-instance {F : Type} : CircuitType F (ProverHint Hint F) Unit where
-  evalVerifier _ _ := ()
+instance : CircuitType F (M (Expression F)) (M F) where
+  eval env v := ProvableType.eval env v
 
-instance {F : Type} : ProverType F (ProverHint Hint F) Hint where
-  evalProver env h := h env
+instance : ProverType F (M (Expression F)) (M F) where
+  eval env v := ProvableType.eval env v
 
-instance {F : Type} : CircuitType F (Var M F) (M F) where
-  evalVerifier env v := ProvableType.eval env v
+instance : CircuitType F (Expression F) F where
+  eval env v := Expression.eval env v
 
-instance {F : Type} : ProverType F (Var M F) (M F) where
-  evalProver env v := ProvableType.eval env v
+instance : ProverType F (Expression F) F where
+  eval env v := Expression.eval env v
 
-instance {F : Type} : CircuitType F (M (Expression F)) (M F) where
-  evalVerifier env v := ProvableType.eval env v
+/--
+Generic product instance: given component-wise evaluators, evaluate a pair pointwise.
+-/
+instance {Env A B A' B'} [Eval Env A A'] [Eval Env B B'] : Eval Env (A × B) (A' × B') where
+  eval env p := (eval env p.1, eval env p.2)
 
-instance {F : Type} : ProverType F (M (Expression F)) (M F) where
-  evalProver env v := ProvableType.eval env v
+/-!
+## Simp bridges
 
-instance {F : Type} : CircuitType F (Expression F) F where
-  evalVerifier env v := Expression.eval env v
+`circuit_norm` should normalize a dispatched evaluation `eval` to a concrete one
+(`Expression.eval` / `ProvableType.eval` / the underlying hint computation), so that
+the existing `circuit_norm` lemma library — which speaks `ProvableType.eval` and
+`Expression.eval` — continues to fire.
 
-instance {F : Type} : ProverType F (Expression F) F where
-  evalProver env v := Expression.eval env v
+Lemmas are stated on `eval` (the primary API); goals or hypotheses written with
+`evalVerifier` / `evalProver` (which are `abbrev`s over `eval`) match by reducibility.
 
--- TODO need simp lemmas!!
+All are `rfl` thanks to the corresponding `Eval` instance.
+-/
+
+@[circuit_norm] theorem eval_expr (env : Environment F) (v : Expression F) :
+    eval env v = Expression.eval env v := rfl
+
+@[circuit_norm] theorem eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
+    eval env v = Expression.eval env.toEnvironment v := rfl
+
+@[circuit_norm] theorem eval_var (env : Environment F) (v : Var M F) :
+    eval env v = ProvableType.eval env v := rfl
+
+@[circuit_norm] theorem eval_var_prover (env : ProverEnvironment F) (v : Var M F) :
+    eval env v = ProvableType.eval env.toEnvironment v := rfl
+
+omit [Field F] in
+@[circuit_norm] theorem eval_hint (env : Environment F) (v : ProverHint Hint F) :
+    eval env v = () := rfl
+
+omit [Field F] in
+@[circuit_norm] theorem eval_hint_prover (env : ProverEnvironment F) (v : ProverHint Hint F) :
+    eval env v = v env := rfl
+
+/-- Product unfolds pointwise via the generic `Eval _ (A × B) _` instance. -/
+@[circuit_norm] theorem eval_prod {Env A B A' B'} [Eval Env A A'] [Eval Env B B']
+    (env : Env) (p : A × B) :
+    eval env p = (eval env p.1, eval env p.2) := rfl

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -77,7 +77,7 @@ Default `CircuitType` for any `ProvableType`: verifier- and prover-value coincid
 with the input type, and `Var` is the usual `α ∘ Expression`.
 -/
 instance ProvableType.toCircuitType {α : TypeMap} [ProvableType α] : CircuitType α where
-  Var := Var α
+  Var := _root_.Var α
   ProverValue := α
   Value := α
   evalVerifier env v := ProvableType.eval env v

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -1,37 +1,23 @@
 import Clean.Circuit.Expression
 
 /--
-'Provable types' are structured collections of field elements.
+_Circuit types_ are usually just structured collections of field elements.
 
  We represent them as types generic over a single type argument (the field element),
  i.e. `Type → Type`.
 -/
-@[reducible]
-def TypeMap := Type → Type
+abbrev TypeMap := Type → Type
 
-variable {F : Type} [Field F] {M N : TypeMap} {Hint : Type}
-
-structure Unconstrained (Hint : Type) (F : Type) where
-  value : Hint
-
-/-
-  Prover hints: additional data that can be passed to a circuit's witness generation
-  but does not affect the circuit's constraints or spec.
--/
-def ProverHint (Hint : Type) (F : Type) := ProverEnvironment F → Hint
+variable {F : Type} [Field F] {M : TypeMap}
 
 /--
-`Eval Env Var Value` says: in environment `Env`, a term `v : Var` evaluates to `Value`.
+Generic typeclass for evaluation of a `Var` (symbolic circuit variable)
+to a `Value` (concrete value in the field), in a given environment.
 
-Generalizes verifier evaluation (`Env = Environment F`) and prover evaluation (`Env = ProverEnvironment F`),
-for both `ProvableType` variables and `ProverHint` hints.
-
-The `Var → Value` mapping is per-instance, so verifier- and prover-side can
-disagree: e.g. a `ProverHint Hint F` evaluates to `Unit` under `Environment F` but to
-`Hint` under `ProverEnvironment F`.
+Generalizes verifier evaluation and prover evaluation for both provable types and prover hints.
 -/
 class Eval (Env : Type) (Var : Type) (Value : outParam Type) where
-eval : Env → Var → Value
+  eval : Env → Var → Value
 
 /-
 `eval` is designed to be the normal form of evaluation statements across instances.
@@ -52,48 +38,35 @@ abbrev VerifierEval (F : Type) Var (Value : outParam Type) := Eval (Environment 
 abbrev ProverEval (F : Type) Var (Value : outParam Type) := Eval (ProverEnvironment F) Var Value
 
 /--
-Explicit "verifier view" — even on a `ProverEnvironment`, this forces the verifier
+Explicit verifier view: even on a `ProverEnvironment`, this forces the verifier
 instance via the `ProverEnvironment → Environment` projection.
 -/
 abbrev evalVerifier {F Var Value} [VerifierEval F Var Value]
   (env : Environment F) (v : Var) : Value := eval env v
 
-/-- Explicit "prover view" — only applies where a `ProverEnvironment` is available. -/
+/-- Explicit prover view. -/
 abbrev evalProver {F Var Value} [ProverEval F Var Value]
   (env : ProverEnvironment F) (v : Var) : Value := eval env v
 
-/-!
-## `CircuitType`: the schema-level class for circuit I/O
-
-`CircuitType Input` bundles the three derived types (`Var`, `ProverValue`, `Value`)
-and the two eval functions that map the variable form to the two value forms
+/--
+`CircuitType M` bundles three derived types (`Var`, `Value`, `ProverValue`)
+and two eval functions that map the variable form to the two value forms
 (verifier-view, prover-view).
 
-Parallel to `ProvableType α`: one class parameterized by a schema `Input : TypeMap`,
-with the derived types as fields. A `GeneralFormalCircuit` can then be parameterized
-as `(Input Output : TypeMap) [CircuitType Input] [CircuitType Output]`.
-
-For pure-provable schemas (no hint fields) the verifier- and prover-value forms
-coincide — see the default instance in `Provable.lean`.
+For fully provable schemas (no hint fields), the verifier- and prover-value forms
+coincide; see the default instance in `Provable.lean`.
 -/
-
-class CircuitType (Input : TypeMap) where
+class CircuitType (M : TypeMap) where
   /--
-  `Var M F` is the type of variables that appear in the monadic notation of
-  `Circuit F _`s. Most elements of `Var M F`, especially interesting ones, are not
-  constant values of `M F` because variables in a circuit can depend on contents of
-  the environment.
-
   An element of `Var M F` represents a `M F` that's polynomially dependent
   on the environment. More concretely, an element of `Var M F` is a value of `M F`
   with missing holes, and each hole contains a polynomial that can refer to fixed
-  positions of the environment. Given an environment, `Var M F` can be evaluated
-  to a `M F` (see `eval` below).
+  positions of the environment.
   -/
   Var : TypeMap
-  /-- Verifier value — hint fields are erased to `Unit`. -/
+  /-- Verifier value: hint fields are erased to `Unit`. -/
   Value : TypeMap
-  /-- Prover value — hint fields carry their underlying type. -/
+  /-- Prover value: hint fields carry their underlying type. -/
   ProverValue : TypeMap
   evalVerifier : ∀ {F : Type} [Field F], Environment F → Var F → Value F
   evalProver   : ∀ {F : Type} [Field F], ProverEnvironment F → Var F → ProverValue F
@@ -101,32 +74,42 @@ class CircuitType (Input : TypeMap) where
 export CircuitType (Var Value ProverValue)
 
 namespace CircuitType
+variable [CircuitType M]
+
+attribute [circuit_norm] evalVerifier evalProver
+
 /--
-A `CircuitType Input` instance induces a verifier-side `Eval` on `Var Input F`.
+A `CircuitType M` instance induces a verifier-side `Eval` on `Var M F`.
 This lets `eval env var` work uniformly whether the Var came from a `ProvableType`-derived
 instance or a hand-written one.
 -/
-instance verifierEval (M : TypeMap) [CircuitType M] :
+instance verifierEval M [CircuitType M] :
   VerifierEval F (Var M F) (Value M F) := ⟨ evalVerifier ⟩
 
-/- `CircuitType` induces a prover-side `Eval` on `Var Input F`. -/
-instance proverEval (M : TypeMap) [CircuitType M] :
+/- `CircuitType` induces a prover-side `Eval` on `Var M F`. -/
+instance proverEval M [CircuitType M] :
   ProverEval F (Var M F) (ProverValue M F) := ⟨ evalProver ⟩
 
-lemma eval_verifier [CircuitType M] (env : Environment F) (v : Var M F) :
+lemma eval_verifier (env : Environment F) (v : Var M F) :
   eval env v = evalVerifier env v := by
   unfold eval
   rfl
 
-lemma eval_prover [CircuitType M] (env : ProverEnvironment F) (v : Var M F) :
+lemma eval_prover (env : ProverEnvironment F) (v : Var M F) :
   eval env v = evalProver env v := by
   unfold eval
   rfl
 end CircuitType
 
-variable {Input : TypeMap} [CircuitType Input]
+/--
+`Unconstrained` acts as a type marker for circuit inputs that should only be hints to the prover.
+-/
+structure Unconstrained (Hint : Type) (F : Type) where
+  value : Hint
 
-instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained Hint) where
+variable {Hint : Type}
+
+instance Unconstrained.toCircuitType : CircuitType (Unconstrained Hint) where
   Var F := ProverEnvironment F → Hint
   ProverValue _ := Hint
   Value _ := Unit
@@ -135,26 +118,21 @@ instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained 
 
 namespace CircuitType
 @[circuit_norm] lemma var_of_unconstrained (Hint F) :
-  Var (Unconstrained Hint) F = ProverHint Hint F := rfl
+  Var (Unconstrained Hint) F = (ProverEnvironment F → Hint) := rfl
 @[circuit_norm] lemma proverValue_of_unconstrained (Hint F) :
   ProverValue (Unconstrained Hint) F = Hint := rfl
 @[circuit_norm] lemma value_of_unconstrained (Hint F) :
   Value (Unconstrained Hint) F = Unit := rfl
 
-
 /- forwarding instances to help instance search get through defeq -/
+instance : VerifierEval F (ProverEnvironment F → Hint) Unit := verifierEval (Unconstrained Hint)
+instance : ProverEval F (ProverEnvironment F → Hint) Hint := proverEval (Unconstrained Hint)
 
-instance : VerifierEval F (ProverHint Hint F) Unit := verifierEval (Unconstrained Hint)
-instance : ProverEval F (ProverHint Hint F) Hint := proverEval (Unconstrained Hint)
-
-attribute [circuit_norm] evalVerifier evalProver
-
-@[circuit_norm] lemma eval_hint (env : Environment F) (v : ProverHint Hint F) :
+@[circuit_norm] lemma eval_hint (env : Environment F) (v : ProverEnvironment F → Hint) :
   eval env v = () := by rfl
 
-@[circuit_norm] lemma eval_hint_prover (env : ProverEnvironment F) (v : ProverHint Hint F) :
+@[circuit_norm] lemma eval_hint_prover (env : ProverEnvironment F) (v : ProverEnvironment F → Hint) :
     eval env v = v env := by
   rw [eval_prover (M := Unconstrained Hint)]
   rfl
-
 end CircuitType

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -33,7 +33,16 @@ disagree: e.g. a `ProverHint Hint F` evaluates to `Unit` under `Environment F` b
 class Eval (Env : Type) (Var : Type) (Value : outParam Type) where
   eval : Env → Var → Value
 
-export Eval (eval)
+/--
+Public evaluator.
+
+Keep this wrapper irreducible so ordinary reduction cannot expose a particular
+`Eval` instance implementation. Normalization should go through explicit simp
+lemmas (`circuit_norm`, `explicit_provable_type`) instead.
+-/
+@[irreducible]
+def eval {Env Var Value : Type} [Eval Env Var Value] : Env → Var → Value :=
+  Eval.eval
 
 /-- Verifier evaluation is `Eval` specialized to `Environment F`. -/
 @[circuit_norm]
@@ -122,9 +131,13 @@ instance proverEval (M : TypeMap) [CircuitType M] :
   ProverEval F (Var M F) (ProverValue M F) := ⟨ evalProver ⟩
 
 lemma eval_verifier [CircuitType M] (env : Environment F) (v : Var M F) :
-  eval env v = evalVerifier env v := rfl
+  eval env v = evalVerifier env v := by
+  unfold eval
+  rfl
 lemma eval_prover [CircuitType M] (env : ProverEnvironment F) (v : Var M F) :
-  eval env v = evalProver env v := rfl
+  eval env v = evalProver env v := by
+  unfold eval
+  rfl
 
 /- forwarding instances to help instance search get through defeq -/
 
@@ -152,9 +165,15 @@ attribute [circuit_norm] evalVerifier evalProver
 -- all the lemmas that prove using `simp only [circuit_norm]` might actually not be needed
 
 @[circuit_norm] lemma eval_hint (env : Environment F) (v : ProverHint Hint F) :
-  eval env v = () := rfl
+  eval env v = () := by
+  unfold eval
+  change (verifierEval (Unconstrained Hint)).eval env v = ()
+  rfl
 
 @[circuit_norm] lemma eval_hint_prover (env : ProverEnvironment F) (v : ProverHint Hint F) :
-  eval env v = v env := rfl
+  eval env v = v env := by
+  unfold eval
+  change (proverEval (Unconstrained Hint)).eval env v = v env
+  rfl
 
 end CircuitType

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -31,9 +31,9 @@ disagree: e.g. a `ProverHint Hint F` evaluates to `Unit` under `Environment F` b
 `Hint` under `ProverEnvironment F`.
 -/
 class Eval (Env : Type) (Var : Type) (Value : outParam Type) where
-  eval' : Env → Var → Value
+  eval : Env → Var → Value
 
-export Eval (eval')
+export Eval (eval)
 
 /-- Verifier evaluation is `Eval` specialized to `Environment F`. -/
 @[circuit_norm]
@@ -48,11 +48,11 @@ Explicit "verifier view" — even on a `ProverEnvironment`, this forces the veri
 instance via the `ProverEnvironment → Environment` projection.
 -/
 abbrev evalVerifier {F Var Value} [VerifierEval F Var Value]
-  (env : Environment F) (v : Var) : Value := eval' env v
+  (env : Environment F) (v : Var) : Value := eval env v
 
 /-- Explicit "prover view" — only applies where a `ProverEnvironment` is available. -/
 abbrev evalProver {F Var Value} [ProverEval F Var Value]
-  (env : ProverEnvironment F) (v : Var) : Value := eval' env v
+  (env : ProverEnvironment F) (v : Var) : Value := eval env v
 
 /-!
 ## `CircuitType`: the schema-level class for circuit I/O
@@ -124,9 +124,9 @@ instance proverEval (M : TypeMap) [CircuitType M] :
   ProverEval F (Var M F) (ProverValue M F) := ⟨ evalProver ⟩
 
 @[circuit_norm] lemma eval_verifier [CircuitType M] (env : Environment F) (v : Var M F) :
-  eval' env v = evalVerifier env v := rfl
+  eval env v = evalVerifier env v := rfl
 @[circuit_norm] lemma eval_prover [CircuitType M] (env : ProverEnvironment F) (v : Var M F) :
-  eval' env v = evalProver env v := rfl
+  eval env v = evalProver env v := rfl
 
 /- forwarding instances to help instance search get through defeq -/
 
@@ -149,15 +149,15 @@ All are `rfl` thanks to the corresponding `Eval` instance.
 ProvableType-specific bridges live in `Provable.lean`.
 -/
 
-attribute [circuit_norm] eval' evalVerifier evalProver
+attribute [circuit_norm] eval evalVerifier evalProver
 
 -- TODO we also need to simp toElements and fromElements to their ProvableType versions
 -- all the lemmas that prove using `simp only [circuit_norm]` might actually not be needed
 
 @[circuit_norm] lemma eval_hint (env : Environment F) (v : ProverHint Hint F) :
-  eval' env v = () := by simp only [circuit_norm]
+  eval env v = () := by simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_hint_prover (env : ProverEnvironment F) (v : ProverHint Hint F) :
-  eval' env v = v env := by simp only [circuit_norm]
+  eval env v = v env := by simp only [circuit_norm]
 
 end CircuitType

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -197,30 +197,35 @@ instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained 
   evalVerifier _ _ := ()
   evalProver env v := v env
 
-@[circuit_norm]
-theorem CircuitType.var_of_provableType (α : TypeMap) [ProvableType α] (F : Type) :
-    CircuitType.Var α F = _root_.Var α F := rfl
+namespace CircuitType
 
-@[circuit_norm]
-theorem CircuitType.value_of_provableType (α : TypeMap) [ProvableType α] (F : Type) :
-    CircuitType.Value α F = α F := rfl
+@[circuit_norm] lemma var_of_provableType (F) :
+  CircuitType.Var M F = _root_.Var M F := rfl
+@[circuit_norm] lemma value_of_provableType (F) :
+  CircuitType.Value M F = M F := rfl
+@[circuit_norm] lemma verifierValue_of_provableType (F) :
+  CircuitType.VerifierValue M F = M F := rfl
 
-@[circuit_norm]
-theorem CircuitType.verifierValue_of_provableType (α : TypeMap) [ProvableType α] (F : Type) :
-    CircuitType.VerifierValue α F = α F := rfl
+@[circuit_norm] lemma var_of_unconstrained (Hint F) :
+  CircuitType.Var (Unconstrained Hint) F = ProverHint Hint F := rfl
+@[circuit_norm] lemma value_of_unconstrained (Hint F) :
+  CircuitType.Value (Unconstrained Hint) F = Hint := rfl
+@[circuit_norm] lemma verifierValue_of_unconstrained (Hint F) :
+  CircuitType.VerifierValue (Unconstrained Hint) F = Unit := rfl
 
 /--
 A `CircuitType Input` instance induces a verifier-side `Eval` on `CircuitType.Var Input F`.
 This lets `eval env var` work uniformly whether the Var came from a `ProvableType`-derived
 instance or a hand-written one.
 -/
-instance CircuitType.evalVerifierInstance {Input : TypeMap} [c : CircuitType Input]
+instance evalVerifierInstance {Input : TypeMap} [c : CircuitType Input]
     {F : Type} [Field F] :
     Eval (Environment F) (CircuitType.Var Input F) (CircuitType.VerifierValue Input F) where
   eval := c.evalVerifier
 
 /-- `CircuitType` induces a prover-side `Eval` on `CircuitType.Var Input F`. -/
-instance CircuitType.evalProverInstance {Input : TypeMap} [c : CircuitType Input]
+instance evalProverInstance {Input : TypeMap} [c : CircuitType Input]
     {F : Type} [Field F] :
     Eval (ProverEnvironment F) (CircuitType.Var Input F) (CircuitType.Value Input F) where
   eval := c.evalProver
+end CircuitType

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -132,6 +132,28 @@ omit [Field F] in
   rw [eval_var_prover (M := (ProvablePair M N))]
   simp only [circuit_norm]
 
+@[circuit_norm] theorem eval_field_pair (F : Type) [Field F]
+  (env : Environment F) (p1 : Var field F) (p2 : Var field F) :
+    eval (Var := Var (ProvablePair field field) F) env (p1, p2) = (eval env p1, eval env p2) := by
+  rw [eval_var (M := (ProvablePair field field))]
+  simp only [circuit_norm]
+
+@[circuit_norm] theorem eval_field_pair_prover (F : Type) [Field F]
+  (env : ProverEnvironment F) (p1 : Var field F) (p2 : Var field F) :
+    eval (Var := Var (ProvablePair field field) F) env (p1, p2) = (eval env p1, eval env p2) := by
+  rw [eval_var_prover (M := (ProvablePair field field))]
+  simp only [circuit_norm]
+
+@[circuit_norm] theorem eval_fields (F : Type) [Field F] {n : ℕ}
+  (env : Environment F) (xs : Var (fields n) F) :
+    eval (Var := Var (fields n) F) env xs = ProvableType.eval env xs := by
+  rw [eval_var (M := (fields n))]
+
+@[circuit_norm] theorem eval_fields_prover (F : Type) [Field F] {n : ℕ}
+  (env : ProverEnvironment F) (xs : Var (fields n) F) :
+    eval (Var := Var (fields n) F) env xs = ProvableType.eval env xs := by
+  rw [eval_var_prover (M := (fields n))]
+
 /-!
 ## `CircuitType`: the schema-level class for circuit I/O
 
@@ -158,8 +180,8 @@ class CircuitType (Input : TypeMap) where
   evalProver   : ∀ {F : Type} [Field F], ProverEnvironment F → Var F → Value F
 
 /--
-Default `CircuitType` for any `ProvableType`: verifier- and prover-value coincide,
-and `Var` is the usual `α ∘ Expression`.
+Default `CircuitType` for any `ProvableType`: verifier- and prover-value coincide
+with the input type, and `Var` is the usual `α ∘ Expression`.
 -/
 instance ProvableType.toCircuitType {α : TypeMap} [ProvableType α] : CircuitType α where
   Var := Var α

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -197,6 +197,18 @@ instance Unconstrained.toCircuitType {Hint : Type} : CircuitType (Unconstrained 
   evalVerifier _ _ := ()
   evalProver env v := v env
 
+@[circuit_norm]
+theorem CircuitType.var_of_provableType (α : TypeMap) [ProvableType α] (F : Type) :
+    CircuitType.Var α F = _root_.Var α F := rfl
+
+@[circuit_norm]
+theorem CircuitType.value_of_provableType (α : TypeMap) [ProvableType α] (F : Type) :
+    CircuitType.Value α F = α F := rfl
+
+@[circuit_norm]
+theorem CircuitType.verifierValue_of_provableType (α : TypeMap) [ProvableType α] (F : Type) :
+    CircuitType.VerifierValue α F = α F := rfl
+
 /--
 A `CircuitType Input` instance induces a verifier-side `Eval` on `CircuitType.Var Input F`.
 This lets `eval env var` work uniformly whether the Var came from a `ProvableType`-derived

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -31,7 +31,7 @@ disagree: e.g. a `ProverHint Hint F` evaluates to `Unit` under `Environment F` b
 `Hint` under `ProverEnvironment F`.
 -/
 class Eval (Env : Type) (Var : Type) (Value : outParam Type) where
-  eval : Env → Var → Value
+eval : Env → Var → Value
 
 /-
 `eval` is designed to be the normal form of evaluation statements across instances.

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -137,8 +137,8 @@ instance proverEval (M : TypeMap) [CircuitType M] :
 ## Simp bridges
 
 `circuit_norm` should normalize a dispatched evaluation `eval` to a concrete one
-(`Expression.eval` / `ProvableType.eval` / the underlying hint computation), so that
-the existing `circuit_norm` lemma library — which speaks `ProvableType.eval` and
+(`Expression.eval` / `ProvableType.eval'` / the underlying hint computation), so that
+the existing `circuit_norm` lemma library — which speaks `ProvableType.eval'` and
 `Expression.eval` — continues to fire.
 
 Lemmas are stated on `eval` (the primary API); goals or hypotheses written with

--- a/Clean/Circuit/Explicit.lean
+++ b/Clean/Circuit/Explicit.lean
@@ -56,6 +56,17 @@ instance ExplicitCircuits.to_single (circuit : α → Circuit F β) (a : α)
   operations_eq n := operations_eq a n
   subcircuitsConsistent n := subcircuitsConsistent a n
 
+instance ExplicitCircuits.from_concrete_provable_input {α : TypeMap} [ProvableType α] {β : Type}
+    {circuit : Var α F → Circuit F β} [explicit : ExplicitCircuits circuit] :
+    ExplicitCircuits (fun input : α (Expression F) => circuit input) where
+  output input n := explicit.output input n
+  localLength input n := explicit.localLength input n
+  operations input n := explicit.operations input n
+  output_eq input n := explicit.output_eq input n
+  localLength_eq input n := explicit.localLength_eq input n
+  operations_eq input n := explicit.operations_eq input n
+  subcircuitsConsistent input n := explicit.subcircuitsConsistent input n
+
 -- `pure` is an explicit circuit
 instance ExplicitCircuit.from_pure {a : α} : ExplicitCircuit (pure a : Circuit F α) where
   output _ := a
@@ -152,6 +163,11 @@ instance : ExplicitCircuits (F:=F) assertZero where
   output _ _ := ()
   localLength _ _ := 0
   operations e n := [.assert e]
+
+instance {e : Var field F} : ExplicitCircuit (assertZero e) where
+  output _ := ()
+  localLength _ := 0
+  operations _ := [.assert e]
 
 instance {α : TypeMap} [ProvableType α] {table : Table F α} : ExplicitCircuits (F:=F) (lookup table) where
   output _ _ := ()

--- a/Clean/Circuit/Expression.lean
+++ b/Clean/Circuit/Expression.lean
@@ -24,11 +24,11 @@ def ProverData (F : Type) :=
 /-- Runtime-only hashmap of prover hints. Same shape as `ProverData`, but
 distinct to emphasize that hints are *not* committed: they feed only the
 witness-generation step and never appear in the proof. -/
-def ProverHint (F : Type) :=
+def ProverHints (F : Type) :=
   String → (n : ℕ) → Array (Vector F n)
 
-/-- Placeholder `ProverHint` that returns an empty array for every key. -/
-def ProverHint.empty (F : Type) : ProverHint F := fun _ _ => #[]
+/-- Placeholder `ProverHints` that returns an empty array for every key. -/
+def ProverHints.empty (F : Type) : ProverHints F := fun _ _ => #[]
 
 /--
   `Environment` represents the data that is provided at runtime to concretely
@@ -56,7 +56,7 @@ structure Environment (F : Type) where
 -/
 structure ProverEnvironment (F : Type) extends Environment F where
   /-- Runtime-only hashmap of prover hints, never committed into the proof. -/
-  hint : ProverHint F
+  hint : ProverHints F
 
 /-- Project a `ProverEnvironment` to its `Environment`. -/
 instance : Coe (ProverEnvironment F) (Environment F) := ⟨ProverEnvironment.toEnvironment⟩

--- a/Clean/Circuit/Expression.lean
+++ b/Clean/Circuit/Expression.lean
@@ -24,11 +24,11 @@ def ProverData (F : Type) :=
 /-- Runtime-only hashmap of prover hints. Same shape as `ProverData`, but
 distinct to emphasize that hints are *not* committed: they feed only the
 witness-generation step and never appear in the proof. -/
-def ProverHints (F : Type) :=
+def ProverHint (F : Type) :=
   String → (n : ℕ) → Array (Vector F n)
 
-/-- Placeholder `ProverHints` that returns an empty array for every key. -/
-def ProverHints.empty (F : Type) : ProverHints F := fun _ _ => #[]
+/-- Placeholder `ProverHint` that returns an empty array for every key. -/
+def ProverHint.empty (F : Type) : ProverHint F := fun _ _ => #[]
 
 /--
   `Environment` represents the data that is provided at runtime to concretely
@@ -56,7 +56,7 @@ structure Environment (F : Type) where
 -/
 structure ProverEnvironment (F : Type) extends Environment F where
   /-- Runtime-only hashmap of prover hints, never committed into the proof. -/
-  hint : ProverHints F
+  hint : ProverHint F
 
 /-- Project a `ProverEnvironment` to its `Environment`. -/
 instance : Coe (ProverEnvironment F) (Environment F) := ⟨ProverEnvironment.toEnvironment⟩

--- a/Clean/Circuit/Foundations.lean
+++ b/Clean/Circuit/Foundations.lean
@@ -20,7 +20,7 @@ variable [CircuitType α] [CircuitType β]
 
 /--
   Justification for using a modified statement for `ConstraintsHold`
-  in the `FormalCircuit` definition.
+  in the `GeneralFormalCircuit` definition.
 -/
 theorem original_soundness (circuit : GeneralFormalCircuit.WithHint F β α) :
     ∀ (offset : ℕ) (env : Environment F) (b_var : Var β F),
@@ -35,7 +35,7 @@ theorem original_soundness (circuit : GeneralFormalCircuit.WithHint F β α) :
 
 /--
   Justification for using modified statements for `UsesLocalWitnesses`
-  and `ConstraintsHold` in the `FormalCircuit` definition.
+  and `ConstraintsHold` in the `GeneralFormalCircuit` definition.
 -/
 theorem original_completeness (circuit : GeneralFormalCircuit.WithHint F β α) :
     ∀ (offset : ℕ) (env : ProverEnvironment F) (b_var : Var β F),

--- a/Clean/Circuit/Foundations.lean
+++ b/Clean/Circuit/Foundations.lean
@@ -20,11 +20,11 @@ open Circuit (ConstraintsHold)
 -/
 theorem FormalCircuit.original_soundness (circuit : FormalCircuit F β α) :
     ∀ (offset : ℕ) (env : Environment F) (b_var : Var β F) (b : β F),
-    eval env b_var = b → circuit.Assumptions b →
+    eval' env b_var = b → circuit.Assumptions b →
     -- if the constraints hold (original definition)
     ConstraintsHold env (circuit.main b_var |>.operations offset) →
     -- the spec holds
-    let a := eval env (circuit.output b_var offset)
+    let a := eval' env (circuit.output b_var offset)
     circuit.Spec b a := by
 
   intro offset env b_var b h_input h_assumptions h_holds
@@ -37,7 +37,7 @@ theorem FormalCircuit.original_soundness (circuit : FormalCircuit F β α) :
 -/
 theorem FormalCircuit.original_completeness (circuit : FormalCircuit F β α) :
     ∀ (offset : ℕ) (env : ProverEnvironment F) (b_var : Var β F) (b : β F),
-    eval env b_var = b → circuit.Assumptions b →
+    eval' env b_var = b → circuit.Assumptions b →
     -- if the environment uses default witness generators (original definition)
     env.UsesLocalWitnesses offset (circuit.main b_var |>.operations offset) →
     -- the constraints hold (original definition)
@@ -54,7 +54,7 @@ theorem FormalCircuit.original_completeness (circuit : FormalCircuit F β α) :
 -/
 theorem FormalAssertion.original_soundness (circuit : FormalAssertion F β) :
     ∀ (offset : ℕ) (env : Environment F) (b_var : Var β F) (b : β F),
-    eval env b_var = b → circuit.Assumptions b →
+    eval' env b_var = b → circuit.Assumptions b →
     -- if the constraints hold (original definition)
     ConstraintsHold env (circuit.main b_var |>.operations offset) →
     -- the spec holds
@@ -70,7 +70,7 @@ theorem FormalAssertion.original_soundness (circuit : FormalAssertion F β) :
 -/
 theorem FormalAssertion.original_completeness (circuit : FormalAssertion F β) :
     ∀ (offset : ℕ) (env : ProverEnvironment F) (b_var : Var β F) (b : β F),
-    eval env b_var = b → circuit.Assumptions b →
+    eval' env b_var = b → circuit.Assumptions b →
     -- if the environment uses default witness generators (original definition)
     env.UsesLocalWitnesses offset (circuit.main b_var |>.operations offset) →
     -- the spec implies that the constraints hold (original definition)

--- a/Clean/Circuit/Foundations.lean
+++ b/Clean/Circuit/Foundations.lean
@@ -10,9 +10,52 @@ This ensures that the `FormalCircuit` and `FormalAssertion` definitions are not 
 -/
 import Clean.Circuit.Theorems
 
-variable {F : Type} [Field F]
-variable {α β : TypeMap} [ProvableType α] [ProvableType β]
 open Circuit (ConstraintsHold)
+
+variable {F : Type} [Field F]
+variable {α β : TypeMap}
+
+namespace GeneralFormalCircuit.WithHint
+variable [CircuitType α] [CircuitType β]
+
+/--
+  Justification for using a modified statement for `ConstraintsHold`
+  in the `FormalCircuit` definition.
+-/
+theorem original_soundness (circuit : GeneralFormalCircuit.WithHint F β α) :
+    ∀ (offset : ℕ) (env : Environment F) (b_var : Var β F),
+    circuit.Assumptions (eval env b_var) env.data →
+    -- if the constraints hold (original definition)
+    ConstraintsHold env (circuit.main b_var |>.operations offset) →
+    -- the spec holds
+    circuit.Spec (eval env b_var) (eval env (circuit.output b_var offset)) env.data := by
+  intro offset env b_var h_assumptions h_holds
+  apply circuit.soundness offset env b_var _ rfl h_assumptions
+  exact Circuit.can_replace_soundness h_holds
+
+/--
+  Justification for using modified statements for `UsesLocalWitnesses`
+  and `ConstraintsHold` in the `FormalCircuit` definition.
+-/
+theorem original_completeness (circuit : GeneralFormalCircuit.WithHint F β α) :
+    ∀ (offset : ℕ) (env : ProverEnvironment F) (b_var : Var β F),
+    circuit.ProverAssumptions (eval env b_var) env.data env.hint →
+    -- if the environment uses default witness generators (original definition)
+    env.UsesLocalWitnesses offset (circuit.main b_var |>.operations offset) →
+    -- the constraints hold (original definition)
+    ConstraintsHold env (circuit.main b_var |>.operations offset) ∧
+    -- and the prover spec holds
+    circuit.ProverSpec (eval env b_var) (eval env (circuit.output b_var offset)) env.hint := by
+  intro offset env b_var h_assumptions h_env
+  have h_env' := ProverEnvironment.can_replace_usesLocalWitnessesCompleteness (circuit.subcircuitsConsistent ..) h_env
+  have completeness := circuit.completeness offset env b_var h_env' _ rfl h_assumptions
+  constructor
+  · apply Circuit.can_replace_completeness (circuit.subcircuitsConsistent ..) h_env
+    exact completeness.1
+  · exact completeness.2
+end GeneralFormalCircuit.WithHint
+
+variable [ProvableType α] [ProvableType β]
 
 /--
   Justification for using a modified statement for `ConstraintsHold`

--- a/Clean/Circuit/Foundations.lean
+++ b/Clean/Circuit/Foundations.lean
@@ -20,11 +20,11 @@ open Circuit (ConstraintsHold)
 -/
 theorem FormalCircuit.original_soundness (circuit : FormalCircuit F β α) :
     ∀ (offset : ℕ) (env : Environment F) (b_var : Var β F) (b : β F),
-    eval' env b_var = b → circuit.Assumptions b →
+    eval env b_var = b → circuit.Assumptions b →
     -- if the constraints hold (original definition)
     ConstraintsHold env (circuit.main b_var |>.operations offset) →
     -- the spec holds
-    let a := eval' env (circuit.output b_var offset)
+    let a := eval env (circuit.output b_var offset)
     circuit.Spec b a := by
 
   intro offset env b_var b h_input h_assumptions h_holds
@@ -37,7 +37,7 @@ theorem FormalCircuit.original_soundness (circuit : FormalCircuit F β α) :
 -/
 theorem FormalCircuit.original_completeness (circuit : FormalCircuit F β α) :
     ∀ (offset : ℕ) (env : ProverEnvironment F) (b_var : Var β F) (b : β F),
-    eval' env b_var = b → circuit.Assumptions b →
+    eval env b_var = b → circuit.Assumptions b →
     -- if the environment uses default witness generators (original definition)
     env.UsesLocalWitnesses offset (circuit.main b_var |>.operations offset) →
     -- the constraints hold (original definition)
@@ -54,7 +54,7 @@ theorem FormalCircuit.original_completeness (circuit : FormalCircuit F β α) :
 -/
 theorem FormalAssertion.original_soundness (circuit : FormalAssertion F β) :
     ∀ (offset : ℕ) (env : Environment F) (b_var : Var β F) (b : β F),
-    eval' env b_var = b → circuit.Assumptions b →
+    eval env b_var = b → circuit.Assumptions b →
     -- if the constraints hold (original definition)
     ConstraintsHold env (circuit.main b_var |>.operations offset) →
     -- the spec holds
@@ -70,7 +70,7 @@ theorem FormalAssertion.original_soundness (circuit : FormalAssertion F β) :
 -/
 theorem FormalAssertion.original_completeness (circuit : FormalAssertion F β) :
     ∀ (offset : ℕ) (env : ProverEnvironment F) (b_var : Var β F) (b : β F),
-    eval' env b_var = b → circuit.Assumptions b →
+    eval env b_var = b → circuit.Assumptions b →
     -- if the environment uses default witness generators (original definition)
     env.UsesLocalWitnesses offset (circuit.main b_var |>.operations offset) →
     -- the spec implies that the constraints hold (original definition)

--- a/Clean/Circuit/Lookup.lean
+++ b/Clean/Circuit/Lookup.lean
@@ -89,7 +89,7 @@ def Completeness (lookup : Lookup F) (env : Environment F) : Prop :=
 lemma soundess_def {Row : TypeMap} [ProvableType Row]
   (table : Table F Row) (env : Environment F) (entry : (Row (Expression F))) :
     let lookup : Lookup F := { table := table.toRaw, entry := toElements entry };
-    lookup.Soundness env ↔ table.Soundness (env.data.getTable table) (eval env entry) := by
+    lookup.Soundness env ↔ table.Soundness (env.data.getTable table) (eval' env entry) := by
   rfl
 
 @[circuit_norm]
@@ -105,7 +105,7 @@ lemma soundess_def_field {F : Type} [Field F]
 lemma completeness_def {Row : TypeMap} [ProvableType Row]
   (table : Table F Row) (env : Environment F) (entry : Row (Expression F)) :
     let lookup : Lookup F := { table := table.toRaw, entry := toElements entry };
-    lookup.Completeness env ↔ table.Completeness (env.data.getTable table) (eval env entry) := by
+    lookup.Completeness env ↔ table.Completeness (env.data.getTable table) (eval' env entry) := by
   rfl
 
 @[circuit_norm]

--- a/Clean/Circuit/Lookup.lean
+++ b/Clean/Circuit/Lookup.lean
@@ -89,7 +89,7 @@ def Completeness (lookup : Lookup F) (env : Environment F) : Prop :=
 lemma soundess_def {Row : TypeMap} [ProvableType Row]
   (table : Table F Row) (env : Environment F) (entry : (Row (Expression F))) :
     let lookup : Lookup F := { table := table.toRaw, entry := toElements entry };
-    lookup.Soundness env ↔ table.Soundness (env.data.getTable table) (eval' env entry) := by
+    lookup.Soundness env ↔ table.Soundness (env.data.getTable table) (eval env entry) := by
   rfl
 
 @[circuit_norm]
@@ -105,7 +105,7 @@ lemma soundess_def_field {F : Type} [Field F]
 lemma completeness_def {Row : TypeMap} [ProvableType Row]
   (table : Table F Row) (env : Environment F) (entry : Row (Expression F)) :
     let lookup : Lookup F := { table := table.toRaw, entry := toElements entry };
-    lookup.Completeness env ↔ table.Completeness (env.data.getTable table) (eval' env entry) := by
+    lookup.Completeness env ↔ table.Completeness (env.data.getTable table) (eval env entry) := by
   rfl
 
 @[circuit_norm]

--- a/Clean/Circuit/Lookup.lean
+++ b/Clean/Circuit/Lookup.lean
@@ -1,4 +1,4 @@
-import Clean.Circuit.CircuitType
+import Clean.Circuit.Provable
 variable {F : Type} [Field F] {α : Type} {n : ℕ}
 variable {Row : TypeMap} [ProvableType Row]
 

--- a/Clean/Circuit/Lookup.lean
+++ b/Clean/Circuit/Lookup.lean
@@ -1,4 +1,4 @@
-import Clean.Circuit.Provable
+import Clean.Circuit.CircuitType
 variable {F : Type} [Field F] {α : Type} {n : ℕ}
 variable {Row : TypeMap} [ProvableType Row]
 
@@ -87,7 +87,7 @@ def Completeness (lookup : Lookup F) (env : Environment F) : Prop :=
 
 @[circuit_norm]
 lemma soundess_def {Row : TypeMap} [ProvableType Row]
-  (table : Table F Row) (env : Environment F) (entry : Row (Expression F)) :
+  (table : Table F Row) (env : Environment F) (entry : (Row (Expression F))) :
     let lookup : Lookup F := { table := table.toRaw, entry := toElements entry };
     lookup.Soundness env ↔ table.Soundness (env.data.getTable table) (eval env entry) := by
   rfl

--- a/Clean/Circuit/Lookup.lean
+++ b/Clean/Circuit/Lookup.lean
@@ -87,7 +87,7 @@ def Completeness (lookup : Lookup F) (env : Environment F) : Prop :=
 
 @[circuit_norm]
 lemma soundess_def {Row : TypeMap} [ProvableType Row]
-  (table : Table F Row) (env : Environment F) (entry : (Row (Expression F))) :
+  (table : Table F Row) (env : Environment F) (entry : Row (Expression F)) :
     let lookup : Lookup F := { table := table.toRaw, entry := toElements entry };
     lookup.Soundness env ↔ table.Soundness (env.data.getTable table) (eval env entry) := by
   simp only [CircuitType.eval_expression]

--- a/Clean/Circuit/Lookup.lean
+++ b/Clean/Circuit/Lookup.lean
@@ -90,6 +90,7 @@ lemma soundess_def {Row : TypeMap} [ProvableType Row]
   (table : Table F Row) (env : Environment F) (entry : (Row (Expression F))) :
     let lookup : Lookup F := { table := table.toRaw, entry := toElements entry };
     lookup.Soundness env ↔ table.Soundness (env.data.getTable table) (eval env entry) := by
+  simp only [CircuitType.eval_expression]
   rfl
 
 @[circuit_norm]
@@ -106,6 +107,7 @@ lemma completeness_def {Row : TypeMap} [ProvableType Row]
   (table : Table F Row) (env : Environment F) (entry : Row (Expression F)) :
     let lookup : Lookup F := { table := table.toRaw, entry := toElements entry };
     lookup.Completeness env ↔ table.Completeness (env.data.getTable table) (eval env entry) := by
+  simp only [CircuitType.eval_expression]
   rfl
 
 @[circuit_norm]

--- a/Clean/Circuit/LookupCircuit.lean
+++ b/Clean/Circuit/LookupCircuit.lean
@@ -55,7 +55,7 @@ def toTable (circuit : LookupCircuit F α β) (hint : ProverHints F) : Table F (
     use 0, circuit.proverEnvironment input hint
     simp only [h_output, LookupCircuit.constantOutput, circuit_norm,and_true]
     set env := circuit.proverEnvironment input hint
-    apply circuit.original_completeness 0 env (const input) input ProvableType.eval_const h_assumptions
+    apply circuit.original_completeness 0 env (const input) input ProvableType.eval_const_prover h_assumptions
     exact circuit.proverEnvironment_usesLocalWitnesses input hint
 
 -- we create another `FormalCircuit` that wraps a lookup into the table defined by the input circuit

--- a/Clean/Circuit/LookupCircuit.lean
+++ b/Clean/Circuit/LookupCircuit.lean
@@ -17,20 +17,20 @@ namespace LookupCircuit
 variable {F : Type} [Field F] {α β : TypeMap} [ProvableType α] [ProvableType β]
 
 def proverEnvironment (circuit : LookupCircuit F α β)
-    (input : α F) (hint : ProverHints F) : ProverEnvironment F :=
+    (input : α F) (hint : ProverHint F) : ProverEnvironment F :=
   circuit.main (const input) |>.proverEnvironment hint
 
 theorem proverEnvironment_usesLocalWitnesses (circuit : LookupCircuit F α β)
-    (input : α F) (hint : ProverHints F) :
+    (input : α F) (hint : ProverHint F) :
     (circuit.proverEnvironment input hint).UsesLocalWitnesses 0 ((circuit.main (const input)).operations 0) := by
   apply Circuit.proverEnvironment_usesLocalWitnesses
   apply circuit.compose_computableWitnesses
   simp [ProverEnvironment.OnlyAccessedBelow, circuit_norm, circuit.computableWitnesses]
 
-def constantOutput (circuit : LookupCircuit F α β) (input : α F) (hint : ProverHints F) : β F :=
+def constantOutput (circuit : LookupCircuit F α β) (input : α F) (hint : ProverHint F) : β F :=
   circuit.output (const input) 0 |> eval (circuit.proverEnvironment input hint)
 
-def toTable (circuit : LookupCircuit F α β) (hint : ProverHints F) : Table F (ProvablePair α β) where
+def toTable (circuit : LookupCircuit F α β) (hint : ProverHint F) : Table F (ProvablePair α β) where
   name := circuit.name
 
   -- for `(input, output)` to be contained in the lookup table defined by a circuit, means that:
@@ -62,7 +62,7 @@ def toTable (circuit : LookupCircuit F α β) (hint : ProverHints F) : Table F (
 -- this gives `circuit.lookup input` _exactly_ the same interface as `circuit input`.
 
 @[circuit_norm]
-def lookupCircuit (circuit : LookupCircuit F α β) (hint : ProverHints F) :
+def lookupCircuit (circuit : LookupCircuit F α β) (hint : ProverHint F) :
     FormalCircuit F α β where
   main (input : Var α F) := do
     -- we witness the output for the given input, and look up the pair in the table
@@ -91,6 +91,6 @@ def lookupCircuit (circuit : LookupCircuit F α β) (hint : ProverHints F) :
     rw [←h_env ⟨ i, hi ⟩, ProvableType.eval_varFromOffset, ProvableType.toElements_fromElements, Vector.getElem_mapRange]
 
 @[circuit_norm]
-def lookup (circuit : LookupCircuit F α β) (hint : ProverHints F) (input : Var α F) : Circuit F (Var β F) :=
+def lookup (circuit : LookupCircuit F α β) (hint : ProverHint F) (input : Var α F) : Circuit F (Var β F) :=
   lookupCircuit circuit hint input
 end LookupCircuit

--- a/Clean/Circuit/LookupCircuit.lean
+++ b/Clean/Circuit/LookupCircuit.lean
@@ -28,7 +28,7 @@ theorem proverEnvironment_usesLocalWitnesses (circuit : LookupCircuit F α β)
   simp [ProverEnvironment.OnlyAccessedBelow, circuit_norm, circuit.computableWitnesses]
 
 def constantOutput (circuit : LookupCircuit F α β) (input : α F) (hint : ProverHints F) : β F :=
-  circuit.output (const input) 0 |> eval (circuit.proverEnvironment input hint)
+  circuit.output (const input) 0 |> eval' (circuit.proverEnvironment input hint)
 
 def toTable (circuit : LookupCircuit F α β) (hint : ProverHints F) : Table F (ProvablePair α β) where
   name := circuit.name
@@ -40,7 +40,7 @@ def toTable (circuit : LookupCircuit F α β) (hint : ProverHints F) : Table F (
     -- the circuit constraints hold
     Circuit.ConstraintsHold env (circuit.main (const input) |>.operations n)
     -- and the output matches
-    ∧ output = eval env (circuit.output (const input) n)
+    ∧ output = eval' env (circuit.output (const input) n)
 
   Soundness := fun _ (input, output) => circuit.Assumptions input → circuit.Spec input output
   Completeness := fun _ (input, output) => circuit.Assumptions input ∧ output = circuit.constantOutput input hint
@@ -66,7 +66,7 @@ def lookupCircuit (circuit : LookupCircuit F α β) (hint : ProverHints F) :
     FormalCircuit F α β where
   main (input : Var α F) := do
     -- we witness the output for the given input, and look up the pair in the table
-    let output ← witness fun env => circuit.constantOutput (eval env input) hint
+    let output ← witness fun env => circuit.constantOutput (eval' env input) hint
 
     lookup (circuit.toTable hint) (input, output)
     return output

--- a/Clean/Circuit/LookupCircuit.lean
+++ b/Clean/Circuit/LookupCircuit.lean
@@ -17,20 +17,20 @@ namespace LookupCircuit
 variable {F : Type} [Field F] {α β : TypeMap} [ProvableType α] [ProvableType β]
 
 def proverEnvironment (circuit : LookupCircuit F α β)
-    (input : α F) (hint : ProverHint F) : ProverEnvironment F :=
+    (input : α F) (hint : ProverHints F) : ProverEnvironment F :=
   circuit.main (const input) |>.proverEnvironment hint
 
 theorem proverEnvironment_usesLocalWitnesses (circuit : LookupCircuit F α β)
-    (input : α F) (hint : ProverHint F) :
+    (input : α F) (hint : ProverHints F) :
     (circuit.proverEnvironment input hint).UsesLocalWitnesses 0 ((circuit.main (const input)).operations 0) := by
   apply Circuit.proverEnvironment_usesLocalWitnesses
   apply circuit.compose_computableWitnesses
   simp [ProverEnvironment.OnlyAccessedBelow, ProvableType.eval_const, circuit.computableWitnesses]
 
-def constantOutput (circuit : LookupCircuit F α β) (input : α F) (hint : ProverHint F) : β F :=
+def constantOutput (circuit : LookupCircuit F α β) (input : α F) (hint : ProverHints F) : β F :=
   circuit.output (const input) 0 |> eval (circuit.proverEnvironment input hint)
 
-def toTable (circuit : LookupCircuit F α β) (hint : ProverHint F) : Table F (ProvablePair α β) where
+def toTable (circuit : LookupCircuit F α β) (hint : ProverHints F) : Table F (ProvablePair α β) where
   name := circuit.name
 
   -- for `(input, output)` to be contained in the lookup table defined by a circuit, means that:
@@ -62,7 +62,7 @@ def toTable (circuit : LookupCircuit F α β) (hint : ProverHint F) : Table F (P
 -- this gives `circuit.lookup input` _exactly_ the same interface as `circuit input`.
 
 @[circuit_norm]
-def lookupCircuit (circuit : LookupCircuit F α β) (hint : ProverHint F) :
+def lookupCircuit (circuit : LookupCircuit F α β) (hint : ProverHints F) :
     FormalCircuit F α β where
   main (input : Var α F) := do
     -- we witness the output for the given input, and look up the pair in the table
@@ -89,6 +89,6 @@ def lookupCircuit (circuit : LookupCircuit F α β) (hint : ProverHint F) :
     rw [←h_env ⟨ i, hi ⟩, ProvableType.eval_varFromOffset, ProvableType.toElements_fromElements, Vector.getElem_mapRange]
 
 @[circuit_norm]
-def lookup (circuit : LookupCircuit F α β) (hint : ProverHint F) (input : Var α F) : Circuit F (Var β F) :=
+def lookup (circuit : LookupCircuit F α β) (hint : ProverHints F) (input : Var α F) : Circuit F (Var β F) :=
   lookupCircuit circuit hint input
 end LookupCircuit

--- a/Clean/Circuit/LookupCircuit.lean
+++ b/Clean/Circuit/LookupCircuit.lean
@@ -28,7 +28,7 @@ theorem proverEnvironment_usesLocalWitnesses (circuit : LookupCircuit F α β)
   simp [ProverEnvironment.OnlyAccessedBelow, circuit_norm, circuit.computableWitnesses]
 
 def constantOutput (circuit : LookupCircuit F α β) (input : α F) (hint : ProverHints F) : β F :=
-  circuit.output (const input) 0 |> eval' (circuit.proverEnvironment input hint)
+  circuit.output (const input) 0 |> eval (circuit.proverEnvironment input hint)
 
 def toTable (circuit : LookupCircuit F α β) (hint : ProverHints F) : Table F (ProvablePair α β) where
   name := circuit.name
@@ -40,7 +40,7 @@ def toTable (circuit : LookupCircuit F α β) (hint : ProverHints F) : Table F (
     -- the circuit constraints hold
     Circuit.ConstraintsHold env (circuit.main (const input) |>.operations n)
     -- and the output matches
-    ∧ output = eval' env (circuit.output (const input) n)
+    ∧ output = eval env (circuit.output (const input) n)
 
   Soundness := fun _ (input, output) => circuit.Assumptions input → circuit.Spec input output
   Completeness := fun _ (input, output) => circuit.Assumptions input ∧ output = circuit.constantOutput input hint
@@ -66,7 +66,7 @@ def lookupCircuit (circuit : LookupCircuit F α β) (hint : ProverHints F) :
     FormalCircuit F α β where
   main (input : Var α F) := do
     -- we witness the output for the given input, and look up the pair in the table
-    let output ← witness fun env => circuit.constantOutput (eval' env input) hint
+    let output ← witness fun env => circuit.constantOutput (eval env input) hint
 
     lookup (circuit.toTable hint) (input, output)
     return output

--- a/Clean/Circuit/LookupCircuit.lean
+++ b/Clean/Circuit/LookupCircuit.lean
@@ -25,7 +25,7 @@ theorem proverEnvironment_usesLocalWitnesses (circuit : LookupCircuit F α β)
     (circuit.proverEnvironment input hint).UsesLocalWitnesses 0 ((circuit.main (const input)).operations 0) := by
   apply Circuit.proverEnvironment_usesLocalWitnesses
   apply circuit.compose_computableWitnesses
-  simp [ProverEnvironment.OnlyAccessedBelow, ProvableType.eval_const, circuit.computableWitnesses]
+  simp [ProverEnvironment.OnlyAccessedBelow, circuit_norm, circuit.computableWitnesses]
 
 def constantOutput (circuit : LookupCircuit F α β) (input : α F) (hint : ProverHints F) : β F :=
   circuit.output (const input) 0 |> eval (circuit.proverEnvironment input hint)
@@ -53,7 +53,7 @@ def toTable (circuit : LookupCircuit F α β) (hint : ProverHints F) : Table F (
   implied_by_completeness := by
     intro _ (input, output) ⟨h_assumptions, h_output⟩
     use 0, circuit.proverEnvironment input hint
-    simp only [h_output, LookupCircuit.constantOutput, and_true]
+    simp only [h_output, LookupCircuit.constantOutput, circuit_norm,and_true]
     set env := circuit.proverEnvironment input hint
     apply circuit.original_completeness 0 env (const input) input ProvableType.eval_const h_assumptions
     exact circuit.proverEnvironment_usesLocalWitnesses input hint
@@ -83,7 +83,9 @@ def lookupCircuit (circuit : LookupCircuit F α β) (hint : ProverHints F) :
 
   completeness := by
     intro n env input_var h_env input h_input h_assumptions
-    simp_all only [circuit_norm, toTable]
+    simp only [circuit_norm, toTable] at *
+    simp only [h_input] at h_env ⊢
+    use h_assumptions
     rw [ProvableType.ext_iff]
     intro i hi
     rw [←h_env ⟨ i, hi ⟩, ProvableType.eval_varFromOffset, ProvableType.toElements_fromElements, Vector.getElem_mapRange]

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -3,18 +3,11 @@ import Clean.Utils.Vector
 import Clean.Circuit.CircuitType
 import Clean.Circuit.SimpGadget
 
-/-
-'Provable types' are structured collections of field elements.
-
- We represent them as types generic over a single type argument (the field element),
- i.e. `Type → Type`.
--/
-
 variable {F : Type} [Field F]
 
 /--
-  Class of types that can be used inside a circuit,
-  because they can be flattened into a vector of (field) elements.
+Class of types that can be used inside a circuit,
+because they can be flattened into a vector of (field) elements.
 -/
 class ProvableType (M : TypeMap) where
   size : ℕ
@@ -44,18 +37,13 @@ class NonEmptyProvableType (M : TypeMap) extends ProvableType M where
 export ProvableType (size toElements fromElements)
 
 attribute [circuit_norm] size ProvableType.toElements_fromElements ProvableType.fromElements_toElements
+
 -- tagged with low priority to prefer higher-level `ProvableStruct` decompositions
 -- note that this is not added to `circuit_norm`, since in general we won't need or want
 -- to explicitly unfold provable type definitions
 attribute [explicit_provable_type low] toElements fromElements
 
 variable {M : TypeMap} [ProvableType M]
-
-@[circuit_norm]
-def toVars (var : M (Expression F)) := toElements var
-
-@[circuit_norm]
-def fromVars (vars : Vector (Expression F) (size M)) := fromElements vars
 
 namespace ProvableType
 variable {α β γ: TypeMap} [ProvableType α] [ProvableType β] [ProvableType γ]
@@ -67,48 +55,44 @@ Note: this is not tagged with `circuit_norm`, to enable higher-level `ProvableSt
 decompositions. Sometimes you will need to add `explicit_provable_type` to the simp set.
 -/
 @[explicit_provable_type]
-def eval' (env : Environment F) (x : α (Expression F)) : α F :=
-  let vars := toVars x
+def eval' (env : Environment F) (x : M (Expression F)) : M F :=
+  let vars := toElements x
   let values := vars.map (Expression.eval env)
   fromElements values
 
 /--
-Default `CircuitType` for any `ProvableType`: verifier- and prover-value coincide
-with the input type, and `Var` is the usual `α ∘ Expression`.
+`ProvableType`s are `CircuitType`s: verifier- and prover-value coincide
+with the input type, and `Var` is `M ∘ Expression`.
 
 The instance lives in `Provable.lean`, after `ProvableType` is defined, to keep
 `CircuitType.lean` below `Provable.lean` in the import graph.
 -/
-instance toCircuitType {α : TypeMap} [ProvableType α] : CircuitType α where
-  Var F := α (Expression F)
-  ProverValue := α
-  Value := α
+instance toCircuitType {M : TypeMap} [ProvableType M] : CircuitType M where
+  Var F := M (Expression F)
+  ProverValue := M
+  Value := M
   evalVerifier env v := eval' env v
   evalProver env v := eval' env.toEnvironment v
 
-def const (x : α F) : α (Expression F) :=
+def const (x : M F) : M (Expression F) :=
   let values : Vector F _ := toElements x
-  fromVars (values.map .const)
+  fromElements (values.map .const)
 
-def synthesizeValue : α F :=
-  let zeros := Vector.fill (size α) 0
-  fromElements zeros
+instance [Field F] : Inhabited (M F) where
+  default :=
+    let zeros := Vector.fill (size M) 0
+    fromElements zeros
 
-instance [Field F] : Inhabited (α F) where
-  default := synthesizeValue
-
-def synthesizeConstVar : α (Expression F) :=
-  let zeros := Vector.fill (size α) 0
-  fromVars (zeros.map .const)
-
-instance [Field F] : Inhabited (α (Expression F)) where
-  default := synthesizeConstVar
+instance [Field F] : Inhabited (M (Expression F)) where
+  default :=
+    let zeros := Vector.fill (size M) 0
+    fromElements (zeros.map .const)
 
 -- TODO this should be simply called `var`, analogous to `const`
 @[explicit_provable_type]
-def varFromOffset (α : TypeMap) [ProvableType α] (offset : ℕ) : α (Expression F) :=
-  let vars := Vector.mapRange (size α) fun i => var ⟨offset + i⟩
-  fromVars vars
+def varFromOffset (M : TypeMap) [ProvableType M] (offset : ℕ) : M (Expression F) :=
+  let vars := Vector.mapRange (size M) fun i => var ⟨offset + i⟩
+  fromElements vars
 
 -- under `explicit_provable_type`, it makes sense to fully resolve `mapRange` as well
 attribute [explicit_provable_type] Vector.mapRange_succ Vector.mapRange_zero
@@ -294,7 +278,7 @@ instance {n : ℕ} : ProverEval F (fields n (Expression F)) (fields n F) :=
 @[circuit_norm] lemma eval_var_fields {n : ℕ} (env : Environment F) (x : Var (fields n) F) :
     eval env x = (x : fields n (Expression F)).map (Expression.eval env) := by
   unfold eval
-  change ProvableType.eval' (α:=fields n) env x =
+  change ProvableType.eval' (M:=fields n) env x =
     (x : fields n (Expression F)).map (Expression.eval env)
   rfl
 
@@ -307,7 +291,7 @@ instance {n : ℕ} : ProverEval F (fields n (Expression F)) (fields n F) :=
 @[circuit_norm] lemma eval_var_fields_prover {n : ℕ} (env : ProverEnvironment F) (x : Var (fields n) F) :
     eval env x = (x : fields n (Expression F)).map (Expression.eval env.toEnvironment) := by
   unfold eval
-  change ProvableType.eval' (α:=fields n) env.toEnvironment x =
+  change ProvableType.eval' (M:=fields n) env.toEnvironment x =
     (x : fields n (Expression F)).map (Expression.eval env.toEnvironment)
   rfl
 
@@ -449,7 +433,7 @@ theorem eval_eq_eval {α : TypeMap} [ProvableStruct α] : ∀ (env : Environment
   intro env x
   rw [CircuitType.eval_expression]
   symm
-  simp only [eval, ProvableType.eval', fromElements, toVars, toElements, size]
+  simp only [eval, ProvableType.eval', fromElements, toElements, size]
   congr 1
   apply eval_eq_eval_aux
 where
@@ -491,7 +475,7 @@ omit [Field F] in
 theorem varFromOffset_eq_varFromOffset {α : TypeMap} [ProvableStruct α] (offset : ℕ) :
     ProvableType.varFromOffset (F:=F) α offset = ProvableStruct.varFromOffset α offset := by
   symm
-  simp only [varFromOffset, ProvableType.varFromOffset, fromVars, size, fromElements]
+  simp only [varFromOffset, ProvableType.varFromOffset, fromElements, size]
   congr
   rw [←Vector.cast_mapRange combinedSize_eq.symm]
   apply varFromOffset_eq_varFromOffset_aux (components α) offset
@@ -501,7 +485,7 @@ where
       Vector.mapRange (combinedSize' cs) (fun i => var (F:=F) ⟨offset + i⟩) |> componentsFromElements cs)
     | [], _ => rfl
     | c :: cs, offset => by
-      simp only [varFromOffset.go, componentsFromElements, ProvableType.varFromOffset, fromVars]
+      simp only [varFromOffset.go, componentsFromElements, ProvableType.varFromOffset]
       have h_size : combinedSize' (c :: cs) = size c.type + combinedSize' cs := rfl
       rw [Vector.cast_mapRange h_size, Vector.mapRange_add_eq_append, Vector.cast_rfl,
         Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
@@ -533,8 +517,8 @@ namespace CircuitType
 @[circuit_norm] lemma eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
   eval env v = Expression.eval env v := by
   unfold eval
-  change ProvableType.eval' (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
-  simp [ProvableType.eval', toVars, toElements, fromElements]
+  change ProvableType.eval' (M:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
+  simp [ProvableType.eval', toElements, fromElements]
 
 @[circuit_norm] lemma eval_var_field (env : Environment F) (v : field (Expression F)) :
   eval env v = Expression.eval env v := by
@@ -543,8 +527,8 @@ namespace CircuitType
 @[circuit_norm] lemma eval_var_field_prover (env : ProverEnvironment F) (v : field (Expression F)) :
   eval env v = Expression.eval env v := by
   unfold eval
-  change ProvableType.eval' (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
-  simp [ProvableType.eval', toVars, toElements, fromElements]
+  change ProvableType.eval' (M:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
+  simp [ProvableType.eval', toElements, fromElements]
 
 end CircuitType
 
@@ -633,7 +617,7 @@ lemma fromElements_eq_iff' {M : TypeMap} [ProvableType M] {F : Type} {B : Vector
 theorem eval_const {F : Type} [Field F] {α : TypeMap} [ProvableType α] {env : Environment F} {x : α F} :
     eval env (const x) = x := by
   rw [CircuitType.eval_expression]
-  simp only [const, fromVars, explicit_provable_type, toVars]
+  simp only [const, explicit_provable_type]
   rw [toElements_fromElements, Vector.map_map]
   have : Expression.eval env ∘ Expression.const = id := by
     funext
@@ -651,7 +635,7 @@ theorem eval_varFromOffset {α : TypeMap} [ProvableType α] (env : Environment F
     (eval env (varFromOffset α offset : α (Expression F)) : α F) =
       fromElements (.mapRange (size α) fun i => env.get (offset + i)) := by
   rw [CircuitType.eval_expression]
-  simp only [explicit_provable_type, varFromOffset, toVars, fromVars]
+  simp only [explicit_provable_type, varFromOffset]
   rw [toElements_fromElements]
   congr
   rw [Vector.ext_iff]
@@ -678,33 +662,25 @@ theorem eval_fromElements {F : Type} [Field F] {α : TypeMap} [ProvableType α] 
   (xs : Vector (Expression F) (size α)) :
     eval env (fromElements (F:=Expression F) xs : α (Expression F)) = fromElements (xs.map env) := by
   rw [CircuitType.eval_expression]
-  simp only [explicit_provable_type, toVars, toElements_fromElements]
-
-theorem eval_fromVars {F : Type} [Field F] {α : TypeMap} [ProvableType α] (env : Environment F)
-  (xs : Vector (Expression F) (size α)) :
-    eval env (fromVars xs : α (Expression F)) = fromElements (xs.map env) := eval_fromElements ..
+  simp only [explicit_provable_type, toElements_fromElements]
 
 theorem getElem_eval_toElements {F : Type} [Field F] {α : TypeMap} [ProvableType α]
   {env : Environment F} (x : α (Expression F)) (i : ℕ) (hi : i < size α) :
     Expression.eval env (toElements x)[i] = (toElements (eval env x))[i] := by
   rw [CircuitType.eval_expression]
-  rw [eval', toElements_fromElements, Vector.getElem_map, toVars]
-
-theorem getElem_eval_toVars {F : Type} [Field F] {α : TypeMap} [ProvableType α]
-  {env : Environment F} (x : α (Expression F)) (i : ℕ) (hi : i < size α) :
-    Expression.eval env (toVars x)[i] = (toElements (eval env x))[i] := getElem_eval_toElements ..
+  rw [eval', toElements_fromElements, Vector.getElem_map]
 
 theorem getElem_eval_fields {F : Type} [Field F] {n : ℕ} {env : Environment F}
   (x : fields n (Expression F)) (i : ℕ) (hi : i < n) :
     Expression.eval env x[i] = (eval env x)[i] := by
   rw [CircuitType.eval_expression]
-  simp only [explicit_provable_type, fromElements, instProvableTypeFields, toVars, Vector.getElem_map]
+  simp only [explicit_provable_type, fromElements, instProvableTypeFields, Vector.getElem_map]
 
 theorem getElem_eval_fields_prover {F : Type} [Field F] {n : ℕ} {env : ProverEnvironment F}
   (x : fields n (Expression F)) (i : ℕ) (hi : i < n) :
     Expression.eval env.toEnvironment x[i] = (eval env x)[i] := by
   rw [CircuitType.eval_expression_prover]
-  simp only [explicit_provable_type, fromElements, instProvableTypeFields, toVars, Vector.getElem_map]
+  simp only [explicit_provable_type, fromElements, instProvableTypeFields, Vector.getElem_map]
 end ProvableType
 
 -- more concrete ProvableType instances
@@ -743,7 +719,7 @@ theorem eval_vector (env : Environment F)
     ext i hi
     simp only [Vector.getElem_map, CircuitType.eval_expression]
   rw [h_map]
-  simp only [explicit_provable_type, toVars, toElements, fromElements]
+  simp only [explicit_provable_type, toElements, fromElements]
   simp only [Vector.map_flatten, Vector.map_map]
   rw [Vector.flatten_toChunks]
   simp [explicit_provable_type]
@@ -792,7 +768,7 @@ theorem varFromOffset_vector {F : Type} [Field F] {α : TypeMap} [NonEmptyProvab
     omega
   | succ n ih =>
     rw [Vector.mapRange_succ, ←ih]
-    simp only [varFromOffset, fromVars, fromElements, size]
+    simp only [varFromOffset, fromElements, size]
     rw [←Vector.map_push, Vector.toChunks_push]
     congr
     conv => rhs; congr; rhs; congr; intro i; rw [mul_comm, add_assoc]
@@ -858,9 +834,9 @@ theorem eval_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (env : En
   (a : α (Expression F)) (b : β (Expression F)) :
     eval env ((a, b) : ProvablePair α β (Expression F)) = (eval env a, eval env b) := by
   unfold eval
-  change ProvableType.eval' (α:=ProvablePair α β) env (a, b) =
+  change ProvableType.eval' (M:=ProvablePair α β) env (a, b) =
     (ProvableType.eval' env a, ProvableType.eval' env b)
-  simp only [ProvableType.eval', toVars, toElements, fromElements, Vector.map_append]
+  simp only [ProvableType.eval', toElements, fromElements, Vector.map_append]
   rw [Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
 
 namespace CircuitType
@@ -886,9 +862,9 @@ namespace CircuitType
     (env : ProverEnvironment F) (p1 : M (Expression F)) (p2 : N (Expression F)) :
     eval env ((p1, p2) : ProvablePair M N (Expression F)) = (eval env p1, eval env p2) := by
   unfold eval
-  change ProvableType.eval' (α:=ProvablePair M N) env.toEnvironment (p1, p2) =
+  change ProvableType.eval' (M:=ProvablePair M N) env.toEnvironment (p1, p2) =
     (ProvableType.eval' env.toEnvironment p1, ProvableType.eval' env.toEnvironment p2)
-  simp only [ProvableType.eval', toVars, toElements, fromElements, Vector.map_append]
+  simp only [ProvableType.eval', toElements, fromElements, Vector.map_append]
   rw [Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
 
 @[circuit_norm] lemma eval_var_provablePair_prover {M N : TypeMap} [ProvableType M] [ProvableType N]
@@ -965,7 +941,7 @@ omit [Field F] in
 theorem varFromOffset_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (offset : ℕ) :
     varFromOffset (F:=F) (ProvablePair α β) offset
     = (varFromOffset α offset, varFromOffset β (offset + size α)) := by
-  simp only [varFromOffset, fromVars, ProvablePair.instance]
+  simp only [varFromOffset, ProvablePair.instance]
   rw [Vector.mapRange_add_eq_append, Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
   ac_rfl
 

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -125,7 +125,6 @@ attribute [explicit_provable_type] Vector.mapRange_succ Vector.mapRange_zero
 end ProvableType
 
 export ProvableType (const varFromOffset)
-open ProvableType (eval)
 
 namespace CircuitType
 
@@ -142,10 +141,10 @@ namespace CircuitType
 @[circuit_norm] instance : ProverEval F (M (Expression F)) (M F) := proverEval M
 
 @[circuit_norm] lemma eval_var (env : Environment F) (v : M (Expression F)) :
-  eval' env v = ProvableType.eval env v := by simp only [circuit_norm]
+  eval env v = ProvableType.eval env v := by simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_var_prover (env : ProverEnvironment F) (v : M (Expression F)) :
-  eval' env v = ProvableType.eval env v := by simp only [circuit_norm]
+  eval env v = ProvableType.eval env v := by simp only [circuit_norm]
 
 end CircuitType
 
@@ -239,12 +238,12 @@ namespace CircuitType
 
 @[circuit_norm] lemma eval_fields (F : Type) [Field F] {n : ℕ}
   (env : Environment F) (xs : fields n (Expression F)) :
-    eval' env xs = ProvableType.eval env xs := by
+    eval env xs = ProvableType.eval env xs := by
   rfl
 
 @[circuit_norm] lemma eval_fields_prover (F : Type) [Field F] {n : ℕ}
   (env : ProverEnvironment F) (xs : fields n (Expression F)) :
-    eval' env xs = ProvableType.eval env xs := by
+    eval env xs = ProvableType.eval env xs := by
   rfl
 
 end CircuitType
@@ -446,22 +445,22 @@ end ProvableType
 namespace CircuitType
 
 @[circuit_norm] lemma eval_expr (env : Environment F) (v : Expression F) :
-  eval' env v = Expression.eval env v := by
+  eval env v = Expression.eval env v := by
   change ProvableType.eval (α:=field) env v = Expression.eval env v
   exact ProvableType.eval_field env v
 
 @[circuit_norm] lemma eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
-  eval' env v = Expression.eval env v := by
+  eval env v = Expression.eval env v := by
   change ProvableType.eval (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
   exact ProvableType.eval_field env.toEnvironment v
 
 @[circuit_norm] lemma eval_var_field (env : Environment F) (v : field (Expression F)) :
-  eval' env v = Expression.eval env v := by
+  eval env v = Expression.eval env v := by
   change ProvableType.eval (α:=field) env v = Expression.eval env v
   exact ProvableType.eval_field env v
 
 @[circuit_norm] lemma eval_var_field_prover (env : ProverEnvironment F) (v : field (Expression F)) :
-  eval' env v = Expression.eval env v := by
+  eval env v = Expression.eval env v := by
   change ProvableType.eval (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
   exact ProvableType.eval_field env.toEnvironment v
 
@@ -616,34 +615,35 @@ instance ProvableVector.instance : ProvableType (ProvableVector α n) where
 
 theorem eval_vector (env : Environment F)
   (x : ProvableVector α n (Expression F)) :
-    eval env x = x.map (eval env) := by
-  simp only [eval, toVars, toElements, fromElements]
+    ProvableType.eval env x = x.map (ProvableType.eval env) := by
+  simp only [ProvableType.eval, toVars, toElements, fromElements]
   simp only [Vector.map_flatten, Vector.map_map]
   rw [Vector.flatten_toChunks]
-  simp [eval, toVars]
+  simp [ProvableType.eval, toVars]
 
 theorem getElem_eval_vector (env : Environment F) (x : ProvableVector α n (Expression F)) (i : ℕ) (h : i < n) :
-    (eval env x[i]) = (eval env x)[i] := by
+    (ProvableType.eval env x[i]) = (ProvableType.eval env x)[i] := by
   have h' := congrArg (fun xs : Vector (α F) n => xs[i]) (eval_vector env x)
   simpa only [Vector.getElem_map] using h'.symm
 
 lemma eval_vector_eq_get {M : TypeMap} [NonEmptyProvableType M] {n : ℕ} (env : Environment F)
     (vars : Vector (M (Expression F)) n)
     (vals : Vector (M F) n)
-    (h : (eval env vars : ProvableVector _ _ _) = (vals : ProvableVector _ _ _))
+    (h : (ProvableType.eval env vars : ProvableVector _ _ _) = (vals : ProvableVector _ _ _))
     (i : ℕ) (h_i : i < n) :
-    eval env vars[i] = vals[i] := by
+    ProvableType.eval env vars[i] = vals[i] := by
   have h' := congrArg (fun xs : Vector (M F) n => xs[i]) h
   simpa only [eval_vector, Vector.getElem_map] using h'
 
 lemma eval_vector_take {M : TypeMap} [NonEmptyProvableType M] {n : ℕ} (env : Environment F)
     (vars : ProvableVector M n (Expression F)) (i : ℕ) :
-    (eval env (vars.take i) : ProvableVector _ _ _) = (eval env vars).take i := by
+    (ProvableType.eval env (vars.take i) : ProvableVector _ _ _) = (ProvableType.eval env vars).take i := by
   simp only [eval_vector, Vector.take_eq_extract, Vector.map_extract]
 
 lemma eval_vector_takeShort {M : TypeMap} [NonEmptyProvableType M] {n : ℕ} (env : Environment F)
     (vars : ProvableVector M n (Expression F)) (i : ℕ) (h_i : i < n) :
-    (eval env (vars.takeShort i h_i) : ProvableVector _ _ _) = (eval env vars).takeShort i h_i := by
+    (ProvableType.eval env (vars.takeShort i h_i) : ProvableVector _ _ _) =
+      (ProvableType.eval env vars).takeShort i h_i := by
   simp only [Vector.takeShort]
   simp only [eval_vector]
   ext j h_j
@@ -730,32 +730,33 @@ def ProvablePair.toElements {α β: TypeMap} [ProvableType α] [ProvableType β]
 @[circuit_norm ↓ high]
 theorem eval_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (env : Environment F)
   (a : α (Expression F)) (b : β (Expression F)) :
-    eval (α:=ProvablePair α β) env (a, b) = (eval env a, eval env b) := by
-  simp only [eval, toVars, toElements, fromElements, Vector.map_append]
+    ProvableType.eval (α:=ProvablePair α β) env (a, b) =
+      (ProvableType.eval env a, ProvableType.eval env b) := by
+  simp only [ProvableType.eval, toVars, toElements, fromElements, Vector.map_append]
   rw [Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
 
 namespace CircuitType
 
 @[circuit_norm] lemma eval_var_pair {M N : TypeMap} [ProvableType M] [ProvableType N]
     (env : Environment F) (p1 : M (Expression F)) (p2 : N (Expression F)) :
-    eval' env ((p1, p2) : ProvablePair M N (Expression F)) = (eval' env p1, eval' env p2) := by
+    eval env ((p1, p2) : ProvablePair M N (Expression F)) = (eval env p1, eval env p2) := by
   simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_var_pair_prover {M N : TypeMap} [ProvableType M] [ProvableType N]
     (env : ProverEnvironment F) (p1 : M (Expression F)) (p2 : N (Expression F)) :
-    eval' env ((p1, p2) : ProvablePair M N (Expression F)) = (eval' env p1, eval' env p2) := by
+    eval env ((p1, p2) : ProvablePair M N (Expression F)) = (eval env p1, eval env p2) := by
   simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_field_pair (F : Type) [Field F]
   (env : Environment F) (p1 : field (Expression F)) (p2 : field (Expression F)) :
-    eval' env ((p1, p2) : ProvablePair field field (Expression F)) = (eval' env p1, eval' env p2) := by
+    eval env ((p1, p2) : ProvablePair field field (Expression F)) = (eval env p1, eval env p2) := by
   change ProvableType.eval (α:=ProvablePair field field) env (p1, p2) =
     (ProvableType.eval (α:=field) env p1, ProvableType.eval (α:=field) env p2)
   exact eval_pair (α:=field) (β:=field) env p1 p2
 
 @[circuit_norm] lemma eval_field_pair_prover (F : Type) [Field F]
   (env : ProverEnvironment F) (p1 : field (Expression F)) (p2 : field (Expression F)) :
-    eval' env ((p1, p2) : ProvablePair field field (Expression F)) = (eval' env p1, eval' env p2) := by
+    eval env ((p1, p2) : ProvablePair field field (Expression F)) = (eval env p1, eval env p2) := by
   change ProvableType.eval (α:=ProvablePair field field) env.toEnvironment (p1, p2) =
     (ProvableType.eval (α:=field) env.toEnvironment p1,
       ProvableType.eval (α:=field) env.toEnvironment p2)
@@ -767,38 +768,44 @@ end CircuitType
 @[circuit_norm ↓ high]
 theorem eval_pair_left_expr {β : TypeMap} [ProvableType β] (env : Environment F)
   (a : Expression F) (b : β (Expression F)) :
-    eval (α:=ProvablePair field β) env (a, b) = (Expression.eval env a, eval env b) := by
+    ProvableType.eval (α:=ProvablePair field β) env (a, b) =
+      (Expression.eval env a, ProvableType.eval env b) := by
   rw [eval_pair (α:=field), ProvableType.eval_field]
 
 @[circuit_norm ↓ high]
 theorem eval_pair_right_expr {α : TypeMap} [ProvableType α] (env : Environment F)
   (a : α (Expression F)) (b : Expression F) :
-    eval (α:=ProvablePair α field) env (a, b) = (eval env a, Expression.eval env b) := by
+    ProvableType.eval (α:=ProvablePair α field) env (a, b) =
+      (ProvableType.eval env a, Expression.eval env b) := by
   rw [eval_pair (β:=field), ProvableType.eval_field]
 
 @[circuit_norm ↓ high]
 theorem eval_pair_both_expr (env : Environment F)
   (a b : Expression F) :
-    eval (α:=ProvablePair field field) env (a, b) = (Expression.eval env a, Expression.eval env b) := by
+    ProvableType.eval (α:=ProvablePair field field) env (a, b) =
+      (Expression.eval env a, Expression.eval env b) := by
   simp only [eval_pair (α:=field) (β:=field), ProvableType.eval_field]
 
 -- Specialized lemmas for Vector (Expression F) to handle type inference issues with vectors
 @[circuit_norm ↓ high]
 theorem eval_pair_left_vector_expr {n : ℕ} {β : TypeMap} [ProvableType β] (env : Environment F)
   (a : Vector (Expression F) n) (b : β (Expression F)) :
-    eval (α:=ProvablePair (fields n) β) env (a, b) = (eval env a, eval env b) :=
+    ProvableType.eval (α:=ProvablePair (fields n) β) env (a, b) =
+      (ProvableType.eval env a, ProvableType.eval env b) :=
   eval_pair (α:=fields n) env a b
 
 @[circuit_norm ↓ high]
 theorem eval_pair_right_vector_expr {n : ℕ} {α : TypeMap} [ProvableType α] (env : Environment F)
   (a : α (Expression F)) (b : Vector (Expression F) n) :
-    eval (α:=ProvablePair α (fields n)) env (a, b) = (eval env a, eval env b) :=
+    ProvableType.eval (α:=ProvablePair α (fields n)) env (a, b) =
+      (ProvableType.eval env a, ProvableType.eval env b) :=
   eval_pair (β:=fields n) env a b
 
 @[circuit_norm ↓ high]
 theorem eval_pair_both_vector_expr {n m : ℕ} (env : Environment F)
   (a : Vector (Expression F) n) (b : Vector (Expression F) m) :
-    eval (α:=ProvablePair (fields n) (fields m)) env (a, b) = (eval env a, eval env b) :=
+    ProvableType.eval (α:=ProvablePair (fields n) (fields m)) env (a, b) =
+      (ProvableType.eval env a, ProvableType.eval env b) :=
   eval_pair (α:=fields n) (β:=fields m) env a b
 
 omit [Field F] in

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -181,17 +181,14 @@ theorem fromElements_eval_toElements {α : TypeMap} [ProvableType α] {env : Env
 
 end ProvableType
 
-@[reducible]
-def unit (_ : Type) := Unit
+abbrev unit (_ : Type) := Unit
 
 instance : ProvableType unit where
   size := 0
   toElements _ := #v[]
   fromElements _ := ()
 
-@[reducible] def field : TypeMap := id
-
-@[reducible] def fieldVar (F : Type) := field (Expression F)
+abbrev field : TypeMap := id
 
 @[circuit_norm]
 instance : ProvableType field where
@@ -227,14 +224,11 @@ instance : ProverEval F (M (Var field F)) (M F) := proverEval M
 
 end CircuitType
 
-@[reducible]
-def ProvablePair (α β : TypeMap) := fun F => α F × β F
+abbrev ProvablePair (α β : TypeMap) := fun F => α F × β F
 
-@[reducible]
-def fieldPair : TypeMap := fun F => F × F
+abbrev fieldPair : TypeMap := fun F => F × F
 
-@[reducible]
-def fieldTriple : TypeMap := fun F => F × F × F
+abbrev fieldTriple : TypeMap := fun F => F × F × F
 
 instance : ProvableType fieldPair where
   size := 2
@@ -249,11 +243,9 @@ instance : ProvableType fieldTriple where
 instance : NonEmptyProvableType fieldTriple where
 
 variable {n : ℕ}
-@[reducible]
-def ProvableVector (α : TypeMap) (n : ℕ) := fun F => Vector (α F) n
+abbrev ProvableVector (α : TypeMap) (n : ℕ) := fun F => Vector (α F) n
 
-@[reducible]
-def fields (n : ℕ) := fun F => Vector F n
+abbrev fields (n : ℕ) := fun F => Vector F n
 
 @[circuit_norm]
 instance : ProvableType (fields n) where
@@ -319,8 +311,7 @@ inductive ProvableTypeList (F : Type) : List WithProvableType → Type 1 where
 | nil : ProvableTypeList F []
 | cons : ∀ {a : WithProvableType} {as : List WithProvableType}, a.type F → ProvableTypeList F as → ProvableTypeList F (a :: as)
 
-@[reducible]
-def combinedSize' (cs : List WithProvableType) : ℕ := cs.map (fun x => x.provableType.size) |>.sum
+abbrev combinedSize' (cs : List WithProvableType) : ℕ := cs.map (fun x => x.provableType.size) |>.sum
 end ProvableStruct
 
 -- if we can split a type into components that are provable types, then this gives us a provable type
@@ -689,8 +680,7 @@ end ProvableType
 section
 variable {n : ℕ} {α : TypeMap} [NonEmptyProvableType α]
 
-@[reducible]
-def psize (α : TypeMap) [NonEmptyProvableType α] : ℕ+ :=
+abbrev psize (α : TypeMap) [NonEmptyProvableType α] : ℕ+ :=
   ⟨ size α, NonEmptyProvableType.nonempty ⟩
 
 instance ProvableVector.instance : ProvableType (ProvableVector α n) where

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -175,7 +175,7 @@ namespace ProvableType
 @[circuit_norm]
 theorem fromElements_eval_toElements {α : TypeMap} [ProvableType α] {env : Environment F}
     (x : α (Expression F)) :
-    fromElements (Vector.map (Expression.eval env) (toElements x)) = eval env x := by
+    fromElements (Vector.map (Expression.eval env) (toElements x)) = Eval.eval env x := by
   simp only [CircuitType.eval_expression]
   rfl
 
@@ -502,7 +502,7 @@ variable {α : TypeMap} [ProvableType α]
 
 @[circuit_norm ↓ high]
 theorem eval_field {F : Type} [Field F] (env : Environment F) (x : field (Expression F)) :
-    eval env x = Expression.eval env x := by
+    Eval.eval env x = Expression.eval env x := by
   rw [CircuitType.eval_expression]
   simp [circuit_norm, explicit_provable_type]
 
@@ -511,22 +511,22 @@ end ProvableType
 namespace CircuitType
 
 @[circuit_norm] lemma eval_expr (env : Environment F) (v : Expression F) :
-  eval env v = Expression.eval env v := by
+  Eval.eval env v = Expression.eval env v := by
   exact ProvableType.eval_field env v
 
 @[circuit_norm] lemma eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
-  eval env v = Expression.eval env v := by
-  unfold eval
+  Eval.eval env v = Expression.eval env v := by
+  unfold Eval.eval
   change ProvableType.eval' (M:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
   simp [ProvableType.eval', toElements, fromElements]
 
 @[circuit_norm] lemma eval_var_field (env : Environment F) (v : field (Expression F)) :
-  eval env v = Expression.eval env v := by
+  Eval.eval env v = Expression.eval env v := by
   exact ProvableType.eval_field env v
 
 @[circuit_norm] lemma eval_var_field_prover (env : ProverEnvironment F) (v : field (Expression F)) :
-  eval env v = Expression.eval env v := by
-  unfold eval
+  Eval.eval env v = Expression.eval env v := by
+  unfold Eval.eval
   change ProvableType.eval' (M:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
   simp [ProvableType.eval', toElements, fromElements]
 
@@ -541,7 +541,7 @@ theorem varFromOffset_field {F} (offset : ℕ) :
 
 @[circuit_norm ↓]
 theorem eval_fields {F : Type} [Field F] (env : Environment F) (x : fields n (Expression F)) :
-  eval env x = x.map (Expression.eval env) := by
+  Eval.eval env x = x.map (Expression.eval env) := by
   rw [CircuitType.eval_expression]
   rfl
 
@@ -551,26 +551,26 @@ theorem varFromOffset_fields {F} (offset : ℕ) :
 
 @[circuit_norm ↓]
 theorem eval_fieldPair {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
-    eval env t = (Expression.eval env t.1, Expression.eval env t.2):= by
+    Eval.eval env t = (Expression.eval env t.1, Expression.eval env t.2):= by
   simp [circuit_norm, explicit_provable_type]
 
 @[circuit_norm] lemma eval_fieldPair_prover (env : ProverEnvironment F) (t : fieldPair (Expression F)) :
-    eval env t = (Expression.eval env t.1, Expression.eval env t.2) := by
+    Eval.eval env t = (Expression.eval env t.1, Expression.eval env t.2) := by
   simp [circuit_norm, explicit_provable_type]
 
 @[circuit_norm ↓]
 theorem eval_fieldPair_fst {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
-    (eval env t).1 = Expression.eval env t.1 := by
+    (Eval.eval env t).1 = Expression.eval env t.1 := by
   simp only [eval_fieldPair]
 
 @[circuit_norm ↓]
 theorem eval_fieldPair_snd {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
-    (eval env t).2 = Expression.eval env t.2 := by
+    (Eval.eval env t).2 = Expression.eval env t.2 := by
   simp only [eval_fieldPair]
 
 @[circuit_norm ↓]
 theorem eval_fieldTriple {F : Type} [Field F] (env : Environment F) (t : fieldTriple (Expression F)) :
-    eval env t = (match t with
+    Eval.eval env t = (match t with
       | (x, y, z) => (Expression.eval env x, Expression.eval env y, Expression.eval env z)) := by
   rw [CircuitType.eval_expression]
   simp [circuit_norm, explicit_provable_type]
@@ -615,7 +615,7 @@ lemma fromElements_eq_iff' {M : TypeMap} [ProvableType M] {F : Type} {B : Vector
 
 @[circuit_norm]
 theorem eval_const {F : Type} [Field F] {α : TypeMap} [ProvableType α] {env : Environment F} {x : α F} :
-    eval env (const x) = x := by
+    Eval.eval env (const x) = x := by
   rw [CircuitType.eval_expression]
   simp only [const, explicit_provable_type]
   rw [toElements_fromElements, Vector.map_map]
@@ -627,12 +627,12 @@ theorem eval_const {F : Type} [Field F] {α : TypeMap} [ProvableType α] {env : 
 @[circuit_norm]
 theorem eval_const_prover {F : Type} [Field F] {α : TypeMap} [ProvableType α]
     {env : ProverEnvironment F} {x : α F} :
-    eval env (const x) = x := by
+    Eval.eval env (const x) = x := by
   exact (CircuitType.eval_expression_prover env (const x)).trans (by
     simpa only [CircuitType.eval_expression] using eval_const (env:=env.toEnvironment) (x:=x))
 
 theorem eval_varFromOffset {α : TypeMap} [ProvableType α] (env : Environment F) (offset : ℕ) :
-    (eval env (varFromOffset α offset : α (Expression F)) : α F) =
+    (Eval.eval env (varFromOffset α offset : α (Expression F)) : α F) =
       fromElements (.mapRange (size α) fun i => env.get (offset + i)) := by
   rw [CircuitType.eval_expression]
   simp only [explicit_provable_type, varFromOffset]
@@ -660,7 +660,7 @@ theorem ext_iff {F : Type} {α : TypeMap} [ProvableType α] (x y : α F) :
 
 theorem eval_fromElements {F : Type} [Field F] {α : TypeMap} [ProvableType α] (env : Environment F)
   (xs : Vector (Expression F) (size α)) :
-    eval env (fromElements (F:=Expression F) xs : α (Expression F)) = fromElements (xs.map env) := by
+    Eval.eval env (fromElements (F:=Expression F) xs : α (Expression F)) = fromElements (xs.map env) := by
   rw [CircuitType.eval_expression]
   simp only [explicit_provable_type, toElements_fromElements]
 

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -151,7 +151,7 @@ ordinary simplification.
 instance : VerifierEval F (Var M F) (M F) := verifierEval M
 instance : ProverEval F (Var M F) (M F) := proverEval M
 instance : VerifierEval F (M (Expression F)) (M F) := verifierEval M
-instance : ProverEval F (M (Expression F)) (M F) := proverEval M
+@[circuit_norm] instance : ProverEval F (M (Expression F)) (M F) := proverEval M
 
 @[explicit_provable_type] lemma eval_var (env : Environment F) (v : Var M F) :
     eval env v = ProvableType.eval' env (v : M (Expression F)) := by
@@ -169,18 +169,19 @@ instance : ProverEval F (M (Expression F)) (M F) := proverEval M
 
 @[explicit_provable_type] lemma eval_expression (env : Environment F) (v : M (Expression F)) :
     eval env v = ProvableType.eval' env v := by
-  unfold eval
-  change (verifierEval M).eval env v = ProvableType.eval' env v
-  rfl
+  rw [eval_var]
 
 @[explicit_provable_type] lemma eval_expression_prover (env : ProverEnvironment F) (v : M (Expression F)) :
     eval env v = ProvableType.eval' env.toEnvironment v := by
-  unfold eval
-  change (proverEval M).eval env v = ProvableType.eval' env.toEnvironment v
-  rfl
+  rw [eval_var_prover]
 
 @[circuit_norm] lemma eval_expression_prover_to_verifier (env : ProverEnvironment F) (v : M (Expression F)) :
     eval env v = eval env.toEnvironment v := by
+  rw [eval_expression_prover, eval_expression]
+
+@[circuit_norm] lemma eval_expression_prover_to_verifier' (env : ProverEnvironment F) :
+    @eval (ProverEnvironment F) (M (Expression F)) (M F) (CircuitType.proverEval M) env = eval env.toEnvironment := by
+  funext v
   rw [eval_expression_prover, eval_expression]
 
 end CircuitType
@@ -434,7 +435,7 @@ where
   @[circuit_norm]
   go: (cs : List WithProvableType) → ProvableTypeList (Expression F) cs → ProvableTypeList F cs
     | [], .nil => .nil
-    | _ :: cs, .cons a as => .cons (_root_.eval env a) (go cs as)
+    | _ :: cs, .cons a as => .cons (Eval.eval env a) (go cs as)
 
 /--
 `eval` === `ProvableStruct.eval`
@@ -445,7 +446,7 @@ It preserves high-level components instead of unfolding everything down to field
 -/
 @[circuit_norm ↓ high]
 theorem eval_eq_eval {α : TypeMap} [ProvableStruct α] : ∀ (env : Environment F) (x : α (Expression F)),
-    _root_.eval env x = ProvableStruct.eval env x := by
+    Eval.eval env x = ProvableStruct.eval env x := by
   intro env x
   rw [CircuitType.eval_expression]
   symm
@@ -467,7 +468,7 @@ where
 @[circuit_norm ↓ high]
 theorem eval_eq_eval_prover {α : TypeMap} [ProvableStruct α] (env : ProverEnvironment F)
     (x : α (Expression F)) :
-    _root_.eval env x = ProvableStruct.eval env.toEnvironment x := by
+    Eval.eval env x = ProvableStruct.eval env.toEnvironment x := by
   rw [CircuitType.eval_expression_prover_to_verifier]
   exact eval_eq_eval env.toEnvironment x
 
@@ -567,9 +568,11 @@ theorem varFromOffset_fields {F} (offset : ℕ) :
 
 @[circuit_norm ↓]
 theorem eval_fieldPair {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
-    eval env t =
-      (match t with | (x, y) => (Expression.eval env x, Expression.eval env y)) := by
-  rw [CircuitType.eval_expression]
+    eval env t = (Expression.eval env t.1, Expression.eval env t.2):= by
+  simp [circuit_norm, explicit_provable_type]
+
+@[circuit_norm] lemma eval_fieldPair_prover (env : ProverEnvironment F) (t : fieldPair (Expression F)) :
+    eval env t = (Expression.eval env t.1, Expression.eval env t.2) := by
   simp [circuit_norm, explicit_provable_type]
 
 @[circuit_norm ↓]

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -123,6 +123,24 @@ export ProvableType (const varFromOffset)
 
 namespace CircuitType
 
+/-!
+For provable types, the preferred normal form is the concrete expression/value
+view:
+
+* variables: `M (Expression F)`, not `Var M F`;
+* verifier values: `M F`, not `Value M F`;
+* prover values: `M F`, not `ProverValue M F`.
+
+`Var M F`, `Value M F`, and `ProverValue M F` are defeq to these concrete
+forms for the default `CircuitType` instance, and are still useful at circuit
+boundaries and in APIs that work for arbitrary `CircuitType`s. Userland
+definitions and lemmas over provable data should usually use the concrete
+expression/value forms directly. This makes elaborated theorem statements line
+up with the `circuit_norm` simp normal form; in particular, lemmas about `eval`
+then elaborate as `@eval _ (M (Expression F)) (M F) ...` and can be applied by
+ordinary simplification.
+-/
+
 @[circuit_norm] lemma var_of_provableType (F) :
   Var M F = M (Expression F) := rfl
 @[circuit_norm] lemma proverValue_of_provableType (F) :
@@ -135,14 +153,35 @@ instance : ProverEval F (Var M F) (M F) := proverEval M
 instance : VerifierEval F (M (Expression F)) (M F) := verifierEval M
 instance : ProverEval F (M (Expression F)) (M F) := proverEval M
 
-lemma eval_var (env : Environment F) (v : M (Expression F)) :
-    eval env v = ProvableType.eval' env v := rfl
+@[explicit_provable_type] lemma eval_var (env : Environment F) (v : Var M F) :
+    eval env v = ProvableType.eval' env (v : M (Expression F)) := by
+  unfold eval
+  rfl
 
-lemma eval_var_prover (env : ProverEnvironment F) (v : M (Expression F)) :
-    eval env v = ProvableType.eval' env.toEnvironment v := rfl
+@[explicit_provable_type] lemma eval_var_prover (env : ProverEnvironment F) (v : Var M F) :
+    eval env v = ProvableType.eval' env.toEnvironment (v : M (Expression F)) := by
+  unfold eval
+  rfl
 
-@[circuit_norm] lemma eval_var_prover_to_verifier (env : ProverEnvironment F) (v : M (Expression F)) :
-    eval env v = eval env.toEnvironment v := rfl
+@[circuit_norm] lemma eval_var_prover_to_verifier (env : ProverEnvironment F) (v : Var M F) :
+    eval env v = eval env.toEnvironment v := by
+  rw [eval_var_prover, eval_var]
+
+@[explicit_provable_type] lemma eval_expression (env : Environment F) (v : M (Expression F)) :
+    eval env v = ProvableType.eval' env v := by
+  unfold eval
+  change (verifierEval M).eval env v = ProvableType.eval' env v
+  rfl
+
+@[explicit_provable_type] lemma eval_expression_prover (env : ProverEnvironment F) (v : M (Expression F)) :
+    eval env v = ProvableType.eval' env.toEnvironment v := by
+  unfold eval
+  change (proverEval M).eval env v = ProvableType.eval' env.toEnvironment v
+  rfl
+
+@[circuit_norm] lemma eval_expression_prover_to_verifier (env : ProverEnvironment F) (v : M (Expression F)) :
+    eval env v = eval env.toEnvironment v := by
+  rw [eval_expression_prover, eval_expression]
 
 end CircuitType
 
@@ -152,7 +191,9 @@ namespace ProvableType
 @[circuit_norm]
 theorem fromElements_eval_toElements {α : TypeMap} [ProvableType α] {env : Environment F}
     (x : α (Expression F)) :
-    fromElements (Vector.map (Expression.eval env) (toElements x)) = eval env x := rfl
+    fromElements (Vector.map (Expression.eval env) (toElements x)) = eval env x := by
+  simp only [CircuitType.eval_expression]
+  rfl
 
 end ProvableType
 
@@ -197,6 +238,8 @@ namespace CircuitType
 
 instance : VerifierEval F (Expression F) F := verifierEval field
 instance : ProverEval F (Expression F) F := proverEval field
+instance : VerifierEval F (M (Var field F)) (M F) := verifierEval M
+instance : ProverEval F (M (Var field F)) (M F) := proverEval M
 
 end CircuitType
 
@@ -247,6 +290,33 @@ instance {n : ℕ} : VerifierEval F (fields n (Expression F)) (fields n F) :=
   verifierEval (fields n)
 instance {n : ℕ} : ProverEval F (fields n (Expression F)) (fields n F) :=
   proverEval (fields n)
+
+@[circuit_norm] lemma eval_var_fields {n : ℕ} (env : Environment F) (x : Var (fields n) F) :
+    eval env x = (x : fields n (Expression F)).map (Expression.eval env) := by
+  unfold eval
+  change ProvableType.eval' (α:=fields n) env x =
+    (x : fields n (Expression F)).map (Expression.eval env)
+  rfl
+
+@[circuit_norm] lemma eval_fields_dispatch {n : ℕ} (env : Environment F) (x : fields n (Expression F)) :
+    @eval (Environment F) (fields n (Expression F)) (fields n F)
+      (verifierEval (fields n)) env x =
+      x.map (Expression.eval env) := by
+  exact eval_var_fields env x
+
+@[circuit_norm] lemma eval_var_fields_prover {n : ℕ} (env : ProverEnvironment F) (x : Var (fields n) F) :
+    eval env x = (x : fields n (Expression F)).map (Expression.eval env.toEnvironment) := by
+  unfold eval
+  change ProvableType.eval' (α:=fields n) env.toEnvironment x =
+    (x : fields n (Expression F)).map (Expression.eval env.toEnvironment)
+  rfl
+
+@[circuit_norm] lemma eval_fields_dispatch_prover {n : ℕ} (env : ProverEnvironment F)
+    (x : fields n (Expression F)) :
+    @eval (ProverEnvironment F) (fields n (Expression F)) (fields n F)
+      (proverEval (fields n)) env x =
+      x.map (Expression.eval env.toEnvironment) := by
+  exact eval_var_fields_prover env x
 
 end CircuitType
 
@@ -364,7 +434,7 @@ where
   @[circuit_norm]
   go: (cs : List WithProvableType) → ProvableTypeList (Expression F) cs → ProvableTypeList F cs
     | [], .nil => .nil
-    | _ :: cs, .cons a as => .cons (Eval.eval env a) (go cs as)
+    | _ :: cs, .cons a as => .cons (_root_.eval env a) (go cs as)
 
 /--
 `eval` === `ProvableStruct.eval`
@@ -375,9 +445,9 @@ It preserves high-level components instead of unfolding everything down to field
 -/
 @[circuit_norm ↓ high]
 theorem eval_eq_eval {α : TypeMap} [ProvableStruct α] : ∀ (env : Environment F) (x : α (Expression F)),
-    Eval.eval env x = ProvableStruct.eval env x := by
+    _root_.eval env x = ProvableStruct.eval env x := by
   intro env x
-  change ProvableType.eval' env x = ProvableStruct.eval env x
+  rw [CircuitType.eval_expression]
   symm
   simp only [eval, ProvableType.eval', fromElements, toVars, toElements, size]
   congr 1
@@ -390,8 +460,16 @@ where
     simp only [componentsToElements, componentsFromElements, eval.go]
     rw [Vector.map_append, Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
     congr
+    · exact (ProvableType.fromElements_eval_toElements (env:=env) a).symm
     -- recursively use this lemma!
     apply eval_eq_eval_aux
+
+@[circuit_norm ↓ high]
+theorem eval_eq_eval_prover {α : TypeMap} [ProvableStruct α] (env : ProverEnvironment F)
+    (x : α (Expression F)) :
+    _root_.eval env x = ProvableStruct.eval env.toEnvironment x := by
+  rw [CircuitType.eval_expression_prover_to_verifier]
+  exact eval_eq_eval env.toEnvironment x
 
 /--
 Alternative `varFromOffset` which creates each component separately.
@@ -441,7 +519,7 @@ variable {α : TypeMap} [ProvableType α]
 @[circuit_norm ↓ high]
 theorem eval_field {F : Type} [Field F] (env : Environment F) (x : field (Expression F)) :
     eval env x = Expression.eval env x := by
-  change ProvableType.eval' (α:=field) env x = Expression.eval env x
+  rw [CircuitType.eval_expression]
   simp [circuit_norm, explicit_provable_type]
 
 end ProvableType
@@ -454,7 +532,9 @@ namespace CircuitType
 
 @[circuit_norm] lemma eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
   eval env v = Expression.eval env v := by
-  exact ProvableType.eval_field env.toEnvironment v
+  unfold eval
+  change ProvableType.eval' (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
+  simp [ProvableType.eval', toVars, toElements, fromElements]
 
 @[circuit_norm] lemma eval_var_field (env : Environment F) (v : field (Expression F)) :
   eval env v = Expression.eval env v := by
@@ -462,7 +542,9 @@ namespace CircuitType
 
 @[circuit_norm] lemma eval_var_field_prover (env : ProverEnvironment F) (v : field (Expression F)) :
   eval env v = Expression.eval env v := by
-  exact ProvableType.eval_field env.toEnvironment v
+  unfold eval
+  change ProvableType.eval' (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
+  simp [ProvableType.eval', toVars, toElements, fromElements]
 
 end CircuitType
 
@@ -476,6 +558,7 @@ theorem varFromOffset_field {F} (offset : ℕ) :
 @[circuit_norm ↓]
 theorem eval_fields {F : Type} [Field F] (env : Environment F) (x : fields n (Expression F)) :
   eval env x = x.map (Expression.eval env) := by
+  rw [CircuitType.eval_expression]
   rfl
 
 @[circuit_norm ↓]
@@ -486,8 +569,7 @@ theorem varFromOffset_fields {F} (offset : ℕ) :
 theorem eval_fieldPair {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
     eval env t =
       (match t with | (x, y) => (Expression.eval env x, Expression.eval env y)) := by
-  change ProvableType.eval' (α:=fieldPair) env t =
-    (match t with | (x, y) => (Expression.eval env x, Expression.eval env y))
+  rw [CircuitType.eval_expression]
   simp [circuit_norm, explicit_provable_type]
 
 @[circuit_norm ↓]
@@ -504,8 +586,7 @@ theorem eval_fieldPair_snd {F : Type} [Field F] (env : Environment F) (t : field
 theorem eval_fieldTriple {F : Type} [Field F] (env : Environment F) (t : fieldTriple (Expression F)) :
     eval env t = (match t with
       | (x, y, z) => (Expression.eval env x, Expression.eval env y, Expression.eval env z)) := by
-  change ProvableType.eval' (α:=fieldTriple) env t = (match t with
-      | (x, y, z) => (Expression.eval env x, Expression.eval env y, Expression.eval env z))
+  rw [CircuitType.eval_expression]
   simp [circuit_norm, explicit_provable_type]
 
 @[circuit_norm ↓]
@@ -549,7 +630,7 @@ lemma fromElements_eq_iff' {M : TypeMap} [ProvableType M] {F : Type} {B : Vector
 @[circuit_norm]
 theorem eval_const {F : Type} [Field F] {α : TypeMap} [ProvableType α] {env : Environment F} {x : α F} :
     eval env (const x) = x := by
-  change eval' env (const x) = x
+  rw [CircuitType.eval_expression]
   simp only [const, fromVars, explicit_provable_type, toVars]
   rw [toElements_fromElements, Vector.map_map]
   have : Expression.eval env ∘ Expression.const = id := by
@@ -561,14 +642,13 @@ theorem eval_const {F : Type} [Field F] {α : TypeMap} [ProvableType α] {env : 
 theorem eval_const_prover {F : Type} [Field F] {α : TypeMap} [ProvableType α]
     {env : ProverEnvironment F} {x : α F} :
     eval env (const x) = x := by
-  change eval' env.toEnvironment (const x) = x
-  exact eval_const (env:=env.toEnvironment) (x:=x)
+  exact (CircuitType.eval_expression_prover env (const x)).trans (by
+    simpa only [CircuitType.eval_expression] using eval_const (env:=env.toEnvironment) (x:=x))
 
 theorem eval_varFromOffset {α : TypeMap} [ProvableType α] (env : Environment F) (offset : ℕ) :
     (eval env (varFromOffset α offset : α (Expression F)) : α F) =
       fromElements (.mapRange (size α) fun i => env.get (offset + i)) := by
-  change eval' env (varFromOffset α offset) =
-    fromElements (.mapRange (size α) fun i => env.get (offset + i))
+  rw [CircuitType.eval_expression]
   simp only [explicit_provable_type, varFromOffset, toVars, fromVars]
   rw [toElements_fromElements]
   congr
@@ -579,9 +659,8 @@ theorem eval_varFromOffset {α : TypeMap} [ProvableType α] (env : Environment F
 theorem eval_varFromOffset_prover {α : TypeMap} [ProvableType α] (env : ProverEnvironment F) (offset : ℕ) :
     (eval env (varFromOffset α offset : α (Expression F)) : α F) =
       fromElements (.mapRange (size α) fun i => env.get (offset + i)) := by
-  change eval' env.toEnvironment (varFromOffset α offset) =
-    fromElements (.mapRange (size α) fun i => env.get (offset + i))
-  exact eval_varFromOffset (α:=α) env.toEnvironment offset
+  exact (CircuitType.eval_expression_prover env (varFromOffset α offset)).trans (by
+    simpa only [CircuitType.eval_expression] using eval_varFromOffset (α:=α) env.toEnvironment offset)
 
 theorem ext_iff {F : Type} {α : TypeMap} [ProvableType α] (x y : α F) :
     x = y ↔ ∀ i (hi : i < size α), (toElements x)[i] = (toElements y)[i] := by
@@ -596,7 +675,7 @@ theorem ext_iff {F : Type} {α : TypeMap} [ProvableType α] (x y : α F) :
 theorem eval_fromElements {F : Type} [Field F] {α : TypeMap} [ProvableType α] (env : Environment F)
   (xs : Vector (Expression F) (size α)) :
     eval env (fromElements (F:=Expression F) xs : α (Expression F)) = fromElements (xs.map env) := by
-  change eval' env (fromElements (F:=Expression F) xs) = fromElements (xs.map env)
+  rw [CircuitType.eval_expression]
   simp only [explicit_provable_type, toVars, toElements_fromElements]
 
 theorem eval_fromVars {F : Type} [Field F] {α : TypeMap} [ProvableType α] (env : Environment F)
@@ -606,7 +685,7 @@ theorem eval_fromVars {F : Type} [Field F] {α : TypeMap} [ProvableType α] (env
 theorem getElem_eval_toElements {F : Type} [Field F] {α : TypeMap} [ProvableType α]
   {env : Environment F} (x : α (Expression F)) (i : ℕ) (hi : i < size α) :
     Expression.eval env (toElements x)[i] = (toElements (eval env x))[i] := by
-  change Expression.eval env (toElements x)[i] = (toElements (eval' env x))[i]
+  rw [CircuitType.eval_expression]
   rw [eval', toElements_fromElements, Vector.getElem_map, toVars]
 
 theorem getElem_eval_toVars {F : Type} [Field F] {α : TypeMap} [ProvableType α]
@@ -616,7 +695,13 @@ theorem getElem_eval_toVars {F : Type} [Field F] {α : TypeMap} [ProvableType α
 theorem getElem_eval_fields {F : Type} [Field F] {n : ℕ} {env : Environment F}
   (x : fields n (Expression F)) (i : ℕ) (hi : i < n) :
     Expression.eval env x[i] = (eval env x)[i] := by
-  change Expression.eval env x[i] = (eval' env x)[i]
+  rw [CircuitType.eval_expression]
+  simp only [explicit_provable_type, fromElements, instProvableTypeFields, toVars, Vector.getElem_map]
+
+theorem getElem_eval_fields_prover {F : Type} [Field F] {n : ℕ} {env : ProverEnvironment F}
+  (x : fields n (Expression F)) (i : ℕ) (hi : i < n) :
+    Expression.eval env.toEnvironment x[i] = (eval env x)[i] := by
+  rw [CircuitType.eval_expression_prover]
   simp only [explicit_provable_type, fromElements, instProvableTypeFields, toVars, Vector.getElem_map]
 end ProvableType
 
@@ -651,7 +736,11 @@ end CircuitType
 theorem eval_vector (env : Environment F)
   (x : ProvableVector α n (Expression F)) :
     eval env x = x.map (eval env) := by
-  change ProvableType.eval' env x = x.map (fun y => ProvableType.eval' env y)
+  rw [CircuitType.eval_expression]
+  have h_map : x.map (eval env) = x.map (fun y => ProvableType.eval' env y) := by
+    ext i hi
+    simp only [Vector.getElem_map, CircuitType.eval_expression]
+  rw [h_map]
   simp only [explicit_provable_type, toVars, toElements, fromElements]
   simp only [Vector.map_flatten, Vector.map_map]
   rw [Vector.flatten_toChunks]
@@ -774,6 +863,7 @@ theorem eval_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (env : En
   (a : α (Expression F)) (b : β (Expression F)) :
     eval env ((a, b) : ProvablePair α β (Expression F)) =
       (eval env a, eval env b) := by
+  unfold eval
   change ProvableType.eval' (α:=ProvablePair α β) env (a, b) =
     (ProvableType.eval' env a, ProvableType.eval' env b)
   simp only [ProvableType.eval', toVars, toElements, fromElements, Vector.map_append]
@@ -786,10 +876,38 @@ namespace CircuitType
     eval env ((p1, p2) : ProvablePair M N (Expression F)) = (eval env p1, eval env p2) := by
   simp only [circuit_norm]
 
+@[circuit_norm] lemma eval_var_provablePair {M N : TypeMap} [ProvableType M] [ProvableType N]
+    (env : Environment F) (p : Var (ProvablePair M N) F) :
+    eval env p = (eval env (p.1 : M (Expression F)), eval env (p.2 : N (Expression F))) := by
+  exact eval_var_pair env p.1 p.2
+
+@[circuit_norm] lemma eval_provablePair_dispatch {M N : TypeMap} [ProvableType M] [ProvableType N]
+    (env : Environment F) (p : ProvablePair M N (Expression F)) :
+    @eval (Environment F) (ProvablePair M N (Expression F)) (ProvablePair M N F)
+      (verifierEval (ProvablePair M N)) env p =
+      (eval env (p.1 : M (Expression F)), eval env (p.2 : N (Expression F))) := by
+  exact eval_var_pair env p.1 p.2
+
 @[circuit_norm] lemma eval_var_pair_prover {M N : TypeMap} [ProvableType M] [ProvableType N]
     (env : ProverEnvironment F) (p1 : M (Expression F)) (p2 : N (Expression F)) :
     eval env ((p1, p2) : ProvablePair M N (Expression F)) = (eval env p1, eval env p2) := by
-  exact eval_pair (α:=M) (β:=N) env.toEnvironment p1 p2
+  unfold eval
+  change ProvableType.eval' (α:=ProvablePair M N) env.toEnvironment (p1, p2) =
+    (ProvableType.eval' env.toEnvironment p1, ProvableType.eval' env.toEnvironment p2)
+  simp only [ProvableType.eval', toVars, toElements, fromElements, Vector.map_append]
+  rw [Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
+
+@[circuit_norm] lemma eval_var_provablePair_prover {M N : TypeMap} [ProvableType M] [ProvableType N]
+    (env : ProverEnvironment F) (p : Var (ProvablePair M N) F) :
+    eval env p = (eval env (p.1 : M (Expression F)), eval env (p.2 : N (Expression F))) := by
+  exact eval_var_pair_prover env p.1 p.2
+
+@[circuit_norm] lemma eval_provablePair_dispatch_prover {M N : TypeMap} [ProvableType M] [ProvableType N]
+    (env : ProverEnvironment F) (p : ProvablePair M N (Expression F)) :
+    @eval (ProverEnvironment F) (ProvablePair M N (Expression F)) (ProvablePair M N F)
+      (proverEval (ProvablePair M N)) env p =
+      (eval env (p.1 : M (Expression F)), eval env (p.2 : N (Expression F))) := by
+  exact eval_var_pair_prover env p.1 p.2
 
 @[circuit_norm] lemma eval_field_pair (F : Type) [Field F]
   (env : Environment F) (p1 : field (Expression F)) (p2 : field (Expression F)) :
@@ -799,7 +917,7 @@ namespace CircuitType
 @[circuit_norm] lemma eval_field_pair_prover (F : Type) [Field F]
   (env : ProverEnvironment F) (p1 : field (Expression F)) (p2 : field (Expression F)) :
     eval env ((p1, p2) : ProvablePair field field (Expression F)) = (eval env p1, eval env p2) := by
-  exact eval_pair (α:=field) (β:=field) env.toEnvironment p1 p2
+  exact eval_var_pair_prover env p1 p2
 
 end CircuitType
 

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -71,8 +71,8 @@ instance toCircuitType {M : TypeMap} [ProvableType M] : CircuitType M where
   Var F := M (Expression F)
   ProverValue := M
   Value := M
-  evalVerifier env v := eval' env v
-  evalProver env v := eval' env.toEnvironment v
+  evalVerifier env v := ProvableType.eval' env v
+  evalProver env v := ProvableType.eval' env.toEnvironment v
 
 def const (x : M F) : M (Expression F) :=
   let values : Vector F _ := toElements x
@@ -643,7 +643,7 @@ theorem eval_varFromOffset {α : TypeMap} [ProvableType α] (env : Environment F
   simp only [Vector.getElem_map, Vector.getElem_mapRange, Expression.eval]
 
 theorem eval_varFromOffset_prover {α : TypeMap} [ProvableType α] (env : ProverEnvironment F) (offset : ℕ) :
-    (eval env (varFromOffset α offset : α (Expression F)) : α F) =
+    (Eval.eval env (varFromOffset α offset : α (Expression F)) : α F) =
       fromElements (.mapRange (size α) fun i => env.get (offset + i)) := by
   exact (CircuitType.eval_expression_prover env (varFromOffset α offset)).trans (by
     simpa only [CircuitType.eval_expression] using eval_varFromOffset (α:=α) env.toEnvironment offset)
@@ -666,19 +666,19 @@ theorem eval_fromElements {F : Type} [Field F] {α : TypeMap} [ProvableType α] 
 
 theorem getElem_eval_toElements {F : Type} [Field F] {α : TypeMap} [ProvableType α]
   {env : Environment F} (x : α (Expression F)) (i : ℕ) (hi : i < size α) :
-    Expression.eval env (toElements x)[i] = (toElements (eval env x))[i] := by
+    Expression.eval env (toElements x)[i] = (toElements (Eval.eval env x))[i] := by
   rw [CircuitType.eval_expression]
   rw [eval', toElements_fromElements, Vector.getElem_map]
 
 theorem getElem_eval_fields {F : Type} [Field F] {n : ℕ} {env : Environment F}
   (x : fields n (Expression F)) (i : ℕ) (hi : i < n) :
-    Expression.eval env x[i] = (eval env x)[i] := by
+    Expression.eval env x[i] = (Eval.eval env x)[i] := by
   rw [CircuitType.eval_expression]
   simp only [explicit_provable_type, fromElements, instProvableTypeFields, Vector.getElem_map]
 
 theorem getElem_eval_fields_prover {F : Type} [Field F] {n : ℕ} {env : ProverEnvironment F}
   (x : fields n (Expression F)) (i : ℕ) (hi : i < n) :
-    Expression.eval env.toEnvironment x[i] = (eval env x)[i] := by
+    Expression.eval env.toEnvironment x[i] = (Eval.eval env x)[i] := by
   rw [CircuitType.eval_expression_prover]
   simp only [explicit_provable_type, fromElements, instProvableTypeFields, Vector.getElem_map]
 end ProvableType

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -73,11 +73,6 @@ def eval' (env : Environment F) (x : α (Expression F)) : α F :=
   let values := vars.map (Expression.eval env)
   fromElements values
 
-/-- `ProvableType.eval'` is the normal form. This is needed to simplify lookup constraints. -/
-@[circuit_norm]
-theorem fromElements_eval_toElements {env : Environment F} (x : α (Expression F)) :
-  fromElements (Vector.map (Expression.eval env) (toElements x)) = eval' env x := rfl
-
 /--
 Default `CircuitType` for any `ProvableType`: verifier- and prover-value coincide
 with the input type, and `Var` is the usual `α ∘ Expression`.
@@ -135,18 +130,31 @@ namespace CircuitType
 @[circuit_norm] lemma value_of_provableType (F) :
   Value M F = M F := rfl
 
-@[circuit_norm] instance : VerifierEval F (Var M F) (M F) := verifierEval M
-@[circuit_norm] instance : ProverEval F (Var M F) (M F) := proverEval M
-@[circuit_norm] instance : VerifierEval F (M (Expression F)) (M F) := verifierEval M
-@[circuit_norm] instance : ProverEval F (M (Expression F)) (M F) := proverEval M
+instance : VerifierEval F (Var M F) (M F) := verifierEval M
+instance : ProverEval F (Var M F) (M F) := proverEval M
+instance : VerifierEval F (M (Expression F)) (M F) := verifierEval M
+instance : ProverEval F (M (Expression F)) (M F) := proverEval M
 
-@[circuit_norm] lemma eval_var (env : Environment F) (v : M (Expression F)) :
-  eval env v = ProvableType.eval' env v := by simp only [circuit_norm]
+lemma eval_var (env : Environment F) (v : M (Expression F)) :
+    eval env v = ProvableType.eval' env v := rfl
 
-@[circuit_norm] lemma eval_var_prover (env : ProverEnvironment F) (v : M (Expression F)) :
-  eval env v = ProvableType.eval' env v := by simp only [circuit_norm]
+lemma eval_var_prover (env : ProverEnvironment F) (v : M (Expression F)) :
+    eval env v = ProvableType.eval' env.toEnvironment v := rfl
+
+@[circuit_norm] lemma eval_var_prover_to_verifier (env : ProverEnvironment F) (v : M (Expression F)) :
+    eval env v = eval env.toEnvironment v := rfl
 
 end CircuitType
+
+namespace ProvableType
+
+/-- `eval` is the normal form. This is needed to simplify lookup constraints. -/
+@[circuit_norm]
+theorem fromElements_eval_toElements {α : TypeMap} [ProvableType α] {env : Environment F}
+    (x : α (Expression F)) :
+    fromElements (Vector.map (Expression.eval env) (toElements x)) = eval env x := rfl
+
+end ProvableType
 
 @[reducible]
 def unit (_ : Type) := Unit
@@ -187,8 +195,8 @@ instance : HDiv (Var field F) ℕ (Var field F) := inferInstanceAs (HDiv (Expres
 
 namespace CircuitType
 
-@[circuit_norm] instance : VerifierEval F (Expression F) F := verifierEval field
-@[circuit_norm] instance : ProverEval F (Expression F) F := proverEval field
+instance : VerifierEval F (Expression F) F := verifierEval field
+instance : ProverEval F (Expression F) F := proverEval field
 
 end CircuitType
 
@@ -231,20 +239,14 @@ nonempty := Nat.zero_lt_succ n
 
 namespace CircuitType
 
-@[circuit_norm] instance {n : ℕ} : VerifierEval F (Var (fields n) F) (fields n F) :=
+instance {n : ℕ} : VerifierEval F (Var (fields n) F) (fields n F) :=
   verifierEval (fields n)
-@[circuit_norm] instance {n : ℕ} : ProverEval F (Var (fields n) F) (fields n F) :=
+instance {n : ℕ} : ProverEval F (Var (fields n) F) (fields n F) :=
   proverEval (fields n)
-
-@[circuit_norm] lemma eval_fields (F : Type) [Field F] {n : ℕ}
-  (env : Environment F) (xs : fields n (Expression F)) :
-    eval env xs = ProvableType.eval' env xs := by
-  rfl
-
-@[circuit_norm] lemma eval_fields_prover (F : Type) [Field F] {n : ℕ}
-  (env : ProverEnvironment F) (xs : fields n (Expression F)) :
-    eval env xs = ProvableType.eval' env xs := by
-  rfl
+instance {n : ℕ} : VerifierEval F (fields n (Expression F)) (fields n F) :=
+  verifierEval (fields n)
+instance {n : ℕ} : ProverEval F (fields n (Expression F)) (fields n F) :=
+  proverEval (fields n)
 
 end CircuitType
 
@@ -362,10 +364,10 @@ where
   @[circuit_norm]
   go: (cs : List WithProvableType) → ProvableTypeList (Expression F) cs → ProvableTypeList F cs
     | [], .nil => .nil
-    | _ :: cs, .cons a as => .cons (ProvableType.eval' env a) (go cs as)
+    | _ :: cs, .cons a as => .cons (Eval.eval env a) (go cs as)
 
 /--
-`ProvableType.eval'` === `ProvableStruct.eval`
+`eval` === `ProvableStruct.eval`
 
 This gets high priority and is applied before simplifying arguments,
 because we prefer `ProvableStruct.eval` if it's available:
@@ -373,8 +375,9 @@ It preserves high-level components instead of unfolding everything down to field
 -/
 @[circuit_norm ↓ high]
 theorem eval_eq_eval {α : TypeMap} [ProvableStruct α] : ∀ (env : Environment F) (x : α (Expression F)),
-    ProvableType.eval' env x = ProvableStruct.eval env x := by
+    Eval.eval env x = ProvableStruct.eval env x := by
   intro env x
+  change ProvableType.eval' env x = ProvableStruct.eval env x
   symm
   simp only [eval, ProvableType.eval', fromElements, toVars, toElements, size]
   congr 1
@@ -384,7 +387,7 @@ where
     eval.go env cs as = (componentsToElements cs as |> Vector.map (Expression.eval env) |> componentsFromElements cs)
   | [], .nil => rfl
   | c :: cs, .cons a as => by
-    simp only [componentsToElements, componentsFromElements, eval.go, ProvableType.eval', toVars]
+    simp only [componentsToElements, componentsFromElements, eval.go]
     rw [Vector.map_append, Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
     congr
     -- recursively use this lemma!
@@ -437,7 +440,8 @@ variable {α : TypeMap} [ProvableType α]
 
 @[circuit_norm ↓ high]
 theorem eval_field {F : Type} [Field F] (env : Environment F) (x : field (Expression F)) :
-    ProvableType.eval' (α:=field) env x = Expression.eval env x := by
+    eval env x = Expression.eval env x := by
+  change ProvableType.eval' (α:=field) env x = Expression.eval env x
   simp [circuit_norm, explicit_provable_type]
 
 end ProvableType
@@ -446,22 +450,18 @@ namespace CircuitType
 
 @[circuit_norm] lemma eval_expr (env : Environment F) (v : Expression F) :
   eval env v = Expression.eval env v := by
-  change ProvableType.eval' (α:=field) env v = Expression.eval env v
   exact ProvableType.eval_field env v
 
 @[circuit_norm] lemma eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
   eval env v = Expression.eval env v := by
-  change ProvableType.eval' (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
   exact ProvableType.eval_field env.toEnvironment v
 
 @[circuit_norm] lemma eval_var_field (env : Environment F) (v : field (Expression F)) :
   eval env v = Expression.eval env v := by
-  change ProvableType.eval' (α:=field) env v = Expression.eval env v
   exact ProvableType.eval_field env v
 
 @[circuit_norm] lemma eval_var_field_prover (env : ProverEnvironment F) (v : field (Expression F)) :
   eval env v = Expression.eval env v := by
-  change ProvableType.eval' (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
   exact ProvableType.eval_field env.toEnvironment v
 
 end CircuitType
@@ -475,7 +475,8 @@ theorem varFromOffset_field {F} (offset : ℕ) :
 
 @[circuit_norm ↓]
 theorem eval_fields {F : Type} [Field F] (env : Environment F) (x : fields n (Expression F)) :
-  ProvableType.eval' (α:=fields n) env x = x.map (Expression.eval env) := rfl
+  eval env x = x.map (Expression.eval env) := by
+  rfl
 
 @[circuit_norm ↓]
 theorem varFromOffset_fields {F} (offset : ℕ) :
@@ -483,24 +484,28 @@ theorem varFromOffset_fields {F} (offset : ℕ) :
 
 @[circuit_norm ↓]
 theorem eval_fieldPair {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
-    ProvableType.eval' (α:=fieldPair) env t =
+    eval env t =
       (match t with | (x, y) => (Expression.eval env x, Expression.eval env y)) := by
+  change ProvableType.eval' (α:=fieldPair) env t =
+    (match t with | (x, y) => (Expression.eval env x, Expression.eval env y))
   simp [circuit_norm, explicit_provable_type]
 
 @[circuit_norm ↓]
 theorem eval_fieldPair_fst {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
-    (ProvableType.eval' (α:=fieldPair) env t).1 = Expression.eval env t.1 := by
+    (eval env t).1 = Expression.eval env t.1 := by
   simp only [eval_fieldPair]
 
 @[circuit_norm ↓]
 theorem eval_fieldPair_snd {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
-    (ProvableType.eval' (α:=fieldPair) env t).2 = Expression.eval env t.2 := by
+    (eval env t).2 = Expression.eval env t.2 := by
   simp only [eval_fieldPair]
 
 @[circuit_norm ↓]
 theorem eval_fieldTriple {F : Type} [Field F] (env : Environment F) (t : fieldTriple (Expression F)) :
-    ProvableType.eval' (α:=fieldTriple) env t = (match t with
+    eval env t = (match t with
       | (x, y, z) => (Expression.eval env x, Expression.eval env y, Expression.eval env z)) := by
+  change ProvableType.eval' (α:=fieldTriple) env t = (match t with
+      | (x, y, z) => (Expression.eval env x, Expression.eval env y, Expression.eval env z))
   simp [circuit_norm, explicit_provable_type]
 
 @[circuit_norm ↓]
@@ -543,7 +548,8 @@ lemma fromElements_eq_iff' {M : TypeMap} [ProvableType M] {F : Type} {B : Vector
 
 @[circuit_norm]
 theorem eval_const {F : Type} [Field F] {α : TypeMap} [ProvableType α] {env : Environment F} {x : α F} :
-    eval' env (const x) = x := by
+    eval env (const x) = x := by
+  change eval' env (const x) = x
   simp only [const, fromVars, explicit_provable_type, toVars]
   rw [toElements_fromElements, Vector.map_map]
   have : Expression.eval env ∘ Expression.const = id := by
@@ -551,14 +557,31 @@ theorem eval_const {F : Type} [Field F] {α : TypeMap} [ProvableType α] {env : 
     simp only [Function.comp_apply, Expression.eval, id_eq]
   rw [this, Vector.map_id_fun, id_eq, fromElements_toElements]
 
+@[circuit_norm]
+theorem eval_const_prover {F : Type} [Field F] {α : TypeMap} [ProvableType α]
+    {env : ProverEnvironment F} {x : α F} :
+    eval env (const x) = x := by
+  change eval' env.toEnvironment (const x) = x
+  exact eval_const (env:=env.toEnvironment) (x:=x)
+
 theorem eval_varFromOffset {α : TypeMap} [ProvableType α] (env : Environment F) (offset : ℕ) :
-    eval' env (varFromOffset α offset) = fromElements (.mapRange (size α) fun i => env.get (offset + i)) := by
-  simp only [eval', varFromOffset, toVars, fromVars]
+    (eval env (varFromOffset α offset : α (Expression F)) : α F) =
+      fromElements (.mapRange (size α) fun i => env.get (offset + i)) := by
+  change eval' env (varFromOffset α offset) =
+    fromElements (.mapRange (size α) fun i => env.get (offset + i))
+  simp only [explicit_provable_type, varFromOffset, toVars, fromVars]
   rw [toElements_fromElements]
   congr
   rw [Vector.ext_iff]
   intro i hi
   simp only [Vector.getElem_map, Vector.getElem_mapRange, Expression.eval]
+
+theorem eval_varFromOffset_prover {α : TypeMap} [ProvableType α] (env : ProverEnvironment F) (offset : ℕ) :
+    (eval env (varFromOffset α offset : α (Expression F)) : α F) =
+      fromElements (.mapRange (size α) fun i => env.get (offset + i)) := by
+  change eval' env.toEnvironment (varFromOffset α offset) =
+    fromElements (.mapRange (size α) fun i => env.get (offset + i))
+  exact eval_varFromOffset (α:=α) env.toEnvironment offset
 
 theorem ext_iff {F : Type} {α : TypeMap} [ProvableType α] (x y : α F) :
     x = y ↔ ∀ i (hi : i < size α), (toElements x)[i] = (toElements y)[i] := by
@@ -572,26 +595,29 @@ theorem ext_iff {F : Type} {α : TypeMap} [ProvableType α] (x y : α F) :
 
 theorem eval_fromElements {F : Type} [Field F] {α : TypeMap} [ProvableType α] (env : Environment F)
   (xs : Vector (Expression F) (size α)) :
-    eval' (α:=α) env (fromElements (F:=Expression F) xs) = fromElements (xs.map env) := by
-  simp only [eval', toVars, toElements_fromElements]
+    eval env (fromElements (F:=Expression F) xs : α (Expression F)) = fromElements (xs.map env) := by
+  change eval' env (fromElements (F:=Expression F) xs) = fromElements (xs.map env)
+  simp only [explicit_provable_type, toVars, toElements_fromElements]
 
 theorem eval_fromVars {F : Type} [Field F] {α : TypeMap} [ProvableType α] (env : Environment F)
   (xs : Vector (Expression F) (size α)) :
-    eval' (α:=α) env (fromVars xs) = fromElements (xs.map env) := eval_fromElements ..
+    eval env (fromVars xs : α (Expression F)) = fromElements (xs.map env) := eval_fromElements ..
 
 theorem getElem_eval_toElements {F : Type} [Field F] {α : TypeMap} [ProvableType α]
   {env : Environment F} (x : α (Expression F)) (i : ℕ) (hi : i < size α) :
-    Expression.eval env (toElements x)[i] = (toElements (eval' env x))[i] := by
+    Expression.eval env (toElements x)[i] = (toElements (eval env x))[i] := by
+  change Expression.eval env (toElements x)[i] = (toElements (eval' env x))[i]
   rw [eval', toElements_fromElements, Vector.getElem_map, toVars]
 
 theorem getElem_eval_toVars {F : Type} [Field F] {α : TypeMap} [ProvableType α]
   {env : Environment F} (x : α (Expression F)) (i : ℕ) (hi : i < size α) :
-    Expression.eval env (toVars x)[i] = (toElements (eval' env x))[i] := getElem_eval_toElements ..
+    Expression.eval env (toVars x)[i] = (toElements (eval env x))[i] := getElem_eval_toElements ..
 
 theorem getElem_eval_fields {F : Type} [Field F] {n : ℕ} {env : Environment F}
   (x : fields n (Expression F)) (i : ℕ) (hi : i < n) :
-    Expression.eval env x[i] = (eval' env x)[i] := by
-  simp only [eval', fromElements, instProvableTypeFields, toVars, Vector.getElem_map]
+    Expression.eval env x[i] = (eval env x)[i] := by
+  change Expression.eval env x[i] = (eval' env x)[i]
+  simp only [explicit_provable_type, fromElements, instProvableTypeFields, toVars, Vector.getElem_map]
 end ProvableType
 
 -- more concrete ProvableType instances
@@ -613,37 +639,53 @@ instance ProvableVector.instance : ProvableType (ProvableVector α n) where
   toElements_fromElements v := by
     rw [Vector.map_map, ProvableType.toElements_comp_fromElements, Vector.map_id, Vector.toChunks_flatten]
 
+namespace CircuitType
+
+instance : VerifierEval F (ProvableVector α n (Expression F)) (ProvableVector α n F) :=
+  verifierEval (ProvableVector α n)
+instance : ProverEval F (ProvableVector α n (Expression F)) (ProvableVector α n F) :=
+  proverEval (ProvableVector α n)
+
+end CircuitType
+
 theorem eval_vector (env : Environment F)
   (x : ProvableVector α n (Expression F)) :
-    ProvableType.eval' env x = x.map (ProvableType.eval' env) := by
-  simp only [ProvableType.eval', toVars, toElements, fromElements]
+    eval env x = x.map (eval env) := by
+  change ProvableType.eval' env x = x.map (fun y => ProvableType.eval' env y)
+  simp only [explicit_provable_type, toVars, toElements, fromElements]
   simp only [Vector.map_flatten, Vector.map_map]
   rw [Vector.flatten_toChunks]
-  simp [ProvableType.eval', toVars]
+  simp [explicit_provable_type]
 
 theorem getElem_eval_vector (env : Environment F) (x : ProvableVector α n (Expression F)) (i : ℕ) (h : i < n) :
-    (ProvableType.eval' env x[i]) = (ProvableType.eval' env x)[i] := by
+    (eval env x[i]) = (eval env x)[i] := by
   have h' := congrArg (fun xs : Vector (α F) n => xs[i]) (eval_vector env x)
   simpa only [Vector.getElem_map] using h'.symm
 
 lemma eval_vector_eq_get {M : TypeMap} [NonEmptyProvableType M] {n : ℕ} (env : Environment F)
     (vars : Vector (M (Expression F)) n)
     (vals : Vector (M F) n)
-    (h : (ProvableType.eval' env vars : ProvableVector _ _ _) = (vals : ProvableVector _ _ _))
+    (h : (eval env (vars : ProvableVector M n (Expression F)) : ProvableVector M n F) =
+      (vals : ProvableVector M n F))
     (i : ℕ) (h_i : i < n) :
-    ProvableType.eval' env vars[i] = vals[i] := by
+    (eval env (vars[i] : M (Expression F)) : M F) = vals[i] := by
   have h' := congrArg (fun xs : Vector (M F) n => xs[i]) h
   simpa only [eval_vector, Vector.getElem_map] using h'
 
 lemma eval_vector_take {M : TypeMap} [NonEmptyProvableType M] {n : ℕ} (env : Environment F)
     (vars : ProvableVector M n (Expression F)) (i : ℕ) :
-    (ProvableType.eval' env (vars.take i) : ProvableVector _ _ _) = (ProvableType.eval' env vars).take i := by
+    (eval (Value:=ProvableVector M (min i n) F) env
+        (vars.take i : ProvableVector M (min i n) (Expression F)) :
+        ProvableVector M (min i n) F) =
+      (eval env vars).take i := by
   simp only [eval_vector, Vector.take_eq_extract, Vector.map_extract]
 
 lemma eval_vector_takeShort {M : TypeMap} [NonEmptyProvableType M] {n : ℕ} (env : Environment F)
     (vars : ProvableVector M n (Expression F)) (i : ℕ) (h_i : i < n) :
-    (ProvableType.eval' env (vars.takeShort i h_i) : ProvableVector _ _ _) =
-      (ProvableType.eval' env vars).takeShort i h_i := by
+    (eval (Value:=ProvableVector M i F) env
+        (vars.takeShort i h_i : ProvableVector M i (Expression F)) :
+        ProvableVector M i F) =
+      (eval env vars).takeShort i h_i := by
   simp only [Vector.takeShort]
   simp only [eval_vector]
   ext j h_j
@@ -688,21 +730,21 @@ instance ProvablePair.instance {α β: TypeMap} [ProvableType α] [ProvableType 
 
 namespace CircuitType
 
-@[circuit_norm] instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
+instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
     VerifierEval F (Var M F × Var N F) (M F × N F) :=
   verifierEval (ProvablePair M N)
-@[circuit_norm] instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
+instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
     ProverEval F (Var M F × Var N F) (M F × N F) :=
   proverEval (ProvablePair M N)
-@[circuit_norm] instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
+instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
     VerifierEval F (M (Expression F) × N (Expression F)) (M F × N F) :=
   verifierEval (ProvablePair M N)
-@[circuit_norm] instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
+instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
     ProverEval F (M (Expression F) × N (Expression F)) (M F × N F) :=
   proverEval (ProvablePair M N)
-@[circuit_norm] instance : VerifierEval F (Var field F × Var field F) (F × F) :=
+instance : VerifierEval F (Var field F × Var field F) (F × F) :=
   verifierEval (ProvablePair field field)
-@[circuit_norm] instance : ProverEval F (Var field F × Var field F) (F × F) :=
+instance : ProverEval F (Var field F × Var field F) (F × F) :=
   proverEval (ProvablePair field field)
 
 end CircuitType
@@ -730,8 +772,10 @@ def ProvablePair.toElements {α β: TypeMap} [ProvableType α] [ProvableType β]
 @[circuit_norm ↓ high]
 theorem eval_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (env : Environment F)
   (a : α (Expression F)) (b : β (Expression F)) :
-    ProvableType.eval' (α:=ProvablePair α β) env (a, b) =
-      (ProvableType.eval' env a, ProvableType.eval' env b) := by
+    eval env ((a, b) : ProvablePair α β (Expression F)) =
+      (eval env a, eval env b) := by
+  change ProvableType.eval' (α:=ProvablePair α β) env (a, b) =
+    (ProvableType.eval' env a, ProvableType.eval' env b)
   simp only [ProvableType.eval', toVars, toElements, fromElements, Vector.map_append]
   rw [Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
 
@@ -745,21 +789,16 @@ namespace CircuitType
 @[circuit_norm] lemma eval_var_pair_prover {M N : TypeMap} [ProvableType M] [ProvableType N]
     (env : ProverEnvironment F) (p1 : M (Expression F)) (p2 : N (Expression F)) :
     eval env ((p1, p2) : ProvablePair M N (Expression F)) = (eval env p1, eval env p2) := by
-  simp only [circuit_norm]
+  exact eval_pair (α:=M) (β:=N) env.toEnvironment p1 p2
 
 @[circuit_norm] lemma eval_field_pair (F : Type) [Field F]
   (env : Environment F) (p1 : field (Expression F)) (p2 : field (Expression F)) :
     eval env ((p1, p2) : ProvablePair field field (Expression F)) = (eval env p1, eval env p2) := by
-  change ProvableType.eval' (α:=ProvablePair field field) env (p1, p2) =
-    (ProvableType.eval' (α:=field) env p1, ProvableType.eval' (α:=field) env p2)
   exact eval_pair (α:=field) (β:=field) env p1 p2
 
 @[circuit_norm] lemma eval_field_pair_prover (F : Type) [Field F]
   (env : ProverEnvironment F) (p1 : field (Expression F)) (p2 : field (Expression F)) :
     eval env ((p1, p2) : ProvablePair field field (Expression F)) = (eval env p1, eval env p2) := by
-  change ProvableType.eval' (α:=ProvablePair field field) env.toEnvironment (p1, p2) =
-    (ProvableType.eval' (α:=field) env.toEnvironment p1,
-      ProvableType.eval' (α:=field) env.toEnvironment p2)
   exact eval_pair (α:=field) (β:=field) env.toEnvironment p1 p2
 
 end CircuitType
@@ -768,21 +807,21 @@ end CircuitType
 @[circuit_norm ↓ high]
 theorem eval_pair_left_expr {β : TypeMap} [ProvableType β] (env : Environment F)
   (a : Expression F) (b : β (Expression F)) :
-    ProvableType.eval' (α:=ProvablePair field β) env (a, b) =
-      (Expression.eval env a, ProvableType.eval' env b) := by
+    eval env ((a, b) : ProvablePair field β (Expression F)) =
+      (Expression.eval env a, eval env b) := by
   rw [eval_pair (α:=field), ProvableType.eval_field]
 
 @[circuit_norm ↓ high]
 theorem eval_pair_right_expr {α : TypeMap} [ProvableType α] (env : Environment F)
   (a : α (Expression F)) (b : Expression F) :
-    ProvableType.eval' (α:=ProvablePair α field) env (a, b) =
-      (ProvableType.eval' env a, Expression.eval env b) := by
+    eval env ((a, b) : ProvablePair α field (Expression F)) =
+      (eval env a, Expression.eval env b) := by
   rw [eval_pair (β:=field), ProvableType.eval_field]
 
 @[circuit_norm ↓ high]
 theorem eval_pair_both_expr (env : Environment F)
   (a b : Expression F) :
-    ProvableType.eval' (α:=ProvablePair field field) env (a, b) =
+    eval env ((a, b) : ProvablePair field field (Expression F)) =
       (Expression.eval env a, Expression.eval env b) := by
   simp only [eval_pair (α:=field) (β:=field), ProvableType.eval_field]
 
@@ -790,22 +829,23 @@ theorem eval_pair_both_expr (env : Environment F)
 @[circuit_norm ↓ high]
 theorem eval_pair_left_vector_expr {n : ℕ} {β : TypeMap} [ProvableType β] (env : Environment F)
   (a : Vector (Expression F) n) (b : β (Expression F)) :
-    ProvableType.eval' (α:=ProvablePair (fields n) β) env (a, b) =
-      (ProvableType.eval' env a, ProvableType.eval' env b) :=
+    eval env ((a, b) : ProvablePair (fields n) β (Expression F)) =
+      ((eval (Value:=fields n F) env (a : fields n (Expression F)) : fields n F), eval env b) :=
   eval_pair (α:=fields n) env a b
 
 @[circuit_norm ↓ high]
 theorem eval_pair_right_vector_expr {n : ℕ} {α : TypeMap} [ProvableType α] (env : Environment F)
   (a : α (Expression F)) (b : Vector (Expression F) n) :
-    ProvableType.eval' (α:=ProvablePair α (fields n)) env (a, b) =
-      (ProvableType.eval' env a, ProvableType.eval' env b) :=
+    eval env ((a, b) : ProvablePair α (fields n) (Expression F)) =
+      (eval env a, (eval (Value:=fields n F) env (b : fields n (Expression F)) : fields n F)) :=
   eval_pair (β:=fields n) env a b
 
 @[circuit_norm ↓ high]
 theorem eval_pair_both_vector_expr {n m : ℕ} (env : Environment F)
   (a : Vector (Expression F) n) (b : Vector (Expression F) m) :
-    ProvableType.eval' (α:=ProvablePair (fields n) (fields m)) env (a, b) =
-      (ProvableType.eval' env a, ProvableType.eval' env b) :=
+    eval env ((a, b) : ProvablePair (fields n) (fields m) (Expression F)) =
+      ((eval (Value:=fields n F) env (a : fields n (Expression F)) : fields n F),
+        (eval (Value:=fields m F) env (b : fields m (Expression F)) : fields m F)) :=
   eval_pair (α:=fields n) (β:=fields m) env a b
 
 omit [Field F] in

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -121,7 +121,8 @@ def varFromOffset (α : TypeMap) [ProvableType α] (offset : ℕ) : Var α F :=
 attribute [explicit_provable_type] Vector.mapRange_succ Vector.mapRange_zero
 end ProvableType
 
-export ProvableType (eval const varFromOffset)
+export ProvableType (const varFromOffset)
+open ProvableType (eval)
 
 @[reducible]
 def unit (_ : Type) := Unit

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -59,7 +59,7 @@ class NonEmptyProvableType (M : TypeMap) extends ProvableType M where
 
 export ProvableType (size toElements fromElements)
 
-attribute [circuit_norm] size
+attribute [circuit_norm] size ProvableType.toElements_fromElements ProvableType.fromElements_toElements
 -- tagged with low priority to prefer higher-level `ProvableStruct` decompositions
 -- note that this is not added to `circuit_norm`, since in general we won't need or want
 -- to explicitly unfold provable type definitions

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -58,7 +58,6 @@ def toVars (var : M (Expression F)) := toElements var
 def fromVars (vars : Vector (Expression F) (size M)) := fromElements vars
 
 namespace ProvableType
-
 variable {α β γ: TypeMap} [ProvableType α] [ProvableType β] [ProvableType γ]
 
 /--
@@ -86,10 +85,6 @@ instance toCircuitType {α : TypeMap} [ProvableType α] : CircuitType α where
   Value := α
   evalVerifier env v := eval' env v
   evalProver env v := eval' env.toEnvironment v
-
-instance {α : TypeMap} [ProvableType α] {elem : Type} {valid : Var α F → ℕ → Prop}
-    [GetElem (α (Expression F)) ℕ elem valid] : GetElem (Var α F) ℕ elem valid :=
-  inferInstanceAs (GetElem (α (Expression F)) ℕ elem valid)
 
 def const (x : α F) : α (Expression F) :=
   let values : Vector F _ := toElements x
@@ -152,6 +147,10 @@ instance : VerifierEval F (Var M F) (M F) := verifierEval M
 instance : ProverEval F (Var M F) (M F) := proverEval M
 instance : VerifierEval F (M (Expression F)) (M F) := verifierEval M
 @[circuit_norm] instance : ProverEval F (M (Expression F)) (M F) := proverEval M
+
+instance {α : TypeMap} [ProvableType α] {elem : Type} {valid : Var α F → ℕ → Prop}
+    [GetElem (α (Expression F)) ℕ elem valid] : GetElem (Var α F) ℕ elem valid :=
+  inferInstanceAs (GetElem (α (Expression F)) ℕ elem valid)
 
 @[explicit_provable_type] lemma eval_var (env : Environment F) (v : Var M F) :
     eval env v = ProvableType.eval' env (v : M (Expression F)) := by
@@ -821,23 +820,16 @@ instance ProvablePair.instance {α β: TypeMap} [ProvableType α] [ProvableType 
     simp [ProvableType.toElements_fromElements, Vector.cast]
 
 namespace CircuitType
+variable {N : TypeMap} [ProvableType N]
 
-instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
-    VerifierEval F (Var M F × Var N F) (M F × N F) :=
-  verifierEval (ProvablePair M N)
-instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
-    ProverEval F (Var M F × Var N F) (M F × N F) :=
-  proverEval (ProvablePair M N)
-instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
-    VerifierEval F (M (Expression F) × N (Expression F)) (M F × N F) :=
-  verifierEval (ProvablePair M N)
-instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
-    ProverEval F (M (Expression F) × N (Expression F)) (M F × N F) :=
-  proverEval (ProvablePair M N)
-instance : VerifierEval F (Var field F × Var field F) (F × F) :=
-  verifierEval (ProvablePair field field)
-instance : ProverEval F (Var field F × Var field F) (F × F) :=
-  proverEval (ProvablePair field field)
+instance : VerifierEval F (Var M F × Var N F) (M F × N F) := verifierEval (ProvablePair M N)
+instance : ProverEval F (Var M F × Var N F) (M F × N F) := proverEval (ProvablePair M N)
+instance : VerifierEval F (M (Expression F) × N (Expression F)) (M F × N F) := verifierEval (ProvablePair M N)
+instance : ProverEval F (M (Expression F) × N (Expression F)) (M F × N F) := proverEval (ProvablePair M N)
+instance : VerifierEval F (Expression F × Expression F) (F × F) := verifierEval (ProvablePair field field)
+instance : ProverEval F (Expression F × Expression F) (F × F) := proverEval (ProvablePair field field)
+instance : VerifierEval F (Var field F × Var field F) (F × F) := verifierEval (ProvablePair field field)
+instance : ProverEval F (Var field F × Var field F) (F × F) := proverEval (ProvablePair field field)
 
 end CircuitType
 
@@ -864,8 +856,7 @@ def ProvablePair.toElements {α β: TypeMap} [ProvableType α] [ProvableType β]
 @[circuit_norm ↓ high]
 theorem eval_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (env : Environment F)
   (a : α (Expression F)) (b : β (Expression F)) :
-    eval env ((a, b) : ProvablePair α β (Expression F)) =
-      (eval env a, eval env b) := by
+    eval env ((a, b) : ProvablePair α β (Expression F)) = (eval env a, eval env b) := by
   unfold eval
   change ProvableType.eval' (α:=ProvablePair α β) env (a, b) =
     (ProvableType.eval' env a, ProvableType.eval' env b)

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -1,30 +1,14 @@
 import Mathlib.Data.ZMod.Basic
 import Clean.Utils.Vector
-import Clean.Circuit.Expression
+import Clean.Circuit.CircuitType
 import Clean.Circuit.SimpGadget
 
-/--
+/-
 'Provable types' are structured collections of field elements.
 
  We represent them as types generic over a single type argument (the field element),
  i.e. `Type → Type`.
 -/
-@[reducible]
-def TypeMap := Type → Type
-
-/--
-`Var M F` is the type of variables that appear in the monadic notation of
-`Circuit F _`s. Most elements of `Var M F`, especially interesting ones, are not
-constant values of `M F` because variables in a circuit can depend on contents of
-the environment.
-
-An element of `Var M F` represents a `M F` that's polynomially dependent
-on the environment. More concretely, an element of `Var M F` is a value of `M F`
-with missing holes, and each hole contains a polynomial that can refer to fixed
-positions of the environment. Given an environment, `Var M F` can be evaluated
-to a `M F` (see `eval` below).
--/
-@[reducible] def Var (M : TypeMap) (F : Type) := M (Expression F)
 
 variable {F : Type} [Field F]
 
@@ -74,6 +58,7 @@ def toVars (var : M (Expression F)) := toElements var
 def fromVars (vars : Vector (Expression F) (size M)) := fromElements vars
 
 namespace ProvableType
+
 variable {α β γ: TypeMap} [ProvableType α] [ProvableType β] [ProvableType γ]
 
 /--
@@ -83,7 +68,7 @@ Note: this is not tagged with `circuit_norm`, to enable higher-level `ProvableSt
 decompositions. Sometimes you will need to add `explicit_provable_type` to the simp set.
 -/
 @[explicit_provable_type]
-def eval (env : Environment F) (x : Var α F) : α F :=
+def eval (env : Environment F) (x : α (Expression F)) : α F :=
   let vars := toVars x
   let values := vars.map (Expression.eval env)
   fromElements values
@@ -93,7 +78,25 @@ def eval (env : Environment F) (x : Var α F) : α F :=
 theorem fromElements_eval_toElements {env : Environment F} (x : α (Expression F)) :
   fromElements (Vector.map (Expression.eval env) (toElements x)) = eval env x := rfl
 
-def const (x : α F) : Var α F :=
+/--
+Default `CircuitType` for any `ProvableType`: verifier- and prover-value coincide
+with the input type, and `Var` is the usual `α ∘ Expression`.
+
+The instance lives in `Provable.lean`, after `ProvableType` is defined, to keep
+`CircuitType.lean` below `Provable.lean` in the import graph.
+-/
+instance toCircuitType {α : TypeMap} [ProvableType α] : CircuitType α where
+  Var F := α (Expression F)
+  ProverValue := α
+  Value := α
+  evalVerifier env v := eval env v
+  evalProver env v := eval env.toEnvironment v
+
+instance {α : TypeMap} [ProvableType α] {elem : Type} {valid : Var α F → ℕ → Prop}
+    [GetElem (α (Expression F)) ℕ elem valid] : GetElem (Var α F) ℕ elem valid :=
+  inferInstanceAs (GetElem (α (Expression F)) ℕ elem valid)
+
+def const (x : α F) : α (Expression F) :=
   let values : Vector F _ := toElements x
   fromVars (values.map .const)
 
@@ -104,16 +107,16 @@ def synthesizeValue : α F :=
 instance [Field F] : Inhabited (α F) where
   default := synthesizeValue
 
-def synthesizeConstVar : Var α F :=
+def synthesizeConstVar : α (Expression F) :=
   let zeros := Vector.fill (size α) 0
   fromVars (zeros.map .const)
 
-instance [Field F] : Inhabited (Var α F) where
+instance [Field F] : Inhabited (α (Expression F)) where
   default := synthesizeConstVar
 
 -- TODO this should be simply called `var`, analogous to `const`
 @[explicit_provable_type]
-def varFromOffset (α : TypeMap) [ProvableType α] (offset : ℕ) : Var α F :=
+def varFromOffset (α : TypeMap) [ProvableType α] (offset : ℕ) : α (Expression F) :=
   let vars := Vector.mapRange (size α) fun i => var ⟨offset + i⟩
   fromVars vars
 
@@ -123,6 +126,28 @@ end ProvableType
 
 export ProvableType (const varFromOffset)
 open ProvableType (eval)
+
+namespace CircuitType
+
+@[circuit_norm] lemma var_of_provableType (F) :
+  Var M F = M (Expression F) := rfl
+@[circuit_norm] lemma proverValue_of_provableType (F) :
+  ProverValue M F = M F := rfl
+@[circuit_norm] lemma value_of_provableType (F) :
+  Value M F = M F := rfl
+
+@[circuit_norm] instance : VerifierEval F (Var M F) (M F) := verifierEval M
+@[circuit_norm] instance : ProverEval F (Var M F) (M F) := proverEval M
+@[circuit_norm] instance : VerifierEval F (M (Expression F)) (M F) := verifierEval M
+@[circuit_norm] instance : ProverEval F (M (Expression F)) (M F) := proverEval M
+
+@[circuit_norm] lemma eval_var (env : Environment F) (v : M (Expression F)) :
+  eval' env v = ProvableType.eval env v := by simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_var_prover (env : ProverEnvironment F) (v : M (Expression F)) :
+  eval' env v = ProvableType.eval env v := by simp only [circuit_norm]
+
+end CircuitType
 
 @[reducible]
 def unit (_ : Type) := Unit
@@ -142,6 +167,31 @@ instance : ProvableType field where
   toElements x := #v[x]
   fromElements := fun ⟨⟨[x]⟩, _⟩ => x
 instance : NonEmptyProvableType field where
+
+instance : Zero (Var field F) := inferInstanceAs (Zero (Expression F))
+instance : One (Var field F) := inferInstanceAs (One (Expression F))
+instance : Add (Var field F) := inferInstanceAs (Add (Expression F))
+instance : Neg (Var field F) := inferInstanceAs (Neg (Expression F))
+instance : Sub (Var field F) := inferInstanceAs (Sub (Expression F))
+instance : Mul (Var field F) := inferInstanceAs (Mul (Expression F))
+instance : Coe F (Var field F) := inferInstanceAs (Coe F (Expression F))
+instance {n : ℕ} [OfNat F n] : OfNat (Var field F) n := inferInstanceAs (OfNat (Expression F) n)
+instance : HMul F (Var field F) (Var field F) := inferInstanceAs (HMul F (Expression F) (Expression F))
+instance : HAdd (Expression F) (Var field F) (Var field F) := inferInstanceAs (HAdd (Expression F) (Expression F) (Expression F))
+instance : HAdd (Var field F) (Expression F) (Var field F) := inferInstanceAs (HAdd (Expression F) (Expression F) (Expression F))
+instance : HSub (Expression F) (Var field F) (Var field F) := inferInstanceAs (HSub (Expression F) (Expression F) (Expression F))
+instance : HSub (Var field F) (Expression F) (Var field F) := inferInstanceAs (HSub (Expression F) (Expression F) (Expression F))
+instance : HMul (Expression F) (Var field F) (Var field F) := inferInstanceAs (HMul (Expression F) (Expression F) (Expression F))
+instance : HMul (Var field F) (Expression F) (Var field F) := inferInstanceAs (HMul (Expression F) (Expression F) (Expression F))
+instance : HDiv (Var field F) F (Var field F) := inferInstanceAs (HDiv (Expression F) F (Expression F))
+instance : HDiv (Var field F) ℕ (Var field F) := inferInstanceAs (HDiv (Expression F) ℕ (Expression F))
+
+namespace CircuitType
+
+@[circuit_norm] instance : VerifierEval F (Expression F) F := verifierEval field
+@[circuit_norm] instance : ProverEval F (Expression F) F := proverEval field
+
+end CircuitType
 
 @[reducible]
 def ProvablePair (α β : TypeMap) := fun F => α F × β F
@@ -179,6 +229,25 @@ instance : ProvableType (fields n) where
 
 instance {n : ℕ} : NonEmptyProvableType (fields (n + 1)) where
 nonempty := Nat.zero_lt_succ n
+
+namespace CircuitType
+
+@[circuit_norm] instance {n : ℕ} : VerifierEval F (Var (fields n) F) (fields n F) :=
+  verifierEval (fields n)
+@[circuit_norm] instance {n : ℕ} : ProverEval F (Var (fields n) F) (fields n F) :=
+  proverEval (fields n)
+
+@[circuit_norm] lemma eval_fields (F : Type) [Field F] {n : ℕ}
+  (env : Environment F) (xs : fields n (Expression F)) :
+    eval' env xs = ProvableType.eval env xs := by
+  rfl
+
+@[circuit_norm] lemma eval_fields_prover (F : Type) [Field F] {n : ℕ}
+  (env : ProverEnvironment F) (xs : fields n (Expression F)) :
+    eval' env xs = ProvableType.eval env xs := by
+  rfl
+
+end CircuitType
 
 namespace ProvableStruct
 structure WithProvableType where
@@ -304,7 +373,7 @@ because we prefer `ProvableStruct.eval` if it's available:
 It preserves high-level components instead of unfolding everything down to field elements.
 -/
 @[circuit_norm ↓ high]
-theorem eval_eq_eval {α : TypeMap} [ProvableStruct α] : ∀ (env : Environment F) (x : Var α F),
+theorem eval_eq_eval {α : TypeMap} [ProvableStruct α] : ∀ (env : Environment F) (x : α (Expression F)),
     ProvableType.eval env x = ProvableStruct.eval env x := by
   intro env x
   symm
@@ -326,7 +395,7 @@ where
 Alternative `varFromOffset` which creates each component separately.
 -/
 @[circuit_norm]
-def varFromOffset (α : TypeMap) [ProvableStruct α] (offset : ℕ) : Var α F :=
+def varFromOffset (α : TypeMap) [ProvableStruct α] (offset : ℕ) : α (Expression F) :=
   go (components α) offset |> fromComponents (F:=Expression F)
 where
   @[circuit_norm]
@@ -368,40 +437,70 @@ variable {α : TypeMap} [ProvableType α]
 -- resolve `eval` and `varFromOffset` for a few basic types
 
 @[circuit_norm ↓ high]
-theorem eval_field {F : Type} [Field F] (env : Environment F) (x : Var field F) :
-    ProvableType.eval env x = Expression.eval env x := by
+theorem eval_field {F : Type} [Field F] (env : Environment F) (x : field (Expression F)) :
+    ProvableType.eval (α:=field) env x = Expression.eval env x := by
   simp [circuit_norm, explicit_provable_type]
+
+end ProvableType
+
+namespace CircuitType
+
+@[circuit_norm] lemma eval_expr (env : Environment F) (v : Expression F) :
+  eval' env v = Expression.eval env v := by
+  change ProvableType.eval (α:=field) env v = Expression.eval env v
+  exact ProvableType.eval_field env v
+
+@[circuit_norm] lemma eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
+  eval' env v = Expression.eval env v := by
+  change ProvableType.eval (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
+  exact ProvableType.eval_field env.toEnvironment v
+
+@[circuit_norm] lemma eval_var_field (env : Environment F) (v : field (Expression F)) :
+  eval' env v = Expression.eval env v := by
+  change ProvableType.eval (α:=field) env v = Expression.eval env v
+  exact ProvableType.eval_field env v
+
+@[circuit_norm] lemma eval_var_field_prover (env : ProverEnvironment F) (v : field (Expression F)) :
+  eval' env v = Expression.eval env v := by
+  change ProvableType.eval (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
+  exact ProvableType.eval_field env.toEnvironment v
+
+end CircuitType
+
+namespace ProvableType
+variable {α : TypeMap} [ProvableType α]
 
 @[circuit_norm ↓]
 theorem varFromOffset_field {F} (offset : ℕ) :
   varFromOffset (F:=F) field offset = var ⟨offset⟩ := rfl
 
 @[circuit_norm ↓]
-theorem eval_fields {F : Type} [Field F] (env : Environment F) (x : Var (fields n) F) :
-  ProvableType.eval env x = x.map (Expression.eval env) := rfl
+theorem eval_fields {F : Type} [Field F] (env : Environment F) (x : fields n (Expression F)) :
+  ProvableType.eval (α:=fields n) env x = x.map (Expression.eval env) := rfl
 
 @[circuit_norm ↓]
 theorem varFromOffset_fields {F} (offset : ℕ) :
   varFromOffset (F:=F) (fields n) offset = .mapRange n fun i => var ⟨offset + i⟩ := rfl
 
 @[circuit_norm ↓]
-theorem eval_fieldPair {F : Type} [Field F] (env : Environment F) (t : Var fieldPair F) :
-    ProvableType.eval env t = (match t with | (x, y) => (Expression.eval env x, Expression.eval env y)) := by
+theorem eval_fieldPair {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
+    ProvableType.eval (α:=fieldPair) env t =
+      (match t with | (x, y) => (Expression.eval env x, Expression.eval env y)) := by
   simp [circuit_norm, explicit_provable_type]
 
 @[circuit_norm ↓]
-theorem eval_fieldPair_fst {F : Type} [Field F] (env : Environment F) (t : Var fieldPair F) :
-    (ProvableType.eval env t).1 = Expression.eval env t.1 := by
+theorem eval_fieldPair_fst {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
+    (ProvableType.eval (α:=fieldPair) env t).1 = Expression.eval env t.1 := by
   simp only [eval_fieldPair]
 
 @[circuit_norm ↓]
-theorem eval_fieldPair_snd {F : Type} [Field F] (env : Environment F) (t : Var fieldPair F) :
-    (ProvableType.eval env t).2 = Expression.eval env t.2 := by
+theorem eval_fieldPair_snd {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
+    (ProvableType.eval (α:=fieldPair) env t).2 = Expression.eval env t.2 := by
   simp only [eval_fieldPair]
 
 @[circuit_norm ↓]
-theorem eval_fieldTriple {F : Type} [Field F] (env : Environment F) (t : Var fieldTriple F) :
-    ProvableType.eval env t = (match t with
+theorem eval_fieldTriple {F : Type} [Field F] (env : Environment F) (t : fieldTriple (Expression F)) :
+    ProvableType.eval (α:=fieldTriple) env t = (match t with
       | (x, y, z) => (Expression.eval env x, Expression.eval env y, Expression.eval env z)) := by
   simp [circuit_norm, explicit_provable_type]
 
@@ -474,12 +573,12 @@ theorem ext_iff {F : Type} {α : TypeMap} [ProvableType α] (x y : α F) :
 
 theorem eval_fromElements {F : Type} [Field F] {α : TypeMap} [ProvableType α] (env : Environment F)
   (xs : Vector (Expression F) (size α)) :
-    eval env (fromElements (F:=Expression F) xs) = fromElements (xs.map env) := by
+    eval (α:=α) env (fromElements (F:=Expression F) xs) = fromElements (xs.map env) := by
   simp only [eval, toVars, toElements_fromElements]
 
 theorem eval_fromVars {F : Type} [Field F] {α : TypeMap} [ProvableType α] (env : Environment F)
   (xs : Vector (Expression F) (size α)) :
-    eval env (fromVars xs) = fromElements (xs.map env) := eval_fromElements ..
+    eval (α:=α) env (fromVars xs) = fromElements (xs.map env) := eval_fromElements ..
 
 theorem getElem_eval_toElements {F : Type} [Field F] {α : TypeMap} [ProvableType α]
   {env : Environment F} (x : α (Expression F)) (i : ℕ) (hi : i < size α) :
@@ -487,11 +586,11 @@ theorem getElem_eval_toElements {F : Type} [Field F] {α : TypeMap} [ProvableTyp
   rw [eval, toElements_fromElements, Vector.getElem_map, toVars]
 
 theorem getElem_eval_toVars {F : Type} [Field F] {α : TypeMap} [ProvableType α]
-  {env : Environment F} (x : Var α F) (i : ℕ) (hi : i < size α) :
+  {env : Environment F} (x : α (Expression F)) (i : ℕ) (hi : i < size α) :
     Expression.eval env (toVars x)[i] = (toElements (eval env x))[i] := getElem_eval_toElements ..
 
 theorem getElem_eval_fields {F : Type} [Field F] {n : ℕ} {env : Environment F}
-  (x : Var (fields n) F) (i : ℕ) (hi : i < n) :
+  (x : fields n (Expression F)) (i : ℕ) (hi : i < n) :
     Expression.eval env x[i] = (eval env x)[i] := by
   simp only [eval, fromElements, instProvableTypeFields, toVars, Vector.getElem_map]
 end ProvableType
@@ -516,34 +615,34 @@ instance ProvableVector.instance : ProvableType (ProvableVector α n) where
     rw [Vector.map_map, ProvableType.toElements_comp_fromElements, Vector.map_id, Vector.toChunks_flatten]
 
 theorem eval_vector (env : Environment F)
-  (x : Var (ProvableVector α n) F) :
+  (x : ProvableVector α n (Expression F)) :
     eval env x = x.map (eval env) := by
   simp only [eval, toVars, toElements, fromElements]
   simp only [Vector.map_flatten, Vector.map_map]
   rw [Vector.flatten_toChunks]
   simp [eval, toVars]
 
-theorem getElem_eval_vector (env : Environment F) (x : Var (ProvableVector α n) F) (i : ℕ) (h : i < n) :
+theorem getElem_eval_vector (env : Environment F) (x : ProvableVector α n (Expression F)) (i : ℕ) (h : i < n) :
     (eval env x[i]) = (eval env x)[i] := by
-  rw [eval_vector, Vector.getElem_map]
+  have h' := congrArg (fun xs : Vector (α F) n => xs[i]) (eval_vector env x)
+  simpa only [Vector.getElem_map] using h'.symm
 
 lemma eval_vector_eq_get {M : TypeMap} [NonEmptyProvableType M] {n : ℕ} (env : Environment F)
-    (vars : Vector (Var M F) n)
+    (vars : Vector (M (Expression F)) n)
     (vals : Vector (M F) n)
     (h : (eval env vars : ProvableVector _ _ _) = (vals : ProvableVector _ _ _))
     (i : ℕ) (h_i : i < n) :
     eval env vars[i] = vals[i] := by
-  rw [← h]
-  rw [eval_vector]
-  rw [Vector.getElem_map]
+  have h' := congrArg (fun xs : Vector (M F) n => xs[i]) h
+  simpa only [eval_vector, Vector.getElem_map] using h'
 
 lemma eval_vector_take {M : TypeMap} [NonEmptyProvableType M] {n : ℕ} (env : Environment F)
-    (vars : Var (ProvableVector M n) F) (i : ℕ) :
+    (vars : ProvableVector M n (Expression F)) (i : ℕ) :
     (eval env (vars.take i) : ProvableVector _ _ _) = (eval env vars).take i := by
   simp only [eval_vector, Vector.take_eq_extract, Vector.map_extract]
 
 lemma eval_vector_takeShort {M : TypeMap} [NonEmptyProvableType M] {n : ℕ} (env : Environment F)
-    (vars : Var (ProvableVector M n) F) (i : ℕ) (h_i : i < n) :
+    (vars : ProvableVector M n (Expression F)) (i : ℕ) (h_i : i < n) :
     (eval env (vars.takeShort i h_i) : ProvableVector _ _ _) = (eval env vars).takeShort i h_i := by
   simp only [Vector.takeShort]
   simp only [eval_vector]
@@ -554,7 +653,10 @@ theorem varFromOffset_vector {F : Type} [Field F] {α : TypeMap} [NonEmptyProvab
     varFromOffset (F:=F) (ProvableVector α n) offset
     = .mapRange n fun i => varFromOffset α (offset + (size α)*i) := by
   induction n with
-  | zero => simp [Vector.mapRange_zero]
+  | zero =>
+    rw [Vector.ext_iff]
+    intro i hi
+    omega
   | succ n ih =>
     rw [Vector.mapRange_succ, ←ih]
     simp only [varFromOffset, fromVars, fromElements, size]
@@ -584,6 +686,27 @@ instance ProvablePair.instance {α β: TypeMap} [ProvableType α] [ProvableType 
   toElements_fromElements v := by
     simp [ProvableType.toElements_fromElements, Vector.cast]
 
+namespace CircuitType
+
+@[circuit_norm] instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
+    VerifierEval F (Var M F × Var N F) (M F × N F) :=
+  verifierEval (ProvablePair M N)
+@[circuit_norm] instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
+    ProverEval F (Var M F × Var N F) (M F × N F) :=
+  proverEval (ProvablePair M N)
+@[circuit_norm] instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
+    VerifierEval F (M (Expression F) × N (Expression F)) (M F × N F) :=
+  verifierEval (ProvablePair M N)
+@[circuit_norm] instance {M N : TypeMap} [ProvableType M] [ProvableType N] :
+    ProverEval F (M (Expression F) × N (Expression F)) (M F × N F) :=
+  proverEval (ProvablePair M N)
+@[circuit_norm] instance : VerifierEval F (Var field F × Var field F) (F × F) :=
+  verifierEval (ProvablePair field field)
+@[circuit_norm] instance : ProverEval F (Var field F × Var field F) (F × F) :=
+  proverEval (ProvablePair field field)
+
+end CircuitType
+
 instance {α β: TypeMap} [NonEmptyProvableType α] [ProvableType β] :
   NonEmptyProvableType (ProvablePair α β) where
   nonempty := by
@@ -606,21 +729,50 @@ def ProvablePair.toElements {α β: TypeMap} [ProvableType α] [ProvableType β]
 
 @[circuit_norm ↓ high]
 theorem eval_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (env : Environment F)
-  (a : Var α F) (b : Var β F) :
+  (a : α (Expression F)) (b : β (Expression F)) :
     eval (α:=ProvablePair α β) env (a, b) = (eval env a, eval env b) := by
   simp only [eval, toVars, toElements, fromElements, Vector.map_append]
   rw [Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
 
+namespace CircuitType
+
+@[circuit_norm] lemma eval_var_pair {M N : TypeMap} [ProvableType M] [ProvableType N]
+    (env : Environment F) (p1 : M (Expression F)) (p2 : N (Expression F)) :
+    eval' env ((p1, p2) : ProvablePair M N (Expression F)) = (eval' env p1, eval' env p2) := by
+  simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_var_pair_prover {M N : TypeMap} [ProvableType M] [ProvableType N]
+    (env : ProverEnvironment F) (p1 : M (Expression F)) (p2 : N (Expression F)) :
+    eval' env ((p1, p2) : ProvablePair M N (Expression F)) = (eval' env p1, eval' env p2) := by
+  simp only [circuit_norm]
+
+@[circuit_norm] lemma eval_field_pair (F : Type) [Field F]
+  (env : Environment F) (p1 : field (Expression F)) (p2 : field (Expression F)) :
+    eval' env ((p1, p2) : ProvablePair field field (Expression F)) = (eval' env p1, eval' env p2) := by
+  change ProvableType.eval (α:=ProvablePair field field) env (p1, p2) =
+    (ProvableType.eval (α:=field) env p1, ProvableType.eval (α:=field) env p2)
+  exact eval_pair (α:=field) (β:=field) env p1 p2
+
+@[circuit_norm] lemma eval_field_pair_prover (F : Type) [Field F]
+  (env : ProverEnvironment F) (p1 : field (Expression F)) (p2 : field (Expression F)) :
+    eval' env ((p1, p2) : ProvablePair field field (Expression F)) = (eval' env p1, eval' env p2) := by
+  change ProvableType.eval (α:=ProvablePair field field) env.toEnvironment (p1, p2) =
+    (ProvableType.eval (α:=field) env.toEnvironment p1,
+      ProvableType.eval (α:=field) env.toEnvironment p2)
+  exact eval_pair (α:=field) (β:=field) env.toEnvironment p1 p2
+
+end CircuitType
+
 -- Specialized lemmas for Expression F to handle type inference issues
 @[circuit_norm ↓ high]
 theorem eval_pair_left_expr {β : TypeMap} [ProvableType β] (env : Environment F)
-  (a : Expression F) (b : Var β F) :
+  (a : Expression F) (b : β (Expression F)) :
     eval (α:=ProvablePair field β) env (a, b) = (Expression.eval env a, eval env b) := by
   rw [eval_pair (α:=field), ProvableType.eval_field]
 
 @[circuit_norm ↓ high]
 theorem eval_pair_right_expr {α : TypeMap} [ProvableType α] (env : Environment F)
-  (a : Var α F) (b : Expression F) :
+  (a : α (Expression F)) (b : Expression F) :
     eval (α:=ProvablePair α field) env (a, b) = (eval env a, Expression.eval env b) := by
   rw [eval_pair (β:=field), ProvableType.eval_field]
 
@@ -633,13 +785,13 @@ theorem eval_pair_both_expr (env : Environment F)
 -- Specialized lemmas for Vector (Expression F) to handle type inference issues with vectors
 @[circuit_norm ↓ high]
 theorem eval_pair_left_vector_expr {n : ℕ} {β : TypeMap} [ProvableType β] (env : Environment F)
-  (a : Vector (Expression F) n) (b : Var β F) :
+  (a : Vector (Expression F) n) (b : β (Expression F)) :
     eval (α:=ProvablePair (fields n) β) env (a, b) = (eval env a, eval env b) :=
   eval_pair (α:=fields n) env a b
 
 @[circuit_norm ↓ high]
 theorem eval_pair_right_vector_expr {n : ℕ} {α : TypeMap} [ProvableType α] (env : Environment F)
-  (a : Var α F) (b : Vector (Expression F) n) :
+  (a : α (Expression F)) (b : Vector (Expression F) n) :
     eval (α:=ProvablePair α (fields n)) env (a, b) = (eval env a, eval env b) :=
   eval_pair (β:=fields n) env a b
 

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -55,7 +55,7 @@ Note: this is not tagged with `circuit_norm`, to enable higher-level `ProvableSt
 decompositions. Sometimes you will need to add `explicit_provable_type` to the simp set.
 -/
 @[explicit_provable_type]
-def eval' (env : Environment F) (x : M (Expression F)) : M F :=
+def eval (env : Environment F) (x : M (Expression F)) : M F :=
   let vars := toElements x
   let values := vars.map (Expression.eval env)
   fromElements values
@@ -71,8 +71,8 @@ instance toCircuitType {M : TypeMap} [ProvableType M] : CircuitType M where
   Var F := M (Expression F)
   ProverValue := M
   Value := M
-  evalVerifier env v := ProvableType.eval' env v
-  evalProver env v := ProvableType.eval' env.toEnvironment v
+  evalVerifier env v := ProvableType.eval env v
+  evalProver env v := ProvableType.eval env.toEnvironment v
 
 def const (x : M F) : M (Expression F) :=
   let values : Vector F _ := toElements x
@@ -137,12 +137,12 @@ instance {α : TypeMap} [ProvableType α] {elem : Type} {valid : Var α F → �
   inferInstanceAs (GetElem (α (Expression F)) ℕ elem valid)
 
 @[explicit_provable_type] lemma eval_var (env : Environment F) (v : Var M F) :
-    eval env v = ProvableType.eval' env (v : M (Expression F)) := by
+    eval env v = ProvableType.eval env (v : M (Expression F)) := by
   unfold eval
   rfl
 
 @[explicit_provable_type] lemma eval_var_prover (env : ProverEnvironment F) (v : Var M F) :
-    eval env v = ProvableType.eval' env.toEnvironment (v : M (Expression F)) := by
+    eval env v = ProvableType.eval env.toEnvironment (v : M (Expression F)) := by
   unfold eval
   rfl
 
@@ -151,11 +151,11 @@ instance {α : TypeMap} [ProvableType α] {elem : Type} {valid : Var α F → �
   rw [eval_var_prover, eval_var]
 
 @[explicit_provable_type] lemma eval_expression (env : Environment F) (v : M (Expression F)) :
-    eval env v = ProvableType.eval' env v := by
+    eval env v = ProvableType.eval env v := by
   rw [eval_var]
 
 @[explicit_provable_type] lemma eval_expression_prover (env : ProverEnvironment F) (v : M (Expression F)) :
-    eval env v = ProvableType.eval' env.toEnvironment v := by
+    eval env v = ProvableType.eval env.toEnvironment v := by
   rw [eval_var_prover]
 
 @[circuit_norm] lemma eval_expression_prover_to_verifier (env : ProverEnvironment F) (v : M (Expression F)) :
@@ -278,7 +278,7 @@ instance {n : ℕ} : ProverEval F (fields n (Expression F)) (fields n F) :=
 @[circuit_norm] lemma eval_var_fields {n : ℕ} (env : Environment F) (x : Var (fields n) F) :
     eval env x = (x : fields n (Expression F)).map (Expression.eval env) := by
   unfold eval
-  change ProvableType.eval' (M:=fields n) env x =
+  change ProvableType.eval (M:=fields n) env x =
     (x : fields n (Expression F)).map (Expression.eval env)
   rfl
 
@@ -291,7 +291,7 @@ instance {n : ℕ} : ProverEval F (fields n (Expression F)) (fields n F) :=
 @[circuit_norm] lemma eval_var_fields_prover {n : ℕ} (env : ProverEnvironment F) (x : Var (fields n) F) :
     eval env x = (x : fields n (Expression F)).map (Expression.eval env.toEnvironment) := by
   unfold eval
-  change ProvableType.eval' (M:=fields n) env.toEnvironment x =
+  change ProvableType.eval (M:=fields n) env.toEnvironment x =
     (x : fields n (Expression F)).map (Expression.eval env.toEnvironment)
   rfl
 
@@ -433,7 +433,7 @@ theorem eval_eq_eval {α : TypeMap} [ProvableStruct α] : ∀ (env : Environment
   intro env x
   rw [CircuitType.eval_expression]
   symm
-  simp only [eval, ProvableType.eval', fromElements, toElements, size]
+  simp only [eval, ProvableType.eval, fromElements, toElements, size]
   congr 1
   apply eval_eq_eval_aux
 where
@@ -517,8 +517,8 @@ namespace CircuitType
 @[circuit_norm] lemma eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
   Eval.eval env v = Expression.eval env v := by
   unfold Eval.eval
-  change ProvableType.eval' (M:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
-  simp [ProvableType.eval', toElements, fromElements]
+  change ProvableType.eval (M:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
+  simp [ProvableType.eval, toElements, fromElements]
 
 @[circuit_norm] lemma eval_var_field (env : Environment F) (v : field (Expression F)) :
   Eval.eval env v = Expression.eval env v := by
@@ -527,8 +527,8 @@ namespace CircuitType
 @[circuit_norm] lemma eval_var_field_prover (env : ProverEnvironment F) (v : field (Expression F)) :
   Eval.eval env v = Expression.eval env v := by
   unfold Eval.eval
-  change ProvableType.eval' (M:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
-  simp [ProvableType.eval', toElements, fromElements]
+  change ProvableType.eval (M:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
+  simp [ProvableType.eval, toElements, fromElements]
 
 end CircuitType
 
@@ -668,7 +668,7 @@ theorem getElem_eval_toElements {F : Type} [Field F] {α : TypeMap} [ProvableTyp
   {env : Environment F} (x : α (Expression F)) (i : ℕ) (hi : i < size α) :
     Expression.eval env (toElements x)[i] = (toElements (Eval.eval env x))[i] := by
   rw [CircuitType.eval_expression]
-  rw [eval', toElements_fromElements, Vector.getElem_map]
+  rw [eval, toElements_fromElements, Vector.getElem_map]
 
 theorem getElem_eval_fields {F : Type} [Field F] {n : ℕ} {env : Environment F}
   (x : fields n (Expression F)) (i : ℕ) (hi : i < n) :
@@ -715,7 +715,7 @@ theorem eval_vector (env : Environment F)
   (x : ProvableVector α n (Expression F)) :
     eval env x = x.map (eval env) := by
   rw [CircuitType.eval_expression]
-  have h_map : x.map (eval env) = x.map (fun y => ProvableType.eval' env y) := by
+  have h_map : x.map (eval env) = x.map (fun y => ProvableType.eval env y) := by
     ext i hi
     simp only [Vector.getElem_map, CircuitType.eval_expression]
   rw [h_map]
@@ -834,9 +834,9 @@ theorem eval_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (env : En
   (a : α (Expression F)) (b : β (Expression F)) :
     eval env ((a, b) : ProvablePair α β (Expression F)) = (eval env a, eval env b) := by
   unfold eval
-  change ProvableType.eval' (M:=ProvablePair α β) env (a, b) =
-    (ProvableType.eval' env a, ProvableType.eval' env b)
-  simp only [ProvableType.eval', toElements, fromElements, Vector.map_append]
+  change ProvableType.eval (M:=ProvablePair α β) env (a, b) =
+    (ProvableType.eval env a, ProvableType.eval env b)
+  simp only [ProvableType.eval, toElements, fromElements, Vector.map_append]
   rw [Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
 
 namespace CircuitType
@@ -862,9 +862,9 @@ namespace CircuitType
     (env : ProverEnvironment F) (p1 : M (Expression F)) (p2 : N (Expression F)) :
     eval env ((p1, p2) : ProvablePair M N (Expression F)) = (eval env p1, eval env p2) := by
   unfold eval
-  change ProvableType.eval' (M:=ProvablePair M N) env.toEnvironment (p1, p2) =
-    (ProvableType.eval' env.toEnvironment p1, ProvableType.eval' env.toEnvironment p2)
-  simp only [ProvableType.eval', toElements, fromElements, Vector.map_append]
+  change ProvableType.eval (M:=ProvablePair M N) env.toEnvironment (p1, p2) =
+    (ProvableType.eval env.toEnvironment p1, ProvableType.eval env.toEnvironment p2)
+  simp only [ProvableType.eval, toElements, fromElements, Vector.map_append]
   rw [Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
 
 @[circuit_norm] lemma eval_var_provablePair_prover {M N : TypeMap} [ProvableType M] [ProvableType N]

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -68,15 +68,15 @@ Note: this is not tagged with `circuit_norm`, to enable higher-level `ProvableSt
 decompositions. Sometimes you will need to add `explicit_provable_type` to the simp set.
 -/
 @[explicit_provable_type]
-def eval (env : Environment F) (x : α (Expression F)) : α F :=
+def eval' (env : Environment F) (x : α (Expression F)) : α F :=
   let vars := toVars x
   let values := vars.map (Expression.eval env)
   fromElements values
 
-/-- `ProvableType.eval` is the normal form. This is needed to simplify lookup constraints. -/
+/-- `ProvableType.eval'` is the normal form. This is needed to simplify lookup constraints. -/
 @[circuit_norm]
 theorem fromElements_eval_toElements {env : Environment F} (x : α (Expression F)) :
-  fromElements (Vector.map (Expression.eval env) (toElements x)) = eval env x := rfl
+  fromElements (Vector.map (Expression.eval env) (toElements x)) = eval' env x := rfl
 
 /--
 Default `CircuitType` for any `ProvableType`: verifier- and prover-value coincide
@@ -89,8 +89,8 @@ instance toCircuitType {α : TypeMap} [ProvableType α] : CircuitType α where
   Var F := α (Expression F)
   ProverValue := α
   Value := α
-  evalVerifier env v := eval env v
-  evalProver env v := eval env.toEnvironment v
+  evalVerifier env v := eval' env v
+  evalProver env v := eval' env.toEnvironment v
 
 instance {α : TypeMap} [ProvableType α] {elem : Type} {valid : Var α F → ℕ → Prop}
     [GetElem (α (Expression F)) ℕ elem valid] : GetElem (Var α F) ℕ elem valid :=
@@ -141,10 +141,10 @@ namespace CircuitType
 @[circuit_norm] instance : ProverEval F (M (Expression F)) (M F) := proverEval M
 
 @[circuit_norm] lemma eval_var (env : Environment F) (v : M (Expression F)) :
-  eval env v = ProvableType.eval env v := by simp only [circuit_norm]
+  eval env v = ProvableType.eval' env v := by simp only [circuit_norm]
 
 @[circuit_norm] lemma eval_var_prover (env : ProverEnvironment F) (v : M (Expression F)) :
-  eval env v = ProvableType.eval env v := by simp only [circuit_norm]
+  eval env v = ProvableType.eval' env v := by simp only [circuit_norm]
 
 end CircuitType
 
@@ -238,12 +238,12 @@ namespace CircuitType
 
 @[circuit_norm] lemma eval_fields (F : Type) [Field F] {n : ℕ}
   (env : Environment F) (xs : fields n (Expression F)) :
-    eval env xs = ProvableType.eval env xs := by
+    eval env xs = ProvableType.eval' env xs := by
   rfl
 
 @[circuit_norm] lemma eval_fields_prover (F : Type) [Field F] {n : ℕ}
   (env : ProverEnvironment F) (xs : fields n (Expression F)) :
-    eval env xs = ProvableType.eval env xs := by
+    eval env xs = ProvableType.eval' env xs := by
   rfl
 
 end CircuitType
@@ -362,10 +362,10 @@ where
   @[circuit_norm]
   go: (cs : List WithProvableType) → ProvableTypeList (Expression F) cs → ProvableTypeList F cs
     | [], .nil => .nil
-    | _ :: cs, .cons a as => .cons (ProvableType.eval env a) (go cs as)
+    | _ :: cs, .cons a as => .cons (ProvableType.eval' env a) (go cs as)
 
 /--
-`ProvableType.eval` === `ProvableStruct.eval`
+`ProvableType.eval'` === `ProvableStruct.eval`
 
 This gets high priority and is applied before simplifying arguments,
 because we prefer `ProvableStruct.eval` if it's available:
@@ -373,10 +373,10 @@ It preserves high-level components instead of unfolding everything down to field
 -/
 @[circuit_norm ↓ high]
 theorem eval_eq_eval {α : TypeMap} [ProvableStruct α] : ∀ (env : Environment F) (x : α (Expression F)),
-    ProvableType.eval env x = ProvableStruct.eval env x := by
+    ProvableType.eval' env x = ProvableStruct.eval env x := by
   intro env x
   symm
-  simp only [eval, ProvableType.eval, fromElements, toVars, toElements, size]
+  simp only [eval, ProvableType.eval', fromElements, toVars, toElements, size]
   congr 1
   apply eval_eq_eval_aux
 where
@@ -384,7 +384,7 @@ where
     eval.go env cs as = (componentsToElements cs as |> Vector.map (Expression.eval env) |> componentsFromElements cs)
   | [], .nil => rfl
   | c :: cs, .cons a as => by
-    simp only [componentsToElements, componentsFromElements, eval.go, ProvableType.eval, toVars]
+    simp only [componentsToElements, componentsFromElements, eval.go, ProvableType.eval', toVars]
     rw [Vector.map_append, Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
     congr
     -- recursively use this lemma!
@@ -437,7 +437,7 @@ variable {α : TypeMap} [ProvableType α]
 
 @[circuit_norm ↓ high]
 theorem eval_field {F : Type} [Field F] (env : Environment F) (x : field (Expression F)) :
-    ProvableType.eval (α:=field) env x = Expression.eval env x := by
+    ProvableType.eval' (α:=field) env x = Expression.eval env x := by
   simp [circuit_norm, explicit_provable_type]
 
 end ProvableType
@@ -446,22 +446,22 @@ namespace CircuitType
 
 @[circuit_norm] lemma eval_expr (env : Environment F) (v : Expression F) :
   eval env v = Expression.eval env v := by
-  change ProvableType.eval (α:=field) env v = Expression.eval env v
+  change ProvableType.eval' (α:=field) env v = Expression.eval env v
   exact ProvableType.eval_field env v
 
 @[circuit_norm] lemma eval_expr_prover (env : ProverEnvironment F) (v : Expression F) :
   eval env v = Expression.eval env v := by
-  change ProvableType.eval (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
+  change ProvableType.eval' (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
   exact ProvableType.eval_field env.toEnvironment v
 
 @[circuit_norm] lemma eval_var_field (env : Environment F) (v : field (Expression F)) :
   eval env v = Expression.eval env v := by
-  change ProvableType.eval (α:=field) env v = Expression.eval env v
+  change ProvableType.eval' (α:=field) env v = Expression.eval env v
   exact ProvableType.eval_field env v
 
 @[circuit_norm] lemma eval_var_field_prover (env : ProverEnvironment F) (v : field (Expression F)) :
   eval env v = Expression.eval env v := by
-  change ProvableType.eval (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
+  change ProvableType.eval' (α:=field) env.toEnvironment v = Expression.eval env.toEnvironment v
   exact ProvableType.eval_field env.toEnvironment v
 
 end CircuitType
@@ -475,7 +475,7 @@ theorem varFromOffset_field {F} (offset : ℕ) :
 
 @[circuit_norm ↓]
 theorem eval_fields {F : Type} [Field F] (env : Environment F) (x : fields n (Expression F)) :
-  ProvableType.eval (α:=fields n) env x = x.map (Expression.eval env) := rfl
+  ProvableType.eval' (α:=fields n) env x = x.map (Expression.eval env) := rfl
 
 @[circuit_norm ↓]
 theorem varFromOffset_fields {F} (offset : ℕ) :
@@ -483,23 +483,23 @@ theorem varFromOffset_fields {F} (offset : ℕ) :
 
 @[circuit_norm ↓]
 theorem eval_fieldPair {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
-    ProvableType.eval (α:=fieldPair) env t =
+    ProvableType.eval' (α:=fieldPair) env t =
       (match t with | (x, y) => (Expression.eval env x, Expression.eval env y)) := by
   simp [circuit_norm, explicit_provable_type]
 
 @[circuit_norm ↓]
 theorem eval_fieldPair_fst {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
-    (ProvableType.eval (α:=fieldPair) env t).1 = Expression.eval env t.1 := by
+    (ProvableType.eval' (α:=fieldPair) env t).1 = Expression.eval env t.1 := by
   simp only [eval_fieldPair]
 
 @[circuit_norm ↓]
 theorem eval_fieldPair_snd {F : Type} [Field F] (env : Environment F) (t : fieldPair (Expression F)) :
-    (ProvableType.eval (α:=fieldPair) env t).2 = Expression.eval env t.2 := by
+    (ProvableType.eval' (α:=fieldPair) env t).2 = Expression.eval env t.2 := by
   simp only [eval_fieldPair]
 
 @[circuit_norm ↓]
 theorem eval_fieldTriple {F : Type} [Field F] (env : Environment F) (t : fieldTriple (Expression F)) :
-    ProvableType.eval (α:=fieldTriple) env t = (match t with
+    ProvableType.eval' (α:=fieldTriple) env t = (match t with
       | (x, y, z) => (Expression.eval env x, Expression.eval env y, Expression.eval env z)) := by
   simp [circuit_norm, explicit_provable_type]
 
@@ -543,7 +543,7 @@ lemma fromElements_eq_iff' {M : TypeMap} [ProvableType M] {F : Type} {B : Vector
 
 @[circuit_norm]
 theorem eval_const {F : Type} [Field F] {α : TypeMap} [ProvableType α] {env : Environment F} {x : α F} :
-    eval env (const x) = x := by
+    eval' env (const x) = x := by
   simp only [const, fromVars, explicit_provable_type, toVars]
   rw [toElements_fromElements, Vector.map_map]
   have : Expression.eval env ∘ Expression.const = id := by
@@ -552,8 +552,8 @@ theorem eval_const {F : Type} [Field F] {α : TypeMap} [ProvableType α] {env : 
   rw [this, Vector.map_id_fun, id_eq, fromElements_toElements]
 
 theorem eval_varFromOffset {α : TypeMap} [ProvableType α] (env : Environment F) (offset : ℕ) :
-    eval env (varFromOffset α offset) = fromElements (.mapRange (size α) fun i => env.get (offset + i)) := by
-  simp only [eval, varFromOffset, toVars, fromVars]
+    eval' env (varFromOffset α offset) = fromElements (.mapRange (size α) fun i => env.get (offset + i)) := by
+  simp only [eval', varFromOffset, toVars, fromVars]
   rw [toElements_fromElements]
   congr
   rw [Vector.ext_iff]
@@ -572,26 +572,26 @@ theorem ext_iff {F : Type} {α : TypeMap} [ProvableType α] (x y : α F) :
 
 theorem eval_fromElements {F : Type} [Field F] {α : TypeMap} [ProvableType α] (env : Environment F)
   (xs : Vector (Expression F) (size α)) :
-    eval (α:=α) env (fromElements (F:=Expression F) xs) = fromElements (xs.map env) := by
-  simp only [eval, toVars, toElements_fromElements]
+    eval' (α:=α) env (fromElements (F:=Expression F) xs) = fromElements (xs.map env) := by
+  simp only [eval', toVars, toElements_fromElements]
 
 theorem eval_fromVars {F : Type} [Field F] {α : TypeMap} [ProvableType α] (env : Environment F)
   (xs : Vector (Expression F) (size α)) :
-    eval (α:=α) env (fromVars xs) = fromElements (xs.map env) := eval_fromElements ..
+    eval' (α:=α) env (fromVars xs) = fromElements (xs.map env) := eval_fromElements ..
 
 theorem getElem_eval_toElements {F : Type} [Field F] {α : TypeMap} [ProvableType α]
   {env : Environment F} (x : α (Expression F)) (i : ℕ) (hi : i < size α) :
-    Expression.eval env (toElements x)[i] = (toElements (eval env x))[i] := by
-  rw [eval, toElements_fromElements, Vector.getElem_map, toVars]
+    Expression.eval env (toElements x)[i] = (toElements (eval' env x))[i] := by
+  rw [eval', toElements_fromElements, Vector.getElem_map, toVars]
 
 theorem getElem_eval_toVars {F : Type} [Field F] {α : TypeMap} [ProvableType α]
   {env : Environment F} (x : α (Expression F)) (i : ℕ) (hi : i < size α) :
-    Expression.eval env (toVars x)[i] = (toElements (eval env x))[i] := getElem_eval_toElements ..
+    Expression.eval env (toVars x)[i] = (toElements (eval' env x))[i] := getElem_eval_toElements ..
 
 theorem getElem_eval_fields {F : Type} [Field F] {n : ℕ} {env : Environment F}
   (x : fields n (Expression F)) (i : ℕ) (hi : i < n) :
-    Expression.eval env x[i] = (eval env x)[i] := by
-  simp only [eval, fromElements, instProvableTypeFields, toVars, Vector.getElem_map]
+    Expression.eval env x[i] = (eval' env x)[i] := by
+  simp only [eval', fromElements, instProvableTypeFields, toVars, Vector.getElem_map]
 end ProvableType
 
 -- more concrete ProvableType instances
@@ -615,35 +615,35 @@ instance ProvableVector.instance : ProvableType (ProvableVector α n) where
 
 theorem eval_vector (env : Environment F)
   (x : ProvableVector α n (Expression F)) :
-    ProvableType.eval env x = x.map (ProvableType.eval env) := by
-  simp only [ProvableType.eval, toVars, toElements, fromElements]
+    ProvableType.eval' env x = x.map (ProvableType.eval' env) := by
+  simp only [ProvableType.eval', toVars, toElements, fromElements]
   simp only [Vector.map_flatten, Vector.map_map]
   rw [Vector.flatten_toChunks]
-  simp [ProvableType.eval, toVars]
+  simp [ProvableType.eval', toVars]
 
 theorem getElem_eval_vector (env : Environment F) (x : ProvableVector α n (Expression F)) (i : ℕ) (h : i < n) :
-    (ProvableType.eval env x[i]) = (ProvableType.eval env x)[i] := by
+    (ProvableType.eval' env x[i]) = (ProvableType.eval' env x)[i] := by
   have h' := congrArg (fun xs : Vector (α F) n => xs[i]) (eval_vector env x)
   simpa only [Vector.getElem_map] using h'.symm
 
 lemma eval_vector_eq_get {M : TypeMap} [NonEmptyProvableType M] {n : ℕ} (env : Environment F)
     (vars : Vector (M (Expression F)) n)
     (vals : Vector (M F) n)
-    (h : (ProvableType.eval env vars : ProvableVector _ _ _) = (vals : ProvableVector _ _ _))
+    (h : (ProvableType.eval' env vars : ProvableVector _ _ _) = (vals : ProvableVector _ _ _))
     (i : ℕ) (h_i : i < n) :
-    ProvableType.eval env vars[i] = vals[i] := by
+    ProvableType.eval' env vars[i] = vals[i] := by
   have h' := congrArg (fun xs : Vector (M F) n => xs[i]) h
   simpa only [eval_vector, Vector.getElem_map] using h'
 
 lemma eval_vector_take {M : TypeMap} [NonEmptyProvableType M] {n : ℕ} (env : Environment F)
     (vars : ProvableVector M n (Expression F)) (i : ℕ) :
-    (ProvableType.eval env (vars.take i) : ProvableVector _ _ _) = (ProvableType.eval env vars).take i := by
+    (ProvableType.eval' env (vars.take i) : ProvableVector _ _ _) = (ProvableType.eval' env vars).take i := by
   simp only [eval_vector, Vector.take_eq_extract, Vector.map_extract]
 
 lemma eval_vector_takeShort {M : TypeMap} [NonEmptyProvableType M] {n : ℕ} (env : Environment F)
     (vars : ProvableVector M n (Expression F)) (i : ℕ) (h_i : i < n) :
-    (ProvableType.eval env (vars.takeShort i h_i) : ProvableVector _ _ _) =
-      (ProvableType.eval env vars).takeShort i h_i := by
+    (ProvableType.eval' env (vars.takeShort i h_i) : ProvableVector _ _ _) =
+      (ProvableType.eval' env vars).takeShort i h_i := by
   simp only [Vector.takeShort]
   simp only [eval_vector]
   ext j h_j
@@ -730,9 +730,9 @@ def ProvablePair.toElements {α β: TypeMap} [ProvableType α] [ProvableType β]
 @[circuit_norm ↓ high]
 theorem eval_pair {α β: TypeMap} [ProvableType α] [ProvableType β] (env : Environment F)
   (a : α (Expression F)) (b : β (Expression F)) :
-    ProvableType.eval (α:=ProvablePair α β) env (a, b) =
-      (ProvableType.eval env a, ProvableType.eval env b) := by
-  simp only [ProvableType.eval, toVars, toElements, fromElements, Vector.map_append]
+    ProvableType.eval' (α:=ProvablePair α β) env (a, b) =
+      (ProvableType.eval' env a, ProvableType.eval' env b) := by
+  simp only [ProvableType.eval', toVars, toElements, fromElements, Vector.map_append]
   rw [Vector.cast_take_append_of_eq_length, Vector.cast_drop_append_of_eq_length]
 
 namespace CircuitType
@@ -750,16 +750,16 @@ namespace CircuitType
 @[circuit_norm] lemma eval_field_pair (F : Type) [Field F]
   (env : Environment F) (p1 : field (Expression F)) (p2 : field (Expression F)) :
     eval env ((p1, p2) : ProvablePair field field (Expression F)) = (eval env p1, eval env p2) := by
-  change ProvableType.eval (α:=ProvablePair field field) env (p1, p2) =
-    (ProvableType.eval (α:=field) env p1, ProvableType.eval (α:=field) env p2)
+  change ProvableType.eval' (α:=ProvablePair field field) env (p1, p2) =
+    (ProvableType.eval' (α:=field) env p1, ProvableType.eval' (α:=field) env p2)
   exact eval_pair (α:=field) (β:=field) env p1 p2
 
 @[circuit_norm] lemma eval_field_pair_prover (F : Type) [Field F]
   (env : ProverEnvironment F) (p1 : field (Expression F)) (p2 : field (Expression F)) :
     eval env ((p1, p2) : ProvablePair field field (Expression F)) = (eval env p1, eval env p2) := by
-  change ProvableType.eval (α:=ProvablePair field field) env.toEnvironment (p1, p2) =
-    (ProvableType.eval (α:=field) env.toEnvironment p1,
-      ProvableType.eval (α:=field) env.toEnvironment p2)
+  change ProvableType.eval' (α:=ProvablePair field field) env.toEnvironment (p1, p2) =
+    (ProvableType.eval' (α:=field) env.toEnvironment p1,
+      ProvableType.eval' (α:=field) env.toEnvironment p2)
   exact eval_pair (α:=field) (β:=field) env.toEnvironment p1 p2
 
 end CircuitType
@@ -768,21 +768,21 @@ end CircuitType
 @[circuit_norm ↓ high]
 theorem eval_pair_left_expr {β : TypeMap} [ProvableType β] (env : Environment F)
   (a : Expression F) (b : β (Expression F)) :
-    ProvableType.eval (α:=ProvablePair field β) env (a, b) =
-      (Expression.eval env a, ProvableType.eval env b) := by
+    ProvableType.eval' (α:=ProvablePair field β) env (a, b) =
+      (Expression.eval env a, ProvableType.eval' env b) := by
   rw [eval_pair (α:=field), ProvableType.eval_field]
 
 @[circuit_norm ↓ high]
 theorem eval_pair_right_expr {α : TypeMap} [ProvableType α] (env : Environment F)
   (a : α (Expression F)) (b : Expression F) :
-    ProvableType.eval (α:=ProvablePair α field) env (a, b) =
-      (ProvableType.eval env a, Expression.eval env b) := by
+    ProvableType.eval' (α:=ProvablePair α field) env (a, b) =
+      (ProvableType.eval' env a, Expression.eval env b) := by
   rw [eval_pair (β:=field), ProvableType.eval_field]
 
 @[circuit_norm ↓ high]
 theorem eval_pair_both_expr (env : Environment F)
   (a b : Expression F) :
-    ProvableType.eval (α:=ProvablePair field field) env (a, b) =
+    ProvableType.eval' (α:=ProvablePair field field) env (a, b) =
       (Expression.eval env a, Expression.eval env b) := by
   simp only [eval_pair (α:=field) (β:=field), ProvableType.eval_field]
 
@@ -790,22 +790,22 @@ theorem eval_pair_both_expr (env : Environment F)
 @[circuit_norm ↓ high]
 theorem eval_pair_left_vector_expr {n : ℕ} {β : TypeMap} [ProvableType β] (env : Environment F)
   (a : Vector (Expression F) n) (b : β (Expression F)) :
-    ProvableType.eval (α:=ProvablePair (fields n) β) env (a, b) =
-      (ProvableType.eval env a, ProvableType.eval env b) :=
+    ProvableType.eval' (α:=ProvablePair (fields n) β) env (a, b) =
+      (ProvableType.eval' env a, ProvableType.eval' env b) :=
   eval_pair (α:=fields n) env a b
 
 @[circuit_norm ↓ high]
 theorem eval_pair_right_vector_expr {n : ℕ} {α : TypeMap} [ProvableType α] (env : Environment F)
   (a : α (Expression F)) (b : Vector (Expression F) n) :
-    ProvableType.eval (α:=ProvablePair α (fields n)) env (a, b) =
-      (ProvableType.eval env a, ProvableType.eval env b) :=
+    ProvableType.eval' (α:=ProvablePair α (fields n)) env (a, b) =
+      (ProvableType.eval' env a, ProvableType.eval' env b) :=
   eval_pair (β:=fields n) env a b
 
 @[circuit_norm ↓ high]
 theorem eval_pair_both_vector_expr {n m : ℕ} (env : Environment F)
   (a : Vector (Expression F) n) (b : Vector (Expression F) m) :
-    ProvableType.eval (α:=ProvablePair (fields n) (fields m)) env (a, b) =
-      (ProvableType.eval env a, ProvableType.eval env b) :=
+    ProvableType.eval' (α:=ProvablePair (fields n) (fields m)) env (a, b) =
+      (ProvableType.eval' env a, ProvableType.eval' env b) :=
   eval_pair (α:=fields n) (β:=fields m) env a b
 
 omit [Field F] in

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -127,6 +127,7 @@ def FormalCircuit.toSubcircuit (circuit : FormalCircuit F β α)
       -- by completeness, the constraints hold
       have h_holds := completeness env h_env as
       -- by soundness, this implies the spec
+      simp only [circuit_norm] at as ⊢
       exact soundness env h_holds as
 
     localLength_eq := by

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -198,8 +198,8 @@ def FormalAssertion.toSubcircuit (circuit : FormalAssertion F β)
 /--
 Theorem and implementation that allows us to take a general formal circuit and use it as a subcircuit.
 -/
-def GeneralFormalCircuit.toSubcircuit [CircuitType α] [CircuitType β]
-    (circuit : GeneralFormalCircuit F β α)
+def GeneralFormalCircuit.WithHint.toSubcircuit [CircuitType α] [CircuitType β]
+    (circuit : GeneralFormalCircuit.WithHint F β α)
     (n : ℕ) (input_var : CircuitType.Var β F) : Subcircuit F n :=
   let ops := circuit.main input_var |>.operations n
   let nestedOps : NestedOperations F := .nested ⟨ circuit.name, ops.toNested ⟩
@@ -264,6 +264,15 @@ def GeneralFormalCircuit.toSubcircuit [CircuitType α] [CircuitType β]
       rw [ops.toNested_toFlat, ← circuit.localLength_eq input_var n,
         FlatOperation.localLength_toFlat]
   }
+
+/--
+Theorem and implementation that allows us to take a pure general formal circuit
+and use it as a subcircuit. The implementation delegates to the hint-aware
+variant through the default `ProvableType.toCircuitType` instance.
+-/
+def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
+    (n : ℕ) (input_var : Var β F) : Subcircuit F n :=
+  circuit.toWithHint.toSubcircuit n input_var
 end
 
 /-- Include a subcircuit. -/
@@ -283,8 +292,17 @@ def assertion (circuit : FormalAssertion F β) (b : Var β F) : Circuit F Unit :
 
 /-- Include a general subcircuit. -/
 @[circuit_norm]
-def subcircuitWithAssertion [CircuitType α] [CircuitType β]
-    (circuit : GeneralFormalCircuit F β α) (b : CircuitType.Var β F) :
+def subcircuitWithAssertion (circuit : GeneralFormalCircuit F β α) (b : Var β F) :
+    Circuit F (Var α F) :=
+  fun offset =>
+    let a := circuit.output b offset
+    let subcircuit := circuit.toSubcircuit offset b
+    (a, [.subcircuit subcircuit])
+
+/-- Include a hint-aware general subcircuit. -/
+@[circuit_norm]
+def subcircuitWithHintAssertion [CircuitType α] [CircuitType β]
+    (circuit : GeneralFormalCircuit.WithHint F β α) (b : CircuitType.Var β F) :
     Circuit F (CircuitType.Var α F) :=
   fun offset =>
     let a := circuit.output b offset
@@ -299,9 +317,13 @@ instance : CoeFun (FormalCircuit F β α) (fun _ => Var β F → Circuit F (Var 
 instance : CoeFun (FormalAssertion F β) (fun _ => Var β F → Circuit F Unit) where
   coe circuit input := assertion circuit input
 
-instance [CircuitType α] [CircuitType β] :
-    CoeFun (GeneralFormalCircuit F β α) (fun _ => CircuitType.Var β F → Circuit F (CircuitType.Var α F)) where
+instance :
+    CoeFun (GeneralFormalCircuit F β α) (fun _ => Var β F → Circuit F (Var α F)) where
   coe circuit input := subcircuitWithAssertion circuit input
+
+instance [CircuitType α] [CircuitType β] :
+    CoeFun (GeneralFormalCircuit.WithHint F β α) (fun _ => CircuitType.Var β F → Circuit F (CircuitType.Var α F)) where
+  coe circuit input := subcircuitWithHintAssertion circuit input
 
 namespace Circuit
 variable {α β: TypeMap} [ProvableType α] [ProvableType β]
@@ -313,9 +335,13 @@ lemma subcircuit_localLength_eq (circuit : FormalCircuit F β α) (input : Var �
 lemma assertion_localLength_eq (circuit : FormalAssertion F β) (input : Var β F) (offset : ℕ) :
   (circuit.toSubcircuit offset input).localLength = circuit.localLength input := rfl
 
+lemma subcircuitWithAssertion_localLength_eq
+    (circuit : GeneralFormalCircuit F β α) (input : Var β F) (offset : ℕ) :
+    (circuit.toSubcircuit offset input).localLength = circuit.localLength input := rfl
+
 omit [ProvableType α] [ProvableType β] in
-lemma subcircuitWithAssertion_localLength_eq [CircuitType α] [CircuitType β]
-    (circuit : GeneralFormalCircuit F β α) (input : CircuitType.Var β F) (offset : ℕ) :
+lemma subcircuitWithHintAssertion_localLength_eq [CircuitType α] [CircuitType β]
+    (circuit : GeneralFormalCircuit.WithHint F β α) (input : CircuitType.Var β F) (offset : ℕ) :
     (circuit.toSubcircuit offset input).localLength = circuit.localLength input := rfl
 end Circuit
 
@@ -391,7 +417,7 @@ theorem Circuit.subcircuit_computableWitnesses (circuit : FormalCircuit F β α)
 
 -- to reduce offsets, `circuit_norm` will use these theorems to unfold subcircuits
 attribute [circuit_norm] Circuit.subcircuit_localLength_eq Circuit.assertion_localLength_eq
-  Circuit.subcircuitWithAssertion_localLength_eq
+  Circuit.subcircuitWithAssertion_localLength_eq Circuit.subcircuitWithHintAssertion_localLength_eq
 
 -- Simplification lemmas for toSubcircuit.UsesLocalWitnesses
 
@@ -407,12 +433,12 @@ theorem FormalCircuit.toSubcircuit_usesLocalWitnesses
   rfl
 
 /--
-Simplifies UsesLocalWitnesses for GeneralFormalCircuit.toSubcircuit to avoid unfolding the entire subcircuit structure.
+Simplifies UsesLocalWitnesses for GeneralFormalCircuit.WithHint.toSubcircuit to avoid unfolding the entire subcircuit structure.
 -/
 @[circuit_norm]
-theorem GeneralFormalCircuit.toSubcircuit_usesLocalWitnesses
+theorem GeneralFormalCircuit.WithHint.toSubcircuit_usesLocalWitnesses
     {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
-    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ)
+    (circuit : GeneralFormalCircuit.WithHint F Input Output) (n : ℕ)
     (input_var : CircuitType.Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverSpec env =
     (circuit.ProverAssumptions (eval' env input_var) env.data env.hint →
@@ -421,6 +447,22 @@ theorem GeneralFormalCircuit.toSubcircuit_usesLocalWitnesses
           (eval' env.toEnvironment (circuit.output input_var n)) env.data)
       ∧ circuit.ProverSpec (eval' env input_var) (eval' env (circuit.output input_var n)) env.hint) := by
   rfl
+
+/--
+Simplifies UsesLocalWitnesses for GeneralFormalCircuit.toSubcircuit to avoid unfolding the entire subcircuit structure.
+-/
+@[circuit_norm]
+theorem GeneralFormalCircuit.toSubcircuit_usesLocalWitnesses
+    {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
+    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
+    (circuit.toSubcircuit n input_var).ProverSpec env =
+    (circuit.ProverAssumptions (eval' env input_var) env.data env.hint →
+      (circuit.Assumptions (eval' env input_var) env.data →
+        circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)) env.data)
+      ∧ circuit.ProverSpec (eval' env input_var) (eval' env (circuit.output input_var n)) env.hint) := by
+  simp only [GeneralFormalCircuit.toSubcircuit, GeneralFormalCircuit.toWithHint,
+    GeneralFormalCircuit.WithHint.toSubcircuit_usesLocalWitnesses, ElaboratedCircuit.toGeneral,
+    CircuitType.eval_var, CircuitType.eval_var_prover]
 
 /--
 Simplifies UsesLocalWitnesses for FormalAssertion.toSubcircuit to avoid unfolding the entire subcircuit structure.
@@ -445,13 +487,23 @@ theorem FormalCircuit.toSubcircuit_localLength
   rfl
 
 /--
+Simplifies localLength for GeneralFormalCircuit.WithHint.toSubcircuit to avoid unfolding the entire subcircuit structure.
+-/
+@[circuit_norm]
+theorem GeneralFormalCircuit.WithHint.toSubcircuit_localLength
+    {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
+    (circuit : GeneralFormalCircuit.WithHint F Input Output) (n : ℕ)
+    (input_var : CircuitType.Var Input F) :
+    (circuit.toSubcircuit n input_var).localLength = circuit.localLength input_var := by
+  rfl
+
+/--
 Simplifies localLength for GeneralFormalCircuit.toSubcircuit to avoid unfolding the entire subcircuit structure.
 -/
 @[circuit_norm]
 theorem GeneralFormalCircuit.toSubcircuit_localLength
-    {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
-    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ)
-    (input_var : CircuitType.Var Input F) :
+    {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
+    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) :
     (circuit.toSubcircuit n input_var).localLength = circuit.localLength input_var := by
   rfl
 
@@ -479,13 +531,25 @@ theorem FormalCircuit.toSubcircuit_soundness
   rfl
 
 /--
+Simplifies Soundness for GeneralFormalCircuit.WithHint.toSubcircuit to avoid unfolding the entire subcircuit structure.
+-/
+@[circuit_norm]
+theorem GeneralFormalCircuit.WithHint.toSubcircuit_soundness
+    {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
+    (circuit : GeneralFormalCircuit.WithHint F Input Output) (n : ℕ)
+    (input_var : CircuitType.Var Input F) (env : Environment F) :
+    (circuit.toSubcircuit n input_var).Spec env =
+    (circuit.Assumptions (eval' env input_var) env.data →
+      circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)) env.data) := by
+  rfl
+
+/--
 Simplifies Soundness for GeneralFormalCircuit.toSubcircuit to avoid unfolding the entire subcircuit structure.
 -/
 @[circuit_norm]
 theorem GeneralFormalCircuit.toSubcircuit_soundness
-    {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
-    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ)
-    (input_var : CircuitType.Var Input F) (env : Environment F) :
+    {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
+    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : Environment F) :
     (circuit.toSubcircuit n input_var).Spec env =
     (circuit.Assumptions (eval' env input_var) env.data →
       circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)) env.data) := by
@@ -516,13 +580,24 @@ theorem FormalCircuit.toSubcircuit_completeness
   rfl
 
 /--
+Simplifies Completeness for GeneralFormalCircuit.WithHint.toSubcircuit to avoid unfolding the entire subcircuit structure.
+-/
+@[circuit_norm]
+theorem GeneralFormalCircuit.WithHint.toSubcircuit_completeness
+    {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
+    (circuit : GeneralFormalCircuit.WithHint F Input Output) (n : ℕ)
+    (input_var : CircuitType.Var Input F) (env : ProverEnvironment F) :
+    (circuit.toSubcircuit n input_var).ProverAssumptions env =
+    circuit.ProverAssumptions (eval' env input_var) env.data env.hint := by
+  rfl
+
+/--
 Simplifies Completeness for GeneralFormalCircuit.toSubcircuit to avoid unfolding the entire subcircuit structure.
 -/
 @[circuit_norm]
 theorem GeneralFormalCircuit.toSubcircuit_completeness
-    {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
-    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ)
-    (input_var : CircuitType.Var Input F) (env : ProverEnvironment F) :
+    {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
+    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverAssumptions env =
     circuit.ProverAssumptions (eval' env input_var) env.data env.hint := by
   rfl

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -71,8 +71,8 @@ def FormalCircuit.toSubcircuit (circuit : FormalCircuit F β α)
   have h_consistent : ops.SubcircuitsConsistent n := circuit.subcircuitsConsistent input_var n
 
   have soundness : ∀ env : Environment F,
-    let input := eval env input_var
-    let output := eval env (circuit.output input_var n)
+    let input := eval' env input_var
+    let output := eval' env (circuit.output input_var n)
     ConstraintsHoldFlat env nestedOps.toFlat → circuit.Assumptions input → circuit.Spec input output := by
     -- we are given an environment where the constraints hold, and can assume the assumptions are true
     intro env input output h_holds (as : circuit.Assumptions input)
@@ -90,10 +90,10 @@ def FormalCircuit.toSubcircuit (circuit : FormalCircuit F β α)
 
   have completeness : ∀ env : ProverEnvironment F,
       env.ExtendsVector (FlatOperation.localWitnesses env nestedOps.toFlat) n →
-      circuit.Assumptions (eval env input_var) → ConstraintsHoldFlat env nestedOps.toFlat := by
+      circuit.Assumptions (eval' env input_var) → ConstraintsHoldFlat env nestedOps.toFlat := by
     -- we are given that the assumptions are true
     intro env h_env
-    let input := eval env input_var
+    let input := eval' env input_var
     intro (as : circuit.Assumptions input)
     rw [ops.toNested_toFlat] at h_env ⊢
 
@@ -112,11 +112,11 @@ def FormalCircuit.toSubcircuit (circuit : FormalCircuit F β α)
 
   {
     ops := nestedOps,
-    Spec env := circuit.Assumptions (eval env input_var) →
-      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)),
-    ProverAssumptions env := circuit.Assumptions (eval env input_var),
-    ProverSpec env := circuit.Assumptions (eval env input_var) →
-      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)),
+    Spec env := circuit.Assumptions (eval' env input_var) →
+      circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)),
+    ProverAssumptions env := circuit.Assumptions (eval' env input_var),
+    ProverSpec env := circuit.Assumptions (eval' env input_var) →
+      circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)),
     localLength := circuit.localLength input_var
 
     soundness
@@ -145,15 +145,15 @@ def FormalAssertion.toSubcircuit (circuit : FormalAssertion F β)
 
   {
     ops := nestedOps,
-    Spec env := circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var),
-    ProverAssumptions env := circuit.Assumptions (eval env input_var) ∧ circuit.Spec (eval env input_var),
+    Spec env := circuit.Assumptions (eval' env input_var) → circuit.Spec (eval' env input_var),
+    ProverAssumptions env := circuit.Assumptions (eval' env input_var) ∧ circuit.Spec (eval' env input_var),
     ProverSpec _ := True,
     localLength := circuit.localLength input_var
 
     soundness := by
       -- we are given an environment where the constraints hold, and can assume the assumptions are true
       intro env h_holds
-      let input : β F := eval env input_var
+      let input : β F := eval' env input_var
       rintro (as : circuit.Assumptions input)
       show circuit.Spec input
       rw [ops.toNested_toFlat] at h_holds
@@ -173,7 +173,7 @@ def FormalAssertion.toSubcircuit (circuit : FormalAssertion F β)
       simp only [and_true]
       intro assumptions
 
-      let input := eval env input_var
+      let input := eval' env input_var
       have as : circuit.Assumptions input ∧ circuit.Spec input := assumptions
       rw [ops.toNested_toFlat] at h_env ⊢
 
@@ -206,8 +206,8 @@ def GeneralFormalCircuit.toSubcircuit [CircuitType α] [CircuitType β]
   have h_consistent : ops.SubcircuitsConsistent n := circuit.subcircuitsConsistent input_var n
 
   have soundness : ∀ env : Environment F,
-      let input := eval env input_var
-      let output := eval env (circuit.output input_var n)
+      let input := eval' env input_var
+      let output := eval' env (circuit.output input_var n)
       ConstraintsHoldFlat env nestedOps.toFlat →
       circuit.Assumptions input env.data →
       circuit.Spec input output env.data := by
@@ -219,10 +219,10 @@ def GeneralFormalCircuit.toSubcircuit [CircuitType α] [CircuitType β]
 
   have implied_by_assumptions : ∀ env : ProverEnvironment F,
       env.ExtendsVector (FlatOperation.localWitnesses env nestedOps.toFlat) n →
-      circuit.ProverAssumptions (eval env input_var) env.data env.hint →
+      circuit.ProverAssumptions (eval' env input_var) env.data env.hint →
       ConstraintsHoldFlat env nestedOps.toFlat := by
     intro env h_env assumptions
-    set input := eval env input_var
+    set input := eval' env input_var
     rw [ops.toNested_toFlat] at h_env ⊢
     rw [←env.usesLocalWitnessesFlat_iff_extends, ←env.usesLocalWitnesses_iff_flat] at h_env
     rw [constraintsHold_toFlat_iff]
@@ -233,17 +233,17 @@ def GeneralFormalCircuit.toSubcircuit [CircuitType α] [CircuitType β]
   {
     ops := nestedOps,
 
-    Spec env := circuit.Assumptions (eval env input_var) env.data →
-      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data,
+    Spec env := circuit.Assumptions (eval' env input_var) env.data →
+      circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)) env.data,
 
-    ProverAssumptions env := circuit.ProverAssumptions (eval env input_var) env.data env.hint,
+    ProverAssumptions env := circuit.ProverAssumptions (eval' env input_var) env.data env.hint,
 
     ProverSpec env :=
-      circuit.ProverAssumptions (eval env input_var) env.data env.hint →
-      (circuit.Assumptions (eval env.toEnvironment input_var) env.data →
-        circuit.Spec (eval env.toEnvironment input_var)
-          (eval env.toEnvironment (circuit.output input_var n)) env.data)
-      ∧ circuit.ProverSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint,
+      circuit.ProverAssumptions (eval' env input_var) env.data env.hint →
+      (circuit.Assumptions (eval' env.toEnvironment input_var) env.data →
+        circuit.Spec (eval' env.toEnvironment input_var)
+          (eval' env.toEnvironment (circuit.output input_var n)) env.data)
+      ∧ circuit.ProverSpec (eval' env input_var) (eval' env (circuit.output input_var n)) env.hint,
 
     localLength := circuit.localLength input_var
 
@@ -328,7 +328,7 @@ only contains variables below the current offset `n`.
  -/
 def ComputableWitnesses' (circuit : ElaboratedCircuit F β α) : Prop :=
   ∀ (n : ℕ) (input : Var β F),
-    ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval · input) →
+    ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval' · input) →
       (circuit.main input).ComputableWitnesses n
 
 /--
@@ -339,7 +339,7 @@ def ComputableWitnesses (circuit : ElaboratedCircuit F β α) : Prop :=
   ∀ (n : ℕ) (input : Var β F) (env env' : ProverEnvironment F),
   circuit.main input |>.operations n |>.forAllFlat n {
     witness n _ compute :=
-      env.AgreesBelow n env' → eval env input = eval env' input → compute env = compute env' }
+      env.AgreesBelow n env' → eval' env input = eval' env' input → compute env = compute env' }
 
 /--
 `ComputableWitnesses` is stronger than `ComputableWitnesses'` (so it's fine to only prove the former).
@@ -373,7 +373,7 @@ then we can conclude that the subcircuit, evaluated at this particular input,
 satisfies `ComputableWitnesses` in the original sense.
 -/
 theorem compose_computableWitnesses (circuit : ElaboratedCircuit F β α) (input : Var β F) (n : ℕ) :
-  ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval · input) ∧ circuit.ComputableWitnesses →
+  ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval' · input) ∧ circuit.ComputableWitnesses →
     (circuit.main input).ComputableWitnesses n := by
   intro ⟨ h_input, h_computable ⟩
   apply ElaboratedCircuit.computableWitnesses_implies h_computable
@@ -382,7 +382,7 @@ end ElaboratedCircuit
 
 theorem Circuit.subcircuit_computableWitnesses (circuit : FormalCircuit F β α)
     (input : Var β F) (n : ℕ) :
-  ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval · input) ∧ circuit.ComputableWitnesses →
+  ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval' · input) ∧ circuit.ComputableWitnesses →
     (subcircuit circuit input).ComputableWitnesses n := by
   intro h env env'
   simp only [circuit_norm, FormalCircuit.toSubcircuit, Operations.ComputableWitnesses,
@@ -403,7 +403,7 @@ theorem FormalCircuit.toSubcircuit_usesLocalWitnesses
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : FormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverSpec env =
-    (circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var) (eval env (circuit.output input_var n))) := by
+    (circuit.Assumptions (eval' env input_var) → circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n))) := by
   rfl
 
 /--
@@ -415,11 +415,11 @@ theorem GeneralFormalCircuit.toSubcircuit_usesLocalWitnesses
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ)
     (input_var : CircuitType.Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverSpec env =
-    (circuit.ProverAssumptions (eval env input_var) env.data env.hint →
-      (circuit.Assumptions (eval env.toEnvironment input_var) env.data →
-        circuit.Spec (eval env.toEnvironment input_var)
-          (eval env.toEnvironment (circuit.output input_var n)) env.data)
-      ∧ circuit.ProverSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint) := by
+    (circuit.ProverAssumptions (eval' env input_var) env.data env.hint →
+      (circuit.Assumptions (eval' env.toEnvironment input_var) env.data →
+        circuit.Spec (eval' env.toEnvironment input_var)
+          (eval' env.toEnvironment (circuit.output input_var n)) env.data)
+      ∧ circuit.ProverSpec (eval' env input_var) (eval' env (circuit.output input_var n)) env.hint) := by
   rfl
 
 /--
@@ -475,7 +475,7 @@ theorem FormalCircuit.toSubcircuit_soundness
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : FormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : Environment F) :
     (circuit.toSubcircuit n input_var).Spec env =
-    (circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var) (eval env (circuit.output input_var n))) := by
+    (circuit.Assumptions (eval' env input_var) → circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n))) := by
   rfl
 
 /--
@@ -487,8 +487,8 @@ theorem GeneralFormalCircuit.toSubcircuit_soundness
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ)
     (input_var : CircuitType.Var Input F) (env : Environment F) :
     (circuit.toSubcircuit n input_var).Spec env =
-    (circuit.Assumptions (eval env input_var) env.data →
-      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data) := by
+    (circuit.Assumptions (eval' env input_var) env.data →
+      circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)) env.data) := by
   rfl
 
 /--
@@ -499,7 +499,7 @@ theorem FormalAssertion.toSubcircuit_soundness
     {F : Type} [Field F] {Input : TypeMap} [ProvableType Input]
     (circuit : FormalAssertion F Input) (n : ℕ) (input_var : Var Input F) (env : Environment F) :
     (circuit.toSubcircuit n input_var).Spec env =
-    (circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var)) := by
+    (circuit.Assumptions (eval' env input_var) → circuit.Spec (eval' env input_var)) := by
   rfl
 
 -- Simplification lemmas for toSubcircuit.Completeness
@@ -512,7 +512,7 @@ theorem FormalCircuit.toSubcircuit_completeness
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : FormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverAssumptions env =
-    circuit.Assumptions (eval env input_var) := by
+    circuit.Assumptions (eval' env input_var) := by
   rfl
 
 /--
@@ -524,7 +524,7 @@ theorem GeneralFormalCircuit.toSubcircuit_completeness
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ)
     (input_var : CircuitType.Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverAssumptions env =
-    circuit.ProverAssumptions (eval env input_var) env.data env.hint := by
+    circuit.ProverAssumptions (eval' env input_var) env.data env.hint := by
   rfl
 
 /--
@@ -535,5 +535,5 @@ theorem FormalAssertion.toSubcircuit_completeness
     {F : Type} [Field F] {Input : TypeMap} [ProvableType Input]
     (circuit : FormalAssertion F Input) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverAssumptions env =
-    (circuit.Assumptions (eval env input_var) ∧ circuit.Spec (eval env input_var)) := by
+    (circuit.Assumptions (eval' env input_var) ∧ circuit.Spec (eval' env input_var)) := by
   rfl

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -462,7 +462,7 @@ theorem GeneralFormalCircuit.toSubcircuit_usesLocalWitnesses
       ∧ circuit.ProverSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint) := by
   simp only [GeneralFormalCircuit.toSubcircuit, GeneralFormalCircuit.toWithHint,
     GeneralFormalCircuit.WithHint.toSubcircuit_usesLocalWitnesses,
-    CircuitType.eval_var, CircuitType.eval_var_prover]
+    CircuitType.eval_var_prover_to_verifier]
 
 /--
 Simplifies UsesLocalWitnesses for FormalAssertion.toSubcircuit to avoid unfolding the entire subcircuit structure.

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -71,8 +71,8 @@ def FormalCircuit.toSubcircuit (circuit : FormalCircuit F β α)
   have h_consistent : ops.SubcircuitsConsistent n := circuit.subcircuitsConsistent input_var n
 
   have soundness : ∀ env : Environment F,
-    let input := eval' env input_var
-    let output := eval' env (circuit.output input_var n)
+    let input := eval env input_var
+    let output := eval env (circuit.output input_var n)
     ConstraintsHoldFlat env nestedOps.toFlat → circuit.Assumptions input → circuit.Spec input output := by
     -- we are given an environment where the constraints hold, and can assume the assumptions are true
     intro env input output h_holds (as : circuit.Assumptions input)
@@ -90,10 +90,10 @@ def FormalCircuit.toSubcircuit (circuit : FormalCircuit F β α)
 
   have completeness : ∀ env : ProverEnvironment F,
       env.ExtendsVector (FlatOperation.localWitnesses env nestedOps.toFlat) n →
-      circuit.Assumptions (eval' env input_var) → ConstraintsHoldFlat env nestedOps.toFlat := by
+      circuit.Assumptions (eval env input_var) → ConstraintsHoldFlat env nestedOps.toFlat := by
     -- we are given that the assumptions are true
     intro env h_env
-    let input := eval' env input_var
+    let input := eval env input_var
     intro (as : circuit.Assumptions input)
     rw [ops.toNested_toFlat] at h_env ⊢
 
@@ -112,11 +112,11 @@ def FormalCircuit.toSubcircuit (circuit : FormalCircuit F β α)
 
   {
     ops := nestedOps,
-    Spec env := circuit.Assumptions (eval' env input_var) →
-      circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)),
-    ProverAssumptions env := circuit.Assumptions (eval' env input_var),
-    ProverSpec env := circuit.Assumptions (eval' env input_var) →
-      circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)),
+    Spec env := circuit.Assumptions (eval env input_var) →
+      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)),
+    ProverAssumptions env := circuit.Assumptions (eval env input_var),
+    ProverSpec env := circuit.Assumptions (eval env input_var) →
+      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)),
     localLength := circuit.localLength input_var
 
     soundness
@@ -145,15 +145,15 @@ def FormalAssertion.toSubcircuit (circuit : FormalAssertion F β)
 
   {
     ops := nestedOps,
-    Spec env := circuit.Assumptions (eval' env input_var) → circuit.Spec (eval' env input_var),
-    ProverAssumptions env := circuit.Assumptions (eval' env input_var) ∧ circuit.Spec (eval' env input_var),
+    Spec env := circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var),
+    ProverAssumptions env := circuit.Assumptions (eval env input_var) ∧ circuit.Spec (eval env input_var),
     ProverSpec _ := True,
     localLength := circuit.localLength input_var
 
     soundness := by
       -- we are given an environment where the constraints hold, and can assume the assumptions are true
       intro env h_holds
-      let input : β F := eval' env input_var
+      let input : β F := eval env input_var
       rintro (as : circuit.Assumptions input)
       show circuit.Spec input
       rw [ops.toNested_toFlat] at h_holds
@@ -173,7 +173,7 @@ def FormalAssertion.toSubcircuit (circuit : FormalAssertion F β)
       simp only [and_true]
       intro assumptions
 
-      let input := eval' env input_var
+      let input := eval env input_var
       have as : circuit.Assumptions input ∧ circuit.Spec input := assumptions
       rw [ops.toNested_toFlat] at h_env ⊢
 
@@ -206,8 +206,8 @@ def GeneralFormalCircuit.WithHint.toSubcircuit [CircuitType α] [CircuitType β]
   have h_consistent : ops.SubcircuitsConsistent n := circuit.subcircuitsConsistent input_var n
 
   have soundness : ∀ env : Environment F,
-      let input := eval' env input_var
-      let output := eval' env (circuit.output input_var n)
+      let input := eval env input_var
+      let output := eval env (circuit.output input_var n)
       ConstraintsHoldFlat env nestedOps.toFlat →
       circuit.Assumptions input env.data →
       circuit.Spec input output env.data := by
@@ -219,10 +219,10 @@ def GeneralFormalCircuit.WithHint.toSubcircuit [CircuitType α] [CircuitType β]
 
   have implied_by_assumptions : ∀ env : ProverEnvironment F,
       env.ExtendsVector (FlatOperation.localWitnesses env nestedOps.toFlat) n →
-      circuit.ProverAssumptions (eval' env input_var) env.data env.hint →
+      circuit.ProverAssumptions (eval env input_var) env.data env.hint →
       ConstraintsHoldFlat env nestedOps.toFlat := by
     intro env h_env assumptions
-    set input := eval' env input_var
+    set input := eval env input_var
     rw [ops.toNested_toFlat] at h_env ⊢
     rw [←env.usesLocalWitnessesFlat_iff_extends, ←env.usesLocalWitnesses_iff_flat] at h_env
     rw [constraintsHold_toFlat_iff]
@@ -233,17 +233,17 @@ def GeneralFormalCircuit.WithHint.toSubcircuit [CircuitType α] [CircuitType β]
   {
     ops := nestedOps,
 
-    Spec env := circuit.Assumptions (eval' env input_var) env.data →
-      circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)) env.data,
+    Spec env := circuit.Assumptions (eval env input_var) env.data →
+      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data,
 
-    ProverAssumptions env := circuit.ProverAssumptions (eval' env input_var) env.data env.hint,
+    ProverAssumptions env := circuit.ProverAssumptions (eval env input_var) env.data env.hint,
 
     ProverSpec env :=
-      circuit.ProverAssumptions (eval' env input_var) env.data env.hint →
-      (circuit.Assumptions (eval' env.toEnvironment input_var) env.data →
-        circuit.Spec (eval' env.toEnvironment input_var)
-          (eval' env.toEnvironment (circuit.output input_var n)) env.data)
-      ∧ circuit.ProverSpec (eval' env input_var) (eval' env (circuit.output input_var n)) env.hint,
+      circuit.ProverAssumptions (eval env input_var) env.data env.hint →
+      (circuit.Assumptions (eval env.toEnvironment input_var) env.data →
+        circuit.Spec (eval env.toEnvironment input_var)
+          (eval env.toEnvironment (circuit.output input_var n)) env.data)
+      ∧ circuit.ProverSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint,
 
     localLength := circuit.localLength input_var
 
@@ -354,7 +354,7 @@ only contains variables below the current offset `n`.
  -/
 def ComputableWitnesses' (circuit : ElaboratedCircuit F β α) : Prop :=
   ∀ (n : ℕ) (input : Var β F),
-    ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval' · input) →
+    ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval · input) →
       (circuit.main input).ComputableWitnesses n
 
 /--
@@ -365,7 +365,7 @@ def ComputableWitnesses (circuit : ElaboratedCircuit F β α) : Prop :=
   ∀ (n : ℕ) (input : Var β F) (env env' : ProverEnvironment F),
   circuit.main input |>.operations n |>.forAllFlat n {
     witness n _ compute :=
-      env.AgreesBelow n env' → eval' env input = eval' env' input → compute env = compute env' }
+      env.AgreesBelow n env' → eval env input = eval env' input → compute env = compute env' }
 
 /--
 `ComputableWitnesses` is stronger than `ComputableWitnesses'` (so it's fine to only prove the former).
@@ -399,7 +399,7 @@ then we can conclude that the subcircuit, evaluated at this particular input,
 satisfies `ComputableWitnesses` in the original sense.
 -/
 theorem compose_computableWitnesses (circuit : ElaboratedCircuit F β α) (input : Var β F) (n : ℕ) :
-  ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval' · input) ∧ circuit.ComputableWitnesses →
+  ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval · input) ∧ circuit.ComputableWitnesses →
     (circuit.main input).ComputableWitnesses n := by
   intro ⟨ h_input, h_computable ⟩
   apply ElaboratedCircuit.computableWitnesses_implies h_computable
@@ -408,7 +408,7 @@ end ElaboratedCircuit
 
 theorem Circuit.subcircuit_computableWitnesses (circuit : FormalCircuit F β α)
     (input : Var β F) (n : ℕ) :
-  ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval' · input) ∧ circuit.ComputableWitnesses →
+  ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval · input) ∧ circuit.ComputableWitnesses →
     (subcircuit circuit input).ComputableWitnesses n := by
   intro h env env'
   simp only [circuit_norm, FormalCircuit.toSubcircuit, Operations.ComputableWitnesses,
@@ -429,7 +429,7 @@ theorem FormalCircuit.toSubcircuit_usesLocalWitnesses
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : FormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverSpec env =
-    (circuit.Assumptions (eval' env input_var) → circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n))) := by
+    (circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var) (eval env (circuit.output input_var n))) := by
   rfl
 
 /--
@@ -441,11 +441,11 @@ theorem GeneralFormalCircuit.WithHint.toSubcircuit_usesLocalWitnesses
     (circuit : GeneralFormalCircuit.WithHint F Input Output) (n : ℕ)
     (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverSpec env =
-    (circuit.ProverAssumptions (eval' env input_var) env.data env.hint →
-      (circuit.Assumptions (eval' env.toEnvironment input_var) env.data →
-        circuit.Spec (eval' env.toEnvironment input_var)
-          (eval' env.toEnvironment (circuit.output input_var n)) env.data)
-      ∧ circuit.ProverSpec (eval' env input_var) (eval' env (circuit.output input_var n)) env.hint) := by
+    (circuit.ProverAssumptions (eval env input_var) env.data env.hint →
+      (circuit.Assumptions (eval env.toEnvironment input_var) env.data →
+        circuit.Spec (eval env.toEnvironment input_var)
+          (eval env.toEnvironment (circuit.output input_var n)) env.data)
+      ∧ circuit.ProverSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint) := by
   rfl
 
 /--
@@ -456,10 +456,10 @@ theorem GeneralFormalCircuit.toSubcircuit_usesLocalWitnesses
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverSpec env =
-    (circuit.ProverAssumptions (eval' env input_var) env.data env.hint →
-      (circuit.Assumptions (eval' env input_var) env.data →
-        circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)) env.data)
-      ∧ circuit.ProverSpec (eval' env input_var) (eval' env (circuit.output input_var n)) env.hint) := by
+    (circuit.ProverAssumptions (eval env input_var) env.data env.hint →
+      (circuit.Assumptions (eval env input_var) env.data →
+        circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data)
+      ∧ circuit.ProverSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint) := by
   simp only [GeneralFormalCircuit.toSubcircuit, GeneralFormalCircuit.toWithHint,
     GeneralFormalCircuit.WithHint.toSubcircuit_usesLocalWitnesses,
     CircuitType.eval_var, CircuitType.eval_var_prover]
@@ -527,7 +527,7 @@ theorem FormalCircuit.toSubcircuit_soundness
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : FormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : Environment F) :
     (circuit.toSubcircuit n input_var).Spec env =
-    (circuit.Assumptions (eval' env input_var) → circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n))) := by
+    (circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var) (eval env (circuit.output input_var n))) := by
   rfl
 
 /--
@@ -539,8 +539,8 @@ theorem GeneralFormalCircuit.WithHint.toSubcircuit_soundness
     (circuit : GeneralFormalCircuit.WithHint F Input Output) (n : ℕ)
     (input_var : Var Input F) (env : Environment F) :
     (circuit.toSubcircuit n input_var).Spec env =
-    (circuit.Assumptions (eval' env input_var) env.data →
-      circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)) env.data) := by
+    (circuit.Assumptions (eval env input_var) env.data →
+      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data) := by
   rfl
 
 /--
@@ -551,8 +551,8 @@ theorem GeneralFormalCircuit.toSubcircuit_soundness
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : Environment F) :
     (circuit.toSubcircuit n input_var).Spec env =
-    (circuit.Assumptions (eval' env input_var) env.data →
-      circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)) env.data) := by
+    (circuit.Assumptions (eval env input_var) env.data →
+      circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data) := by
   rfl
 
 /--
@@ -563,7 +563,7 @@ theorem FormalAssertion.toSubcircuit_soundness
     {F : Type} [Field F] {Input : TypeMap} [ProvableType Input]
     (circuit : FormalAssertion F Input) (n : ℕ) (input_var : Var Input F) (env : Environment F) :
     (circuit.toSubcircuit n input_var).Spec env =
-    (circuit.Assumptions (eval' env input_var) → circuit.Spec (eval' env input_var)) := by
+    (circuit.Assumptions (eval env input_var) → circuit.Spec (eval env input_var)) := by
   rfl
 
 -- Simplification lemmas for toSubcircuit.Completeness
@@ -576,7 +576,7 @@ theorem FormalCircuit.toSubcircuit_completeness
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : FormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverAssumptions env =
-    circuit.Assumptions (eval' env input_var) := by
+    circuit.Assumptions (eval env input_var) := by
   rfl
 
 /--
@@ -588,7 +588,7 @@ theorem GeneralFormalCircuit.WithHint.toSubcircuit_completeness
     (circuit : GeneralFormalCircuit.WithHint F Input Output) (n : ℕ)
     (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverAssumptions env =
-    circuit.ProverAssumptions (eval' env input_var) env.data env.hint := by
+    circuit.ProverAssumptions (eval env input_var) env.data env.hint := by
   rfl
 
 /--
@@ -599,7 +599,7 @@ theorem GeneralFormalCircuit.toSubcircuit_completeness
     {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
     (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverAssumptions env =
-    circuit.ProverAssumptions (eval' env input_var) env.data env.hint := by
+    circuit.ProverAssumptions (eval env input_var) env.data env.hint := by
   rfl
 
 /--
@@ -610,5 +610,5 @@ theorem FormalAssertion.toSubcircuit_completeness
     {F : Type} [Field F] {Input : TypeMap} [ProvableType Input]
     (circuit : FormalAssertion F Input) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverAssumptions env =
-    (circuit.Assumptions (eval' env input_var) ∧ circuit.Spec (eval' env input_var)) := by
+    (circuit.Assumptions (eval env input_var) ∧ circuit.Spec (eval env input_var)) := by
   rfl

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -321,7 +321,7 @@ only contains variables below the current offset `n`.
  -/
 def ComputableWitnesses' (circuit : ElaboratedCircuit F β α) : Prop :=
   ∀ (n : ℕ) (input : Var β F),
-    ProverEnvironment.OnlyAccessedBelow n (eval ·.toEnvironment input) →
+    ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval · input) →
       (circuit.main input).ComputableWitnesses n
 
 /--
@@ -366,7 +366,7 @@ then we can conclude that the subcircuit, evaluated at this particular input,
 satisfies `ComputableWitnesses` in the original sense.
 -/
 theorem compose_computableWitnesses (circuit : ElaboratedCircuit F β α) (input : Var β F) (n : ℕ) :
-  ProverEnvironment.OnlyAccessedBelow n (eval ·.toEnvironment input) ∧ circuit.ComputableWitnesses →
+  ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval · input) ∧ circuit.ComputableWitnesses →
     (circuit.main input).ComputableWitnesses n := by
   intro ⟨ h_input, h_computable ⟩
   apply ElaboratedCircuit.computableWitnesses_implies h_computable
@@ -375,7 +375,7 @@ end ElaboratedCircuit
 
 theorem Circuit.subcircuit_computableWitnesses (circuit : FormalCircuit F β α)
     (input : Var β F) (n : ℕ) :
-  ProverEnvironment.OnlyAccessedBelow n (eval ·.toEnvironment input) ∧ circuit.ComputableWitnesses →
+  ProverEnvironment.OnlyAccessedBelow n (F:=F) (eval · input) ∧ circuit.ComputableWitnesses →
     (subcircuit circuit input).ComputableWitnesses n := by
   intro h env env'
   simp only [circuit_norm, FormalCircuit.toSubcircuit, Operations.ComputableWitnesses,

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -198,8 +198,9 @@ def FormalAssertion.toSubcircuit (circuit : FormalAssertion F β)
 /--
 Theorem and implementation that allows us to take a general formal circuit and use it as a subcircuit.
 -/
-def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
-    (n : ℕ) (input_var : Var β F) : Subcircuit F n :=
+def GeneralFormalCircuit.toSubcircuit [CircuitType α] [CircuitType β]
+    (circuit : GeneralFormalCircuit F β α)
+    (n : ℕ) (input_var : CircuitType.Var β F) : Subcircuit F n :=
   let ops := circuit.main input_var |>.operations n
   let nestedOps : NestedOperations F := .nested ⟨ circuit.name, ops.toNested ⟩
   have h_consistent : ops.SubcircuitsConsistent n := circuit.subcircuitsConsistent input_var n
@@ -239,8 +240,9 @@ def GeneralFormalCircuit.toSubcircuit (circuit : GeneralFormalCircuit F β α)
 
     ProverSpec env :=
       circuit.ProverAssumptions (eval env input_var) env.data env.hint →
-      (circuit.Assumptions (eval env input_var) env.data →
-        circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data)
+      (circuit.Assumptions (eval env.toEnvironment input_var) env.data →
+        circuit.Spec (eval env.toEnvironment input_var)
+          (eval env.toEnvironment (circuit.output input_var n)) env.data)
       ∧ circuit.ProverSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint,
 
     localLength := circuit.localLength input_var
@@ -281,7 +283,9 @@ def assertion (circuit : FormalAssertion F β) (b : Var β F) : Circuit F Unit :
 
 /-- Include a general subcircuit. -/
 @[circuit_norm]
-def subcircuitWithAssertion (circuit : GeneralFormalCircuit F β α) (b : Var β F) : Circuit F (Var α F) :=
+def subcircuitWithAssertion [CircuitType α] [CircuitType β]
+    (circuit : GeneralFormalCircuit F β α) (b : CircuitType.Var β F) :
+    Circuit F (CircuitType.Var α F) :=
   fun offset =>
     let a := circuit.output b offset
     let subcircuit := circuit.toSubcircuit offset b
@@ -295,7 +299,8 @@ instance : CoeFun (FormalCircuit F β α) (fun _ => Var β F → Circuit F (Var 
 instance : CoeFun (FormalAssertion F β) (fun _ => Var β F → Circuit F Unit) where
   coe circuit input := assertion circuit input
 
-instance : CoeFun (GeneralFormalCircuit F β α) (fun _ => Var β F → Circuit F (Var α F)) where
+instance [CircuitType α] [CircuitType β] :
+    CoeFun (GeneralFormalCircuit F β α) (fun _ => CircuitType.Var β F → Circuit F (CircuitType.Var α F)) where
   coe circuit input := subcircuitWithAssertion circuit input
 
 namespace Circuit
@@ -308,8 +313,10 @@ lemma subcircuit_localLength_eq (circuit : FormalCircuit F β α) (input : Var �
 lemma assertion_localLength_eq (circuit : FormalAssertion F β) (input : Var β F) (offset : ℕ) :
   (circuit.toSubcircuit offset input).localLength = circuit.localLength input := rfl
 
-lemma subcircuitWithAssertion_localLength_eq (circuit : GeneralFormalCircuit F β α) (input : Var β F) (offset : ℕ) :
-  (circuit.toSubcircuit offset input).localLength = circuit.localLength input := rfl
+omit [ProvableType α] [ProvableType β] in
+lemma subcircuitWithAssertion_localLength_eq [CircuitType α] [CircuitType β]
+    (circuit : GeneralFormalCircuit F β α) (input : CircuitType.Var β F) (offset : ℕ) :
+    (circuit.toSubcircuit offset input).localLength = circuit.localLength input := rfl
 end Circuit
 
 -- subcircuit composability for `ComputableWitnesses`
@@ -404,12 +411,14 @@ Simplifies UsesLocalWitnesses for GeneralFormalCircuit.toSubcircuit to avoid unf
 -/
 @[circuit_norm]
 theorem GeneralFormalCircuit.toSubcircuit_usesLocalWitnesses
-    {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
-    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
+    {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
+    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ)
+    (input_var : CircuitType.Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverSpec env =
     (circuit.ProverAssumptions (eval env input_var) env.data env.hint →
-      (circuit.Assumptions (eval env input_var) env.data →
-        circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data)
+      (circuit.Assumptions (eval env.toEnvironment input_var) env.data →
+        circuit.Spec (eval env.toEnvironment input_var)
+          (eval env.toEnvironment (circuit.output input_var n)) env.data)
       ∧ circuit.ProverSpec (eval env input_var) (eval env (circuit.output input_var n)) env.hint) := by
   rfl
 
@@ -440,8 +449,9 @@ Simplifies localLength for GeneralFormalCircuit.toSubcircuit to avoid unfolding 
 -/
 @[circuit_norm]
 theorem GeneralFormalCircuit.toSubcircuit_localLength
-    {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
-    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) :
+    {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
+    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ)
+    (input_var : CircuitType.Var Input F) :
     (circuit.toSubcircuit n input_var).localLength = circuit.localLength input_var := by
   rfl
 
@@ -473,8 +483,9 @@ Simplifies Soundness for GeneralFormalCircuit.toSubcircuit to avoid unfolding th
 -/
 @[circuit_norm]
 theorem GeneralFormalCircuit.toSubcircuit_soundness
-    {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
-    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : Environment F) :
+    {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
+    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ)
+    (input_var : CircuitType.Var Input F) (env : Environment F) :
     (circuit.toSubcircuit n input_var).Spec env =
     (circuit.Assumptions (eval env input_var) env.data →
       circuit.Spec (eval env input_var) (eval env (circuit.output input_var n)) env.data) := by
@@ -509,8 +520,9 @@ Simplifies Completeness for GeneralFormalCircuit.toSubcircuit to avoid unfolding
 -/
 @[circuit_norm]
 theorem GeneralFormalCircuit.toSubcircuit_completeness
-    {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [ProvableType Output]
-    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ) (input_var : Var Input F) (env : ProverEnvironment F) :
+    {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
+    (circuit : GeneralFormalCircuit F Input Output) (n : ℕ)
+    (input_var : CircuitType.Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverAssumptions env =
     circuit.ProverAssumptions (eval env input_var) env.data env.hint := by
   rfl

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -461,7 +461,7 @@ theorem GeneralFormalCircuit.toSubcircuit_usesLocalWitnesses
         circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)) env.data)
       ∧ circuit.ProverSpec (eval' env input_var) (eval' env (circuit.output input_var n)) env.hint) := by
   simp only [GeneralFormalCircuit.toSubcircuit, GeneralFormalCircuit.toWithHint,
-    GeneralFormalCircuit.WithHint.toSubcircuit_usesLocalWitnesses, ElaboratedCircuit.toGeneral,
+    GeneralFormalCircuit.WithHint.toSubcircuit_usesLocalWitnesses,
     CircuitType.eval_var, CircuitType.eval_var_prover]
 
 /--

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -200,7 +200,7 @@ Theorem and implementation that allows us to take a general formal circuit and u
 -/
 def GeneralFormalCircuit.WithHint.toSubcircuit [CircuitType α] [CircuitType β]
     (circuit : GeneralFormalCircuit.WithHint F β α)
-    (n : ℕ) (input_var : CircuitType.Var β F) : Subcircuit F n :=
+    (n : ℕ) (input_var : Var β F) : Subcircuit F n :=
   let ops := circuit.main input_var |>.operations n
   let nestedOps : NestedOperations F := .nested ⟨ circuit.name, ops.toNested ⟩
   have h_consistent : ops.SubcircuitsConsistent n := circuit.subcircuitsConsistent input_var n
@@ -302,8 +302,8 @@ def subcircuitWithAssertion (circuit : GeneralFormalCircuit F β α) (b : Var β
 /-- Include a hint-aware general subcircuit. -/
 @[circuit_norm]
 def subcircuitWithHintAssertion [CircuitType α] [CircuitType β]
-    (circuit : GeneralFormalCircuit.WithHint F β α) (b : CircuitType.Var β F) :
-    Circuit F (CircuitType.Var α F) :=
+    (circuit : GeneralFormalCircuit.WithHint F β α) (b : Var β F) :
+    Circuit F (Var α F) :=
   fun offset =>
     let a := circuit.output b offset
     let subcircuit := circuit.toSubcircuit offset b
@@ -322,7 +322,7 @@ instance :
   coe circuit input := subcircuitWithAssertion circuit input
 
 instance [CircuitType α] [CircuitType β] :
-    CoeFun (GeneralFormalCircuit.WithHint F β α) (fun _ => CircuitType.Var β F → Circuit F (CircuitType.Var α F)) where
+    CoeFun (GeneralFormalCircuit.WithHint F β α) (fun _ => Var β F → Circuit F (Var α F)) where
   coe circuit input := subcircuitWithHintAssertion circuit input
 
 namespace Circuit
@@ -341,7 +341,7 @@ lemma subcircuitWithAssertion_localLength_eq
 
 omit [ProvableType α] [ProvableType β] in
 lemma subcircuitWithHintAssertion_localLength_eq [CircuitType α] [CircuitType β]
-    (circuit : GeneralFormalCircuit.WithHint F β α) (input : CircuitType.Var β F) (offset : ℕ) :
+    (circuit : GeneralFormalCircuit.WithHint F β α) (input : Var β F) (offset : ℕ) :
     (circuit.toSubcircuit offset input).localLength = circuit.localLength input := rfl
 end Circuit
 
@@ -439,7 +439,7 @@ Simplifies UsesLocalWitnesses for GeneralFormalCircuit.WithHint.toSubcircuit to 
 theorem GeneralFormalCircuit.WithHint.toSubcircuit_usesLocalWitnesses
     {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
     (circuit : GeneralFormalCircuit.WithHint F Input Output) (n : ℕ)
-    (input_var : CircuitType.Var Input F) (env : ProverEnvironment F) :
+    (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverSpec env =
     (circuit.ProverAssumptions (eval' env input_var) env.data env.hint →
       (circuit.Assumptions (eval' env.toEnvironment input_var) env.data →
@@ -493,7 +493,7 @@ Simplifies localLength for GeneralFormalCircuit.WithHint.toSubcircuit to avoid u
 theorem GeneralFormalCircuit.WithHint.toSubcircuit_localLength
     {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
     (circuit : GeneralFormalCircuit.WithHint F Input Output) (n : ℕ)
-    (input_var : CircuitType.Var Input F) :
+    (input_var : Var Input F) :
     (circuit.toSubcircuit n input_var).localLength = circuit.localLength input_var := by
   rfl
 
@@ -537,7 +537,7 @@ Simplifies Soundness for GeneralFormalCircuit.WithHint.toSubcircuit to avoid unf
 theorem GeneralFormalCircuit.WithHint.toSubcircuit_soundness
     {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
     (circuit : GeneralFormalCircuit.WithHint F Input Output) (n : ℕ)
-    (input_var : CircuitType.Var Input F) (env : Environment F) :
+    (input_var : Var Input F) (env : Environment F) :
     (circuit.toSubcircuit n input_var).Spec env =
     (circuit.Assumptions (eval' env input_var) env.data →
       circuit.Spec (eval' env input_var) (eval' env (circuit.output input_var n)) env.data) := by
@@ -586,7 +586,7 @@ Simplifies Completeness for GeneralFormalCircuit.WithHint.toSubcircuit to avoid 
 theorem GeneralFormalCircuit.WithHint.toSubcircuit_completeness
     {F : Type} [Field F] {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
     (circuit : GeneralFormalCircuit.WithHint F Input Output) (n : ℕ)
-    (input_var : CircuitType.Var Input F) (env : ProverEnvironment F) :
+    (input_var : Var Input F) (env : ProverEnvironment F) :
     (circuit.toSubcircuit n input_var).ProverAssumptions env =
     circuit.ProverAssumptions (eval' env input_var) env.data env.hint := by
   rfl

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -468,7 +468,7 @@ lemma ProverEnvironment.usesLocalWitnesses_iff_flat {n : ℕ} {ops : Operations 
 -- theorems about witness generation
 
 namespace FlatOperation
-variable {hint : ProverHints F}
+variable {hint : ProverHint F}
 
 lemma dynamicWitness_length {op : FlatOperation F} {init : List F} :
     (op.dynamicWitness hint init).length = op.singleLocalLength := by
@@ -542,7 +542,7 @@ end FlatOperation
 If a circuit satisfies `computableWitnesses`, then the `proverEnvironment` agrees with the
 circuit's witness generators.
 -/
-theorem Circuit.proverEnvironment_usesLocalWitnesses (circuit : Circuit F α) (hint : ProverHints F) (init : List F) :
+theorem Circuit.proverEnvironment_usesLocalWitnesses (circuit : Circuit F α) (hint : ProverHint F) (init : List F) :
   circuit.ComputableWitnesses init.length →
     (circuit.proverEnvironment hint init).UsesLocalWitnesses init.length (circuit.operations init.length) := by
   intro h_computable

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -599,7 +599,7 @@ by assuming it within `GeneralFormalCircuit.Spec`.
 def FormalCircuit.isGeneralFormalCircuit {F : Type} {Input Output : TypeMap}
   [Field F] [ProvableType Output] [ProvableType Input]
     (orig : FormalCircuit F Input Output) : GeneralFormalCircuit F Input Output where
-  elaborated := orig.elaborated.toGeneral
+  elaborated := orig.elaborated
   Assumptions i _ := orig.Assumptions i
   Spec i o _ := orig.Spec i o
   ProverAssumptions i _ _ := orig.Assumptions i
@@ -621,7 +621,7 @@ by putting it within `GeneralFormalCircuit.Assumption`.
 def FormalAssertion.isGeneralFormalCircuit {F : Type} {Input : TypeMap}
   [Field F] [ProvableType Input]
     (orig : FormalAssertion F Input) : GeneralFormalCircuit F Input unit where
-  elaborated := orig.elaborated.toGeneral
+  elaborated := orig.elaborated
   Assumptions i _ := orig.Assumptions i
   Spec i _ _ := orig.Spec i
   ProverAssumptions i _ _ := orig.Assumptions i ∧ orig.Spec i

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -608,9 +608,10 @@ def FormalCircuit.isGeneralFormalCircuit {F : Type} {Input Output : TypeMap}
       intros
       apply orig.soundness <;> trivial
   completeness := by
-    simp only [circuit_norm, forall_eq']
-    intros
-    apply orig.completeness <;> trivial
+    intro offset env input_var h_env input h_input h_assumptions
+    constructor
+    · exact orig.completeness offset env input_var h_env input h_input h_assumptions
+    · trivial
 
 /--
 `FormalAssertion.isGeneralFormalCircuit` explains how `GeneralFormalCircuit` is a generalization of
@@ -630,6 +631,8 @@ def FormalAssertion.isGeneralFormalCircuit {F : Type} {Input : TypeMap}
     intros
     apply orig.soundness <;> trivial
   completeness := by
-    simp only [circuit_norm, forall_eq']
-    rintro _ _ _ _ ⟨ _, _ ⟩
-    apply orig.completeness <;> trivial
+    intro offset env input_var h_env input h_input h_assumptions
+    rcases h_assumptions with ⟨h_assumptions, h_spec⟩
+    constructor
+    · exact orig.completeness offset env input_var h_env input h_input h_assumptions h_spec
+    · trivial

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -599,7 +599,7 @@ by assuming it within `GeneralFormalCircuit.Spec`.
 def FormalCircuit.isGeneralFormalCircuit {F : Type} {Input Output : TypeMap}
   [Field F] [ProvableType Output] [ProvableType Input]
     (orig : FormalCircuit F Input Output) : GeneralFormalCircuit F Input Output where
-  elaborated := orig.elaborated
+  elaborated := orig.elaborated.toGeneral
   Assumptions i _ := orig.Assumptions i
   Spec i o _ := orig.Spec i o
   ProverAssumptions i _ _ := orig.Assumptions i
@@ -621,7 +621,7 @@ by putting it within `GeneralFormalCircuit.Assumption`.
 def FormalAssertion.isGeneralFormalCircuit {F : Type} {Input : TypeMap}
   [Field F] [ProvableType Input]
     (orig : FormalAssertion F Input) : GeneralFormalCircuit F Input unit where
-  elaborated := orig.elaborated
+  elaborated := orig.elaborated.toGeneral
   Assumptions i _ := orig.Assumptions i
   Spec i _ _ := orig.Spec i
   ProverAssumptions i _ _ := orig.Assumptions i ∧ orig.Spec i

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -468,7 +468,7 @@ lemma ProverEnvironment.usesLocalWitnesses_iff_flat {n : ℕ} {ops : Operations 
 -- theorems about witness generation
 
 namespace FlatOperation
-variable {hint : ProverHint F}
+variable {hint : ProverHints F}
 
 lemma dynamicWitness_length {op : FlatOperation F} {init : List F} :
     (op.dynamicWitness hint init).length = op.singleLocalLength := by
@@ -542,7 +542,7 @@ end FlatOperation
 If a circuit satisfies `computableWitnesses`, then the `proverEnvironment` agrees with the
 circuit's witness generators.
 -/
-theorem Circuit.proverEnvironment_usesLocalWitnesses (circuit : Circuit F α) (hint : ProverHint F) (init : List F) :
+theorem Circuit.proverEnvironment_usesLocalWitnesses (circuit : Circuit F α) (hint : ProverHints F) (init : List F) :
   circuit.ComputableWitnesses init.length →
     (circuit.proverEnvironment hint init).UsesLocalWitnesses init.length (circuit.operations init.length) := by
   intro h_computable

--- a/Clean/Examples/Add32Explicit.lean
+++ b/Clean/Examples/Add32Explicit.lean
@@ -24,7 +24,7 @@ example : ExplicitCircuit.output (circuit32 default) 0
 example : ((circuit32 default).operations 0).SubcircuitsConsistent 0 :=
   ExplicitCircuits.subcircuitsConsistent ..
 
-example (x0 x1 x2 x3 y0 y1 y2 y3 carryIn : Var field (F pBabybear)) env (i0 : ℕ) :
+example (x0 x1 x2 x3 y0 y1 y2 y3 carryIn : Expression (F pBabybear)) env (i0 : ℕ) :
   Circuit.ConstraintsHold.Soundness env ((circuit32 ⟨ ⟨ x0, x1, x2, x3 ⟩, ⟨ y0, y1, y2, y3 ⟩, carryIn ⟩).operations i0)
   ↔
   (ZMod.val (env.get i0) < 256 ∧ IsBool (env.get (i0 + 1)) ∧

--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -25,40 +25,14 @@ variable {p : ℕ} [Fact p.Prime] [p_large_enough: Fact (p > 512)]
 
   To represent, e.g., a read-write memory we will need a more complex construction.
 -/
-def ReadOnlyTableFromFunction
-    {n : ℕ} (f : Fin n → (F p)) (h : n < p) [NeZero n] :
-    Table (F p) fieldPair
-  := .fromStatic {
-  name := "ReadOnlyMemory"
+def Table.staticOfFn {n : ℕ} (h : n < p) (name : String) (f : Fin n → F p) :
+    Table (F p) fieldPair := .fromStatic {
+  name
   length := n
   row i := (i, f i)
-  index := fun (i, _) => i.val
-  Spec := fun (i, v) => v = f (Fin.ofNat n i.val) ∧ i.val < n
-  contains_iff := by
-    rintro ⟨row_index, row_value⟩
-    constructor
-    · rintro ⟨ i', h' ⟩
-      split
-      case h_1 i snd h_eq =>
-        simp only [Prod.mk.injEq] at h' h_eq
-        rw [←h_eq.left, ←h_eq.right, h'.left, h'.right, Fin.ofNat.eq_1]
-        have h := Fin.isLt i'
-        constructor
-        · congr
-          rw [←Fin.val_eq_val]
-          simp only
-          rw [ZMod.val_cast_of_lt (by linarith), Nat.mod_eq_of_lt h]
-        · rw [ZMod.val_cast_of_lt (by linarith)]
-          assumption
-    · intro h
-      simp_all only [Fin.ofNat_eq_cast, Prod.mk.injEq]
-      use (Fin.ofNat n row_index.val)
-      simp only [Fin.ofNat_eq_cast, Fin.val_natCast, and_true]
-      rw [Nat.mod_eq_of_lt (by linarith)]
-      simp only [ZMod.natCast_val]
-      apply_fun ZMod.val
-      · rw [ZMod.val_cast_eq_val_of_lt (by linarith)]
-      · apply ZMod.val_injective
+  index | (i, _) => i.val
+  Spec | (i, v) => ∃ hi: i.val < n, v = f ⟨ i.val, hi ⟩
+  contains_iff := by grind
 }
 
 def decodeInstructionMain (instruction : Expression (F p)) : Circuit (F p) (Var DecodedInstruction (F p)) := do
@@ -155,15 +129,19 @@ def decodeInstruction : GeneralFormalCircuit (F p) field DecodedInstruction wher
   This circuit is not satisfiable if the program counter is out of bounds.
 -/
 def fetchInstruction
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p)) (h_programSize : programSize < p) :
+    {programSize : ℕ} (program : Fin programSize → (F p)) (h_programSize : programSize < p) :
     GeneralFormalCircuit (F p) field RawInstruction where
   main (pc : Expression (F p)) := do
-    let programTable := ReadOnlyTableFromFunction program h_programSize
+    let programTable := .staticOfFn h_programSize "program" program
 
-    let rawInstrType ← witness fun eval => program <| Fin.ofNat _ (eval pc).val
-    let op1 ← witness fun eval => program <| Fin.ofNat _ (eval (pc + 1)).val
-    let op2 ← witness fun eval => program <| Fin.ofNat _ (eval (pc + 2)).val
-    let op3 ← witness fun eval => program <| Fin.ofNat _ (eval (pc + 3)).val
+    let rawInstrType ← witness fun eval => if hpc : (eval pc).val < programSize
+      then program ⟨ (eval pc).val, hpc ⟩ else 0
+    let op1 ← witness fun eval => if hpc : (eval pc).val + 1 < programSize
+      then program ⟨ (eval pc).val + 1, hpc ⟩ else 0
+    let op2 ← witness fun eval => if hpc : (eval pc).val + 2 < programSize
+      then program ⟨ (eval pc).val + 2, hpc ⟩ else 0
+    let op3 ← witness fun eval => if hpc : (eval pc).val + 3 < programSize
+      then program ⟨ (eval pc).val + 3, hpc ⟩ else 0
 
     lookup programTable ⟨pc, rawInstrType⟩
     lookup programTable ⟨pc + 1, op1⟩
@@ -183,65 +161,32 @@ def fetchInstruction
     match Spec.fetchInstruction program pc with
       | some claimed_output => output = claimed_output
       | none => False -- impossible, lookups ensure that memory accesses are valid
-  soundness := by
-    circuit_proof_start [ReadOnlyTableFromFunction, Spec.fetchInstruction, Spec.memoryAccess]
-    split
 
+  soundness := by
+    circuit_proof_start [Table.staticOfFn, Spec.fetchInstruction, Spec.memoryAccess]
+    split
     -- the lookups imply that the memory accesses are valid, therefore
     -- here we prove that Spec.memoryAccess never returns none
-    case h_2 x h_eq =>
-      -- does reading the type return some or none?
-      split at h_eq
-      · -- does reading op1 return some or none?
-        split at h_eq
-        · -- does reading op2 return some or none?
-          split at h_eq
-          · -- does reading op3 return some or none?
-            split at h_eq
-            · simp_all only [id_eq, Fin.ofNat_eq_cast, and_true, Option.bind_eq_bind,
-              Option.bind_some, reduceCtorEq]
-            · simp_all only [id_eq, Fin.ofNat_eq_cast, and_false]
-          · simp_all only [id_eq, Fin.ofNat_eq_cast, and_false, false_and]
-        · simp_all only [id_eq, Fin.ofNat_eq_cast, and_false, false_and]
-      · simp_all only [id_eq, Fin.ofNat_eq_cast, and_false, false_and]
-
+    case h_2 x h_eq => grind
     case h_1 rawInstrType claimed_instruction instruction h_eq =>
-      simp_all [circuit_norm, explicit_provable_type]
-      -- obtain ⟨ h_eq_type, h_eq_op1, h_eq_op2, h_eq_op3 ⟩ := h_eq
-      rw [←h_eq]
+      simp_all only [circuit_norm, explicit_provable_type]
+      grind
 
-      simp only [and_assoc] at h_holds
-      obtain ⟨ h1, h1', h2, h2', h3, h3', h4, h4' ⟩ := h_holds
-
-      congr <;>
-      · rw [←Fin.val_eq_val]
-        simp only [Fin.val_natCast, Nat.mod_eq_of_lt h1',
-          Nat.mod_eq_of_lt h2', Nat.mod_eq_of_lt h3', Nat.mod_eq_of_lt h4']
   completeness := by
     circuit_proof_start
-    simp only [ReadOnlyTableFromFunction, circuit_norm]
-    and_intros
-    · aesop
-    · simp_all; omega
-    · aesop
-    · simp_all only [id_eq, Fin.ofNat_eq_cast]
-      calc
-      _ ≤ ZMod.val input + ZMod.val 1 := by apply ZMod.val_add_le
-      _ < programSize := by simp only [ZMod.val_one]; omega
-    · aesop
-    · simp_all only [id_eq, Fin.ofNat_eq_cast]
-      calc
-      _ ≤ ZMod.val input + ZMod.val 2 := by apply ZMod.val_add_le
-      _ < programSize := by
-        simp only [ZMod.val_two_eq_two_mod]
-        rw [Nat.mod_eq_of_lt] <;> omega
-    · aesop
-    · simp_all only [id_eq, Fin.ofNat_eq_cast]
-      calc
-      _ ≤ ZMod.val input + ZMod.val 3 := by apply ZMod.val_add_le
-      _ < programSize := by
-        rw [← Nat.cast_three, ZMod.val_natCast]
-        rw [Nat.mod_eq_of_lt] <;> omega
+    simp only [Table.staticOfFn, circuit_norm]
+    have val_3 : ZMod.val (3 : F p) = 3 := ZMod.val_natCast_of_lt (by linarith)
+    have val_2 : ZMod.val (2 : F p) = 2 := ZMod.val_natCast_of_lt (by linarith)
+    have val_1 : ZMod.val (1 : F p) = 1 := ZMod.val_one p
+    have : input.val < programSize := by linarith
+    have : input.val + 1 < programSize := by linarith
+    have : input.val + 2 < programSize := by linarith
+    -- TODO `field` should get simped away
+    change F p at input
+    have : (input + 1).val = input.val + 1 := by field_to_nat
+    have : (input + 2).val = input.val + 2 := by field_to_nat
+    have : (input + 3).val = input.val + 3 := by field_to_nat
+    simp_all
 
 structure MemoryEntry F where
   address : F
@@ -268,9 +213,11 @@ def memory (env : ProverData (F p)) : Fin (memorySize env) → F p :=
   let mem := env.getTable MemoryTable
   fun i => mem[i.val].value
 
--- to satisfy memory lookup constraints, the prover needs to make sure that `memory[addr] = (addr, ·)`
+-- to satisfy memory lookup constraints, the prover needs to make sure that `memory[addr] = (addr, ·)`,
+-- and that the memory is non-empty (so we can use address 0 as a dummy address)
 def MemoryCompletenessAssumption (env : ProverData (F p)) : Prop :=
   let mem := env.getTable MemoryTable;
+  mem.size > 0 ∧
   ∀ (addr : F p) (ha : addr.val < mem.size), mem[addr.val].address = addr
 
 /--
@@ -284,8 +231,7 @@ def MemoryCompletenessAssumption (env : ProverData (F p)) : Prop :=
   The circuit uses lookups into a read-only table representing the memory.
   This circuit is not satisfiable if the memory access is out of bounds.
 -/
-def readFromMemory :
-    GeneralFormalCircuit (F p) MemoryReadInput field where
+def readFromMemory : GeneralFormalCircuit (F p) MemoryReadInput field where
   main := fun { state, offset, mode } => do
     /-
       read into memory for all cases of addressing mode.
@@ -327,7 +273,6 @@ def readFromMemory :
     mode.isEncodedCorrectly ∧
     MemoryCompletenessAssumption data ∧
     -- for completeness, we assume that the memory access succeeds
-    ∃ hm : NeZero (memorySize data),
     (Spec.dataMemoryAccess (memory data) offset mode.val state.ap state.fp).isSome
 
   Assumptions
@@ -335,13 +280,12 @@ def readFromMemory :
 
   Spec
   | {state, offset, mode}, output, env =>
-    ∃ hm : NeZero (memorySize env),
     match Spec.dataMemoryAccess (memory env) offset mode.val state.ap state.fp with
       | some value => output = value
       | none => False -- impossible, constraints ensure that memory accesses are valid
 
   soundness := by
-    circuit_proof_start [ReadOnlyTableFromFunction, Spec.dataMemoryAccess,
+    circuit_proof_start [Table.staticOfFn, Spec.dataMemoryAccess,
       Spec.memoryAccess, DecodedAddressingMode.val, DecodedAddressingMode.isEncodedCorrectly,
       memorySize, memoryValue, memory, MemoryEntry, MemoryReadInput.mk.injEq]
     set memoryTable := env.data.getTable MemoryTable with h_memory_table_def
@@ -351,7 +295,8 @@ def readFromMemory :
     obtain ⟨isDoubleAddressing, isApRelative, isFpRelative, isImmediate⟩ := input_mode
     obtain ⟨_pc, ap, fp⟩ := input_state
 
-    simp only [id_eq, fromElements, ProvableType.eval', size, toVars, toElements, Vector.map_mk, List.map_toArray,
+    simp only [id_eq, CircuitType.eval_expression, fromElements, ProvableType.eval',
+      size, toVars, toElements, Vector.map_mk, List.map_toArray,
       List.map_cons, List.map_nil, Vector.getElem_mk, ↓List.getElem_toArray,
       ↓List.getElem_cons_zero, ↓List.getElem_cons_succ, State.mk.injEq,
       DecodedAddressingMode.mk.injEq] at h_holds h_assumptions h_input
@@ -360,10 +305,6 @@ def readFromMemory :
     obtain ⟨ h_addr1, h_addr2, ⟨ h_addr1_lt, h_mem1 ⟩, ⟨ h_addr2_lt, h_mem2 ⟩, h_value ⟩ := h_holds
     obtain ⟨ h_addr1', h_value1 ⟩ := h_mem1
     obtain ⟨ h_addr2', h_value2 ⟩ := h_mem2
-
-    -- prove that memory is non-empty
-    have hm : NeZero (env.data.getTable MemoryTable).size := NeZero.of_gt h_addr1_lt
-    use hm
 
     simp only [h_addr1] at h_value1 h_addr1_lt
     rw [h_value1] at h_addr2
@@ -406,7 +347,7 @@ def readFromMemory :
       · rw [← h_eq, h_value]
 
   completeness := by
-    circuit_proof_start [ReadOnlyTableFromFunction, DecodedAddressingMode.isEncodedCorrectly,
+    circuit_proof_start [Table.staticOfFn, DecodedAddressingMode.isEncodedCorrectly,
       Spec.dataMemoryAccess, memory, memorySize, memoryValue, MemoryReadInput.mk.injEq]
     set addr1 := env.get i₀
     set value1 := env.get (i₀ + 1)
@@ -425,7 +366,7 @@ def readFromMemory :
     obtain ⟨_pc, ap, fp⟩ := input_state
     simp only [circuit_norm, explicit_provable_type, DecodedAddressingMode.mk.injEq, State.mk.injEq] at h_input
     simp only [h_input, DecodedAddressingMode.val, memoryAccess, MemoryCompletenessAssumption] at h_assumptions addr1_def addr2_def ⊢
-    obtain ⟨ h_mode_encode, h_mem_completeness, h_pos, h_mem_access ⟩ := h_assumptions
+    obtain ⟨ h_mode_encode, ⟨ h_pos, h_mem_completeness ⟩, h_mem_access ⟩ := h_assumptions
 
     -- simplify the goal using MemoryCompletenessAssumption and witness info
     suffices h_goal : addr1.val < memoryTable.size ∧ addr2.val < memoryTable.size by
@@ -440,7 +381,6 @@ def readFromMemory :
         rw [value2_def]
         split_ifs <;> trivial
 
-    have : (env.data.getTable MemoryTable).size > 0 := NeZero.pos _
     -- by cases on the addressing mode
     rcases h_mode_encode with h_mode|h_mode|h_mode|h_mode
     <;> simp only [h_mode, one_mul, zero_mul, add_zero, zero_add, reduceIte] at *
@@ -625,7 +565,7 @@ def nextState : GeneralFormalCircuit (F p) StateTransitionInput State where
   The circuit is not satisfiable if the state transition is invalid.
 -/
 def femtoCairoStepElaboratedCircuit
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p)) (h_programSize : programSize < p) :
+    {programSize : ℕ} (program : Fin programSize → (F p)) (h_programSize : programSize < p) :
     ElaboratedCircuit (F p) State State where
     main (state : Var State (F p)) := do
       -- Fetch instruction
@@ -644,29 +584,27 @@ def femtoCairoStepElaboratedCircuit
     localLength := 30
 
 def femtoCairoStepSpec
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p))
+    {programSize : ℕ} (program : Fin programSize → (F p))
     (state : State (F p)) (nextState : State (F p)) (data : ProverData (F p)) : Prop :=
-  ∃ _hm : NeZero (memorySize data),
   Spec.femtoCairoMachineTransition program (memory data) state = some nextState
 
 /--
   Assumptions required for the FemtoCairo step circuit completeness.
   1. ValidProgramSize: programSize + 3 < p (ensures no field wraparound in address arithmetic)
   2. ValidProgram: All instruction bytes in program memory are < 256
-  3. MemoryCompletenessAssumption: memory table is filled correctly
+  3. MemoryCompletenessAssumption: memory table is non-empty and filled correctly
   4. The state transition succeeds (execution doesn't fail)
 -/
 def femtoCairoStepAssumptions
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → F p)
+    {programSize : ℕ} (program : Fin programSize → F p)
     (state : State (F p)) (data : ProverData (F p)) (_hint : ProverHints (F p)) : Prop :=
   ValidProgramSize p programSize ∧
   ValidProgram program ∧
   MemoryCompletenessAssumption data ∧
-  ∃ _hm : NeZero (memorySize data),
   (Spec.femtoCairoMachineTransition program (memory data) state).isSome
 
 def femtoCairoStepSoundness
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p)) (h_programSize : programSize < p)
+    {programSize : ℕ} (program : Fin programSize → (F p)) (h_programSize : programSize < p)
     : GeneralFormalCircuit.Soundness (F p) (femtoCairoStepElaboratedCircuit program h_programSize) (fun _ _ => True)
       (femtoCairoStepSpec program) := by
   circuit_proof_start [femtoCairoStepSpec, femtoCairoStepAssumptions, femtoCairoStepElaboratedCircuit,
@@ -718,10 +656,6 @@ def femtoCairoStepSoundness
       rw [h_instr_type_val] at c_next
 
       simp only [circuit_norm, explicit_provable_type] at c_read1 c_read2 c_read3 c_next
-      rcases c_read1 with ⟨ hm, c_read1 ⟩
-      rcases c_read2 with ⟨ hm, c_read2 ⟩
-      rcases c_read3 with ⟨ hm, c_read3 ⟩
-      use hm
 
       split at c_read1
       case h_2 =>
@@ -754,14 +688,14 @@ def femtoCairoStepSoundness
             case h_1 next_state h_eq_next =>
               rw [h_eq_next, ←c_next]
 
-def femtoCairoStepCompleteness {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p))
+def femtoCairoStepCompleteness {programSize : ℕ} (program : Fin programSize → (F p))
   (h_programSize : programSize < p) :
     GeneralFormalCircuit.Completeness (F p) (femtoCairoStepElaboratedCircuit program h_programSize)
       (femtoCairoStepAssumptions program) (fun _ _ _ => True) := by
   circuit_proof_start [femtoCairoStepAssumptions, femtoCairoStepElaboratedCircuit,
     fetchInstruction, decodeInstruction, readFromMemory, nextState]
 
-  obtain ⟨h_valid_size, h_valid_program, h_memory_completeness, h_pos, h_transition_isSome⟩ := h_assumptions
+  obtain ⟨h_valid_size, h_valid_program, h_memory_completeness, h_transition_isSome⟩ := h_assumptions
 
   -- Decompose transition into components
   have h_decompose := Spec.transition_isSome_implies_computeNextState_isSome
@@ -790,7 +724,7 @@ def femtoCairoStepCompleteness {programSize : ℕ} [NeZero programSize] (program
   simp only [h_fetch, circuit_norm, explicit_provable_type, RawInstruction.mk.injEq] at h_fetch_env
   simp_all
 
-variable {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p)) (h_programSize : programSize < p)
+variable {programSize : ℕ} (program : Fin programSize → (F p)) (h_programSize : programSize < p)
 variable (h_program : ValidProgramSize p programSize ∧ ValidProgram program)
 
 def femtoCairoStep : GeneralFormalCircuit (F p) State State where
@@ -815,14 +749,12 @@ def femtoCairoTable (n : ℕ) : InductiveTable (F p) State unit where
     femtoCairoStep program h_programSize state
 
   Spec initialState _ i _ state env : Prop :=
-    ∃ hm : NeZero (memorySize env),
     (Spec.femtoCairoMachineBoundedExecution program (memory env) (some initialState) i) = some state
 
   -- For completeness, we assume that execution on the initial state succeeds, for all steps up to a maximum N
   InputAssumptions i _ _ := i < n
   InitialStateAssumptions initialState env :=
     MemoryCompletenessAssumption env ∧
-    ∃ hm : NeZero (memorySize env),
     ∀ i ≤ n, (Spec.femtoCairoMachineBoundedExecution program (memory env) (some initialState) i).isSome
 
   soundness := by
@@ -832,7 +764,7 @@ def femtoCairoTable (n : ℕ) : InductiveTable (F p) State unit where
 
   completeness := by
     intro initialState i env acc_var x_var acc x xs xs_len h_eval h_witnesses
-    rintro ⟨ ⟨ h_mem_completeness, hm, h_initial_state ⟩, ⟨ _, h_spec ⟩, h_i⟩
+    rintro ⟨ ⟨ h_mem_completeness, h_initial_state ⟩, h_spec, h_i⟩
     specialize h_initial_state (i+1) h_i
     simp_all [circuit_norm, Spec.femtoCairoMachineBoundedExecution, femtoCairoStep, femtoCairoStepAssumptions, MemoryCompletenessAssumption]
 
@@ -848,7 +780,7 @@ def femtoCairoTable (n : ℕ) : InductiveTable (F p) State unit where
 theorem femtoCairoTableStatement (finalState : State (F p)) :
   let initialState : State (F p) := { pc := 0, ap := 0, fp := 0 };
 
-  ∀ n > 0, ∀ trace data (_ : NeZero (memorySize data)),
+  ∀ n > 0, ∀ trace data,
 
   let table := femtoCairoTable program h_programSize h_program n
     |>.toFormal initialState finalState
@@ -856,9 +788,9 @@ theorem femtoCairoTableStatement (finalState : State (F p)) :
   table.statement n trace data →
     (Spec.femtoCairoMachineBoundedExecution program (memory data) (some initialState) (n - 1)) = some finalState
   := by
-  intro initialState n hn trace data hm table Spec
+  intro initialState n hn trace data table Spec
   simp only [table, FormalTable.statement, InductiveTable.toFormal, femtoCairoTable,
     FemtoCairo.Spec.femtoCairoMachineBoundedExecution] at Spec
-  simp_all [exists_true_left]
+  simp_all
 
 end Examples.FemtoCairo

--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -295,7 +295,7 @@ def readFromMemory : GeneralFormalCircuit (F p) MemoryReadInput field where
     obtain ⟨isDoubleAddressing, isApRelative, isFpRelative, isImmediate⟩ := input_mode
     obtain ⟨_pc, ap, fp⟩ := input_state
 
-    simp only [id_eq, CircuitType.eval_expression, fromElements, ProvableType.eval',
+    simp only [id_eq, CircuitType.eval_expression, fromElements, ProvableType.eval,
       size, toElements, Vector.map_mk, List.map_toArray,
       List.map_cons, List.map_nil, Vector.getElem_mk, ↓List.getElem_toArray,
       ↓List.getElem_cons_zero, ↓List.getElem_cons_succ, State.mk.injEq,

--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -597,7 +597,7 @@ def femtoCairoStepSpec
 -/
 def femtoCairoStepAssumptions
     {programSize : ℕ} (program : Fin programSize → F p)
-    (state : State (F p)) (data : ProverData (F p)) (_hint : ProverHints (F p)) : Prop :=
+    (state : State (F p)) (data : ProverData (F p)) (_hint : ProverHint (F p)) : Prop :=
   ValidProgramSize p programSize ∧
   ValidProgram program ∧
   MemoryCompletenessAssumption data ∧

--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -351,7 +351,7 @@ def readFromMemory :
     obtain ⟨isDoubleAddressing, isApRelative, isFpRelative, isImmediate⟩ := input_mode
     obtain ⟨_pc, ap, fp⟩ := input_state
 
-    simp only [id_eq, fromElements, ProvableType.eval, size, toVars, toElements, Vector.map_mk, List.map_toArray,
+    simp only [id_eq, fromElements, ProvableType.eval', size, toVars, toElements, Vector.map_mk, List.map_toArray,
       List.map_cons, List.map_nil, Vector.getElem_mk, ↓List.getElem_toArray,
       ↓List.getElem_cons_zero, ↓List.getElem_cons_succ, State.mk.injEq,
       DecodedAddressingMode.mk.injEq] at h_holds h_assumptions h_input

--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -510,7 +510,7 @@ def nextState : GeneralFormalCircuit (F p) StateTransitionInput State where
 
   soundness := by
     circuit_proof_start [DecodedInstructionType.isEncodedCorrectly, Spec.computeNextState,
-      DecodedInstructionType.val, StateTransitionInput.mk.injEq, DecodedInstruction.mk.injEq]
+      DecodedInstructionType.val]
 
     -- unpack the decoded instruction type
     obtain ⟨isAdd, isMul, isStoreState, isLoadState⟩ := input_decoded_instrType
@@ -530,7 +530,7 @@ def nextState : GeneralFormalCircuit (F p) StateTransitionInput State where
     <;> split <;> simp_all [add_eq_zero_iff_eq_neg]
 
   completeness := by
-    circuit_proof_start [Spec.computeNextState, StateTransitionInput.mk.injEq, DecodedInstruction.mk.injEq]
+    circuit_proof_start [Spec.computeNextState]
     rcases h_assumptions with ⟨ h_encode, h_exec ⟩
     -- Turning DecodedInstructionType into ProvableStruct leads to performance problem in soundness,
     -- that's why manual decomposition follows.

--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -296,7 +296,7 @@ def readFromMemory : GeneralFormalCircuit (F p) MemoryReadInput field where
     obtain ⟨_pc, ap, fp⟩ := input_state
 
     simp only [id_eq, CircuitType.eval_expression, fromElements, ProvableType.eval',
-      size, toVars, toElements, Vector.map_mk, List.map_toArray,
+      size, toElements, Vector.map_mk, List.map_toArray,
       List.map_cons, List.map_nil, Vector.getElem_mk, ↓List.getElem_toArray,
       ↓List.getElem_cons_zero, ↓List.getElem_cons_succ, State.mk.injEq,
       DecodedAddressingMode.mk.injEq] at h_holds h_assumptions h_input
@@ -497,32 +497,32 @@ def nextState : GeneralFormalCircuit (F p) StateTransitionInput State where
       · have h_env0 := h_env 0
         simp only [explicit_provable_type, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.zero_mod,
           add_zero, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero] at h_env0
-        simp only [circuit_norm, explicit_provable_type, fromVars, h_env0]; ring_nf
+        simp only [circuit_norm, explicit_provable_type, h_env0]; ring_nf
       · have h_env1 := h_env 1
         simp only [explicit_provable_type, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.one_mod,
           Vector.getElem_mk, List.getElem_toArray, List.getElem_cons, one_ne_zero, ↓reduceDIte] at h_env1
-        simp only [circuit_norm, explicit_provable_type, fromVars, h_env1]
+        simp only [circuit_norm, explicit_provable_type, h_env1]
       · have h_env2 := h_env 2
         simp only [explicit_provable_type, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.mod_succ,
           OfNat.ofNat_ne_zero, Nat.add_one_sub_one, one_ne_zero, ↓reduceDIte,
           Vector.getElem_mk, List.getElem_toArray, List.getElem_cons] at h_env2
-        simp only [circuit_norm, explicit_provable_type, fromVars, h_env2]
+        simp only [circuit_norm, explicit_provable_type, h_env2]
     · simp only [h_mul, zero_ne_one, ↓reduceIte, Option.isSome_ite] at h_exec h_env ⊢
       ring_nf; simp only [true_and, circuit_norm]; and_intros
       · simp only [← h_exec]; ring_nf
       · have h_env0 := h_env 0
         simp only [explicit_provable_type, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.zero_mod,
           add_zero, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero] at h_env0
-        simp only [circuit_norm, explicit_provable_type, fromVars, h_env0]; ring_nf
+        simp only [circuit_norm, explicit_provable_type, h_env0]; ring_nf
       · have h_env1 := h_env 1
         simp only [explicit_provable_type, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.one_mod,
           Vector.getElem_mk, List.getElem_toArray, List.getElem_cons, one_ne_zero, ↓reduceDIte] at h_env1
-        simp only [circuit_norm, explicit_provable_type, fromVars, h_env1]
+        simp only [circuit_norm, explicit_provable_type, h_env1]
       · have h_env2 := h_env 2
         simp only [explicit_provable_type, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.mod_succ,
           OfNat.ofNat_ne_zero, Nat.add_one_sub_one, one_ne_zero, ↓reduceDIte,
           Vector.getElem_mk, List.getElem_toArray, List.getElem_cons] at h_env2
-        simp only [circuit_norm, explicit_provable_type, fromVars, h_env2]
+        simp only [circuit_norm, explicit_provable_type, h_env2]
     · simp only [h_load, zero_ne_one, ↓reduceIte, Option.isSome_ite] at h_exec h_env ⊢
       ring_nf; simp only [true_and, circuit_norm]; and_intros
       · simp only [h_exec, ← h_input1]; ring_nf
@@ -531,31 +531,31 @@ def nextState : GeneralFormalCircuit (F p) StateTransitionInput State where
       · have h_env0 := h_env 0
         simp only [explicit_provable_type, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.zero_mod,
           add_zero, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero] at h_env0
-        simp only [circuit_norm, explicit_provable_type, fromVars, h_env0]; ring_nf
+        simp only [circuit_norm, explicit_provable_type, h_env0]; ring_nf
       · have h_env1 := h_env 1
         simp only [explicit_provable_type, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.one_mod,
           Vector.getElem_mk, List.getElem_toArray, List.getElem_cons, one_ne_zero, ↓reduceDIte] at h_env1
-        simp only [circuit_norm, explicit_provable_type, fromVars, h_env1]
+        simp only [circuit_norm, explicit_provable_type, h_env1]
       · have h_env2 := h_env 2
         simp only [explicit_provable_type, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.mod_succ,
           OfNat.ofNat_ne_zero, Nat.add_one_sub_one, one_ne_zero, ↓reduceDIte,
           Vector.getElem_mk, List.getElem_toArray, List.getElem_cons] at h_env2
-        simp only [circuit_norm, explicit_provable_type, fromVars, h_env2]
+        simp only [circuit_norm, explicit_provable_type, h_env2]
     · simp only [h_store, zero_ne_one, ↓reduceIte] at h_exec h_env ⊢
       ring_nf; simp only [true_and, circuit_norm]; and_intros
       · have h_env0 := h_env 0
         simp only [explicit_provable_type, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.zero_mod,
           add_zero, Vector.getElem_mk, List.getElem_toArray, List.getElem_cons_zero] at h_env0
-        simp only [circuit_norm, explicit_provable_type, fromVars, h_env0]
+        simp only [circuit_norm, explicit_provable_type, h_env0]
       · have h_env1 := h_env 1
         simp only [explicit_provable_type, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.one_mod,
           Vector.getElem_mk, List.getElem_toArray, List.getElem_cons, one_ne_zero, ↓reduceDIte] at h_env1
-        simp only [circuit_norm, explicit_provable_type, fromVars, h_env1]
+        simp only [circuit_norm, explicit_provable_type, h_env1]
       · have h_env2 := h_env 2
         simp only [explicit_provable_type, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.mod_succ,
           OfNat.ofNat_ne_zero, Nat.add_one_sub_one, one_ne_zero, ↓reduceDIte,
           Vector.getElem_mk, List.getElem_toArray, List.getElem_cons] at h_env2
-        simp only [circuit_norm, explicit_provable_type, fromVars, h_env2]
+        simp only [circuit_norm, explicit_provable_type, h_env2]
 
 /--
   The main femtoCairo step circuit, which combines instruction fetch, decode,

--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -657,7 +657,7 @@ def femtoCairoStepSpec
 -/
 def femtoCairoStepAssumptions
     {programSize : ℕ} [NeZero programSize] (program : Fin programSize → F p)
-    (state : State (F p)) (data : ProverData (F p)) (_hint : ProverHint (F p)) : Prop :=
+    (state : State (F p)) (data : ProverData (F p)) (_hint : ProverHints (F p)) : Prop :=
   ValidProgramSize p programSize ∧
   ValidProgram program ∧
   MemoryCompletenessAssumption data ∧

--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -626,7 +626,7 @@ def nextState : GeneralFormalCircuit (F p) StateTransitionInput State where
 -/
 def femtoCairoStepElaboratedCircuit
     {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p)) (h_programSize : programSize < p) :
-    GeneralElaboratedCircuit (F p) State State where
+    ElaboratedCircuit (F p) State State where
     main (state : Var State (F p)) := do
       -- Fetch instruction
       let { rawInstrType, op1, op2, op3 } ← fetchInstruction program h_programSize state.pc

--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -62,7 +62,7 @@ def ReadOnlyTableFromFunction
 }
 
 def decodeInstructionMain (instruction : Expression (F p)) : Circuit (F p) (Var DecodedInstruction (F p)) := do
-  let bits ← Gadgets.toBits 8 (by linarith [p_large_enough.elim]) instruction
+  let bits : Var (fields 8) (F p) ← Gadgets.toBits 8 (by linarith [p_large_enough.elim]) instruction
   return {
     instrType := {
       isAdd := (1 : Expression _) - bits[0] - bits[1] + bits[0] * bits[1],
@@ -157,7 +157,7 @@ def decodeInstruction : GeneralFormalCircuit (F p) field DecodedInstruction wher
 def fetchInstruction
     {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p)) (h_programSize : programSize < p) :
     GeneralFormalCircuit (F p) field RawInstruction where
-  main := fun pc => do
+  main (pc : Expression (F p)) := do
     let programTable := ReadOnlyTableFromFunction program h_programSize
 
     let rawInstrType ← witness fun eval => program <| Fin.ofNat _ (eval pc).val
@@ -343,7 +343,7 @@ def readFromMemory :
   soundness := by
     circuit_proof_start [ReadOnlyTableFromFunction, Spec.dataMemoryAccess,
       Spec.memoryAccess, DecodedAddressingMode.val, DecodedAddressingMode.isEncodedCorrectly,
-      memorySize, memoryValue, memory, MemoryEntry]
+      memorySize, memoryValue, memory, MemoryEntry, MemoryReadInput.mk.injEq]
     set memoryTable := env.data.getTable MemoryTable with h_memory_table_def
     simp only [MemoryTable] at h_holds
 
@@ -351,7 +351,7 @@ def readFromMemory :
     obtain ⟨isDoubleAddressing, isApRelative, isFpRelative, isImmediate⟩ := input_mode
     obtain ⟨_pc, ap, fp⟩ := input_state
 
-    simp only [id_eq, fromElements, eval, size, toVars, toElements, Vector.map_mk, List.map_toArray,
+    simp only [id_eq, fromElements, ProvableType.eval, size, toVars, toElements, Vector.map_mk, List.map_toArray,
       List.map_cons, List.map_nil, Vector.getElem_mk, ↓List.getElem_toArray,
       ↓List.getElem_cons_zero, ↓List.getElem_cons_succ, State.mk.injEq,
       DecodedAddressingMode.mk.injEq] at h_holds h_assumptions h_input
@@ -407,7 +407,7 @@ def readFromMemory :
 
   completeness := by
     circuit_proof_start [ReadOnlyTableFromFunction, DecodedAddressingMode.isEncodedCorrectly,
-      Spec.dataMemoryAccess, memory, memorySize, memoryValue]
+      Spec.dataMemoryAccess, memory, memorySize, memoryValue, MemoryReadInput.mk.injEq]
     set addr1 := env.get i₀
     set value1 := env.get (i₀ + 1)
     set addr2 := env.get (i₀ + 2)
@@ -465,11 +465,12 @@ def readFromMemory :
   Returns the next state.
 -/
 def nextState : GeneralFormalCircuit (F p) StateTransitionInput State where
-  main := fun { state, decoded, v1, v2, v3 } => do
+  main (input : Var StateTransitionInput (F p)) := do
+    let { state, decoded, v1, v2, v3 } := input
     let { instrType := { isAdd, isMul, isStoreState, isLoadState }, .. } := decoded
 
     -- Witness the claimed next state
-    let nextState ← witness fun eval => {
+    let nextState : Var State (F p) ← witness fun eval => {
       pc := if eval isLoadState = 1 then eval v1 else eval state.pc + 4
       ap := if eval isLoadState = 1 then eval v2 else eval state.ap
       fp := if eval isLoadState = 1 then eval v3 else eval state.fp
@@ -509,7 +510,7 @@ def nextState : GeneralFormalCircuit (F p) StateTransitionInput State where
 
   soundness := by
     circuit_proof_start [DecodedInstructionType.isEncodedCorrectly, Spec.computeNextState,
-      DecodedInstructionType.val]
+      DecodedInstructionType.val, StateTransitionInput.mk.injEq, DecodedInstruction.mk.injEq]
 
     -- unpack the decoded instruction type
     obtain ⟨isAdd, isMul, isStoreState, isLoadState⟩ := input_decoded_instrType
@@ -529,7 +530,7 @@ def nextState : GeneralFormalCircuit (F p) StateTransitionInput State where
     <;> split <;> simp_all [add_eq_zero_iff_eq_neg]
 
   completeness := by
-    circuit_proof_start [Spec.computeNextState]
+    circuit_proof_start [Spec.computeNextState, StateTransitionInput.mk.injEq, DecodedInstruction.mk.injEq]
     rcases h_assumptions with ⟨ h_encode, h_exec ⟩
     -- Turning DecodedInstructionType into ProvableStruct leads to performance problem in soundness,
     -- that's why manual decomposition follows.
@@ -625,8 +626,8 @@ def nextState : GeneralFormalCircuit (F p) StateTransitionInput State where
 -/
 def femtoCairoStepElaboratedCircuit
     {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p)) (h_programSize : programSize < p) :
-    ElaboratedCircuit (F p) State State where
-    main := fun state => do
+    GeneralElaboratedCircuit (F p) State State where
+    main (state : Var State (F p)) := do
       -- Fetch instruction
       let { rawInstrType, op1, op2, op3 } ← fetchInstruction program h_programSize state.pc
 

--- a/Clean/Examples/FemtoCairo/Spec.lean
+++ b/Clean/Examples/FemtoCairo/Spec.lean
@@ -27,7 +27,7 @@ def decodeInstruction (instr : (F p)) : Option (ℕ × ℕ × ℕ × ℕ) :=
   Safe memory access function. Returns `some value` if the address is within bounds,
   otherwise returns `none`.
 -/
-def memoryAccess {n : ℕ} [NeZero n] (memory : Fin n → F p) (addr : F p) : Option (F p) :=
+def memoryAccess {n : ℕ} (memory : Fin n → F p) (addr : F p) : Option (F p) :=
   if h : addr.val < n then
     some (memory ⟨addr.val, h⟩)
   else
@@ -37,7 +37,7 @@ def memoryAccess {n : ℕ} [NeZero n] (memory : Fin n → F p) (addr : F p) : Op
   Fetch an instruction from the program memory at the given program counter (pc).
 -/
 def fetchInstruction
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p))
+    {programSize : ℕ} (program : Fin programSize → (F p))
     (pc : (F p)) : Option (RawInstruction (F p)) := do
   let type ← memoryAccess program pc
   let op1 ← memoryAccess program (pc + 1)
@@ -51,7 +51,7 @@ def fetchInstruction
   - mode: addressing mode (0=double, 1=ap-relative, 2=fp-relative, 3=immediate)
 -/
 def dataMemoryAccess
-    {memorySize : ℕ} [NeZero memorySize] (memory : Fin memorySize → (F p))
+    {memorySize : ℕ} (memory : Fin memorySize → (F p))
     (addr : (F p)) (mode : ℕ) (ap : F p) (fp : F p) : Option (F p) :=
   match mode with
   | 0 => do
@@ -59,7 +59,7 @@ def dataMemoryAccess
       memoryAccess memory addr'
   | 1 => memoryAccess memory (ap + addr)
   | 2 => memoryAccess memory (fp + addr)
-  | _ => addr
+  | _ => some addr
 
 /--
   Compute the next state of the femtoCairo machine based on the current state and instruction
@@ -99,8 +99,8 @@ def computeNextState
   if all individual transitions are valid.
 -/
 def femtoCairoMachineTransition
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p))
-    {memorySize : ℕ} [NeZero memorySize] (memory : Fin memorySize → (F p))
+    {programSize : ℕ} (program : Fin programSize → (F p))
+    {memorySize : ℕ} (memory : Fin memorySize → (F p))
     (state : State (F p)) : Option (State (F p)) := do
   -- fetch instruction
   let { rawInstrType, op1, op2, op3 } ← fetchInstruction program state.pc
@@ -122,8 +122,8 @@ def femtoCairoMachineTransition
   transition execution completed successfully, otherwise returns None.
 -/
 def femtoCairoMachineBoundedExecution
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → (F p))
-    {memorySize : ℕ} [NeZero memorySize] (memory : Fin memorySize → (F p))
+    {programSize : ℕ} (program : Fin programSize → (F p))
+    {memorySize : ℕ} (memory : Fin memorySize → (F p))
     (state : Option (State (F p))) (steps : Nat) :
     Option (State (F p)) := match steps with
   | 0 => state

--- a/Clean/Examples/FemtoCairo/SpecLemmas.lean
+++ b/Clean/Examples/FemtoCairo/SpecLemmas.lean
@@ -22,7 +22,7 @@ lemma ZMod_val_add_nat (x : F p) (n : ℕ) (h : x.val + n < p) :
 
 omit [Fact p.Prime] p_large_enough in
 /-- If memoryAccess succeeds, the address is in bounds -/
-lemma memoryAccess_isSome_implies_bounds {n : ℕ} [NeZero n]
+lemma memoryAccess_isSome_implies_bounds {n : ℕ}
     (memory : Fin n → F p) (addr : F p)
     (h : (memoryAccess memory addr).isSome) : addr.val < n := by
   simp only [memoryAccess, Option.isSome_iff_exists] at h
@@ -32,7 +32,7 @@ lemma memoryAccess_isSome_implies_bounds {n : ℕ} [NeZero n]
 
 omit [Fact p.Prime] p_large_enough in
 /-- If memoryAccess returns some value, the address is in bounds -/
-lemma memoryAccess_eq_some_implies_bounds {n : ℕ} [NeZero n]
+lemma memoryAccess_eq_some_implies_bounds {n : ℕ}
     (memory : Fin n → F p) (addr : F p) (v : F p)
     (h : memoryAccess memory addr = some v) : addr.val < n :=
   memoryAccess_isSome_implies_bounds memory addr (Option.isSome_iff_exists.mpr ⟨v, h⟩)
@@ -55,8 +55,8 @@ lemma decodeInstruction_eq_some_implies_bound (instr : F p) (result : ℕ × ℕ
 omit p_large_enough in
 /-- If femtoCairoMachineTransition succeeds, fetchInstruction succeeds -/
 lemma transition_isSome_implies_fetch_isSome
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → F p)
-    {memorySize : ℕ} [NeZero memorySize] (memory : Fin memorySize → F p)
+    {programSize : ℕ} (program : Fin programSize → F p)
+    {memorySize : ℕ} (memory : Fin memorySize → F p)
     (state : State (F p))
     (h : (femtoCairoMachineTransition program memory state).isSome) :
     (fetchInstruction program state.pc).isSome := by
@@ -70,7 +70,7 @@ lemma transition_isSome_implies_fetch_isSome
 omit p_large_enough in
 /-- If fetchInstruction succeeds and programSize + 3 < p (no wraparound), then pc.val + 3 < programSize -/
 lemma fetchInstruction_isSome_implies_pc_bound
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → F p)
+    {programSize : ℕ} (program : Fin programSize → F p)
     (h_valid_size : ValidProgramSize p programSize)
     (pc : F p)
     (h : (fetchInstruction program pc).isSome) : pc.val + 3 < programSize := by
@@ -99,8 +99,8 @@ lemma fetchInstruction_isSome_implies_pc_bound
 omit p_large_enough in
 /-- If transition succeeds, decode succeeds -/
 lemma transition_isSome_implies_decode_isSome
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → F p)
-    {memorySize : ℕ} [NeZero memorySize] (memory : Fin memorySize → F p)
+    {programSize : ℕ} (program : Fin programSize → F p)
+    {memorySize : ℕ} (memory : Fin memorySize → F p)
     (state : State (F p))
     (h : (femtoCairoMachineTransition program memory state).isSome) :
     ∃ raw, fetchInstruction program state.pc = some raw ∧
@@ -122,8 +122,8 @@ lemma transition_isSome_implies_decode_isSome
 omit p_large_enough in
 /-- If transition succeeds with ValidProgram, the fetched instruction type is < 256 -/
 lemma transition_isSome_with_valid_program_implies_instr_bound
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → F p)
-    {memorySize : ℕ} [NeZero memorySize] (memory : Fin memorySize → F p)
+    {programSize : ℕ} (program : Fin programSize → F p)
+    {memorySize : ℕ} (memory : Fin memorySize → F p)
     (state : State (F p))
     (_h_valid : ValidProgram program)
     (h_trans : (femtoCairoMachineTransition program memory state).isSome) :
@@ -137,8 +137,8 @@ lemma transition_isSome_with_valid_program_implies_instr_bound
 omit p_large_enough in
 /-- If transition succeeds, all intermediate steps succeed -/
 lemma transition_isSome_implies_computeNextState_isSome
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → F p)
-    {memorySize : ℕ} [NeZero memorySize] (memory : Fin memorySize → F p)
+    {programSize : ℕ} (program : Fin programSize → F p)
+    {memorySize : ℕ} (memory : Fin memorySize → F p)
     (state : State (F p))
     (h : (femtoCairoMachineTransition program memory state).isSome) :
     ∃ raw decode v1 v2 v3,
@@ -174,8 +174,8 @@ lemma transition_isSome_implies_computeNextState_isSome
 omit p_large_enough in
 /-- If boundedExec n = some state and boundedExec (n+1).isSome, then transition(state).isSome -/
 lemma transition_isSome_of_boundedExecution_succ_isSome
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → F p)
-    {memorySize : ℕ} [NeZero memorySize] (memory : Fin memorySize → F p)
+    {programSize : ℕ} (program : Fin programSize → F p)
+    {memorySize : ℕ} (memory : Fin memorySize → F p)
     (initialState : Option (State (F p))) (state : State (F p)) (n : ℕ)
     (h_n : femtoCairoMachineBoundedExecution program memory initialState n = some state)
     (h_succ : (femtoCairoMachineBoundedExecution program memory initialState (n + 1)).isSome) :
@@ -187,15 +187,9 @@ lemma transition_isSome_of_boundedExecution_succ_isSome
 
 omit [Fact (Nat.Prime p)] p_large_enough in
 /-- ValidProgram ensures any program access returns a value < 256 -/
-lemma validProgram_bound {programSize : ℕ} [NeZero programSize] {program : Fin programSize → F p}
+lemma validProgram_bound {programSize : ℕ} {program : Fin programSize → F p}
     (h_valid : ValidProgram program) (i : Fin programSize) :
     (program i).val < 256 := h_valid i
-
-omit [Fact (Nat.Prime p)] p_large_enough in
-/-- ValidProgram + Fin.ofNat gives bound < 256 (useful when index comes from witness computation) -/
-lemma validProgram_bound_at_ofNat {programSize : ℕ} [NeZero programSize] {program : Fin programSize → F p}
-    (h_valid : ValidProgram program) (n : ℕ) :
-    (program (Fin.ofNat programSize n)).val < 256 := h_valid _
 
 omit p_large_enough in
 /-- If decodeInstruction succeeds, the result encodes a valid instruction type -/
@@ -275,7 +269,7 @@ lemma decodeInstruction_eq_some_implies_modes_encoded (instr : F p) (result : �
 omit [Fact (Nat.Prime p)] p_large_enough in
 /-- If dataMemoryAccess succeeds, specific accessed addresses are in bounds -/
 lemma dataMemoryAccess_mode0_bound
-    {memorySize : ℕ} [NeZero memorySize] (memory : Fin memorySize → F p)
+    {memorySize : ℕ} (memory : Fin memorySize → F p)
     (offset ap fp result : F p)
     (h : dataMemoryAccess memory offset 0 ap fp = some result) :
     (ap + offset).val < memorySize ∧
@@ -296,7 +290,7 @@ lemma dataMemoryAccess_mode0_bound
 omit [Fact (Nat.Prime p)] p_large_enough in
 /-- If dataMemoryAccess succeeds in mode 1 (ap-relative), the address is in bounds -/
 lemma dataMemoryAccess_mode1_bound
-    {memorySize : ℕ} [NeZero memorySize] (memory : Fin memorySize → F p)
+    {memorySize : ℕ} (memory : Fin memorySize → F p)
     (offset ap fp result : F p)
     (h : dataMemoryAccess memory offset 1 ap fp = some result) :
     (ap + offset).val < memorySize := by
@@ -306,7 +300,7 @@ lemma dataMemoryAccess_mode1_bound
 omit [Fact (Nat.Prime p)] p_large_enough in
 /-- If dataMemoryAccess succeeds in mode 2 (fp-relative), the address is in bounds -/
 lemma dataMemoryAccess_mode2_bound
-    {memorySize : ℕ} [NeZero memorySize] (memory : Fin memorySize → F p)
+    {memorySize : ℕ} (memory : Fin memorySize → F p)
     (offset ap fp result : F p)
     (h : dataMemoryAccess memory offset 2 ap fp = some result) :
     (fp + offset).val < memorySize := by
@@ -316,8 +310,8 @@ lemma dataMemoryAccess_mode2_bound
 omit p_large_enough in
 /-- If transition succeeds, all memory addresses accessed are in bounds -/
 lemma transition_isSome_implies_all_memory_bounds
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → F p)
-    {memorySize : ℕ} [NeZero memorySize] (memory : Fin memorySize → F p)
+    {programSize : ℕ} (program : Fin programSize → F p)
+    {memorySize : ℕ} (memory : Fin memorySize → F p)
     (state : State (F p))
     (h : (femtoCairoMachineTransition program memory state).isSome) :
     ∃ raw decode,
@@ -336,7 +330,7 @@ lemma transition_isSome_implies_all_memory_bounds
 omit p_large_enough in
 /-- If fetchInstruction succeeds, rawInstrType is a valid program memory value -/
 lemma fetchInstruction_rawInstrType_eq_program
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → F p)
+    {programSize : ℕ} (program : Fin programSize → F p)
     (pc : F p) (raw : Types.RawInstruction (F p))
     (h : fetchInstruction program pc = some raw)
     (h_bound : pc.val < programSize) :
@@ -364,7 +358,7 @@ lemma fetchInstruction_rawInstrType_eq_program
 omit p_large_enough in
 /-- Combining ValidProgram with fetchInstruction success gives rawInstrType.val < 256 -/
 lemma fetchInstruction_rawInstrType_bound
-    {programSize : ℕ} [NeZero programSize] (program : Fin programSize → F p)
+    {programSize : ℕ} (program : Fin programSize → F p)
     (h_valid : ValidProgram program)
     (pc : F p) (raw : Types.RawInstruction (F p))
     (h : fetchInstruction program pc = some raw)

--- a/Clean/Examples/FemtoCairo/TypesLemmas.lean
+++ b/Clean/Examples/FemtoCairo/TypesLemmas.lean
@@ -19,19 +19,19 @@ variable {F : Type} [Field F]
 /-- Evaluating a State variable and extracting pc equals evaluating the pc expression -/
 @[circuit_norm]
 lemma State.eval_pc (env : Environment F) (s : Var State F) :
-    (ProvableType.eval env s).pc = Expression.eval env s.pc := by
+    (ProvableType.eval' env s).pc = Expression.eval env s.pc := by
   simp [circuit_norm, explicit_provable_type]
 
 /-- Evaluating a State variable and extracting ap equals evaluating the ap expression -/
 @[circuit_norm]
 lemma State.eval_ap (env : Environment F) (s : Var State F) :
-    (ProvableType.eval env s).ap = Expression.eval env s.ap := by
+    (ProvableType.eval' env s).ap = Expression.eval env s.ap := by
   simp [circuit_norm, explicit_provable_type]
 
 /-- Evaluating a State variable and extracting fp equals evaluating the fp expression -/
 @[circuit_norm]
 lemma State.eval_fp (env : Environment F) (s : Var State F) :
-    (ProvableType.eval env s).fp = Expression.eval env s.fp := by
+    (ProvableType.eval' env s).fp = Expression.eval env s.fp := by
   simp [circuit_norm, explicit_provable_type]
 
 end StateEval
@@ -42,25 +42,25 @@ variable {F : Type} [Field F]
 /-- Evaluating a RawInstruction variable and extracting rawInstrType equals evaluating the rawInstrType expression -/
 @[circuit_norm]
 lemma RawInstruction.eval_rawInstrType (env : Environment F) (r : Var RawInstruction F) :
-    (ProvableType.eval env r).rawInstrType = Expression.eval env r.rawInstrType := by
+    (ProvableType.eval' env r).rawInstrType = Expression.eval env r.rawInstrType := by
   simp [circuit_norm, explicit_provable_type]
 
 /-- Evaluating a RawInstruction variable and extracting op1 equals evaluating the op1 expression -/
 @[circuit_norm]
 lemma RawInstruction.eval_op1 (env : Environment F) (r : Var RawInstruction F) :
-    (ProvableType.eval env r).op1 = Expression.eval env r.op1 := by
+    (ProvableType.eval' env r).op1 = Expression.eval env r.op1 := by
   simp [circuit_norm, explicit_provable_type]
 
 /-- Evaluating a RawInstruction variable and extracting op2 equals evaluating the op2 expression -/
 @[circuit_norm]
 lemma RawInstruction.eval_op2 (env : Environment F) (r : Var RawInstruction F) :
-    (ProvableType.eval env r).op2 = Expression.eval env r.op2 := by
+    (ProvableType.eval' env r).op2 = Expression.eval env r.op2 := by
   simp [circuit_norm, explicit_provable_type]
 
 /-- Evaluating a RawInstruction variable and extracting op3 equals evaluating the op3 expression -/
 @[circuit_norm]
 lemma RawInstruction.eval_op3 (env : Environment F) (r : Var RawInstruction F) :
-    (ProvableType.eval env r).op3 = Expression.eval env r.op3 := by
+    (ProvableType.eval' env r).op3 = Expression.eval env r.op3 := by
   simp [circuit_norm, explicit_provable_type]
 
 end RawInstructionEval

--- a/Clean/Examples/FemtoCairo/TypesLemmas.lean
+++ b/Clean/Examples/FemtoCairo/TypesLemmas.lean
@@ -19,19 +19,19 @@ variable {F : Type} [Field F]
 /-- Evaluating a State variable and extracting pc equals evaluating the pc expression -/
 @[circuit_norm]
 lemma State.eval_pc (env : Environment F) (s : Var State F) :
-    (ProvableType.eval' env s).pc = Expression.eval env s.pc := by
+    (eval env s).pc = Expression.eval env s.pc := by
   simp [circuit_norm, explicit_provable_type]
 
 /-- Evaluating a State variable and extracting ap equals evaluating the ap expression -/
 @[circuit_norm]
 lemma State.eval_ap (env : Environment F) (s : Var State F) :
-    (ProvableType.eval' env s).ap = Expression.eval env s.ap := by
+    (eval env s).ap = Expression.eval env s.ap := by
   simp [circuit_norm, explicit_provable_type]
 
 /-- Evaluating a State variable and extracting fp equals evaluating the fp expression -/
 @[circuit_norm]
 lemma State.eval_fp (env : Environment F) (s : Var State F) :
-    (ProvableType.eval' env s).fp = Expression.eval env s.fp := by
+    (eval env s).fp = Expression.eval env s.fp := by
   simp [circuit_norm, explicit_provable_type]
 
 end StateEval
@@ -42,25 +42,25 @@ variable {F : Type} [Field F]
 /-- Evaluating a RawInstruction variable and extracting rawInstrType equals evaluating the rawInstrType expression -/
 @[circuit_norm]
 lemma RawInstruction.eval_rawInstrType (env : Environment F) (r : Var RawInstruction F) :
-    (ProvableType.eval' env r).rawInstrType = Expression.eval env r.rawInstrType := by
+    (eval env r).rawInstrType = Expression.eval env r.rawInstrType := by
   simp [circuit_norm, explicit_provable_type]
 
 /-- Evaluating a RawInstruction variable and extracting op1 equals evaluating the op1 expression -/
 @[circuit_norm]
 lemma RawInstruction.eval_op1 (env : Environment F) (r : Var RawInstruction F) :
-    (ProvableType.eval' env r).op1 = Expression.eval env r.op1 := by
+    (eval env r).op1 = Expression.eval env r.op1 := by
   simp [circuit_norm, explicit_provable_type]
 
 /-- Evaluating a RawInstruction variable and extracting op2 equals evaluating the op2 expression -/
 @[circuit_norm]
 lemma RawInstruction.eval_op2 (env : Environment F) (r : Var RawInstruction F) :
-    (ProvableType.eval' env r).op2 = Expression.eval env r.op2 := by
+    (eval env r).op2 = Expression.eval env r.op2 := by
   simp [circuit_norm, explicit_provable_type]
 
 /-- Evaluating a RawInstruction variable and extracting op3 equals evaluating the op3 expression -/
 @[circuit_norm]
 lemma RawInstruction.eval_op3 (env : Environment F) (r : Var RawInstruction F) :
-    (ProvableType.eval' env r).op3 = Expression.eval env r.op3 := by
+    (eval env r).op3 = Expression.eval env r.op3 := by
   simp [circuit_norm, explicit_provable_type]
 
 end RawInstructionEval

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -1,14 +1,11 @@
 /-
-  Example: Using prover hints in a `GeneralFormalCircuit.WithHint` under the new
-  `CircuitType`-based API.
+Example: Using prover hints in a `GeneralFormalCircuit.WithHint` under the new
+`CircuitType`-based API.
 
-  The hint is modelled as `Input = Unconstrained Bool`:
-    - verifier-view of the input: `Unit` (hints are erased)
-    - prover-view of the input: `Bool`
-    - variable form: `ProverHint Bool F = ProverEnvironment F → Bool`
+`witnessBool` witnesses a field element (1 if the hint returns true, 0 otherwise),
+and constrains it to be boolean.
 
-  `witnessBool` witnesses a field element (1 if the hint returns true, 0 otherwise),
-  and constrains it to be boolean.
+`andBool` uses `witnessBool` as a subcircuit.
 -/
 import Clean.Circuit
 import Clean.Gadgets.Boolean

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -1,5 +1,5 @@
 /-
-  Example: Using prover hints in a `GeneralFormalCircuit` under the new
+  Example: Using prover hints in a `GeneralFormalCircuit.WithHint` under the new
   `CircuitType`-based API.
 
   The hint is modelled as `Input = Unconstrained Bool`:
@@ -23,7 +23,7 @@ namespace Examples.HintExample
   The hint callback tells the prover which boolean value to witness.
   The circuit constrains the output to be boolean (0 or 1).
 -/
-def witnessBool : GeneralFormalCircuit (F p) (Unconstrained Bool) field where
+def witnessBool : GeneralFormalCircuit.WithHint (F p) (Unconstrained Bool) field where
   main (hint : ProverEnvironment (F p) → Bool) := do
     let b ← witness fun env => if hint env then 1 else 0
     assertBool b
@@ -54,13 +54,12 @@ deriving ProvableStruct
   A circuit that computes the AND of two boolean inputs.
 
   This is a plain `FormalCircuit` (no hint input). It creates the hint
-  internally from its inputs and passes it to `witnessBool` via
-  `subcircuitWithAssertion`.
+  internally from its inputs and passes it to `witnessBool`.
 -/
 def booleanAnd : FormalCircuit (F p) Input field where
   main | ⟨x, y⟩ => do
     -- Use witnessBool as a subcircuit with a hint synthesized from the inputs
-    let z ← witnessBool fun env => eval env x = 1 ∧ eval env y = 1
+    let z ← witnessBool fun env => eval' env x = 1 ∧ eval' env y = 1
     -- Constrain result = x * y (multiplication is AND for booleans)
     z === x * y
     return z
@@ -69,17 +68,19 @@ def booleanAnd : FormalCircuit (F p) Input field where
   output _ i := var ⟨i⟩
 
   Assumptions | ⟨x, y⟩ => IsBool x ∧ IsBool y
-  Spec | ⟨x, y⟩, output => output = x * y
+  Spec | ⟨x, y⟩, z => IsBool z ∧ z.val = x.val &&& y.val
 
   soundness := by
-    circuit_proof_start [witnessBool, assertBool]
-    simp_all [circuit_norm]
+    circuit_proof_start [witnessBool, assertBool, IsBool]
+    rcases h_holds.1 with z | notz
+    · simp_all
+      cases h_holds <;> simp_all
+    · grind
 
   completeness := by
     circuit_proof_start [witnessBool, assertBool, IsBool]
     simp_all
     rcases h_assumptions with ⟨ x | notx, y | noty ⟩
       <;> simp_all
-
 
 end Examples.HintExample

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -10,7 +10,7 @@
   `witnessBool` witnesses a field element (1 if the hint returns true, 0 otherwise),
   and constrains it to be boolean.
 -/
-import Clean.Circuit.Subcircuit
+import Clean.Circuit
 import Clean.Gadgets.Boolean
 
 variable {p : ℕ} [Fact p.Prime] [Fact (p > 2)]
@@ -25,14 +25,18 @@ namespace Examples.HintExample
 -/
 def witnessBool : GeneralFormalCircuit (F p) (Unconstrained Bool) field where
   main (hint : ProverEnvironment (F p) → Bool) := do
-    let b ← witnessField fun env => if hint env then (1 : F p) else 0
+    let b ← witness fun env => if hint env then 1 else 0
     assertBool b
     return b
 
   localLength _ := 1
   output _ i := var ⟨i⟩
 
+  Assumptions (_ : Unit) _ := True
   Spec (_ : Unit) (output : F p) _ := IsBool output
+
+  ProverAssumptions (hint : Bool) _ _ := True
+  ProverSpec (hint : Bool) (b : F p) _ := b = if hint then 1 else 0
 
   soundness := by
     circuit_proof_all [assertBool, IsBool.iff_mul_sub_one, sub_eq_add_neg]
@@ -40,5 +44,42 @@ def witnessBool : GeneralFormalCircuit (F p) (Unconstrained Bool) field where
   completeness := by
     circuit_proof_start [assertBool, IsBool.iff_mul_sub_one, sub_eq_add_neg]
     cases input_var env <;> simp_all
+
+structure Input (F : Type) where
+  x : F
+  y : F
+deriving ProvableStruct
+
+/--
+  A circuit that computes the AND of two boolean inputs.
+
+  This is a plain `FormalCircuit` (no hint input). It creates the hint
+  internally from its inputs and passes it to `witnessBool` via
+  `subcircuitWithAssertion`.
+-/
+def booleanAnd : FormalCircuit (F p) Input field where
+  main | ⟨x, y⟩ => do
+    -- Use witnessBool as a subcircuit with a hint synthesized from the inputs
+    let z ← witnessBool fun env => eval env x = 1 ∧ eval env y = 1
+    -- Constrain result = x * y (multiplication is AND for booleans)
+    z === x * y
+    return z
+
+  localLength _ := 1
+  output _ i := var ⟨i⟩
+
+  Assumptions | ⟨x, y⟩ => IsBool x ∧ IsBool y
+  Spec | ⟨x, y⟩, output => output = x * y
+
+  soundness := by
+    circuit_proof_start [witnessBool, assertBool]
+    simp_all [circuit_norm]
+
+  completeness := by
+    circuit_proof_start [witnessBool, assertBool, IsBool]
+    simp_all
+    rcases h_assumptions with ⟨ x | notx, y | noty ⟩
+      <;> simp_all
+
 
 end Examples.HintExample

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -1,0 +1,44 @@
+/-
+  Example: Using prover hints in a `GeneralFormalCircuit` under the new
+  `CircuitType`-based API.
+
+  The hint is modelled as `Input = Unconstrained Bool`:
+    - verifier-view of the input: `Unit` (hints are erased)
+    - prover-view of the input: `Bool`
+    - variable form: `ProverHint Bool F = ProverEnvironment F → Bool`
+
+  `witnessBool` witnesses a field element (1 if the hint returns true, 0 otherwise),
+  and constrains it to be boolean.
+-/
+import Clean.Circuit.Subcircuit
+import Clean.Gadgets.Boolean
+
+variable {p : ℕ} [Fact p.Prime] [Fact (p > 2)]
+
+namespace Examples.HintExample
+
+/--
+  A circuit that witnesses a boolean field element using a prover hint.
+
+  The hint callback tells the prover which boolean value to witness.
+  The circuit constrains the output to be boolean (0 or 1).
+-/
+def witnessBool : GeneralFormalCircuit (F p) (Unconstrained Bool) field where
+  main (hint : ProverEnvironment (F p) → Bool) := do
+    let b ← witnessField fun env => if hint env then (1 : F p) else 0
+    assertBool b
+    return b
+
+  localLength _ := 1
+  output _ i := var ⟨i⟩
+
+  Spec (_ : Unit) (output : F p) _ := IsBool output
+
+  soundness := by
+    circuit_proof_all [assertBool, IsBool.iff_mul_sub_one, sub_eq_add_neg]
+
+  completeness := by
+    circuit_proof_start [assertBool, IsBool.iff_mul_sub_one, sub_eq_add_neg]
+    cases input_var env <;> simp_all
+
+end Examples.HintExample

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -59,7 +59,7 @@ deriving ProvableStruct
 def booleanAnd : FormalCircuit (F p) Input field where
   main | ⟨x, y⟩ => do
     -- Use witnessBool as a subcircuit with a hint synthesized from the inputs
-    let z ← witnessBool fun env => eval' env x = 1 ∧ eval' env y = 1
+    let z ← witnessBool fun env => eval env x = 1 ∧ eval env y = 1
     -- Constrain result = x * y (multiplication is AND for booleans)
     z === x * y
     return z

--- a/Clean/Gadgets/Addition32/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32/Addition32Full.lean
@@ -55,7 +55,7 @@ instance elaborated : ElaboratedCircuit (F p) Inputs Outputs where
     simp only [circuit_norm, main, Addition8FullCarry.main]
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start [Addition8FullCarry.main, ByteTable, U32.value, U32.Normalized]
+  circuit_proof_start [Addition8FullCarry.main, ByteTable, U32.value, U32.Normalized, Inputs.mk.injEq, U32.mk.injEq]
 
   -- simplify circuit further
   -- TODO handle simplification of general provable types in `circuit_proof_start`
@@ -95,7 +95,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     h0 h1 h2 h3
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start [Addition8FullCarry.main, ByteTable, U32.Normalized]
+  circuit_proof_start [Addition8FullCarry.main, ByteTable, U32.Normalized, Inputs.mk.injEq, U32.mk.injEq]
 
   -- simplify circuit further TODO
   let ⟨ x0, x1, x2, x3 ⟩ := input_x

--- a/Clean/Gadgets/Addition32/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32/Addition32Full.lean
@@ -55,7 +55,7 @@ instance elaborated : ElaboratedCircuit (F p) Inputs Outputs where
     simp only [circuit_norm, main, Addition8FullCarry.main]
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start [Addition8FullCarry.main, ByteTable, U32.value, U32.Normalized, Inputs.mk.injEq, U32.mk.injEq]
+  circuit_proof_start [Addition8FullCarry.main, ByteTable, U32.value, U32.Normalized]
 
   -- simplify circuit further
   -- TODO handle simplification of general provable types in `circuit_proof_start`
@@ -95,7 +95,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     h0 h1 h2 h3
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start [Addition8FullCarry.main, ByteTable, U32.Normalized, Inputs.mk.injEq, U32.mk.injEq]
+  circuit_proof_start [Addition8FullCarry.main, ByteTable, U32.Normalized]
 
   -- simplify circuit further TODO
   let ⟨ x0, x1, x2, x3 ⟩ := input_x

--- a/Clean/Gadgets/And/And8.lean
+++ b/Clean/Gadgets/And/And8.lean
@@ -21,7 +21,7 @@ def Spec (input : Inputs (F p)) (z : F p) :=
   let ⟨x, y⟩ := input
   z.val = x.val &&& y.val
 
-def main (input : Var Inputs (F p)) : Circuit (F p) (fieldVar (F p)) := do
+def main (input : Var Inputs (F p)) : Circuit (F p) (Expression (F p)) := do
   let ⟨x, y⟩ := input
   let and ← witness fun eval => (eval x).val &&& (eval y).val
   -- we prove AND correct using an XOR lookup and the following identity:

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -68,9 +68,7 @@ def roundWithPermute : FormalCircuit (F p) Round.Inputs Round.Inputs where
     specialize h_holds2 asm2
 
     -- Now we need to show the spec holds for the output
-    simp only
-    rw [ProvableStruct.eval_eq_eval]
-    simp only [ProvableStruct.eval]
+    simp only [circuit_norm]
     simp only [Round.Spec, Permute.Spec] at h_holds1 h_holds2
 
     constructor
@@ -377,7 +375,7 @@ lemma applyRounds_eq_applySevenRounds
 
 lemma eval_decomposeNatExpr_small (env : Environment (F p)) (x : ℕ) :
     x < 256^4 ->
-    (eval env (U32.decomposeNatExpr x)).value = x := by
+    (ProvableType.eval env (U32.decomposeNatExpr x)).value = x := by
   intro h
   simp only [U32.decomposeNatExpr, circuit_norm]
   exact U32.value_of_decomposedNat_of_small x h
@@ -463,20 +461,20 @@ lemma initial_state_and_messages_are_normalized
     (input_var : Var Inputs (F p))
     (block_words : BLAKE3State (F p))
     (chaining_value counter_high counter_low block_len flags)
-    (h_input : eval env input_var = { chaining_value, block_words, counter_high, counter_low, block_len, flags })
+    (h_input : ProvableType.eval env input_var = { chaining_value, block_words, counter_high, counter_low, block_len, flags })
     (h_normalized : Assumptions { chaining_value, block_words, counter_high, counter_low, block_len, flags }) :
-    (eval env (initializeStateVector input_var)).Normalized ∧ ∀ (i : Fin 16), block_words[i].Normalized := by
+    (ProvableType.eval env (initializeStateVector input_var)).Normalized ∧ ∀ (i : Fin 16), block_words[i].Normalized := by
   set state_vec := initializeStateVector input_var
   simp only [Assumptions] at h_normalized
   provable_struct_simp
 
   -- Helper to prove normalization of chaining value elements
-  have h_chaining_value_normalized (i : ℕ) (h_i : i < 8) : (eval env input_var_chaining_value[i]).Normalized := by
+  have h_chaining_value_normalized (i : ℕ) (h_i : i < 8) : (ProvableType.eval env input_var_chaining_value[i]).Normalized := by
     simp_all only [circuit_norm, eval_vector_eq_get]
     convert h_normalized.1 ⟨ i, h_i ⟩
 
   -- Show the state is normalized
-  have h_state_normalized : (eval env state_vec).Normalized := by
+  have h_state_normalized : (ProvableType.eval env state_vec).Normalized := by
     simp only [BLAKE3State.Normalized, state_vec, initializeStateVector, eval_vector]
     intro i
     fin_cases i
@@ -495,7 +493,7 @@ lemma initial_state_and_messages_are_normalized
     exact h_normalized.2.1 i
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start
+  circuit_proof_start [Inputs.mk.injEq]
 
   -- Equations for counter values
   have h_counter_low_eq : input_counter_low.value % 4294967296 = input_counter_low.value := by
@@ -553,7 +551,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     exact h_normalized
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start
+  circuit_proof_start [Inputs.mk.injEq]
 
   -- Use the helper lemma to prove normalization
   apply initial_state_and_messages_are_normalized (p := p) env

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -375,7 +375,7 @@ lemma applyRounds_eq_applySevenRounds
 
 lemma eval_decomposeNatExpr_small (env : Environment (F p)) (x : ℕ) :
     x < 256^4 ->
-    (ProvableType.eval env (U32.decomposeNatExpr x)).value = x := by
+    (ProvableType.eval' env (U32.decomposeNatExpr x)).value = x := by
   intro h
   simp only [U32.decomposeNatExpr, circuit_norm]
   exact U32.value_of_decomposedNat_of_small x h
@@ -461,7 +461,7 @@ lemma initial_state_and_messages_are_normalized
     (input_var : Var Inputs (F p))
     (block_words : BLAKE3State (F p))
     (chaining_value counter_high counter_low block_len flags)
-    (h_input : ProvableType.eval env input_var = { chaining_value, block_words, counter_high, counter_low, block_len, flags })
+    (h_input : ProvableType.eval' env input_var = { chaining_value, block_words, counter_high, counter_low, block_len, flags })
     (h_normalized : Assumptions { chaining_value, block_words, counter_high, counter_low, block_len, flags }) :
     (eval env (initializeStateVector input_var)).Normalized ∧ ∀ (i : Fin 16), block_words[i].Normalized := by
   set state_vec : BLAKE3State (Expression (F p)) := initializeStateVector input_var
@@ -470,12 +470,12 @@ lemma initial_state_and_messages_are_normalized
   provable_struct_simp
 
   -- Helper to prove normalization of chaining value elements
-  have h_chaining_value_normalized (i : ℕ) (h_i : i < 8) : (ProvableType.eval env input_var.chaining_value[i]).Normalized := by
+  have h_chaining_value_normalized (i : ℕ) (h_i : i < 8) : (ProvableType.eval' env input_var.chaining_value[i]).Normalized := by
     simp_all only [circuit_norm, eval_vector_eq_get]
     convert h_normalized.1 ⟨ i, h_i ⟩
 
   -- Show the state is normalized
-  have h_state_normalized : (ProvableType.eval env state_vec).Normalized := by
+  have h_state_normalized : (ProvableType.eval' env state_vec).Normalized := by
     simp only [BLAKE3State.Normalized, state_vec, initializeStateVector, eval_vector]
     intro i
     fin_cases i

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -374,8 +374,8 @@ lemma applyRounds_eq_applySevenRounds
   simp only [applyRounds, applySevenRounds]
 
 lemma eval_decomposeNatExpr_small (env : Environment (F p)) (x : ℕ) :
-    x < 256^4 ->
-    (ProvableType.eval' env (U32.decomposeNatExpr x)).value = x := by
+    x < 256^4 →
+    (eval env (U32.decomposeNatExpr (p:=p) x)).value = x := by
   intro h
   simp only [U32.decomposeNatExpr, circuit_norm]
   exact U32.value_of_decomposedNat_of_small x h
@@ -461,7 +461,7 @@ lemma initial_state_and_messages_are_normalized
     (input_var : Var Inputs (F p))
     (block_words : BLAKE3State (F p))
     (chaining_value counter_high counter_low block_len flags)
-    (h_input : ProvableType.eval' env input_var = { chaining_value, block_words, counter_high, counter_low, block_len, flags })
+    (h_input : eval env input_var = { chaining_value, block_words, counter_high, counter_low, block_len, flags })
     (h_normalized : Assumptions { chaining_value, block_words, counter_high, counter_low, block_len, flags }) :
     (eval env (initializeStateVector input_var)).Normalized ∧ ∀ (i : Fin 16), block_words[i].Normalized := by
   set state_vec : BLAKE3State (Expression (F p)) := initializeStateVector input_var
@@ -470,12 +470,12 @@ lemma initial_state_and_messages_are_normalized
   provable_struct_simp
 
   -- Helper to prove normalization of chaining value elements
-  have h_chaining_value_normalized (i : ℕ) (h_i : i < 8) : (ProvableType.eval' env input_var.chaining_value[i]).Normalized := by
+  have h_chaining_value_normalized (i : ℕ) (h_i : i < 8) : (eval env input_var.chaining_value[i]).Normalized := by
     simp_all only [circuit_norm, eval_vector_eq_get]
     convert h_normalized.1 ⟨ i, h_i ⟩
 
   -- Show the state is normalized
-  have h_state_normalized : (ProvableType.eval' env state_vec).Normalized := by
+  have h_state_normalized : BLAKE3State.Normalized (eval env state_vec) := by
     simp only [BLAKE3State.Normalized, state_vec, initializeStateVector, eval_vector]
     intro i
     fin_cases i

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -463,7 +463,7 @@ lemma initial_state_and_messages_are_normalized
     (chaining_value counter_high counter_low block_len flags)
     (h_input : ProvableType.eval env input_var = { chaining_value, block_words, counter_high, counter_low, block_len, flags })
     (h_normalized : Assumptions { chaining_value, block_words, counter_high, counter_low, block_len, flags }) :
-    (eval' env (initializeStateVector input_var)).Normalized ∧ ∀ (i : Fin 16), block_words[i].Normalized := by
+    (eval env (initializeStateVector input_var)).Normalized ∧ ∀ (i : Fin 16), block_words[i].Normalized := by
   set state_vec : BLAKE3State (Expression (F p)) := initializeStateVector input_var
   simp only [Assumptions] at h_normalized
   simp only [circuit_norm] at *

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -493,7 +493,7 @@ lemma initial_state_and_messages_are_normalized
     exact h_normalized.2.1 i
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start [Inputs.mk.injEq]
+  circuit_proof_start
 
   -- Equations for counter values
   have h_counter_low_eq : input_counter_low.value % 4294967296 = input_counter_low.value := by
@@ -551,7 +551,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     exact h_normalized
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start [Inputs.mk.injEq]
+  circuit_proof_start
 
   -- Use the helper lemma to prove normalization
   apply initial_state_and_messages_are_normalized (p := p) env

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -463,13 +463,14 @@ lemma initial_state_and_messages_are_normalized
     (chaining_value counter_high counter_low block_len flags)
     (h_input : ProvableType.eval env input_var = { chaining_value, block_words, counter_high, counter_low, block_len, flags })
     (h_normalized : Assumptions { chaining_value, block_words, counter_high, counter_low, block_len, flags }) :
-    (ProvableType.eval env (initializeStateVector input_var)).Normalized ∧ ∀ (i : Fin 16), block_words[i].Normalized := by
-  set state_vec := initializeStateVector input_var
+    (eval' env (initializeStateVector input_var)).Normalized ∧ ∀ (i : Fin 16), block_words[i].Normalized := by
+  set state_vec : BLAKE3State (Expression (F p)) := initializeStateVector input_var
   simp only [Assumptions] at h_normalized
+  simp only [circuit_norm] at *
   provable_struct_simp
 
   -- Helper to prove normalization of chaining value elements
-  have h_chaining_value_normalized (i : ℕ) (h_i : i < 8) : (ProvableType.eval env input_var_chaining_value[i]).Normalized := by
+  have h_chaining_value_normalized (i : ℕ) (h_i : i < 8) : (ProvableType.eval env input_var.chaining_value[i]).Normalized := by
     simp_all only [circuit_norm, eval_vector_eq_get]
     convert h_normalized.1 ⟨ i, h_i ⟩
 

--- a/Clean/Gadgets/BLAKE3/BLAKE3G.lean
+++ b/Clean/Gadgets/BLAKE3/BLAKE3G.lean
@@ -72,8 +72,7 @@ def Spec (a b c d : Fin 16) (input : Inputs (F p)) (out : BLAKE3State (F p)) :=
   out.value = g state.value a b c d x.value y.value ∧ out.Normalized
 
 theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) Assumptions (Spec a b c d) := by
-  circuit_proof_start [BLAKE3State.Normalized,
-    Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated, and_imp,
+  circuit_proof_start [BLAKE3State.Normalized, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated, and_imp,
     Addition32.Assumptions, Addition32.Spec, Rotation32.Assumptions, Rotation32.Spec,
     Xor32.Assumptions, Xor32.Spec, getElem_eval_vector]
 

--- a/Clean/Gadgets/BLAKE3/BLAKE3G.lean
+++ b/Clean/Gadgets/BLAKE3/BLAKE3G.lean
@@ -72,7 +72,8 @@ def Spec (a b c d : Fin 16) (input : Inputs (F p)) (out : BLAKE3State (F p)) :=
   out.value = g state.value a b c d x.value y.value ∧ out.Normalized
 
 theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) Assumptions (Spec a b c d) := by
-  circuit_proof_start [BLAKE3State.Normalized, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated, and_imp,
+  circuit_proof_start [BLAKE3State.Normalized, Inputs.mk.injEq,
+    Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated, and_imp,
     Addition32.Assumptions, Addition32.Spec, Rotation32.Assumptions, Rotation32.Spec,
     Xor32.Assumptions, Xor32.Spec, getElem_eval_vector]
 
@@ -118,7 +119,7 @@ theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) Assu
     · simp only [Vector.getElem_map, getElem_eval_vector, h_input, h_assumptions]
 
 theorem completeness (a b c d : Fin 16) : Completeness (F p) (elaborated a b c d) Assumptions := by
-  circuit_proof_start [BLAKE3State.Normalized]
+  circuit_proof_start [BLAKE3State.Normalized, Inputs.mk.injEq]
 
   dsimp only [main, circuit_norm, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated] at h_env ⊢
   simp only [circuit_norm, and_imp,

--- a/Clean/Gadgets/BLAKE3/BLAKE3G.lean
+++ b/Clean/Gadgets/BLAKE3/BLAKE3G.lean
@@ -106,12 +106,12 @@ theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) Assu
     simp only [eval_vector, Vector.map_set, ↓Vector.getElem_set]
     repeat' split
     · exact c11.right
-    · simp only [U32.Normalized, explicit_provable_type, toVars, Vector.map_mk, List.map_toArray,
+    · simp only [U32.Normalized, explicit_provable_type, Vector.map_mk, List.map_toArray,
         List.map_cons, List.map_nil, fromElements] at c12 ⊢
       simp +arith only [Nat.reducePow, Nat.add_mod_mod, Nat.reduceMod] at c12 ⊢
       exact c12.right
     · exact c14.right
-    · simp only [U32.Normalized, explicit_provable_type, toVars, Vector.map_mk, List.map_toArray,
+    · simp only [U32.Normalized, explicit_provable_type, Vector.map_mk, List.map_toArray,
         List.map_cons, List.map_nil, fromElements] at c9 ⊢
       simp +arith only [Nat.reducePow, Nat.add_mod_mod, Nat.reduceMod] at c9 ⊢
       exact c9.right

--- a/Clean/Gadgets/BLAKE3/BLAKE3G.lean
+++ b/Clean/Gadgets/BLAKE3/BLAKE3G.lean
@@ -72,7 +72,7 @@ def Spec (a b c d : Fin 16) (input : Inputs (F p)) (out : BLAKE3State (F p)) :=
   out.value = g state.value a b c d x.value y.value ∧ out.Normalized
 
 theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) Assumptions (Spec a b c d) := by
-  circuit_proof_start [BLAKE3State.Normalized, Inputs.mk.injEq,
+  circuit_proof_start [BLAKE3State.Normalized,
     Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated, and_imp,
     Addition32.Assumptions, Addition32.Spec, Rotation32.Assumptions, Rotation32.Spec,
     Xor32.Assumptions, Xor32.Spec, getElem_eval_vector]
@@ -119,7 +119,7 @@ theorem soundness (a b c d : Fin 16) : Soundness (F p) (elaborated a b c d) Assu
     · simp only [Vector.getElem_map, getElem_eval_vector, h_input, h_assumptions]
 
 theorem completeness (a b c d : Fin 16) : Completeness (F p) (elaborated a b c d) Assumptions := by
-  circuit_proof_start [BLAKE3State.Normalized, Inputs.mk.injEq]
+  circuit_proof_start [BLAKE3State.Normalized]
 
   dsimp only [main, circuit_norm, Xor32.circuit, Addition32.circuit, Rotation32.circuit, Rotation32.elaborated] at h_env ⊢
   simp only [circuit_norm, and_imp,

--- a/Clean/Gadgets/BLAKE3/Compress.lean
+++ b/Clean/Gadgets/BLAKE3/Compress.lean
@@ -45,7 +45,7 @@ def Spec (input : ApplyRounds.Inputs (F p)) (output : BLAKE3State (F p)) : Prop 
   output.Normalized
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start [ApplyRounds.Inputs.mk.injEq]
+  circuit_proof_start
   simp_all only [circuit_norm, ApplyRounds.circuit,
     ApplyRounds.Spec, FinalStateUpdate.circuit, FinalStateUpdate.Assumptions, compress,
     ApplyRounds.Assumptions, FinalStateUpdate.Spec]
@@ -57,7 +57,7 @@ lemma ApplyRouunds.circuit_spec_is :
   ApplyRounds.circuit.Spec (F := F p) = ApplyRounds.Spec := rfl
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start [ApplyRounds.Inputs.mk.injEq]
+  circuit_proof_start
   simp_all only [circuit_norm, ApplyRounds.circuit_assumptions_is, ApplyRouunds.circuit_spec_is,
     ApplyRounds.Spec, FinalStateUpdate.circuit, FinalStateUpdate.Assumptions,
     ApplyRounds.Assumptions, FinalStateUpdate.Spec]

--- a/Clean/Gadgets/BLAKE3/Compress.lean
+++ b/Clean/Gadgets/BLAKE3/Compress.lean
@@ -45,7 +45,7 @@ def Spec (input : ApplyRounds.Inputs (F p)) (output : BLAKE3State (F p)) : Prop 
   output.Normalized
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start
+  circuit_proof_start [ApplyRounds.Inputs.mk.injEq]
   simp_all only [circuit_norm, ApplyRounds.circuit,
     ApplyRounds.Spec, FinalStateUpdate.circuit, FinalStateUpdate.Assumptions, compress,
     ApplyRounds.Assumptions, FinalStateUpdate.Spec]
@@ -57,7 +57,7 @@ lemma ApplyRouunds.circuit_spec_is :
   ApplyRounds.circuit.Spec (F := F p) = ApplyRounds.Spec := rfl
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start
+  circuit_proof_start [ApplyRounds.Inputs.mk.injEq]
   simp_all only [circuit_norm, ApplyRounds.circuit_assumptions_is, ApplyRouunds.circuit_spec_is,
     ApplyRounds.Spec, FinalStateUpdate.circuit, FinalStateUpdate.Assumptions,
     ApplyRounds.Assumptions, FinalStateUpdate.Spec]

--- a/Clean/Gadgets/BLAKE3/FinalStateUpdate.lean
+++ b/Clean/Gadgets/BLAKE3/FinalStateUpdate.lean
@@ -115,7 +115,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     c14, Fin.val_eq_zero, zero_add, c15, implies_true, and_self]
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start [BLAKE3State.Normalized, Inputs.mk.injEq]
+  circuit_proof_start [BLAKE3State.Normalized]
 
   obtain ⟨h_input_state, h_input_cv⟩ := h_input
   obtain ⟨state_norm, chaining_value_norm⟩ := h_assumptions

--- a/Clean/Gadgets/BLAKE3/FinalStateUpdate.lean
+++ b/Clean/Gadgets/BLAKE3/FinalStateUpdate.lean
@@ -79,12 +79,8 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   intro i0 env ⟨state_var, chaining_value_var⟩ ⟨state, chaining_value⟩ h_input h_normalized h_holds
   simp only [circuit_norm, Inputs.mk.injEq] at h_input
 
-  dsimp only [main, circuit_norm, Xor32.circuit, Xor32.elaborated] at h_holds
-  simp only [FormalCircuit.toSubcircuit, Circuit.operations, ElaboratedCircuit.main,
-    ElaboratedCircuit.localLength, Xor32.Assumptions,
-    ProvableStruct.eval_eq_eval, ProvableStruct.eval, fromComponents, components, toComponents,
-    ProvableStruct.eval.go, getElem_eval_vector, h_input, Xor32.Spec, ElaboratedCircuit.output,
-    and_imp, Nat.add_zero, add_zero, and_true] at h_holds
+  simp only [main, circuit_norm, Xor32.circuit, Xor32.elaborated] at h_holds
+  simp only [Xor32.Assumptions, getElem_eval_vector, h_input, Xor32.Spec, and_imp] at h_holds
 
   ring_nf at h_holds
 
@@ -119,7 +115,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     c14, Fin.val_eq_zero, zero_add, c15, implies_true, and_self]
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start [BLAKE3State.Normalized]
+  circuit_proof_start [BLAKE3State.Normalized, Inputs.mk.injEq]
 
   obtain ⟨h_input_state, h_input_cv⟩ := h_input
   obtain ⟨state_norm, chaining_value_norm⟩ := h_assumptions

--- a/Clean/Gadgets/BLAKE3/FinalizeChunk.lean
+++ b/Clean/Gadgets/BLAKE3/FinalizeChunk.lean
@@ -44,8 +44,8 @@ def bytesToWords {F} (bytes : Vector F 64) : Vector (U32 F) 16 :=
 
 omit p_large_enough in
 lemma bytesToWords_normalized (env : Environment (F p)) (bytes_var : Var (ProvableVector field 64) (F p))
-    (h_bytes : ∀ i : Fin 64, (eval env bytes_var)[i].val < 256) :
-    ∀ i : Fin 16, (eval env (α := ProvableVector U32 16) (bytesToWords bytes_var))[i].Normalized := by
+    (h_bytes : ∀ i : Fin 64, (ProvableType.eval env bytes_var)[i].val < 256) :
+    ∀ i : Fin 16, (ProvableType.eval env (α := ProvableVector U32 16) (bytesToWords bytes_var))[i].Normalized := by
   rintro ⟨i, h_i⟩
   simp only [bytesToWords, Fin.getElem_fin]
   have h0 := h_bytes ⟨ i*4, by omega ⟩
@@ -124,8 +124,8 @@ private lemma ZMod_val_chunkEnd :
 omit p_large_enough in
 private lemma eval_bytesToWords (env : Environment (F p))
     (input_var_buffer_data : Vector (Expression (F p)) 64) :
-    eval env (α := ProvableVector U32 16) (bytesToWords input_var_buffer_data) =
-      bytesToWords (eval (α:=ProvableVector field 64) env input_var_buffer_data) := by
+    ProvableType.eval env (α := ProvableVector U32 16) (bytesToWords input_var_buffer_data) =
+      bytesToWords (ProvableType.eval (α:=ProvableVector field 64) env input_var_buffer_data) := by
   simp only [bytesToWords, circuit_norm, eval_vector]
   simp only [id_eq]
   rw [Vector.ext_iff]
@@ -135,10 +135,11 @@ private lemma eval_bytesToWords (env : Environment (F p))
   have := getElem_eval_vector (α:=field) env input_var_buffer_data (i*4 + 1) (by omega)
   have := getElem_eval_vector (α:=field) env input_var_buffer_data (i*4 + 2) (by omega)
   have := getElem_eval_vector (α:=field) env input_var_buffer_data (i*4 + 3) (by omega)
-  simp_all
+  simp_all [circuit_norm]
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start [IsZero.circuit, Or32.circuit, Compress.circuit, ApplyRounds.circuit,
+  circuit_proof_start [Inputs.mk.injEq, ProcessBlocksState.mk.injEq,
+    IsZero.circuit, Or32.circuit, Compress.circuit, ApplyRounds.circuit,
     IsZero.Spec, IsZero.Assumptions,
     Or32.Spec, Or32.Assumptions,
     Compress.Spec, Compress.Assumptions,
@@ -171,7 +172,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     rw [h_compress']
     simp only [finalizeChunk]
     apply congrArg (fun (v : Vector ℕ 16) => v.take 8)
-    have : Vector.map (U32.value ∘ eval env) (bytesToWords input_var_buffer_data) =
+    have : Vector.map (U32.value ∘ ProvableType.eval env) (bytesToWords input_var_buffer_data) =
         (Specs.BLAKE3.bytesToWords
         (List.map (fun x ↦ ZMod.val x) (input_buffer_data.extract 0 (ZMod.val input_buffer_len)).toList)) := by
       clear h_compress' h_Or32_2 h_Or32_1 h_IsZero h_Compress
@@ -209,7 +210,10 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     simp only [getElem_eval_vector, h_Compress_Normalized]
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start
+  circuit_proof_start [Inputs.mk.injEq, ProcessBlocksState.mk.injEq]
+  rcases input_state with ⟨cv, counter, blocks_compressed⟩
+  simp only [circuit_norm, ProcessBlocksState.mk.injEq] at *
+  simp only [h_input] at h_env ⊢
   apply And.intro
   · trivial
   rcases h_env with ⟨h_iszero, h_env⟩
@@ -259,14 +263,13 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     omega
   )
   simp only [Or32.circuit, Or32.Spec] at h_or2
-  simp only [ProcessBlocksState.Normalized] at h_assumptions
-  simp only [h_or2, h_assumptions]
-  simp only [circuit_norm]
+  simp only [circuit_norm, ProcessBlocksState.Normalized] at h_assumptions
+  simp only [circuit_norm, h_or2, h_assumptions]
+  clear h_or2 h_or h_env
   constructor
   · apply bytesToWords_normalized
-    simp only [h_input]
-    aesop
-  omega
+    simp_all
+  · omega
 
 def circuit : FormalCircuit (F p) Inputs (ProvableVector U32 8) := {
   elaborated with Assumptions, Spec, soundness, completeness

--- a/Clean/Gadgets/BLAKE3/FinalizeChunk.lean
+++ b/Clean/Gadgets/BLAKE3/FinalizeChunk.lean
@@ -44,8 +44,8 @@ def bytesToWords {F} (bytes : Vector F 64) : Vector (U32 F) 16 :=
 
 omit p_large_enough in
 lemma bytesToWords_normalized (env : Environment (F p)) (bytes_var : BLAKE3Buffer (Expression (F p)))
-    (h_bytes : ∀ i : Fin 64, (ProvableType.eval env bytes_var)[i].val < 256) :
-    ∀ i : Fin 16, (ProvableType.eval env (α := ProvableVector U32 16) (bytesToWords bytes_var))[i].Normalized := by
+    (h_bytes : ∀ i : Fin 64, (ProvableType.eval' env bytes_var)[i].val < 256) :
+    ∀ i : Fin 16, (ProvableType.eval' env (α := ProvableVector U32 16) (bytesToWords bytes_var))[i].Normalized := by
   rintro ⟨i, h_i⟩
   simp only [bytesToWords, Fin.getElem_fin]
   have h0 := h_bytes ⟨ i*4, by omega ⟩
@@ -124,8 +124,8 @@ private lemma ZMod_val_chunkEnd :
 omit p_large_enough in
 private lemma eval_bytesToWords (env : Environment (F p))
     (input_var_buffer_data : Vector (Expression (F p)) 64) :
-    ProvableType.eval env (α := ProvableVector U32 16) (bytesToWords input_var_buffer_data) =
-      bytesToWords (ProvableType.eval (α:=ProvableVector field 64) env input_var_buffer_data) := by
+    ProvableType.eval' env (α := ProvableVector U32 16) (bytesToWords input_var_buffer_data) =
+      bytesToWords (ProvableType.eval' (α:=ProvableVector field 64) env input_var_buffer_data) := by
   simp only [bytesToWords, circuit_norm, eval_vector]
   simp only [id_eq]
   rw [Vector.ext_iff]
@@ -171,7 +171,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     rw [h_compress']
     simp only [finalizeChunk]
     apply congrArg (fun (v : Vector ℕ 16) => v.take 8)
-    have : Vector.map (U32.value ∘ ProvableType.eval env) (bytesToWords input_var_buffer_data) =
+    have : Vector.map (U32.value ∘ ProvableType.eval' env) (bytesToWords input_var_buffer_data) =
         (Specs.BLAKE3.bytesToWords
         (List.map (fun x ↦ ZMod.val x) (input_buffer_data.extract 0 (ZMod.val input_buffer_len)).toList)) := by
       clear h_compress' h_Or32_2 h_Or32_1 h_IsZero h_Compress

--- a/Clean/Gadgets/BLAKE3/FinalizeChunk.lean
+++ b/Clean/Gadgets/BLAKE3/FinalizeChunk.lean
@@ -138,8 +138,7 @@ private lemma eval_bytesToWords (env : Environment (F p))
   simp_all [circuit_norm]
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start [Inputs.mk.injEq, ProcessBlocksState.mk.injEq,
-    IsZero.circuit, Or32.circuit, Compress.circuit, ApplyRounds.circuit,
+  circuit_proof_start [IsZero.circuit, Or32.circuit, Compress.circuit, ApplyRounds.circuit,
     IsZero.Spec, IsZero.Assumptions,
     Or32.Spec, Or32.Assumptions,
     Compress.Spec, Compress.Assumptions,
@@ -210,10 +209,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     simp only [getElem_eval_vector, h_Compress_Normalized]
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start [Inputs.mk.injEq, ProcessBlocksState.mk.injEq]
-  rcases input_state with ⟨cv, counter, blocks_compressed⟩
-  simp only [circuit_norm, ProcessBlocksState.mk.injEq] at *
-  simp only [h_input] at h_env ⊢
+  circuit_proof_start
   apply And.intro
   · trivial
   rcases h_env with ⟨h_iszero, h_env⟩

--- a/Clean/Gadgets/BLAKE3/FinalizeChunk.lean
+++ b/Clean/Gadgets/BLAKE3/FinalizeChunk.lean
@@ -54,7 +54,7 @@ lemma bytesToWords_normalized (env : Environment (F p)) (bytes_var : BLAKE3Buffe
   have h2 := h_bytes ⟨ i*4 + 2, by omega ⟩
   have h3 := h_bytes ⟨ i*4 + 3, by omega ⟩
   simp only [circuit_norm, eval_vector] at h0 h1 h2 h3 ⊢
-  simp only [Vector.getElem_ofFn, U32.Normalized, explicit_provable_type, toVars]
+  simp only [Vector.getElem_ofFn, U32.Normalized, explicit_provable_type]
   simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil]
   and_intros <;> assumption
 

--- a/Clean/Gadgets/BLAKE3/FinalizeChunk.lean
+++ b/Clean/Gadgets/BLAKE3/FinalizeChunk.lean
@@ -43,7 +43,7 @@ def bytesToWords {F} (bytes : Vector F 64) : Vector (U32 F) 16 :=
       bytes[base + 3]
 
 omit p_large_enough in
-lemma bytesToWords_normalized (env : Environment (F p)) (bytes_var : Var (ProvableVector field 64) (F p))
+lemma bytesToWords_normalized (env : Environment (F p)) (bytes_var : BLAKE3Buffer (Expression (F p)))
     (h_bytes : ∀ i : Fin 64, (ProvableType.eval env bytes_var)[i].val < 256) :
     ∀ i : Fin 16, (ProvableType.eval env (α := ProvableVector U32 16) (bytesToWords bytes_var))[i].Normalized := by
   rintro ⟨i, h_i⟩

--- a/Clean/Gadgets/BLAKE3/FinalizeChunk.lean
+++ b/Clean/Gadgets/BLAKE3/FinalizeChunk.lean
@@ -44,8 +44,9 @@ def bytesToWords {F} (bytes : Vector F 64) : Vector (U32 F) 16 :=
 
 omit p_large_enough in
 lemma bytesToWords_normalized (env : Environment (F p)) (bytes_var : BLAKE3Buffer (Expression (F p)))
-    (h_bytes : ∀ i : Fin 64, (ProvableType.eval' env bytes_var)[i].val < 256) :
-    ∀ i : Fin 16, (ProvableType.eval' env (α := ProvableVector U32 16) (bytesToWords bytes_var))[i].Normalized := by
+    (h_bytes : ∀ i : Fin 64, (eval env bytes_var)[i].val < 256) :
+    ∀ i : Fin 16,
+      (eval env (bytesToWords bytes_var : ProvableVector U32 16 (Expression (F p))))[i].Normalized := by
   rintro ⟨i, h_i⟩
   simp only [bytesToWords, Fin.getElem_fin]
   have h0 := h_bytes ⟨ i*4, by omega ⟩
@@ -123,19 +124,14 @@ private lemma ZMod_val_chunkEnd :
 
 omit p_large_enough in
 private lemma eval_bytesToWords (env : Environment (F p))
-    (input_var_buffer_data : Vector (Expression (F p)) 64) :
-    ProvableType.eval' env (α := ProvableVector U32 16) (bytesToWords input_var_buffer_data) =
-      bytesToWords (ProvableType.eval' (α:=ProvableVector field 64) env input_var_buffer_data) := by
+    (input_var_buffer_data : BLAKE3Buffer (Expression (F p))) :
+  eval env (bytesToWords input_var_buffer_data : ProvableVector U32 16 (Expression (F p))) =
+      bytesToWords (eval env input_var_buffer_data : BLAKE3Buffer (F p)) := by
   simp only [bytesToWords, circuit_norm, eval_vector]
-  simp only [id_eq]
   rw [Vector.ext_iff]
   intro i hi
-  simp only [Vector.getElem_map, Vector.getElem_ofFn, U32.eval_of_literal, U32.mk.injEq]
-  have := getElem_eval_vector (α:=field) env input_var_buffer_data (i*4) (by omega)
-  have := getElem_eval_vector (α:=field) env input_var_buffer_data (i*4 + 1) (by omega)
-  have := getElem_eval_vector (α:=field) env input_var_buffer_data (i*4 + 2) (by omega)
-  have := getElem_eval_vector (α:=field) env input_var_buffer_data (i*4 + 3) (by omega)
-  simp_all [circuit_norm]
+  simp only [Vector.getElem_map, Vector.getElem_ofFn, U32.eval_of_literal]
+  rfl
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   circuit_proof_start [IsZero.circuit, Or32.circuit, Compress.circuit, ApplyRounds.circuit,
@@ -171,7 +167,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     rw [h_compress']
     simp only [finalizeChunk]
     apply congrArg (fun (v : Vector ℕ 16) => v.take 8)
-    have : Vector.map (U32.value ∘ ProvableType.eval' env) (bytesToWords input_var_buffer_data) =
+    have : Vector.map (U32.value ∘ eval env) (bytesToWords input_var_buffer_data) =
         (Specs.BLAKE3.bytesToWords
         (List.map (fun x ↦ ZMod.val x) (input_buffer_data.extract 0 (ZMod.val input_buffer_len)).toList)) := by
       clear h_compress' h_Or32_2 h_Or32_1 h_IsZero h_Compress

--- a/Clean/Gadgets/BLAKE3/Permute.lean
+++ b/Clean/Gadgets/BLAKE3/Permute.lean
@@ -1,4 +1,5 @@
 import Clean.Gadgets.BLAKE3.BLAKE3State
+import Clean.Circuit
 
 namespace Gadgets.BLAKE3.Permute
 variable {p : ℕ} [Fact p.Prime]
@@ -19,8 +20,8 @@ def Spec (state : BLAKE3State (F p)) (out : BLAKE3State (F p)) :=
   out.value = permute state.value ∧ out.Normalized
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  intro i0 env state_var state h_input h_normalized h_holds
-  simp only [Spec, BLAKE3State.value, Vector.map, ElaboratedCircuit.output, ↓Fin.getElem_fin,
+  circuit_proof_start
+  simp only [BLAKE3State.value, Vector.map, ↓Fin.getElem_fin,
     eval_vector, Vector.toArray_ofFn, Array.map_map, permute, Vector.getElem_mk, Array.getElem_map,
     ↓Vector.getElem_toArray, Vector.mk_eq]
   constructor
@@ -31,13 +32,11 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   · simp [BLAKE3State.Normalized]
     intro i
     rw [getElem_eval_vector, h_input]
-    simp only [Assumptions, BLAKE3State.Normalized] at h_normalized
-    fin_cases i <;> simp only [msgPermutation, h_normalized]
+    simp only [BLAKE3State.Normalized] at h_assumptions
+    fin_cases i <;> simp only [msgPermutation, h_assumptions]
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  rintro i0 env state_var henv state h_inputs h_normalized
-  simp_all only [Circuit.operations, ElaboratedCircuit.main, main, pure, ↓Fin.getElem_fin,
-    ProverEnvironment.UsesLocalWitnessesCompleteness.eq_1, Circuit.ConstraintsHold.Completeness.eq_1]
+  circuit_proof_all
 
 def circuit : FormalCircuit (F p) BLAKE3State BLAKE3State :=
   { elaborated with Assumptions, Spec, soundness, completeness }

--- a/Clean/Gadgets/BLAKE3/Round.lean
+++ b/Clean/Gadgets/BLAKE3/Round.lean
@@ -46,7 +46,7 @@ def Spec (input : Inputs (F p)) (out : BLAKE3State (F p)) :=
   out.value = round state.value (message.map U32.value) ∧ out.Normalized
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start
+  circuit_proof_start [Inputs.mk.injEq]
 
   obtain ⟨h_state, h_message⟩ := h_assumptions
 
@@ -93,7 +93,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   · exact c8.right
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start [G.circuit, G.Assumptions, G.Spec, ProverEnvironment.UsesLocalWitnessesCompleteness,
+  circuit_proof_start [Inputs.mk.injEq, G.circuit, G.Assumptions, G.Spec, ProverEnvironment.UsesLocalWitnessesCompleteness,
     getElem_eval_vector, Fin.isValue, and_imp, and_true]
 
   obtain ⟨c1, c2, c3, c4, c5, c6, c7, c8⟩ := h_env

--- a/Clean/Gadgets/BLAKE3/Round.lean
+++ b/Clean/Gadgets/BLAKE3/Round.lean
@@ -46,7 +46,7 @@ def Spec (input : Inputs (F p)) (out : BLAKE3State (F p)) :=
   out.value = round state.value (message.map U32.value) ∧ out.Normalized
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start [Inputs.mk.injEq]
+  circuit_proof_start
 
   obtain ⟨h_state, h_message⟩ := h_assumptions
 
@@ -93,7 +93,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   · exact c8.right
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start [Inputs.mk.injEq, G.circuit, G.Assumptions, G.Spec, ProverEnvironment.UsesLocalWitnessesCompleteness,
+  circuit_proof_start [G.circuit, G.Assumptions, G.Spec, ProverEnvironment.UsesLocalWitnessesCompleteness,
     getElem_eval_vector, Fin.isValue, and_imp, and_true]
 
   obtain ⟨c1, c2, c3, c4, c5, c6, c7, c8⟩ := h_env

--- a/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
@@ -96,7 +96,7 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (circuit := elaborated offs
 
 theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) Assumptions := by
   rintro i0 env x_var henv (x : F p) h_input (x_byte : x.val < 256)
-  simp only [circuit_norm, ProvableType.eval_field] at h_input
+  simp only [circuit_norm] at h_input
   simp only [circuit_norm, main, elaborated, h_input, ByteTable] at henv ⊢
   simp only [henv]
   have pow_8_nat : 2^8 = 2^(8-offset.val) * 2^offset.val := by simp [←pow_add]

--- a/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
@@ -96,7 +96,7 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (circuit := elaborated offs
 
 theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) Assumptions := by
   rintro i0 env x_var henv (x : F p) h_input (x_byte : x.val < 256)
-  simp only [ProvableType.eval_field] at h_input
+  simp only [circuit_norm, ProvableType.eval_field] at h_input
   simp only [circuit_norm, main, elaborated, h_input, ByteTable] at henv ⊢
   simp only [henv]
   have pow_8_nat : 2^8 = 2^(8-offset.val) * 2^offset.val := by simp [←pow_add]

--- a/Clean/Gadgets/Conditional.lean
+++ b/Clean/Gadgets/Conditional.lean
@@ -117,8 +117,8 @@ omit [Field F] in
 @[circuit_norm]
 theorem eval_ifElse_output [Field F] [DecidableEq F] {M : TypeMap} [ProvableType M] {env}
   (selector : Expression F) (ifTrue ifFalse : M (Expression F)) :
-  eval env (output selector ifTrue ifFalse) =
-    outputValue (selector.eval env) (eval env ifTrue) (eval env ifFalse) := by
+  eval' env (output selector ifTrue ifFalse) =
+    outputValue (selector.eval env) (eval' env ifTrue) (eval' env ifFalse) := by
   simp only [output, outputValue, circuit_norm]
 
   -- Show that the result equals the conditional expression

--- a/Clean/Gadgets/Conditional.lean
+++ b/Clean/Gadgets/Conditional.lean
@@ -10,8 +10,6 @@ section
 variable {F : Type} [Field F]
 variable {M : TypeMap} [ProvableType M]
 
-open ProvableType
-
 /--
 Inputs for conditional selection between two ProvableTypes.
 Contains a selector bit and two data values.
@@ -121,14 +119,13 @@ theorem eval_ifElse_output [Field F] [DecidableEq F] {M : TypeMap} [ProvableType
   (selector : Expression F) (ifTrue ifFalse : M (Expression F)) :
   eval env (output selector ifTrue ifFalse) =
     outputValue (selector.eval env) (eval env ifTrue) (eval env ifFalse) := by
-  simp only [output, outputValue]
+  simp only [output, outputValue, circuit_norm]
 
   -- Show that the result equals the conditional expression
-  rw [ProvableType.ext_iff, fromVars, toVars]
+  rw [ProvableType.ext_iff]
   intro i hi
   rw [ProvableType.eval_fromElements]
-  simp only [circuit_norm, ProvableType.toElements_fromElements,
-    Vector.getElem_map, Vector.getElem_ofFn, ProvableType.getElem_eval_toElements]
+  simp only [circuit_norm, Vector.getElem_map, Vector.getElem_ofFn, ProvableType.getElem_eval_toElements]
   ring
 end
 

--- a/Clean/Gadgets/Conditional.lean
+++ b/Clean/Gadgets/Conditional.lean
@@ -117,8 +117,8 @@ omit [Field F] in
 @[circuit_norm]
 theorem eval_ifElse_output [Field F] [DecidableEq F] {M : TypeMap} [ProvableType M] {env}
   (selector : Expression F) (ifTrue ifFalse : M (Expression F)) :
-  eval' env (output selector ifTrue ifFalse) =
-    outputValue (selector.eval env) (eval' env ifTrue) (eval' env ifFalse) := by
+  eval env (output selector ifTrue ifFalse) =
+    outputValue (selector.eval env) (eval env ifTrue) (eval env ifFalse) := by
   simp only [output, outputValue, circuit_norm]
 
   -- Show that the result equals the conditional expression

--- a/Clean/Gadgets/Conditional.lean
+++ b/Clean/Gadgets/Conditional.lean
@@ -24,18 +24,18 @@ def main [DecidableEq F] (input : Var (Inputs M) F) : Circuit F (Var M F) := do
   let { selector, ifTrue, ifFalse } := input
 
   -- Inline element-wise scalar multiplication / addition
-  let trueVars := toVars ifTrue
-  let falseVars := toVars ifFalse
+  let trueVars := toElements ifTrue
+  let falseVars := toElements ifFalse
   let resultVars := Vector.ofFn fun i => selector * (trueVars[i] - falseVars[i]) + falseVars[i]
 
-  return fromVars resultVars
+  return fromElements (M:=M) resultVars
 
 def output (selector: Expression F) (ifTrue ifFalse : Var M F) : Var M F :=
   -- Inline element-wise scalar multiplication / addition
-  let trueVars := toVars ifTrue
-  let falseVars := toVars ifFalse
+  let trueVars := toElements (M:=M) ifTrue
+  let falseVars := toElements (M:=M) ifFalse
   let resultVars := Vector.ofFn fun i => selector * (trueVars[i] - falseVars[i]) + falseVars[i]
-  fromVars resultVars
+  fromElements (M:=M) resultVars
 
 def outputValue (selector: F) (ifTrue ifFalse : M F) : M F :=
   -- Inline element-wise scalar multiplication / addition

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -98,12 +98,12 @@ lemma elaborated_eq (α : TypeMap) [ProvableType α] : (circuit α (F:=F)).elabo
 
 @[circuit_norm]
 theorem spec (α : TypeMap) [ProvableType α] (n : ℕ) (env : Environment F) (x y : Var α F) :
-    ((circuit α).toSubcircuit n (x, y)).Spec env = (eval env x = eval env y) := by
+    ((circuit α).toSubcircuit n (x, y)).Spec env = (eval' env x = eval' env y) := by
   simp only [circuit_norm, circuit]
 
 @[circuit_norm]
 theorem proverAssumptions (α : TypeMap) [ProvableType α] (n : ℕ) (env : ProverEnvironment F) (x y : Var α F) :
-    ((circuit α).toSubcircuit n (x, y)).ProverAssumptions env = (eval env x = eval env y) := by
+    ((circuit α).toSubcircuit n (x, y)).ProverAssumptions env = (eval' env x = eval' env y) := by
   simp only [circuit_norm, circuit]
 
 @[circuit_norm]
@@ -153,7 +153,7 @@ instance {F : Type} [Field F] : HasAssignEq (Expression F) F where
 instance {F : Type} [Field F] {α : TypeMap} [ProvableType α] :
   HasAssignEq (α (Expression F)) F where
   assignEq := fun rhs => do
-    let witness ← ProvableType.witness fun env => eval env rhs
+    let witness ← ProvableType.witness fun env => eval' env rhs
     witness === rhs
     return witness
 

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -55,7 +55,7 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
     simp only [circuit_norm, Prod.mk.injEq] at h_input
     obtain ⟨ hx, hy ⟩ := h_input
     rw [←hx, ←hy]
-    simp only [ProvableType.eval]
+    simp only [ProvableType.eval']
     congr 1
     ext i hi
     simp only [Vector.getElem_map]
@@ -79,7 +79,7 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
     rw [←hx, ←hy] at h_spec
     clear hx hy
     apply_fun toElements at h_spec
-    simp only [ProvableType.eval, ProvableType.toElements_fromElements, toVars] at h_spec
+    simp only [ProvableType.eval', ProvableType.toElements_fromElements, toVars] at h_spec
     rw [Vector.ext_iff] at h_spec
 
     rw [toVars, toVars, ←Vector.forall_getElem]

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -55,7 +55,7 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
     simp only [circuit_norm, Prod.mk.injEq] at h_input
     obtain ⟨ hx, hy ⟩ := h_input
     rw [←hx, ←hy]
-    simp only [CircuitType.eval_expression, ProvableType.eval']
+    simp only [CircuitType.eval_expression, ProvableType.eval]
     congr 1
     ext i hi
     simp only [Vector.getElem_map]
@@ -79,7 +79,7 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
     rw [←hx, ←hy] at h_spec
     clear hx hy
     apply_fun toElements at h_spec
-    simp only [CircuitType.eval_expression, ProvableType.eval',
+    simp only [CircuitType.eval_expression, ProvableType.eval,
       ProvableType.toElements_fromElements] at h_spec
     rw [Vector.ext_iff] at h_spec
 

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -55,7 +55,7 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
     simp only [circuit_norm, Prod.mk.injEq] at h_input
     obtain ⟨ hx, hy ⟩ := h_input
     rw [←hx, ←hy]
-    simp only [eval]
+    simp only [ProvableType.eval]
     congr 1
     ext i hi
     simp only [Vector.getElem_map]
@@ -79,7 +79,7 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
     rw [←hx, ←hy] at h_spec
     clear hx hy
     apply_fun toElements at h_spec
-    simp only [eval, ProvableType.toElements_fromElements, toVars] at h_spec
+    simp only [ProvableType.eval, ProvableType.toElements_fromElements, toVars] at h_spec
     rw [Vector.ext_iff] at h_spec
 
     rw [toVars, toVars, ←Vector.forall_getElem]

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -24,9 +24,9 @@ theorem allZero.completeness {offset : ℕ} {env : ProverEnvironment F} {n} {xs 
   exact h_holds xs[i] (Vector.mem_of_getElem rfl)
 
 namespace Equality
-def main {α : TypeMap} [ProvableType α] (input : Var α F × Var α F) : Circuit F Unit := do
+def main {M : TypeMap} [ProvableType M] (input : Var M F × Var M F) : Circuit F Unit := do
   let (x, y) := input
-  let diffs := (toVars x).zip (toVars y) |>.map (fun (xi, yi) => xi - yi)
+  let diffs := (toElements (M:=M) x).zip (toElements y) |>.map (fun (xi, yi) => xi - yi)
   .forEach diffs assertZero
 
 @[reducible]
@@ -60,7 +60,7 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
     ext i hi
     simp only [Vector.getElem_map]
 
-    rw [toVars, toVars, ←Vector.forall_getElem] at h_holds
+    rw [←Vector.forall_getElem] at h_holds
     specialize h_holds i hi
     rw [Vector.getElem_map, Vector.getElem_zip] at h_holds
     simp only [Expression.eval] at h_holds
@@ -80,10 +80,10 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
     clear hx hy
     apply_fun toElements at h_spec
     simp only [CircuitType.eval_expression, ProvableType.eval',
-      ProvableType.toElements_fromElements, toVars] at h_spec
+      ProvableType.toElements_fromElements] at h_spec
     rw [Vector.ext_iff] at h_spec
 
-    rw [toVars, toVars, ←Vector.forall_getElem]
+    rw [←Vector.forall_getElem]
     intro i hi
     specialize h_spec i hi
     simp only [Vector.getElem_map] at h_spec

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -55,7 +55,7 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
     simp only [circuit_norm, Prod.mk.injEq] at h_input
     obtain ⟨ hx, hy ⟩ := h_input
     rw [←hx, ←hy]
-    simp only [ProvableType.eval']
+    simp only [CircuitType.eval_var, ProvableType.eval']
     congr 1
     ext i hi
     simp only [Vector.getElem_map]
@@ -79,7 +79,8 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
     rw [←hx, ←hy] at h_spec
     clear hx hy
     apply_fun toElements at h_spec
-    simp only [ProvableType.eval', ProvableType.toElements_fromElements, toVars] at h_spec
+    simp only [CircuitType.eval_var, ProvableType.eval',
+      ProvableType.toElements_fromElements, toVars] at h_spec
     rw [Vector.ext_iff] at h_spec
 
     rw [toVars, toVars, ←Vector.forall_getElem]

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -55,7 +55,7 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
     simp only [circuit_norm, Prod.mk.injEq] at h_input
     obtain ⟨ hx, hy ⟩ := h_input
     rw [←hx, ←hy]
-    simp only [CircuitType.eval_var, ProvableType.eval']
+    simp only [CircuitType.eval_expression, ProvableType.eval']
     congr 1
     ext i hi
     simp only [Vector.getElem_map]
@@ -79,7 +79,7 @@ def circuit (α : TypeMap) [ProvableType α] : FormalAssertion F (ProvablePair �
     rw [←hx, ←hy] at h_spec
     clear hx hy
     apply_fun toElements at h_spec
-    simp only [CircuitType.eval_var, ProvableType.eval',
+    simp only [CircuitType.eval_expression, ProvableType.eval',
       ProvableType.toElements_fromElements, toVars] at h_spec
     rw [Vector.ext_iff] at h_spec
 

--- a/Clean/Gadgets/Equality.lean
+++ b/Clean/Gadgets/Equality.lean
@@ -98,12 +98,12 @@ lemma elaborated_eq (α : TypeMap) [ProvableType α] : (circuit α (F:=F)).elabo
 
 @[circuit_norm]
 theorem spec (α : TypeMap) [ProvableType α] (n : ℕ) (env : Environment F) (x y : Var α F) :
-    ((circuit α).toSubcircuit n (x, y)).Spec env = (eval' env x = eval' env y) := by
+    ((circuit α).toSubcircuit n (x, y)).Spec env = (eval env x = eval env y) := by
   simp only [circuit_norm, circuit]
 
 @[circuit_norm]
 theorem proverAssumptions (α : TypeMap) [ProvableType α] (n : ℕ) (env : ProverEnvironment F) (x y : Var α F) :
-    ((circuit α).toSubcircuit n (x, y)).ProverAssumptions env = (eval' env x = eval' env y) := by
+    ((circuit α).toSubcircuit n (x, y)).ProverAssumptions env = (eval env x = eval env y) := by
   simp only [circuit_norm, circuit]
 
 @[circuit_norm]
@@ -153,7 +153,7 @@ instance {F : Type} [Field F] : HasAssignEq (Expression F) F where
 instance {F : Type} [Field F] {α : TypeMap} [ProvableType α] :
   HasAssignEq (α (Expression F)) F where
   assignEq := fun rhs => do
-    let witness ← ProvableType.witness fun env => eval' env rhs
+    let witness ← ProvableType.witness fun env => eval env rhs
     witness === rhs
     return witness
 

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -56,7 +56,7 @@ lemma foldl_isZero_eq_one_iff {n : ℕ} {vars : Vector (Expression F) n} {vals :
     if ∀ (i : ℕ) (x : i < n), vals[i] = 0 then 1 else 0 := by
   simp only [IsZeroField.circuit, IsZeroField.Assumptions, IsZeroField.Spec] at h_isZero
   induction n generalizing i₀
-  · simp only [id_eq, Fin.getElem_fin, Fin.foldl_zero, Expression.eval]
+  · simp only [Fin.getElem_fin, Fin.foldl_zero, Expression.eval]
     simp only [not_lt_zero', IsEmpty.forall_iff, implies_true, ↓reduceIte]
   · rename_i pre h_ih
     simp only [Fin.foldl_succ_last, Expression.eval]
@@ -69,8 +69,8 @@ lemma foldl_isZero_eq_one_iff {n : ℕ} {vars : Vector (Expression F) n} {vals :
     specialize h_ih h_eval_pre (i₀:=i₀)
     simp only [vars_pre, vals_pre] at *
     simp only [Fin.getElem_fin,
-      Vector.getElem_cast, forall_const, id_eq] at h_ih
-    simp only [id_eq, Fin.getElem_fin, Fin.val_castSucc, Fin.val_last]
+      Vector.getElem_cast, forall_const] at h_ih
+    simp only [Fin.getElem_fin, Fin.val_castSucc, Fin.val_last]
     specialize h_ih (by
       intro i
       specialize h_isZero i.castSucc

--- a/Clean/Gadgets/IsZero.lean
+++ b/Clean/Gadgets/IsZero.lean
@@ -16,7 +16,7 @@ Main circuit that checks if all elements of a ProvableType are zero.
 Returns 1 if all elementts are 0, otherwise returns 0.
 -/
 def main (input : Var M F) : Circuit F (Var field F) := do
-  let elemVars := toVars input
+  let elemVars := toElements (M:=M) input
   -- Use foldlRange to multiply all IsZero results together
   -- Start with 1, and for each element, multiply by its IsZero result
   let result ← Circuit.foldlRange (size M) (1 : Expression F) fun acc i => do

--- a/Clean/Gadgets/IsZeroField.lean
+++ b/Clean/Gadgets/IsZeroField.lean
@@ -12,7 +12,7 @@ variable {F : Type} [Field F] [DecidableEq F]
 Main circuit that checks if a field element is zero.
 Returns 1 if the input is 0, otherwise returns 0.
 -/
-def main (x : Var field F) : Circuit F (Var field F) := do
+def main (x : Expression F) : Circuit F (Expression F) := do
   -- When x ≠ 0, we need x_inv such that x * x_inv = 1
   -- When x = 0, x_inv can be anything (we use 0)
   let xInv ← witness fun env =>

--- a/Clean/Gadgets/Keccak/AbsorbBlock.lean
+++ b/Clean/Gadgets/Keccak/AbsorbBlock.lean
@@ -53,8 +53,8 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     (Vector.mapFinRange 17 fun i => varFromOffset (F:=F p) U64 (i0 + i.val * 8)) ++
     (Vector.mapFinRange 8 fun i => state_var[17 + i.val])
 
-  suffices goal : (eval env state_after_absorb).Normalized
-    ∧ (eval env state_after_absorb).value =
+  suffices goal : (ProvableType.eval env state_after_absorb).Normalized
+    ∧ (ProvableType.eval env state_after_absorb).value =
       .mapFinRange 25 fun i => state.value[i.val] ^^^ if h : i.val < 17 then block.value[i.val] else 0 by
     simp_all
   replace h_holds := h_holds.left
@@ -91,8 +91,8 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     (Vector.mapFinRange 17 fun i => varFromOffset (F:=F p) U64 (i0 + i.val * 8)) ++
     (Vector.mapFinRange 8 fun i => state_var[17 + i.val])
 
-  suffices goal : (eval env state_after_absorb).Normalized
-    ∧ (eval env state_after_absorb).value =
+  suffices goal : (ProvableType.eval env state_after_absorb).Normalized
+    ∧ (ProvableType.eval env state_after_absorb).value =
       .mapFinRange 25 fun i => state.value[i.val] ^^^ if h : i.val < 17 then block.value[i.val] else 0 by
     simp_all
   replace h_env := h_env.left

--- a/Clean/Gadgets/Keccak/AbsorbBlock.lean
+++ b/Clean/Gadgets/Keccak/AbsorbBlock.lean
@@ -53,9 +53,9 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     (Vector.mapFinRange 17 fun i => varFromOffset (F:=F p) U64 (i0 + i.val * 8)) ++
     (Vector.mapFinRange 8 fun i => state_var[17 + i.val])
 
-  suffices goal : (ProvableType.eval' env state_after_absorb).Normalized
-    ∧ (ProvableType.eval' env state_after_absorb).value =
-      .mapFinRange 25 fun i => state.value[i.val] ^^^ if h : i.val < 17 then block.value[i.val] else 0 by
+  suffices goal : KeccakState.Normalized (eval env state_after_absorb)
+    ∧ KeccakState.value (eval env state_after_absorb) =
+      Vector.mapFinRange 25 fun i => state.value[i.val] ^^^ if h : i.val < 17 then block.value[i.val] else 0 by
     simp_all
   replace h_holds := h_holds.left
 
@@ -91,8 +91,8 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     (Vector.mapFinRange 17 fun i => varFromOffset (F:=F p) U64 (i0 + i.val * 8)) ++
     (Vector.mapFinRange 8 fun i => state_var[17 + i.val])
 
-  suffices goal : (ProvableType.eval' env state_after_absorb).Normalized
-    ∧ (ProvableType.eval' env state_after_absorb).value =
+  suffices goal : KeccakState.Normalized (eval env.toEnvironment state_after_absorb)
+    ∧ KeccakState.value (eval env.toEnvironment state_after_absorb) =
       .mapFinRange 25 fun i => state.value[i.val] ^^^ if h : i.val < 17 then block.value[i.val] else 0 by
     simp_all
   replace h_env := h_env.left

--- a/Clean/Gadgets/Keccak/AbsorbBlock.lean
+++ b/Clean/Gadgets/Keccak/AbsorbBlock.lean
@@ -53,8 +53,8 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     (Vector.mapFinRange 17 fun i => varFromOffset (F:=F p) U64 (i0 + i.val * 8)) ++
     (Vector.mapFinRange 8 fun i => state_var[17 + i.val])
 
-  suffices goal : (ProvableType.eval env state_after_absorb).Normalized
-    ∧ (ProvableType.eval env state_after_absorb).value =
+  suffices goal : (ProvableType.eval' env state_after_absorb).Normalized
+    ∧ (ProvableType.eval' env state_after_absorb).value =
       .mapFinRange 25 fun i => state.value[i.val] ^^^ if h : i.val < 17 then block.value[i.val] else 0 by
     simp_all
   replace h_holds := h_holds.left
@@ -91,8 +91,8 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
     (Vector.mapFinRange 17 fun i => varFromOffset (F:=F p) U64 (i0 + i.val * 8)) ++
     (Vector.mapFinRange 8 fun i => state_var[17 + i.val])
 
-  suffices goal : (ProvableType.eval env state_after_absorb).Normalized
-    ∧ (ProvableType.eval env state_after_absorb).value =
+  suffices goal : (ProvableType.eval' env state_after_absorb).Normalized
+    ∧ (ProvableType.eval' env state_after_absorb).value =
       .mapFinRange 25 fun i => state.value[i.val] ^^^ if h : i.val < 17 then block.value[i.val] else 0 by
     simp_all
   replace h_env := h_env.left

--- a/Clean/Gadgets/Keccak/AbsorbBlock.lean
+++ b/Clean/Gadgets/Keccak/AbsorbBlock.lean
@@ -49,7 +49,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
     Input.mk.injEq] at *
 
   -- reduce goal to characterizing absorb step
-  set state_after_absorb : Var KeccakState (F p) :=
+  set state_after_absorb : KeccakState (Expression (F p)) :=
     (Vector.mapFinRange 17 fun i => varFromOffset (F:=F p) U64 (i0 + i.val * 8)) ++
     (Vector.mapFinRange 8 fun i => state_var[17 + i.val])
 
@@ -87,7 +87,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
   simp only [assumptions', and_true, true_implies, implies_true, true_and] at h_env ⊢
 
   -- reduce goal to characterizing absorb step
-  set state_after_absorb : Var KeccakState (F p) :=
+  set state_after_absorb : KeccakState (Expression (F p)) :=
     (Vector.mapFinRange 17 fun i => varFromOffset (F:=F p) U64 (i0 + i.val * 8)) ++
     (Vector.mapFinRange 8 fun i => state_var[17 + i.val])
 

--- a/Clean/Gadgets/Keccak/Chi.lean
+++ b/Clean/Gadgets/Keccak/Chi.lean
@@ -44,7 +44,8 @@ lemma chi_loop (state : Vector ℕ 25) :
   rfl
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  intro i0 env state_var state h_input state_norm h_holds
+  circuit_proof_start [ Xor64.circuit, And.And64.circuit, Not.circuit,
+    Xor64.Assumptions, Xor64.Spec, And.And64.Assumptions, And.And64.Spec]
 
   -- simplify goal
   apply KeccakState.normalized_value_ext
@@ -52,22 +53,17 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
 
   -- simplify constraints
   simp only [circuit_norm, eval_vector, Vector.ext_iff] at h_input
-  simp only [Assumptions, KeccakState.Normalized] at state_norm
-  simp only [main, circuit_norm, Xor64.circuit, And.And64.circuit, Not.circuit,
-    Xor64.Assumptions, Xor64.Spec, And.And64.Assumptions, And.And64.Spec, Nat.reduceAdd] at h_holds
+  simp only [KeccakState.Normalized] at h_assumptions
+  simp only [circuit_norm, Nat.reduceAdd] at h_holds
 
   simp_all
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  intro i0 env state_var h_env state h_input state_norm
-
-  -- simplify Assumptions
+  circuit_proof_start [Xor64.circuit, And.And64.circuit, Not.circuit,
+    Xor64.Assumptions, Xor64.Spec, And.And64.Assumptions, And.And64.Spec,
+    KeccakState.Normalized]
   simp only [circuit_norm, eval_vector, Vector.ext_iff] at h_input
-  simp only [Assumptions, KeccakState.Normalized] at state_norm
-
-  -- simplify constraints (goal + environment) and apply assumptions
-  simp_all [main, circuit_norm, Xor64.circuit, And.And64.circuit, Not.circuit,
-    Xor64.Assumptions, Xor64.Spec, And.And64.Assumptions, And.And64.Spec, Nat.reduceAdd]
+  simp_all
 
 def circuit : FormalCircuit (F p) KeccakState KeccakState :=
   { elaborated with Assumptions, Spec, soundness, completeness }

--- a/Clean/Gadgets/Keccak/KeccakRound.lean
+++ b/Clean/Gadgets/Keccak/KeccakRound.lean
@@ -56,7 +56,7 @@ theorem soundness (rc : UInt64) : Soundness (F p) (elaborated rc) Assumptions (S
   clear theta_norm theta_eq h_rhopi rhopi_eq rhopi_norm h_chi state_norm h_input
 
   -- simplify round constant constraint
-  set state0_before_rc := ProvableType.eval' env (varFromOffset U64 (i0 + 888))
+  set state0_before_rc := eval env (varFromOffset U64 (F:=F p) (i0 + 888))
   have h_rc_norm : state0_before_rc.Normalized := by
     simp only [KeccakState.Normalized, eval_vector, circuit_norm] at chi_norm
     exact chi_norm 0

--- a/Clean/Gadgets/Keccak/KeccakRound.lean
+++ b/Clean/Gadgets/Keccak/KeccakRound.lean
@@ -56,7 +56,7 @@ theorem soundness (rc : UInt64) : Soundness (F p) (elaborated rc) Assumptions (S
   clear theta_norm theta_eq h_rhopi rhopi_eq rhopi_norm h_chi state_norm h_input
 
   -- simplify round constant constraint
-  set state0_before_rc := ProvableType.eval env (varFromOffset U64 (i0 + 888))
+  set state0_before_rc := ProvableType.eval' env (varFromOffset U64 (i0 + 888))
   have h_rc_norm : state0_before_rc.Normalized := by
     simp only [KeccakState.Normalized, eval_vector, circuit_norm] at chi_norm
     exact chi_norm 0

--- a/Clean/Gadgets/Keccak/KeccakRound.lean
+++ b/Clean/Gadgets/Keccak/KeccakRound.lean
@@ -41,6 +41,7 @@ theorem soundness (rc : UInt64) : Soundness (F p) (elaborated rc) Assumptions (S
 
   -- simplify constraints
   simp only [Assumptions] at state_norm
+  simp only [circuit_norm] at h_input state_norm
   simp only [main, h_input, state_norm, circuit_norm,
     Theta.circuit, RhoPi.circuit, Chi.circuit, Xor64.circuit,
     Theta.Assumptions, Theta.Spec, RhoPi.Assumptions, RhoPi.Spec,
@@ -55,7 +56,7 @@ theorem soundness (rc : UInt64) : Soundness (F p) (elaborated rc) Assumptions (S
   clear theta_norm theta_eq h_rhopi rhopi_eq rhopi_norm h_chi state_norm h_input
 
   -- simplify round constant constraint
-  set state0_before_rc := eval env (varFromOffset U64 (i0 + 888))
+  set state0_before_rc := ProvableType.eval env (varFromOffset U64 (i0 + 888))
   have h_rc_norm : state0_before_rc.Normalized := by
     simp only [KeccakState.Normalized, eval_vector, circuit_norm] at chi_norm
     exact chi_norm 0

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -53,7 +53,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   specialize h_init h_assumptions
 
   -- clean up formulation
-  let state (i : ℕ) : KeccakState (F p) := ProvableType.eval env (stateVar n i)
+  let state (i : ℕ) : KeccakState (F p) := ProvableType.eval' env (stateVar n i)
 
   change (state 0).Normalized ∧
     (state 0).value = keccakRound initial_state.value roundConstants[0]
@@ -97,7 +97,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
   intro i hi
 
   -- clean up formulation
-  let state (i : ℕ) : KeccakState (F p) := ProvableType.eval env (stateVar n i)
+  let state (i : ℕ) : KeccakState (F p) := ProvableType.eval' env (stateVar n i)
 
   change (state 0).Normalized at h_init
 

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -53,7 +53,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   specialize h_init h_assumptions
 
   -- clean up formulation
-  let state (i : ℕ) : KeccakState (F p) := ProvableType.eval' env (stateVar n i)
+  let state (i : ℕ) : KeccakState (F p) := eval env (stateVar (p:=p) n i)
 
   change (state 0).Normalized ∧
     (state 0).value = keccakRound initial_state.value roundConstants[0]
@@ -97,7 +97,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
   intro i hi
 
   -- clean up formulation
-  let state (i : ℕ) : KeccakState (F p) := ProvableType.eval' env (stateVar n i)
+  let state (i : ℕ) : KeccakState (F p) := eval env.toEnvironment (stateVar (p:=p) n i)
 
   change (state 0).Normalized at h_init
 

--- a/Clean/Gadgets/Keccak/Permutation.lean
+++ b/Clean/Gadgets/Keccak/Permutation.lean
@@ -44,6 +44,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   intro n env initial_state_var initial_state h_input h_assumptions h_holds
 
   -- simplify
+  simp only [circuit_norm] at h_input
   simp only [main, circuit_norm, Spec,
     KeccakRound.circuit, KeccakRound.elaborated,
     KeccakRound.Spec, KeccakRound.Assumptions] at h_holds ⊢
@@ -52,7 +53,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   specialize h_init h_assumptions
 
   -- clean up formulation
-  let state (i : ℕ) : KeccakState (F p) := eval env (stateVar n i)
+  let state (i : ℕ) : KeccakState (F p) := ProvableType.eval env (stateVar n i)
 
   change (state 0).Normalized ∧
     (state 0).value = keccakRound initial_state.value roundConstants[0]
@@ -84,6 +85,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
 
   -- simplify
   dsimp only [Assumptions] at h_assumptions
+  simp only [circuit_norm] at h_input h_assumptions
   simp only [main, h_input, h_assumptions, circuit_norm, KeccakRound.circuit,
     KeccakRound.elaborated, KeccakRound.Spec,
     KeccakRound.Assumptions] at h_env ⊢
@@ -95,7 +97,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
   intro i hi
 
   -- clean up formulation
-  let state (i : ℕ) : KeccakState (F p) := eval env (stateVar n i)
+  let state (i : ℕ) : KeccakState (F p) := ProvableType.eval env (stateVar n i)
 
   change (state 0).Normalized at h_init
 

--- a/Clean/Gadgets/Keccak/RhoPi.lean
+++ b/Clean/Gadgets/Keccak/RhoPi.lean
@@ -41,7 +41,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
 
   -- simplify goal
   apply KeccakState.normalized_value_ext
-  simp only [elaborated, eval_vector, Vector.getElem_map,
+  simp only [elaborated, Vector.getElem_map,
     KeccakState.value, rhoPi_loop]
 
   -- simplify constraints
@@ -49,7 +49,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   simp only [Assumptions, KeccakState.Normalized] at state_norm
   simp only [h_input, state_norm, main, circuit_norm,
     Rotation64.circuit, Rotation64.Assumptions, Rotation64.Spec, Rotation64.elaborated] at h_holds ⊢
-  simp_all [rhoPiConstants, rotLeft64_eq_rotRight64]
+  simp_all [rhoPiConstants, rotLeft64_eq_rotRight64, ←getElem_eval_vector, Vector.getElem_mapIdx]
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
   intro i0 env state_var h_env state h_input state_norm

--- a/Clean/Gadgets/Keccak/RhoPi.lean
+++ b/Clean/Gadgets/Keccak/RhoPi.lean
@@ -37,30 +37,28 @@ lemma rhoPi_loop (state : Vector ℕ 25) :
   simp [Specs.Keccak256.rhoPi, rhoPiConstants, rhoPiIndices, rhoPiShifts]
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  intro i0 env state_var state h_input state_norm h_holds
+  circuit_proof_start
 
   -- simplify goal
   apply KeccakState.normalized_value_ext
-  simp only [elaborated, Vector.getElem_map,
-    KeccakState.value, rhoPi_loop]
+  simp only [eval_vector, Vector.getElem_map, KeccakState.value, rhoPi_loop]
 
   -- simplify constraints
   simp only [circuit_norm, eval_vector, Vector.ext_iff] at h_input
-  simp only [Assumptions, KeccakState.Normalized] at state_norm
-  simp only [h_input, state_norm, main, circuit_norm,
+  simp only [KeccakState.Normalized] at h_assumptions
+  simp only [h_input, h_assumptions, circuit_norm,
     Rotation64.circuit, Rotation64.Assumptions, Rotation64.Spec, Rotation64.elaborated] at h_holds ⊢
-  simp_all [rhoPiConstants, rotLeft64_eq_rotRight64, ←getElem_eval_vector, Vector.getElem_mapIdx]
+  simp_all [rhoPiConstants, rotLeft64_eq_rotRight64]
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  intro i0 env state_var h_env state h_input state_norm
+  circuit_proof_start
 
   -- simplify assumptions
   simp only [circuit_norm, eval_vector, Vector.ext_iff] at h_input
-  simp only [Assumptions, KeccakState.Normalized] at state_norm
+  simp only [KeccakState.Normalized] at h_assumptions
 
   -- simplify constraints (goal + environment) and apply assumptions
-  simp_all [main, circuit_norm,
-    Rotation64.circuit, Rotation64.Assumptions, Rotation64.Spec]
+  simp_all [circuit_norm, Rotation64.circuit, Rotation64.Assumptions, Rotation64.Spec]
 
 def circuit : FormalCircuit (F p) KeccakState KeccakState :=
   { elaborated with Assumptions, Spec, soundness, completeness }

--- a/Clean/Gadgets/Keccak/ThetaD.lean
+++ b/Clean/Gadgets/Keccak/ThetaD.lean
@@ -45,7 +45,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   simp only [zero_sub, Fin.coe_neg_one, and_imp, add_assoc, Nat.reduceAdd] at h_holds
   simp only [circuit_norm, KeccakRow.normalized_iff, KeccakRow.value, eval_vector]
 
-  have s (i : ℕ) (hi : i < 5) : ProvableType.eval env (row_var[i]) = row[i] := by
+  have s (i : ℕ) (hi : i < 5) : ProvableType.eval' env (row_var[i]) = row[i] := by
     rw [←h_input, Vector.getElem_map]
 
   simp only [s] at h_holds

--- a/Clean/Gadgets/Keccak/ThetaD.lean
+++ b/Clean/Gadgets/Keccak/ThetaD.lean
@@ -45,7 +45,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   simp only [zero_sub, Fin.coe_neg_one, and_imp, add_assoc, Nat.reduceAdd] at h_holds
   simp only [circuit_norm, KeccakRow.normalized_iff, KeccakRow.value, eval_vector]
 
-  have s (i : ℕ) (hi : i < 5) : eval env (row_var[i]) = row[i] := by
+  have s (i : ℕ) (hi : i < 5) : ProvableType.eval env (row_var[i]) = row[i] := by
     rw [←h_input, Vector.getElem_map]
 
   simp only [s] at h_holds
@@ -79,7 +79,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
   dsimp only [circuit_norm, main, Xor64.circuit, Rotation64.circuit, Rotation64.elaborated] at h_env ⊢
   simp_all only [circuit_norm, getElem_eval_vector,
     Xor64.Assumptions, Xor64.Spec, Rotation64.Assumptions, Rotation64.Spec,
-    add_assoc, seval, true_and, true_implies]
+    add_assoc, seval, true_and]
 
 def circuit : FormalCircuit (F p) KeccakRow KeccakRow :=
   { elaborated with Assumptions, Spec, soundness, completeness }

--- a/Clean/Gadgets/Keccak/ThetaD.lean
+++ b/Clean/Gadgets/Keccak/ThetaD.lean
@@ -45,7 +45,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   simp only [zero_sub, Fin.coe_neg_one, and_imp, add_assoc, Nat.reduceAdd] at h_holds
   simp only [circuit_norm, KeccakRow.normalized_iff, KeccakRow.value, eval_vector]
 
-  have s (i : ℕ) (hi : i < 5) : ProvableType.eval' env (row_var[i]) = row[i] := by
+  have s (i : ℕ) (hi : i < 5) : eval env (row_var[i]) = row[i] := by
     rw [←h_input, Vector.getElem_map]
 
   simp only [s] at h_holds
@@ -74,9 +74,8 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   simp [Specs.Keccak256.thetaD, h_xor0, h_xor1, h_xor2, h_xor3, h_xor4, rotLeft64]
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  intro i0 env row_var h_env row h_input h_assumptions
-  simp only [Assumptions, KeccakRow.normalized_iff] at h_assumptions
-  dsimp only [circuit_norm, main, Xor64.circuit, Rotation64.circuit, Rotation64.elaborated] at h_env ⊢
+  circuit_proof_start [Xor64.circuit, Rotation64.circuit, Rotation64.elaborated]
+  simp only [KeccakRow.normalized_iff] at h_assumptions
   simp_all only [circuit_norm, getElem_eval_vector,
     Xor64.Assumptions, Xor64.Spec, Rotation64.Assumptions, Rotation64.Spec,
     add_assoc, seval, true_and]

--- a/Clean/Gadgets/Not/Not64.lean
+++ b/Clean/Gadgets/Not/Not64.lean
@@ -14,7 +14,7 @@ def not64_bytewise_value (x : U64 (F p)) : U64 (F p) := x.map (fun x => 255 - x)
 
 omit p_large_enough in
 lemma eval_not {env} {x_var : Var U64 (F p)} :
-    eval env (not64_bytewise x_var) = not64_bytewise_value (eval env x_var) := by
+    ProvableType.eval env (not64_bytewise x_var) = not64_bytewise_value (ProvableType.eval env x_var) := by
   rw [not64_bytewise, not64_bytewise_value, U64.map, U64.map]
   simp only [circuit_norm, explicit_provable_type]
   ring_nf

--- a/Clean/Gadgets/Not/Not64.lean
+++ b/Clean/Gadgets/Not/Not64.lean
@@ -8,13 +8,13 @@ variable {p : ℕ} [Fact p.Prime] [p_large_enough: Fact (p > 512)]
 
 namespace Gadgets.Not
 
-def not64_bytewise (x : Var U64 (F p)) : Var U64 (F p) := U64.map x (fun x => 255 - x)
+def not64_bytewise (x : U64 (Expression (F p))) : U64 (Expression (F p)) := U64.map x (fun x => 255 - x)
 
 def not64_bytewise_value (x : U64 (F p)) : U64 (F p) := x.map (fun x => 255 - x)
 
 omit p_large_enough in
-lemma eval_not {env} {x_var : Var U64 (F p)} :
-    ProvableType.eval' env (not64_bytewise x_var) = not64_bytewise_value (ProvableType.eval' env x_var) := by
+lemma eval_not {env : Environment (F p)} {x_var : U64 (Expression (F p))} :
+    eval env (not64_bytewise x_var) = not64_bytewise_value (eval env x_var) := by
   rw [not64_bytewise, not64_bytewise_value, U64.map, U64.map]
   simp only [circuit_norm, explicit_provable_type]
   ring_nf

--- a/Clean/Gadgets/Not/Not64.lean
+++ b/Clean/Gadgets/Not/Not64.lean
@@ -14,7 +14,7 @@ def not64_bytewise_value (x : U64 (F p)) : U64 (F p) := x.map (fun x => 255 - x)
 
 omit p_large_enough in
 lemma eval_not {env} {x_var : Var U64 (F p)} :
-    ProvableType.eval env (not64_bytewise x_var) = not64_bytewise_value (ProvableType.eval env x_var) := by
+    ProvableType.eval' env (not64_bytewise x_var) = not64_bytewise_value (ProvableType.eval' env x_var) := by
   rw [not64_bytewise, not64_bytewise_value, U64.map, U64.map]
   simp only [circuit_norm, explicit_provable_type]
   ring_nf

--- a/Clean/Gadgets/Or/Or32.lean
+++ b/Clean/Gadgets/Or/Or32.lean
@@ -37,6 +37,7 @@ instance elaborated : ElaboratedCircuit (F p) Inputs U32 where
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   circuit_proof_start [Or8.circuit, Or8.Assumptions, Or8.Spec]
+
   have l_components := U32.or_componentwise h_assumptions.1 h_assumptions.2
   rcases input_x
   rcases input_y
@@ -56,11 +57,11 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   simp
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start
+  -- TODO it's a regression that `Inputs.mk.injEq` is no longer identified and used automatically
+  circuit_proof_start [Inputs.mk.injEq]
   rcases input_x
   rcases input_y
-  simp only [explicit_provable_type, toVars, fromElements] at h_input ⊢
-  simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, U32.mk.injEq] at h_input ⊢
+  simp only [explicit_provable_type, toVars, fromElements, circuit_norm, U32.mk.injEq] at h_input ⊢
   simp only [Or8.circuit, Or8.Assumptions, h_input]
   simp only [U32.Normalized] at h_assumptions
   omega

--- a/Clean/Gadgets/Or/Or32.lean
+++ b/Clean/Gadgets/Or/Or32.lean
@@ -36,16 +36,13 @@ instance elaborated : ElaboratedCircuit (F p) Inputs U32 where
   localLength _ := 4
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start
+  circuit_proof_start [Or8.circuit, Or8.Assumptions, Or8.Spec]
   have l_components := U32.or_componentwise h_assumptions.1 h_assumptions.2
   rcases input_x
   rcases input_y
-  rcases input_var_x
-  rcases input_var_y
-  simp only [U32.Normalized] at *
-  simp only [explicit_provable_type, toVars, fromElements] at h_input ⊢ l_components
-  simp only [Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil, U32.mk.injEq] at h_input ⊢ l_components
-  simp only [Or8.circuit, Or8.Assumptions, Or8.Spec, h_input] at h_holds
+  simp only [circuit_norm, explicit_provable_type, toVars, fromElements,
+    Inputs.mk.injEq, U32.mk.injEq] at h_input ⊢ l_components
+  simp only [U32.Normalized, circuit_norm, h_input] at *
   rcases h_holds with ⟨h_holds1, h_holds⟩
   specialize h_holds1 (by omega)
   rcases h_holds with ⟨h_holds2, h_holds⟩
@@ -53,7 +50,6 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   rcases h_holds with ⟨h_holds3, h_holds4⟩
   specialize h_holds3 (by omega)
   specialize h_holds4 (by omega)
-  simp only [U32.value] at ⊢ l_components
   simp only [h_holds1.2, h_holds2.2, h_holds3.2, h_holds4.2] -- use the Normalized conditions
   simp only [h_holds1.1, h_holds2.1, h_holds3.1, h_holds4.1, l_components]
   ring_nf

--- a/Clean/Gadgets/Or/Or32.lean
+++ b/Clean/Gadgets/Or/Or32.lean
@@ -42,7 +42,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   rcases input_x
   rcases input_y
   simp only [circuit_norm, explicit_provable_type, toVars, fromElements,
-    Inputs.mk.injEq, U32.mk.injEq] at h_input ⊢ l_components
+    U32.mk.injEq] at h_input ⊢ l_components
   simp only [U32.Normalized, circuit_norm, h_input] at *
   rcases h_holds with ⟨h_holds1, h_holds⟩
   specialize h_holds1 (by omega)
@@ -57,8 +57,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   simp
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by
-  -- TODO it's a regression that `Inputs.mk.injEq` is no longer identified and used automatically
-  circuit_proof_start [Inputs.mk.injEq]
+  circuit_proof_start
   rcases input_x
   rcases input_y
   simp only [explicit_provable_type, toVars, fromElements, circuit_norm, U32.mk.injEq] at h_input ⊢

--- a/Clean/Gadgets/Or/Or32.lean
+++ b/Clean/Gadgets/Or/Or32.lean
@@ -41,7 +41,7 @@ theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   have l_components := U32.or_componentwise h_assumptions.1 h_assumptions.2
   rcases input_x
   rcases input_y
-  simp only [circuit_norm, explicit_provable_type, toVars, fromElements,
+  simp only [circuit_norm, explicit_provable_type, fromElements,
     U32.mk.injEq] at h_input ⊢ l_components
   simp only [U32.Normalized, circuit_norm, h_input] at *
   rcases h_holds with ⟨h_holds1, h_holds⟩
@@ -60,7 +60,7 @@ theorem completeness : Completeness (F p) elaborated Assumptions := by
   circuit_proof_start
   rcases input_x
   rcases input_y
-  simp only [explicit_provable_type, toVars, fromElements, circuit_norm, U32.mk.injEq] at h_input ⊢
+  simp only [explicit_provable_type, fromElements, circuit_norm, U32.mk.injEq] at h_input ⊢
   simp only [Or8.circuit, Or8.Assumptions, h_input]
   simp only [U32.Normalized] at h_assumptions
   omega

--- a/Clean/Gadgets/Or/Or8.lean
+++ b/Clean/Gadgets/Or/Or8.lean
@@ -20,7 +20,7 @@ def Spec (input : Inputs (F p)) (z : F p) :=
   let ⟨x, y⟩ := input
   z.val = x.val ||| y.val ∧ z.val < 256
 
-def main (input : Var Inputs (F p)) : Circuit (F p) (fieldVar (F p)) := do
+def main (input : Var Inputs (F p)) : Circuit (F p) (Expression (F p)) := do
   let ⟨x, y⟩ := input
   let or ← witness fun eval => (eval x).val ||| (eval y).val
   -- we prove OR correct using an XOR lookup

--- a/Clean/Gadgets/Rotation32/Rotation32.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32.lean
@@ -48,13 +48,13 @@ theorem soundness (offset : Fin 32) : Soundness (F p) (circuit := elaborated off
   -- abstract away intermediate U32
   let byte_offset : Fin 4 := ⟨ offset.val / 8, by omega ⟩
   let bit_offset : Fin 8 := ⟨ offset.val % 8, by omega ⟩
-  set byte_rotated := ProvableType.eval env
+  set byte_rotated := ProvableType.eval' env
     ((Rotation32Bytes.circuit byte_offset).output input_var i₀)
 
   simp only [Rotation32Bytes.circuit, Rotation32Bytes.elaborated,
     Rotation32Bytes.Assumptions, Rotation32Bytes.Spec, add_zero,
     Rotation32Bits.Assumptions, Rotation32Bits.Spec, output] at h_holds ⊢
-  set y := ProvableType.eval env (Rotation32Bits.output ⟨ offset.val % 8, by omega ⟩ i₀)
+  set y := ProvableType.eval' env (Rotation32Bits.output ⟨ offset.val % 8, by omega ⟩ i₀)
   simp_all only [forall_const, and_true]
 
   -- reason about rotation

--- a/Clean/Gadgets/Rotation32/Rotation32.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32.lean
@@ -43,52 +43,28 @@ def elaborated (off : Fin 32) : ElaboratedCircuit (F p) U32 U32 where
   output _inputs i0 := output off i0
 
 theorem soundness (offset : Fin 32) : Soundness (F p) (circuit := elaborated offset) Assumptions (Spec offset) := by
-  intro i0 env x_var x h_input x_normalized h_holds
-
-  simp [circuit_norm, main, elaborated,
-    Rotation32Bits.circuit, Rotation32Bits.elaborated] at h_holds
+  circuit_proof_start [Rotation32Bits.circuit, Rotation32Bits.elaborated]
 
   -- abstract away intermediate U32
   let byte_offset : Fin 4 := ⟨ offset.val / 8, by omega ⟩
   let bit_offset : Fin 8 := ⟨ offset.val % 8, by omega ⟩
-  set byte_rotated := ProvableType.eval env (ElaboratedCircuit.output (self:=Rotation32Bytes.elaborated byte_offset) (x_var : Var U32 _) i0)
+  set byte_rotated := ProvableType.eval env
+    ((Rotation32Bytes.circuit byte_offset).output input_var i₀)
 
-  simp only [Rotation32Bytes.circuit, Rotation32Bytes.elaborated, Rotation32Bytes.Assumptions,
-    Rotation32Bytes.Spec, Rotation32Bits.Assumptions, Rotation32Bits.Spec, add_zero] at h_holds
-
-  simp only [Spec, elaborated, output, ElaboratedCircuit.output]
-  set y := ProvableType.eval env (Rotation32Bits.output ⟨ offset.val % 8, by omega ⟩ i0)
-
-  simp [Assumptions] at x_normalized
-  rw [←h_input] at x_normalized
-  obtain ⟨h0, h1⟩ := h_holds
-  specialize h0 x_normalized
-  obtain ⟨hy_rot, hy_norm⟩ := h0
-  specialize h1 hy_norm
-  rw [hy_rot] at h1
-  obtain ⟨hy, hy_norm⟩ := h1
-  simp only [hy_norm, and_true]
-  rw [h_input] at hy x_normalized
+  simp only [Rotation32Bytes.circuit, Rotation32Bytes.elaborated,
+    Rotation32Bytes.Assumptions, Rotation32Bytes.Spec, add_zero,
+    Rotation32Bits.Assumptions, Rotation32Bits.Spec, output] at h_holds ⊢
+  set y := ProvableType.eval env (Rotation32Bits.output ⟨ offset.val % 8, by omega ⟩ i₀)
+  simp_all only [forall_const, and_true]
 
   -- reason about rotation
-  rw [rotRight32_composition _ _ _ (U32.value_lt_of_normalized x_normalized)] at hy
-  rw [hy, Nat.div_add_mod']
+  rw [rotRight32_composition _ _ _ (U32.value_lt_of_normalized h_assumptions),
+    Nat.div_add_mod']
 
 theorem completeness (offset : Fin 32) : Completeness (F p) (elaborated offset) Assumptions := by
-  intro i0 env x_var h_env x h_eval x_normalized
-
-  simp only [circuit_norm, main, elaborated,
-    Rotation32Bits.circuit, Rotation32Bits.elaborated, Rotation32Bits.Assumptions,
-    Rotation32Bytes.circuit, Rotation32Bytes.Assumptions, Rotation32Bytes.Spec] at h_env ⊢
-
-  obtain ⟨h0, _⟩ := h_env
-  rw [h_eval] at h0
-  specialize h0 x_normalized
-  obtain ⟨h_rot, h_norm⟩ := h0
-
-  simp only [Assumptions] at x_normalized
-  rw [h_eval]
-  simp only [x_normalized, true_and, h_norm]
+  circuit_proof_all [Rotation32Bits.circuit, Rotation32Bits.elaborated,
+    Rotation32Bits.Assumptions, Rotation32Bytes.circuit,
+    Rotation32Bytes.Assumptions, Rotation32Bytes.Spec]
 
 def circuit (offset : Fin 32) : FormalCircuit (F p) U32 U32 := {
   elaborated offset with

--- a/Clean/Gadgets/Rotation32/Rotation32.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32.lean
@@ -48,13 +48,13 @@ theorem soundness (offset : Fin 32) : Soundness (F p) (circuit := elaborated off
   -- abstract away intermediate U32
   let byte_offset : Fin 4 := ⟨ offset.val / 8, by omega ⟩
   let bit_offset : Fin 8 := ⟨ offset.val % 8, by omega ⟩
-  set byte_rotated := ProvableType.eval' env
+  set byte_rotated := eval env
     ((Rotation32Bytes.circuit byte_offset).output input_var i₀)
 
   simp only [Rotation32Bytes.circuit, Rotation32Bytes.elaborated,
     Rotation32Bytes.Assumptions, Rotation32Bytes.Spec, add_zero,
     Rotation32Bits.Assumptions, Rotation32Bits.Spec, output] at h_holds ⊢
-  set y := ProvableType.eval' env (Rotation32Bits.output ⟨ offset.val % 8, by omega ⟩ i₀)
+  set y : U32 (F p) := eval env (Rotation32Bits.output (p:=p) ⟨ offset.val % 8, by omega ⟩ i₀)
   simp_all only [forall_const, and_true]
 
   -- reason about rotation

--- a/Clean/Gadgets/Rotation32/Rotation32.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32.lean
@@ -51,13 +51,13 @@ theorem soundness (offset : Fin 32) : Soundness (F p) (circuit := elaborated off
   -- abstract away intermediate U32
   let byte_offset : Fin 4 := ⟨ offset.val / 8, by omega ⟩
   let bit_offset : Fin 8 := ⟨ offset.val % 8, by omega ⟩
-  set byte_rotated := eval env (ElaboratedCircuit.output (self:=Rotation32Bytes.elaborated byte_offset) (x_var : Var U32 _) i0)
+  set byte_rotated := ProvableType.eval env (ElaboratedCircuit.output (self:=Rotation32Bytes.elaborated byte_offset) (x_var : Var U32 _) i0)
 
   simp only [Rotation32Bytes.circuit, Rotation32Bytes.elaborated, Rotation32Bytes.Assumptions,
     Rotation32Bytes.Spec, Rotation32Bits.Assumptions, Rotation32Bits.Spec, add_zero] at h_holds
 
   simp only [Spec, elaborated, output, ElaboratedCircuit.output]
-  set y := eval env (Rotation32Bits.output ⟨ offset.val % 8, by omega ⟩ i0)
+  set y := ProvableType.eval env (Rotation32Bits.output ⟨ offset.val % 8, by omega ⟩ i0)
 
   simp [Assumptions] at x_normalized
   rw [←h_input] at x_normalized

--- a/Clean/Gadgets/Rotation32/Rotation32Bits.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32Bits.lean
@@ -70,7 +70,7 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumpt
 
   -- capture the rotation relation in terms of byte vectors
   set x := input
-  set y := ProvableType.eval' env (output offset i₀)
+  set y : U32 (F p) := eval env (output (p:=p) offset i₀)
   set xs := x.toLimbs
   set ys := y.toLimbs
   set o := offset.val

--- a/Clean/Gadgets/Rotation32/Rotation32Bits.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32Bits.lean
@@ -56,17 +56,12 @@ def elaborated (off : Fin 8) : ElaboratedCircuit (F p) U32 U32 where
       ByteDecomposition.circuit, ByteDecomposition.elaborated]
 
 theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumptions (Spec offset) := by
-  intro i0 env x_var x h_input x_normalized h_holds
-
-  -- simplify statements
-  dsimp only [circuit_norm, elaborated, main,
-    ByteDecomposition.circuit, ByteDecomposition.elaborated] at h_holds
-  simp only [Spec, circuit_norm, elaborated,
-    ByteDecomposition.Assumptions, ByteDecomposition.Spec] at h_holds ⊢
+  circuit_proof_start [ByteDecomposition.circuit, ByteDecomposition.elaborated,
+    ByteDecomposition.Assumptions, ByteDecomposition.Spec]
 
   -- targeted rewriting of the assumptions
-  rw [Assumptions, U32.ByteVector.normalized_iff] at x_normalized
-  simp only [U32.ByteVector.getElem_eval_toLimbs, h_input, x_normalized, true_implies,
+  rw [U32.ByteVector.normalized_iff] at h_assumptions
+  simp only [circuit_norm, U32.ByteVector.getElem_eval_toLimbs, h_input, h_assumptions, true_implies,
     Fin.forall_iff] at h_holds
 
   set base := ((2^(8-offset.val) : ℕ) : F p)
@@ -74,7 +69,8 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumpt
     rw [tsub_le_iff_right, le_add_iff_nonneg_right]; apply zero_le
 
   -- capture the rotation relation in terms of byte vectors
-  set y := eval env (output offset i0)
+  set x := input
+  set y := ProvableType.eval env (output offset i₀)
   set xs := x.toLimbs
   set ys := y.toLimbs
   set o := offset.val
@@ -84,8 +80,8 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumpt
       ys[i].val = xs[i].val / 2^o + (xs[(i + 1) % 4].val % 2^o) * 2^(8-o) := by
     simp only [ys, y, output, U32.ByteVector.eval_fromLimbs, U32.ByteVector.toLimbs_fromLimbs,
       Vector.getElem_map, Vector.getElem_ofFn, Expression.eval]
-    set high := env.get (i0 + i * 2 + 1)
-    set next_low := env.get (i0 + (i + 1) % 4 * 2)
+    set high := env.get (i₀ + i * 2 + 1)
+    set next_low := env.get (i₀ + (i + 1) % 4 * 2)
     have ⟨⟨_, high_eq⟩, ⟨_, high_lt⟩⟩ := h_holds i hi
     have ⟨⟨next_low_eq, _⟩, ⟨next_low_lt, _⟩⟩ := h_holds ((i + 1) % 4) (Nat.mod_lt _ (by norm_num))
     have next_low_lt' : next_low.val < 2^(8 - (8 - o)) := by rw [Nat.sub_sub_self offset.is_le']; exact next_low_lt
@@ -110,14 +106,11 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumpt
   exact ⟨ rotation32_bits_soundness offset.is_lt, y_norm ⟩
 
 theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) Assumptions := by
-  intro i0 env x_var _ x h_input x_normalized
-
-  -- simplify goal
-  simp only [main, elaborated, circuit_norm,
-    ByteDecomposition.circuit, ByteDecomposition.Assumptions]
+  circuit_proof_start [ByteDecomposition.circuit, ByteDecomposition.elaborated,
+    ByteDecomposition.Assumptions, ByteDecomposition.Spec]
 
   -- we only have to prove the byte decomposition assumptions
-  rw [Assumptions, U32.ByteVector.normalized_iff] at x_normalized
+  rw [U32.ByteVector.normalized_iff] at h_assumptions
   simp_all only [U32.ByteVector.getElem_eval_toLimbs, forall_const]
 
 def circuit (offset : Fin 8) : FormalCircuit (F p) U32 U32 := {

--- a/Clean/Gadgets/Rotation32/Rotation32Bits.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32Bits.lean
@@ -70,7 +70,7 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumpt
 
   -- capture the rotation relation in terms of byte vectors
   set x := input
-  set y := ProvableType.eval env (output offset i₀)
+  set y := ProvableType.eval' env (output offset i₀)
   set xs := x.toLimbs
   set ys := y.toLimbs
   set o := offset.val

--- a/Clean/Gadgets/Rotation32/Rotation32Bytes.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32Bytes.lean
@@ -53,8 +53,7 @@ instance elaborated (off : Fin 4): ElaboratedCircuit (F p) U32 U32 where
 theorem soundness (off : Fin 4) : Soundness (F p) (elaborated off) Assumptions (Spec off) := by
   rintro i0 env ⟨ x0_var, x1_var, x2_var, x3_var ⟩ ⟨ x0, x1, x2, x3 ⟩ h_inputs as h
 
-  simp only [circuit_norm, explicit_provable_type, toVars, Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil,
-    fromElements, U32.mk.injEq] at h_inputs
+  simp only [circuit_norm, explicit_provable_type, U32.mk.injEq] at h_inputs
   obtain ⟨h_x0, h_x1, h_x2, h_x3⟩ := h_inputs
   clear h
 

--- a/Clean/Gadgets/Rotation32/Rotation32Bytes.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32Bytes.lean
@@ -53,7 +53,7 @@ instance elaborated (off : Fin 4): ElaboratedCircuit (F p) U32 U32 where
 theorem soundness (off : Fin 4) : Soundness (F p) (elaborated off) Assumptions (Spec off) := by
   rintro i0 env ⟨ x0_var, x1_var, x2_var, x3_var ⟩ ⟨ x0, x1, x2, x3 ⟩ h_inputs as h
 
-  simp only [explicit_provable_type, toVars, Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil,
+  simp only [circuit_norm, explicit_provable_type, toVars, Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil,
     fromElements, U32.mk.injEq] at h_inputs
   obtain ⟨h_x0, h_x1, h_x2, h_x3⟩ := h_inputs
   clear h

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -49,13 +49,13 @@ theorem soundness (offset : Fin 64) : Soundness (F p) (circuit := elaborated off
   -- abstract away intermediate U64
   let byte_offset : Fin 8 := ⟨ offset.val / 8, by omega ⟩
   let bit_offset : Fin 8 := ⟨ offset.val % 8, by omega ⟩
-  set byte_rotated := ProvableType.eval env
+  set byte_rotated := ProvableType.eval' env
     ((Rotation64Bytes.circuit byte_offset).output input_var i₀)
 
   simp only [Rotation64Bytes.circuit, Rotation64Bytes.elaborated,
     Rotation64Bytes.Assumptions, Rotation64Bytes.Spec, add_zero,
     Rotation64Bits.Assumptions, Rotation64Bits.Spec, output] at h_holds ⊢
-  set y := ProvableType.eval env (Rotation64Bits.output ⟨ offset.val % 8, by omega ⟩ i₀)
+  set y := ProvableType.eval' env (Rotation64Bits.output ⟨ offset.val % 8, by omega ⟩ i₀)
   simp_all only [forall_const, and_true]
 
   -- reason about rotation

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -44,51 +44,28 @@ def elaborated (off : Fin 64) : ElaboratedCircuit (F p) U64 U64 where
   output _ i0 := output off i0
 
 theorem soundness (offset : Fin 64) : Soundness (F p) (circuit := elaborated offset) Assumptions (Spec offset) := by
-  intro i0 env x_var x h_input x_normalized h_holds
-
-  simp [circuit_norm, main, elaborated,
-    Rotation64Bits.circuit, Rotation64Bits.elaborated] at h_holds
+  circuit_proof_start [Rotation64Bits.circuit, Rotation64Bits.elaborated]
 
   -- abstract away intermediate U64
   let byte_offset : Fin 8 := ⟨ offset.val / 8, by omega ⟩
   let bit_offset : Fin 8 := ⟨ offset.val % 8, by omega ⟩
-  set byte_rotated := eval env (ElaboratedCircuit.output (self:=Rotation64Bytes.elaborated byte_offset) (x_var : Var U64 _) i0)
+  set byte_rotated := ProvableType.eval env
+    ((Rotation64Bytes.circuit byte_offset).output input_var i₀)
 
-  simp only [Rotation64Bytes.circuit, Rotation64Bytes.elaborated, Rotation64Bytes.Assumptions,
-    Rotation64Bytes.Spec, Rotation64Bits.Assumptions, Rotation64Bits.Spec, add_zero] at h_holds
-  simp only [Spec, elaborated, output, ElaboratedCircuit.output]
-  set y := eval env (Rotation64Bits.output ⟨ offset.val % 8, by omega ⟩ i0)
-
-  simp [Assumptions] at x_normalized
-  rw [←h_input] at x_normalized
-  obtain ⟨h0, h1⟩ := h_holds
-  specialize h0 x_normalized
-  obtain ⟨hy_rot, hy_norm⟩ := h0
-  specialize h1 hy_norm
-  rw [hy_rot] at h1
-  obtain ⟨hy, hy_norm⟩ := h1
-  simp only [hy_norm, and_true]
-  rw [h_input] at hy x_normalized
+  simp only [Rotation64Bytes.circuit, Rotation64Bytes.elaborated,
+    Rotation64Bytes.Assumptions, Rotation64Bytes.Spec, add_zero,
+    Rotation64Bits.Assumptions, Rotation64Bits.Spec, output] at h_holds ⊢
+  set y := ProvableType.eval env (Rotation64Bits.output ⟨ offset.val % 8, by omega ⟩ i₀)
+  simp_all only [forall_const, and_true]
 
   -- reason about rotation
-  rw [rotRight64_composition _ _ _ (U64.value_lt_of_normalized x_normalized)] at hy
-  rw [hy, Nat.div_add_mod']
+  rw [rotRight64_composition _ _ _ (U64.value_lt_of_normalized h_assumptions),
+    Nat.div_add_mod']
 
 theorem completeness (offset : Fin 64) : Completeness (F p) (elaborated offset) Assumptions := by
-  intro i0 env x_var h_env x h_eval x_normalized
-
-  simp only [circuit_norm, main, elaborated,
-    Rotation64Bits.circuit, Rotation64Bits.elaborated, Rotation64Bits.Assumptions,
-    Rotation64Bytes.circuit, Rotation64Bytes.Assumptions, Rotation64Bytes.Spec] at h_env ⊢
-
-  obtain ⟨h0, _⟩ := h_env
-  rw [h_eval] at h0
-  specialize h0 x_normalized
-  obtain ⟨h_rot, h_norm⟩ := h0
-
-  simp only [Assumptions] at x_normalized
-  rw [h_eval]
-  simp only [x_normalized, true_and, h_norm]
+  circuit_proof_all [Rotation64Bits.circuit, Rotation64Bits.elaborated,
+    Rotation64Bits.Assumptions, Rotation64Bytes.circuit,
+    Rotation64Bytes.Assumptions, Rotation64Bytes.Spec]
 
 def circuit (offset : Fin 64) : FormalCircuit (F p) U64 U64 := {
   elaborated offset with

--- a/Clean/Gadgets/Rotation64/Rotation64.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64.lean
@@ -49,13 +49,13 @@ theorem soundness (offset : Fin 64) : Soundness (F p) (circuit := elaborated off
   -- abstract away intermediate U64
   let byte_offset : Fin 8 := ⟨ offset.val / 8, by omega ⟩
   let bit_offset : Fin 8 := ⟨ offset.val % 8, by omega ⟩
-  set byte_rotated := ProvableType.eval' env
+  set byte_rotated := eval env
     ((Rotation64Bytes.circuit byte_offset).output input_var i₀)
 
   simp only [Rotation64Bytes.circuit, Rotation64Bytes.elaborated,
     Rotation64Bytes.Assumptions, Rotation64Bytes.Spec, add_zero,
     Rotation64Bits.Assumptions, Rotation64Bits.Spec, output] at h_holds ⊢
-  set y := ProvableType.eval' env (Rotation64Bits.output ⟨ offset.val % 8, by omega ⟩ i₀)
+  set y : U64 (F p) := eval env (Rotation64Bits.output (p:=p) ⟨ offset.val % 8, by omega ⟩ i₀)
   simp_all only [forall_const, and_true]
 
   -- reason about rotation

--- a/Clean/Gadgets/Rotation64/Rotation64Bits.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bits.lean
@@ -67,7 +67,7 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumpt
 
   -- capture the rotation relation in terms of byte vectors
   set x := input
-  set y := ProvableType.eval' env (output offset i₀)
+  set y : U64 (F p) := eval env (output (p:=p) offset i₀)
   set xs := x.toLimbs
   set ys := y.toLimbs
   set o := offset.val

--- a/Clean/Gadgets/Rotation64/Rotation64Bits.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bits.lean
@@ -67,7 +67,7 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumpt
 
   -- capture the rotation relation in terms of byte vectors
   set x := input
-  set y := ProvableType.eval env (output offset i₀)
+  set y := ProvableType.eval' env (output offset i₀)
   set xs := x.toLimbs
   set ys := y.toLimbs
   set o := offset.val

--- a/Clean/Gadgets/Rotation64/Rotation64Bits.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bits.lean
@@ -53,17 +53,12 @@ def elaborated (off : Fin 8) : ElaboratedCircuit (F p) U64 U64 where
       ByteDecomposition.circuit, ByteDecomposition.elaborated]
 
 theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumptions (Spec offset) := by
-  intro i0 env x_var x h_input x_normalized h_holds
-
-  -- simplify statements
-  dsimp only [circuit_norm, elaborated, main,
-    ByteDecomposition.circuit, ByteDecomposition.elaborated] at h_holds
-  simp only [Spec, circuit_norm, elaborated,
-    ByteDecomposition.Assumptions, ByteDecomposition.Spec] at h_holds ⊢
+  circuit_proof_start [ByteDecomposition.circuit, ByteDecomposition.elaborated,
+    ByteDecomposition.Assumptions, ByteDecomposition.Spec]
 
   -- targeted rewriting of the assumptions
-  rw [Assumptions, U64.ByteVector.normalized_iff] at x_normalized
-  simp only [U64.ByteVector.getElem_eval_toLimbs, h_input, x_normalized, true_implies,
+  rw [U64.ByteVector.normalized_iff] at h_assumptions
+  simp only [circuit_norm, U64.ByteVector.getElem_eval_toLimbs, h_input, h_assumptions, true_implies,
     Fin.forall_iff] at h_holds
 
   set base := ((2^(8-offset.val) : ℕ) : F p)
@@ -71,7 +66,8 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumpt
     rw [tsub_le_iff_right, le_add_iff_nonneg_right]; apply zero_le
 
   -- capture the rotation relation in terms of byte vectors
-  set y := eval env (output offset i0)
+  set x := input
+  set y := ProvableType.eval env (output offset i₀)
   set xs := x.toLimbs
   set ys := y.toLimbs
   set o := offset.val
@@ -81,8 +77,8 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumpt
       ys[i].val = xs[i].val / 2^o + (xs[(i + 1) % 8].val % 2^o) * 2^(8-o) := by
     simp only [ys, y, output, U64.ByteVector.eval_fromLimbs, U64.ByteVector.toLimbs_fromLimbs,
       Vector.getElem_map, Vector.getElem_ofFn, Expression.eval]
-    set high := env.get (i0 + i * 2 + 1)
-    set next_low := env.get (i0 + (i + 1) % 8 * 2)
+    set high := env.get (i₀ + i * 2 + 1)
+    set next_low := env.get (i₀ + (i + 1) % 8 * 2)
     have ⟨⟨_, high_eq⟩, ⟨_, high_lt⟩⟩ := h_holds i hi
     have ⟨⟨next_low_eq, _⟩, ⟨next_low_lt, _⟩⟩ := h_holds ((i + 1) % 8) (Nat.mod_lt _ (by norm_num))
     have next_low_lt' : next_low.val < 2^(8 - (8 - o)) := by rw [Nat.sub_sub_self offset.is_le']; exact next_low_lt
@@ -107,14 +103,11 @@ theorem soundness (offset : Fin 8) : Soundness (F p) (elaborated offset) Assumpt
   exact ⟨ rotation64_bits_soundness offset.is_lt, y_norm ⟩
 
 theorem completeness (offset : Fin 8) : Completeness (F p) (elaborated offset) Assumptions := by
-  intro i0 env x_var _ x h_input x_normalized
-
-  -- simplify goal
-  simp only [main, elaborated, circuit_norm,
-    ByteDecomposition.circuit, ByteDecomposition.Assumptions]
+  circuit_proof_start [ByteDecomposition.circuit, ByteDecomposition.elaborated,
+    ByteDecomposition.Assumptions, ByteDecomposition.Spec]
 
   -- we only have to prove the byte decomposition assumptions
-  rw [Assumptions, U64.ByteVector.normalized_iff] at x_normalized
+  rw [U64.ByteVector.normalized_iff] at h_assumptions
   simp_all only [U64.ByteVector.getElem_eval_toLimbs, forall_const]
 
 def circuit (offset : Fin 8) : FormalCircuit (F p) U64 U64 := {

--- a/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
@@ -64,7 +64,7 @@ instance elaborated (off : Fin 8): ElaboratedCircuit (F p) U64 U64 where
 theorem soundness (off : Fin 8) : Soundness (F p) (elaborated off) Assumptions (Spec off) := by
   rintro i0 env ⟨ x0_var, x1_var, x2_var, x3_var, x4_var, x5_var, x6_var, x7_var ⟩ ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ h_inputs as h
 
-  simp only [explicit_provable_type, toVars, Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil,
+  simp only [circuit_norm, explicit_provable_type, toVars, Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil,
     fromElements, U64.mk.injEq] at h_inputs
   obtain ⟨h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7⟩ := h_inputs
   clear h

--- a/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
@@ -64,7 +64,7 @@ instance elaborated (off : Fin 8): ElaboratedCircuit (F p) U64 U64 where
 theorem soundness (off : Fin 8) : Soundness (F p) (elaborated off) Assumptions (Spec off) := by
   rintro i0 env ⟨ x0_var, x1_var, x2_var, x3_var, x4_var, x5_var, x6_var, x7_var ⟩ ⟨ x0, x1, x2, x3, x4, x5, x6, x7 ⟩ h_inputs as h
 
-  simp only [circuit_norm, explicit_provable_type, toVars, Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil,
+  simp only [circuit_norm, explicit_provable_type, Vector.map_mk, List.map_toArray, List.map_cons, List.map_nil,
     fromElements, U64.mk.injEq] at h_inputs
   obtain ⟨h_x0, h_x1, h_x2, h_x3, h_x4, h_x5, h_x6, h_x7⟩ := h_inputs
   clear h

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -460,13 +460,13 @@ def assign (off : CellOffset W S) : Expression F → TableConstraint W S F Unit
 
 @[table_norm, table_assignment_norm]
 def assignCurrRow {W : ℕ+} (curr : Var S F) : TableConstraint W S F Unit :=
-  let vars := toVars curr
+  let vars := toElements (M:=S) curr
   forM (List.finRange (size S)) fun i =>
     assign (.curr i) vars[i]
 
 @[table_norm, table_assignment_norm]
 def assignNextRow {W : ℕ+} (next : Var S F) : TableConstraint W S F Unit :=
-  let vars := toVars next
+  let vars := toElements (M:=S) next
   forM (List.finRange (size S)) fun i =>
     assign (.next i) vars[i]
 end TableConstraint
@@ -624,7 +624,7 @@ def FormalTable.statement (table : FormalTable F S) (N : ℕ) (trace : TraceOfLe
 
 -- add some important lemmas to simp sets
 attribute [table_norm] List.mapIdx List.mapIdx.go
-attribute [table_norm low] size fromElements toElements toVars fromVars
+attribute [table_norm low] size fromElements toElements
 attribute [table_assignment_norm low] toElements
 attribute [table_norm] Circuit.ConstraintsHold.Soundness
 
@@ -654,5 +654,5 @@ macro_rules
     rw [Fin.foldr_zero]
     repeat rw [List.forM_cons]
     rw [List.forM_nil, bind_pure_unit]
-    simp only [seval, toVars, toElements, Fin.cast_eq_self, Fin.val_zero, Fin.val_one, Fin.isValue,
+    simp only [seval, toElements, Fin.cast_eq_self, Fin.val_zero, Fin.val_one, Fin.isValue,
       List.getElem_toArray, List.getElem_cons_zero, List.getElem_cons_succ, Fin.succ_zero_eq_one]))

--- a/Clean/Table/Inductive.lean
+++ b/Clean/Table/Inductive.lean
@@ -16,14 +16,14 @@ def InductiveTable.Soundness (F : Type) [Field F] (State Input : Type → Type) 
   -- for all rows and inputs
   ∀ (acc_var : Var State F) (x_var : Var Input F)
     (acc : State F) (x : Input F) (xs : List (Input F)) (xs_len : xs.length = row_index),
-      (ProvableType.eval' env acc_var = acc) ∧ (ProvableType.eval' env x_var = x) →
+      (eval env acc_var = acc) ∧ (eval env x_var = x) →
     -- if the constraints hold
     Circuit.ConstraintsHold.Soundness env (step acc_var x_var |>.operations ((size State) + (size Input))) →
     -- and assuming the spec on the current row and previous inputs
     Spec initialState xs row_index xs_len acc env.data →
     -- we can conclude the spec on the next row and inputs including the current input
     Spec initialState (xs.concat x) (row_index + 1) (xs_len ▸ List.length_concat)
-      (ProvableType.eval' env (step acc_var x_var |>.output ((size State) + (size Input)))) env.data
+      (eval env (step acc_var x_var |>.output ((size State) + (size Input)))) env.data
 
 def InductiveTable.Completeness (F : Type) [Field F] (State Input : Type → Type) [ProvableType State] [ProvableType Input]
     (InputAssumptions : ℕ → Input F → ProverData F → Prop)
@@ -34,7 +34,7 @@ def InductiveTable.Completeness (F : Type) [Field F] (State Input : Type → Typ
   -- for all rows and inputs
   ∀ (acc_var : Var State F) (x_var : Var Input F)
     (acc : State F) (x : Input F) (xs : List (Input F)) (xs_len : xs.length = row_index),
-    (ProvableType.eval' env acc_var = acc) ∧ (ProvableType.eval' env x_var = x) →
+    (eval env acc_var = acc) ∧ (eval env x_var = x) →
   -- when using honest-prover witnesses
   env.UsesLocalWitnessesCompleteness ((size State) + (size Input)) (step acc_var x_var |>.operations ((size State) + (size Input))) →
   -- assuming the spec on the current row, the input_spec on the input, and initial state assumptions
@@ -121,7 +121,7 @@ theorem equalityConstraint.soundness {row : State F × Input F} {input_state : S
     simp [h_env', hi, hi', Vector.getElem_mapFinRange, Trace.getLeFromBottom, _root_.Row.get,
       Vector.mapRange_zero, Vector.append_empty, ProvablePair.instance]
 
-  have h_env : ProvableType.eval' env' (varFromOffset State 0) = row.1 := by
+  have h_env : (eval env'.toEnvironment (varFromOffset State 0 : State (Expression F)) : State F) = row.1 := by
     rw [ProvableType.ext_iff]
     intro i hi
     rw [h_env_in i hi, ProvableType.eval_varFromOffset,
@@ -238,24 +238,26 @@ lemma table_soundness_aux (table : InductiveTable F State Input) (input output :
       · omega
     clear h_env'
 
-    have input_eq_1 : ProvableType.eval' env' curr_var.1 = curr.1 := by
+    have input_eq_1 : eval env'.toEnvironment curr_var.1 = curr.1 := by
       rw [ProvableType.ext_iff]
       intro i hi
       simp only [curr_var, varFromOffset_pair]
-      rw [h_env_input_1 i hi]
+      convert (h_env_input_1 i hi).symm
       simp only [ProvableType.eval_varFromOffset,
-        ProvableType.toElements_fromElements, Vector.getElem_mapRange, zero_add]
+        ProvableType.toElements_fromElements, zero_add]
+      convert Vector.getElem_mapRange _ hi
 
-    have input_eq_2 : ProvableType.eval' env' curr_var.2 = curr.2 := by
+    have input_eq_2 : eval env'.toEnvironment curr_var.2 = curr.2 := by
       rw [ProvableType.ext_iff]
       intro i hi
       simp only [curr_var, varFromOffset_pair]
-      rw [h_env_input_2 i hi]
+      convert (h_env_input_2 i hi).symm
       simp only [s, ProvableType.eval_varFromOffset,
-        ProvableType.toElements_fromElements, Vector.getElem_mapRange, zero_add]
+        ProvableType.toElements_fromElements, zero_add]
+      convert Vector.getElem_mapRange _ hi using 1
       ac_rfl
 
-    have next_eq : ProvableType.eval' env' (varFromOffset State (size State + size Input + main_ops.localLength)) = next.1 := by
+    have next_eq : eval env'.toEnvironment (varFromOffset (F := F) State (size State + size Input + main_ops.localLength)) = next.1 := by
       rw [ProvableType.ext_iff]
       intro i hi
       rw [h_env_output i hi, ProvableType.eval_varFromOffset,

--- a/Clean/Table/Inductive.lean
+++ b/Clean/Table/Inductive.lean
@@ -16,14 +16,14 @@ def InductiveTable.Soundness (F : Type) [Field F] (State Input : Type → Type) 
   -- for all rows and inputs
   ∀ (acc_var : Var State F) (x_var : Var Input F)
     (acc : State F) (x : Input F) (xs : List (Input F)) (xs_len : xs.length = row_index),
-      (ProvableType.eval env acc_var = acc) ∧ (ProvableType.eval env x_var = x) →
+      (ProvableType.eval' env acc_var = acc) ∧ (ProvableType.eval' env x_var = x) →
     -- if the constraints hold
     Circuit.ConstraintsHold.Soundness env (step acc_var x_var |>.operations ((size State) + (size Input))) →
     -- and assuming the spec on the current row and previous inputs
     Spec initialState xs row_index xs_len acc env.data →
     -- we can conclude the spec on the next row and inputs including the current input
     Spec initialState (xs.concat x) (row_index + 1) (xs_len ▸ List.length_concat)
-      (ProvableType.eval env (step acc_var x_var |>.output ((size State) + (size Input)))) env.data
+      (ProvableType.eval' env (step acc_var x_var |>.output ((size State) + (size Input)))) env.data
 
 def InductiveTable.Completeness (F : Type) [Field F] (State Input : Type → Type) [ProvableType State] [ProvableType Input]
     (InputAssumptions : ℕ → Input F → ProverData F → Prop)
@@ -34,7 +34,7 @@ def InductiveTable.Completeness (F : Type) [Field F] (State Input : Type → Typ
   -- for all rows and inputs
   ∀ (acc_var : Var State F) (x_var : Var Input F)
     (acc : State F) (x : Input F) (xs : List (Input F)) (xs_len : xs.length = row_index),
-    (ProvableType.eval env acc_var = acc) ∧ (ProvableType.eval env x_var = x) →
+    (ProvableType.eval' env acc_var = acc) ∧ (ProvableType.eval' env x_var = x) →
   -- when using honest-prover witnesses
   env.UsesLocalWitnessesCompleteness ((size State) + (size Input)) (step acc_var x_var |>.operations ((size State) + (size Input))) →
   -- assuming the spec on the current row, the input_spec on the input, and initial state assumptions
@@ -121,7 +121,7 @@ theorem equalityConstraint.soundness {row : State F × Input F} {input_state : S
     simp [h_env', hi, hi', Vector.getElem_mapFinRange, Trace.getLeFromBottom, _root_.Row.get,
       Vector.mapRange_zero, Vector.append_empty, ProvablePair.instance]
 
-  have h_env : ProvableType.eval env' (varFromOffset State 0) = row.1 := by
+  have h_env : ProvableType.eval' env' (varFromOffset State 0) = row.1 := by
     rw [ProvableType.ext_iff]
     intro i hi
     rw [h_env_in i hi, ProvableType.eval_varFromOffset,
@@ -238,7 +238,7 @@ lemma table_soundness_aux (table : InductiveTable F State Input) (input output :
       · omega
     clear h_env'
 
-    have input_eq_1 : ProvableType.eval env' curr_var.1 = curr.1 := by
+    have input_eq_1 : ProvableType.eval' env' curr_var.1 = curr.1 := by
       rw [ProvableType.ext_iff]
       intro i hi
       simp only [curr_var, varFromOffset_pair]
@@ -246,7 +246,7 @@ lemma table_soundness_aux (table : InductiveTable F State Input) (input output :
       simp only [ProvableType.eval_varFromOffset,
         ProvableType.toElements_fromElements, Vector.getElem_mapRange, zero_add]
 
-    have input_eq_2 : ProvableType.eval env' curr_var.2 = curr.2 := by
+    have input_eq_2 : ProvableType.eval' env' curr_var.2 = curr.2 := by
       rw [ProvableType.ext_iff]
       intro i hi
       simp only [curr_var, varFromOffset_pair]
@@ -255,7 +255,7 @@ lemma table_soundness_aux (table : InductiveTable F State Input) (input output :
         ProvableType.toElements_fromElements, Vector.getElem_mapRange, zero_add]
       ac_rfl
 
-    have next_eq : ProvableType.eval env' (varFromOffset State (size State + size Input + main_ops.localLength)) = next.1 := by
+    have next_eq : ProvableType.eval' env' (varFromOffset State (size State + size Input + main_ops.localLength)) = next.1 := by
       rw [ProvableType.ext_iff]
       intro i hi
       rw [h_env_output i hi, ProvableType.eval_varFromOffset,

--- a/Clean/Table/Inductive.lean
+++ b/Clean/Table/Inductive.lean
@@ -16,14 +16,14 @@ def InductiveTable.Soundness (F : Type) [Field F] (State Input : Type → Type) 
   -- for all rows and inputs
   ∀ (acc_var : Var State F) (x_var : Var Input F)
     (acc : State F) (x : Input F) (xs : List (Input F)) (xs_len : xs.length = row_index),
-      (eval env acc_var = acc) ∧ (eval env x_var = x) →
+      (ProvableType.eval env acc_var = acc) ∧ (ProvableType.eval env x_var = x) →
     -- if the constraints hold
     Circuit.ConstraintsHold.Soundness env (step acc_var x_var |>.operations ((size State) + (size Input))) →
     -- and assuming the spec on the current row and previous inputs
     Spec initialState xs row_index xs_len acc env.data →
     -- we can conclude the spec on the next row and inputs including the current input
     Spec initialState (xs.concat x) (row_index + 1) (xs_len ▸ List.length_concat)
-      (eval env (step acc_var x_var |>.output ((size State) + (size Input)))) env.data
+      (ProvableType.eval env (step acc_var x_var |>.output ((size State) + (size Input)))) env.data
 
 def InductiveTable.Completeness (F : Type) [Field F] (State Input : Type → Type) [ProvableType State] [ProvableType Input]
     (InputAssumptions : ℕ → Input F → ProverData F → Prop)
@@ -34,7 +34,7 @@ def InductiveTable.Completeness (F : Type) [Field F] (State Input : Type → Typ
   -- for all rows and inputs
   ∀ (acc_var : Var State F) (x_var : Var Input F)
     (acc : State F) (x : Input F) (xs : List (Input F)) (xs_len : xs.length = row_index),
-    (eval env acc_var = acc) ∧ (eval env x_var = x) →
+    (ProvableType.eval env acc_var = acc) ∧ (ProvableType.eval env x_var = x) →
   -- when using honest-prover witnesses
   env.UsesLocalWitnessesCompleteness ((size State) + (size Input)) (step acc_var x_var |>.operations ((size State) + (size Input))) →
   -- assuming the spec on the current row, the input_spec on the input, and initial state assumptions
@@ -121,7 +121,7 @@ theorem equalityConstraint.soundness {row : State F × Input F} {input_state : S
     simp [h_env', hi, hi', Vector.getElem_mapFinRange, Trace.getLeFromBottom, _root_.Row.get,
       Vector.mapRange_zero, Vector.append_empty, ProvablePair.instance]
 
-  have h_env : eval env' (varFromOffset State 0) = row.1 := by
+  have h_env : ProvableType.eval env' (varFromOffset State 0) = row.1 := by
     rw [ProvableType.ext_iff]
     intro i hi
     rw [h_env_in i hi, ProvableType.eval_varFromOffset,
@@ -238,7 +238,7 @@ lemma table_soundness_aux (table : InductiveTable F State Input) (input output :
       · omega
     clear h_env'
 
-    have input_eq_1 : eval env' curr_var.1 = curr.1 := by
+    have input_eq_1 : ProvableType.eval env' curr_var.1 = curr.1 := by
       rw [ProvableType.ext_iff]
       intro i hi
       simp only [curr_var, varFromOffset_pair]
@@ -246,7 +246,7 @@ lemma table_soundness_aux (table : InductiveTable F State Input) (input output :
       simp only [ProvableType.eval_varFromOffset,
         ProvableType.toElements_fromElements, Vector.getElem_mapRange, zero_add]
 
-    have input_eq_2 : eval env' curr_var.2 = curr.2 := by
+    have input_eq_2 : ProvableType.eval env' curr_var.2 = curr.2 := by
       rw [ProvableType.ext_iff]
       intro i hi
       simp only [curr_var, varFromOffset_pair]
@@ -255,7 +255,7 @@ lemma table_soundness_aux (table : InductiveTable F State Input) (input output :
         ProvableType.toElements_fromElements, Vector.getElem_mapRange, zero_add]
       ac_rfl
 
-    have next_eq : eval env' (varFromOffset State (size State + size Input + main_ops.localLength)) = next.1 := by
+    have next_eq : ProvableType.eval env' (varFromOffset State (size State + size Input + main_ops.localLength)) = next.1 := by
       rw [ProvableType.ext_iff]
       intro i hi
       rw [h_env_output i hi, ProvableType.eval_varFromOffset,

--- a/Clean/Table/WitnessGeneration.lean
+++ b/Clean/Table/WitnessGeneration.lean
@@ -32,7 +32,7 @@ def buildAuxMap (as : CellAssignment W S) : Std.HashMap ℕ ℕ := Id.run do
   - According to `CellAssignment` for input cells, the input columns are assigned to
   the corresponding columns in the trace row.
 -/
-def generateNextRow (tc : TableConstraint W S F Unit) (hint : ProverHint F) (cur_row : Array F) : Array F :=
+def generateNextRow (tc : TableConstraint W S F Unit) (hint : ProverHints F) (cur_row : Array F) : Array F :=
   let ctx := (tc .empty).2
 
   let assignment := ctx.assignment
@@ -84,7 +84,7 @@ def generateNextRow (tc : TableConstraint W S F Unit) (hint : ProverHint F) (cur
   table constraint's witness generators.
 -/
 def witnesses (tc : TableConstraint W S F Unit)
-    (hint : ProverHint F) (init_row : Row F S) (n : ℕ) : Array (Array F) := Id.run do
+    (hint : ProverHints F) (init_row : Row F S) (n : ℕ) : Array (Array F) := Id.run do
 
   -- append auxiliary columns to the current row
   let aux_cols := Array.replicate tc.finalAssignment.numAux 0

--- a/Clean/Table/WitnessGeneration.lean
+++ b/Clean/Table/WitnessGeneration.lean
@@ -32,7 +32,7 @@ def buildAuxMap (as : CellAssignment W S) : Std.HashMap ℕ ℕ := Id.run do
   - According to `CellAssignment` for input cells, the input columns are assigned to
   the corresponding columns in the trace row.
 -/
-def generateNextRow (tc : TableConstraint W S F Unit) (hint : ProverHints F) (cur_row : Array F) : Array F :=
+def generateNextRow (tc : TableConstraint W S F Unit) (hint : ProverHint F) (cur_row : Array F) : Array F :=
   let ctx := (tc .empty).2
 
   let assignment := ctx.assignment
@@ -84,7 +84,7 @@ def generateNextRow (tc : TableConstraint W S F Unit) (hint : ProverHints F) (cu
   table constraint's witness generators.
 -/
 def witnesses (tc : TableConstraint W S F Unit)
-    (hint : ProverHints F) (init_row : Row F S) (n : ℕ) : Array (Array F) := Id.run do
+    (hint : ProverHint F) (init_row : Row F S) (n : ℕ) : Array (Array F) := Id.run do
 
   -- append auxiliary columns to the current row
   let aux_cols := Array.replicate tc.finalAssignment.numAux 0

--- a/Clean/Tables/BLAKE3/ProcessBlocksInductive.lean
+++ b/Clean/Tables/BLAKE3/ProcessBlocksInductive.lean
@@ -83,18 +83,13 @@ def circuit : FormalAssertion (F p) ProcessBlocksState where
     simp_all [← h_input, eval_vector]
 
   completeness := by
-    circuit_proof_start [U32.AssertNormalized.circuit]
+    circuit_proof_start [U32.AssertNormalized.circuit, getElem_eval_vector] -- provable_vector_simp wanted
     simp only [ProcessBlocksState.Normalized] at h_spec
     constructor
     · rintro ⟨i, h_i⟩
-      have : (ProvableType.eval' env input_var_chaining_value : ProvableVector _ 8 _)[i] = input_chaining_value[i] := by simp only [h_input]
-      simp only [eval_vector] at this
-      simp only [Vector.getElem_map] at this
-      simp only [this]
       rcases h_spec with ⟨h_spec, _⟩
       specialize h_spec ⟨ i, h_i ⟩
       convert h_spec
-    simp only [←h_input, eval_vector] at h_spec -- provable_vector_simp wanted
     simp_all
 
 end BLAKE3ProcessBlocksStateNormalized
@@ -224,15 +219,15 @@ Shows that the step correctly processes a block using processBlockWords.
 private lemma step_process_block (env : Environment (F p))
     (acc_var : Var ProcessBlocksState (F p)) (x_var : Var BlockInput (F p))
     (acc : ProcessBlocksState (F p)) (x : BlockInput (F p))
-    (h_eval : ProvableType.eval' env acc_var = acc ∧ ProvableType.eval' env x_var = x)
+    (h_eval : eval env acc_var = acc ∧ eval env x_var = x)
     (h_x : x.block_exists = 1)
     (h_holds : Circuit.ConstraintsHold.Soundness env ((step acc_var x_var).operations (size ProcessBlocksState + size BlockInput)))
     (acc_normalized : acc.Normalized)
     (x_normalized : x.Normalized)
     (blocks_compressed_not_many : acc.toChunkState.blocks_compressed < 2^32 - 1) :
-    (ProvableType.eval' env ((step acc_var x_var).output (size ProcessBlocksState + size BlockInput))).toChunkState =
+    (eval env ((step acc_var x_var).output (size ProcessBlocksState + size BlockInput))).toChunkState =
       processBlockWords acc.toChunkState (x.block_data.map (·.value)) ∧
-    (ProvableType.eval' env ((step acc_var x_var).output (size ProcessBlocksState + size BlockInput))).Normalized := by
+    (eval env ((step acc_var x_var).output (size ProcessBlocksState + size BlockInput))).Normalized := by
   have := p_large.elim
   simp only [step, circuit_norm, BLAKE3.Compress.circuit, BLAKE3BlockInputNormalized.circuit, Addition32.circuit, IsZero.circuit, Conditional.circuit,
     Conditional.Assumptions, IsZero.Assumptions, IsZero.Spec, BLAKE3.Compress.Assumptions, BLAKE3.Compress.Spec, BLAKE3.ApplyRounds.Assumptions] at ⊢ h_holds

--- a/Clean/Tables/BLAKE3/ProcessBlocksInductive.lean
+++ b/Clean/Tables/BLAKE3/ProcessBlocksInductive.lean
@@ -79,15 +79,15 @@ def circuit : FormalAssertion (F p) ProcessBlocksState where
   Spec x := x.Normalized
 
   soundness := by
-    circuit_proof_start [ProcessBlocksState.Normalized, U32.AssertNormalized.circuit]
+    circuit_proof_start [ProcessBlocksState.Normalized, ProcessBlocksState.mk.injEq, U32.AssertNormalized.circuit]
     simp_all [← h_input, eval_vector]
 
   completeness := by
-    circuit_proof_start [U32.AssertNormalized.circuit]
+    circuit_proof_start [ProcessBlocksState.mk.injEq, U32.AssertNormalized.circuit]
     simp only [ProcessBlocksState.Normalized] at h_spec
     constructor
     · rintro ⟨i, h_i⟩
-      have : (eval env input_var_chaining_value : ProvableVector _ 8 _)[i] = input_chaining_value[i] := by simp only [h_input]
+      have : (ProvableType.eval env input_var_chaining_value : ProvableVector _ 8 _)[i] = input_chaining_value[i] := by simp only [h_input]
       simp only [eval_vector] at this
       simp only [Vector.getElem_map] at this
       simp only [this]
@@ -129,14 +129,14 @@ def circuit : FormalAssertion (F p) BlockInput where
   Spec x := x.Normalized
 
   soundness := by
-    circuit_proof_start [BlockInput.Normalized, U32.AssertNormalized.circuit]
+    circuit_proof_start [BlockInput.Normalized, BlockInput.mk.injEq, U32.AssertNormalized.circuit]
     constructor
     · simp_all
     simp only [←h_input, eval_vector] -- provable_vector_simp wanted
     simp_all
 
   completeness := by
-    circuit_proof_start [U32.AssertNormalized.circuit]
+    circuit_proof_start [BlockInput.mk.injEq, U32.AssertNormalized.circuit]
     simp only [BlockInput.Normalized] at h_spec
     constructor
     · simp_all
@@ -224,15 +224,15 @@ Shows that the step correctly processes a block using processBlockWords.
 private lemma step_process_block (env : Environment (F p))
     (acc_var : Var ProcessBlocksState (F p)) (x_var : Var BlockInput (F p))
     (acc : ProcessBlocksState (F p)) (x : BlockInput (F p))
-    (h_eval : eval env acc_var = acc ∧ eval env x_var = x)
+    (h_eval : ProvableType.eval env acc_var = acc ∧ ProvableType.eval env x_var = x)
     (h_x : x.block_exists = 1)
     (h_holds : Circuit.ConstraintsHold.Soundness env ((step acc_var x_var).operations (size ProcessBlocksState + size BlockInput)))
     (acc_normalized : acc.Normalized)
     (x_normalized : x.Normalized)
     (blocks_compressed_not_many : acc.toChunkState.blocks_compressed < 2^32 - 1) :
-    (eval env ((step acc_var x_var).output (size ProcessBlocksState + size BlockInput))).toChunkState =
+    (ProvableType.eval env ((step acc_var x_var).output (size ProcessBlocksState + size BlockInput))).toChunkState =
       processBlockWords acc.toChunkState (x.block_data.map (·.value)) ∧
-    (eval env ((step acc_var x_var).output (size ProcessBlocksState + size BlockInput))).Normalized := by
+    (ProvableType.eval env ((step acc_var x_var).output (size ProcessBlocksState + size BlockInput))).Normalized := by
   have := p_large.elim
   simp only [step, circuit_norm, BLAKE3.Compress.circuit, BLAKE3BlockInputNormalized.circuit, Addition32.circuit, IsZero.circuit, Conditional.circuit,
     Conditional.Assumptions, IsZero.Assumptions, IsZero.Spec, BLAKE3.Compress.Assumptions, BLAKE3.Compress.Spec, BLAKE3.ApplyRounds.Assumptions] at ⊢ h_holds

--- a/Clean/Tables/BLAKE3/ProcessBlocksInductive.lean
+++ b/Clean/Tables/BLAKE3/ProcessBlocksInductive.lean
@@ -79,11 +79,11 @@ def circuit : FormalAssertion (F p) ProcessBlocksState where
   Spec x := x.Normalized
 
   soundness := by
-    circuit_proof_start [ProcessBlocksState.Normalized, ProcessBlocksState.mk.injEq, U32.AssertNormalized.circuit]
+    circuit_proof_start [ProcessBlocksState.Normalized, U32.AssertNormalized.circuit]
     simp_all [← h_input, eval_vector]
 
   completeness := by
-    circuit_proof_start [ProcessBlocksState.mk.injEq, U32.AssertNormalized.circuit]
+    circuit_proof_start [U32.AssertNormalized.circuit]
     simp only [ProcessBlocksState.Normalized] at h_spec
     constructor
     · rintro ⟨i, h_i⟩
@@ -129,14 +129,14 @@ def circuit : FormalAssertion (F p) BlockInput where
   Spec x := x.Normalized
 
   soundness := by
-    circuit_proof_start [BlockInput.Normalized, BlockInput.mk.injEq, U32.AssertNormalized.circuit]
+    circuit_proof_start [BlockInput.Normalized, U32.AssertNormalized.circuit]
     constructor
     · simp_all
     simp only [←h_input, eval_vector] -- provable_vector_simp wanted
     simp_all
 
   completeness := by
-    circuit_proof_start [BlockInput.mk.injEq, U32.AssertNormalized.circuit]
+    circuit_proof_start [U32.AssertNormalized.circuit]
     simp only [BlockInput.Normalized] at h_spec
     constructor
     · simp_all

--- a/Clean/Tables/BLAKE3/ProcessBlocksInductive.lean
+++ b/Clean/Tables/BLAKE3/ProcessBlocksInductive.lean
@@ -87,7 +87,7 @@ def circuit : FormalAssertion (F p) ProcessBlocksState where
     simp only [ProcessBlocksState.Normalized] at h_spec
     constructor
     · rintro ⟨i, h_i⟩
-      have : (ProvableType.eval env input_var_chaining_value : ProvableVector _ 8 _)[i] = input_chaining_value[i] := by simp only [h_input]
+      have : (ProvableType.eval' env input_var_chaining_value : ProvableVector _ 8 _)[i] = input_chaining_value[i] := by simp only [h_input]
       simp only [eval_vector] at this
       simp only [Vector.getElem_map] at this
       simp only [this]
@@ -224,15 +224,15 @@ Shows that the step correctly processes a block using processBlockWords.
 private lemma step_process_block (env : Environment (F p))
     (acc_var : Var ProcessBlocksState (F p)) (x_var : Var BlockInput (F p))
     (acc : ProcessBlocksState (F p)) (x : BlockInput (F p))
-    (h_eval : ProvableType.eval env acc_var = acc ∧ ProvableType.eval env x_var = x)
+    (h_eval : ProvableType.eval' env acc_var = acc ∧ ProvableType.eval' env x_var = x)
     (h_x : x.block_exists = 1)
     (h_holds : Circuit.ConstraintsHold.Soundness env ((step acc_var x_var).operations (size ProcessBlocksState + size BlockInput)))
     (acc_normalized : acc.Normalized)
     (x_normalized : x.Normalized)
     (blocks_compressed_not_many : acc.toChunkState.blocks_compressed < 2^32 - 1) :
-    (ProvableType.eval env ((step acc_var x_var).output (size ProcessBlocksState + size BlockInput))).toChunkState =
+    (ProvableType.eval' env ((step acc_var x_var).output (size ProcessBlocksState + size BlockInput))).toChunkState =
       processBlockWords acc.toChunkState (x.block_data.map (·.value)) ∧
-    (ProvableType.eval env ((step acc_var x_var).output (size ProcessBlocksState + size BlockInput))).Normalized := by
+    (ProvableType.eval' env ((step acc_var x_var).output (size ProcessBlocksState + size BlockInput))).Normalized := by
   have := p_large.elim
   simp only [step, circuit_norm, BLAKE3.Compress.circuit, BLAKE3BlockInputNormalized.circuit, Addition32.circuit, IsZero.circuit, Conditional.circuit,
     Conditional.Assumptions, IsZero.Assumptions, IsZero.Spec, BLAKE3.Compress.Assumptions, BLAKE3.Compress.Spec, BLAKE3.ApplyRounds.Assumptions] at ⊢ h_holds

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -100,10 +100,10 @@ lemma fib_assignment : (recursiveRelation (p:=p)).finalAssignment.vars =
 
 lemma fib_vars (curr next : Row (F p) RowType) (aux_env : ProverEnvironment (F p)) :
     let env := recursiveRelation.windowEnv ⟨<+> +> curr +> next, rfl⟩ aux_env;
-    ProvableType.eval env (varFromOffset U32 0) = curr.x ∧
-    ProvableType.eval env (varFromOffset U32 4) = curr.y ∧
-    ProvableType.eval env (varFromOffset U32 8) = next.x ∧
-    ProvableType.eval env (U32.mk (var ⟨16⟩) (var ⟨18⟩) (var ⟨20⟩) (var ⟨22⟩)) = next.y
+    ProvableType.eval' env (varFromOffset U32 0) = curr.x ∧
+    ProvableType.eval' env (varFromOffset U32 4) = curr.y ∧
+    ProvableType.eval' env (varFromOffset U32 8) = next.x ∧
+    ProvableType.eval' env (U32.mk (var ⟨16⟩) (var ⟨18⟩) (var ⟨20⟩) (var ⟨22⟩)) = next.y
   := by
   intro env
   dsimp only [env, windowEnv]
@@ -156,8 +156,8 @@ lemma boundary_assignment : (boundary (p:=p)).finalAssignment.vars =
 omit p_large_enough in
 lemma boundary_vars (first_row : Row (F p) RowType) (aux_env : ProverEnvironment (F p)) :
     let env := boundary.windowEnv ⟨<+> +> first_row, rfl⟩ aux_env;
-    ProvableType.eval env (varFromOffset U32 0) = first_row.x ∧
-    ProvableType.eval env (varFromOffset U32 4) = first_row.y := by
+    ProvableType.eval' env (varFromOffset U32 0) = first_row.x ∧
+    ProvableType.eval' env (varFromOffset U32 4) = first_row.y := by
   intro env
   dsimp only [env, windowEnv]
   have h_offset : (boundary (p:=p)).finalAssignment.offset = 8 := rfl

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -100,10 +100,10 @@ lemma fib_assignment : (recursiveRelation (p:=p)).finalAssignment.vars =
 
 lemma fib_vars (curr next : Row (F p) RowType) (aux_env : ProverEnvironment (F p)) :
     let env := recursiveRelation.windowEnv ⟨<+> +> curr +> next, rfl⟩ aux_env;
-    eval env (varFromOffset U32 0) = curr.x ∧
-    eval env (varFromOffset U32 4) = curr.y ∧
-    eval env (varFromOffset U32 8) = next.x ∧
-    eval env (U32.mk (var ⟨16⟩) (var ⟨18⟩) (var ⟨20⟩) (var ⟨22⟩)) = next.y
+    ProvableType.eval env (varFromOffset U32 0) = curr.x ∧
+    ProvableType.eval env (varFromOffset U32 4) = curr.y ∧
+    ProvableType.eval env (varFromOffset U32 8) = next.x ∧
+    ProvableType.eval env (U32.mk (var ⟨16⟩) (var ⟨18⟩) (var ⟨20⟩) (var ⟨22⟩)) = next.y
   := by
   intro env
   dsimp only [env, windowEnv]
@@ -156,8 +156,8 @@ lemma boundary_assignment : (boundary (p:=p)).finalAssignment.vars =
 omit p_large_enough in
 lemma boundary_vars (first_row : Row (F p) RowType) (aux_env : ProverEnvironment (F p)) :
     let env := boundary.windowEnv ⟨<+> +> first_row, rfl⟩ aux_env;
-    eval env (varFromOffset U32 0) = first_row.x ∧
-    eval env (varFromOffset U32 4) = first_row.y := by
+    ProvableType.eval env (varFromOffset U32 0) = first_row.x ∧
+    ProvableType.eval env (varFromOffset U32 4) = first_row.y := by
   intro env
   dsimp only [env, windowEnv]
   have h_offset : (boundary (p:=p)).finalAssignment.offset = 8 := rfl

--- a/Clean/Tables/Fibonacci32.lean
+++ b/Clean/Tables/Fibonacci32.lean
@@ -100,10 +100,10 @@ lemma fib_assignment : (recursiveRelation (p:=p)).finalAssignment.vars =
 
 lemma fib_vars (curr next : Row (F p) RowType) (aux_env : ProverEnvironment (F p)) :
     let env := recursiveRelation.windowEnv ⟨<+> +> curr +> next, rfl⟩ aux_env;
-    ProvableType.eval' env (varFromOffset U32 0) = curr.x ∧
-    ProvableType.eval' env (varFromOffset U32 4) = curr.y ∧
-    ProvableType.eval' env (varFromOffset U32 8) = next.x ∧
-    ProvableType.eval' env (U32.mk (var ⟨16⟩) (var ⟨18⟩) (var ⟨20⟩) (var ⟨22⟩)) = next.y
+    eval env (varFromOffset (F:=F p) U32 0) = curr.x ∧
+    eval env (varFromOffset (F:=F p) U32 4) = curr.y ∧
+    eval env (varFromOffset (F:=F p) U32 8) = next.x ∧
+    eval env (U32.mk (var (F:=F p) ⟨16⟩) (var ⟨18⟩) (var ⟨20⟩) (var ⟨22⟩)) = next.y
   := by
   intro env
   dsimp only [env, windowEnv]
@@ -132,7 +132,7 @@ lemma fib_constraints (curr next : Row (F p) RowType) (aux_env : ProverEnvironme
     assignU32, Gadgets.Addition32.circuit]
   rintro ⟨ h_add, h_eq ⟩
   simp only [table_norm, circuit_norm, Nat.reduceAdd, zero_add] at h_add
-  simp only [circuit_norm] at hnext_y
+  simp only [circuit_norm] at hcurr_x hcurr_y hnext_x hnext_y
   rw [hcurr_x, hcurr_y, hnext_y] at h_add
   rw [hcurr_y, hnext_x] at h_eq
   clear hcurr_x hcurr_y hnext_x hnext_y
@@ -156,8 +156,8 @@ lemma boundary_assignment : (boundary (p:=p)).finalAssignment.vars =
 omit p_large_enough in
 lemma boundary_vars (first_row : Row (F p) RowType) (aux_env : ProverEnvironment (F p)) :
     let env := boundary.windowEnv ⟨<+> +> first_row, rfl⟩ aux_env;
-    ProvableType.eval' env (varFromOffset U32 0) = first_row.x ∧
-    ProvableType.eval' env (varFromOffset U32 4) = first_row.y := by
+    eval env (varFromOffset (F:=F p) U32 0) = first_row.x ∧
+    eval env (varFromOffset (F:=F p) U32 4) = first_row.y := by
   intro env
   dsimp only [env, windowEnv]
   have h_offset : (boundary (p:=p)).finalAssignment.offset = 8 := rfl
@@ -176,6 +176,7 @@ lemma boundary_constraints (first_row : Row (F p) RowType) (aux_env : ProverEnvi
   simp only [table_norm, boundary, circuit_norm]
   simp only [and_imp]
   have ⟨hx, hy⟩ := boundary_vars first_row aux_env
+  simp only [circuit_norm] at hx hy
   rw [hx, hy]
   intro x_zero y_one
   rw [x_zero, y_one]

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -218,7 +218,7 @@ omit p_large_enough in
 lemma eval_of_literal (env : Environment (F p)) (a b c d : Expression (F p)) :
     eval env (U32.mk a b c d) =
     U32.mk (a.eval env) (b.eval env) (c.eval env) (d.eval env) := by
-  simp only [CircuitType.eval_var, explicit_provable_type, circuit_norm]
+  simp only [explicit_provable_type, circuit_norm]
 
 omit p_large_enough in
 omit [Fact (Nat.Prime p)] in
@@ -281,11 +281,11 @@ def circuit : FormalAssertion (F p) U32 where
 
   soundness := by
     rintro i0 env x_var ⟨ x0, x1, x2, x3 ⟩ h_eval _as
-    simp_all [CircuitType.eval_var, main, circuit_norm, ByteTable, Normalized, explicit_provable_type]
+    simp_all [main, circuit_norm, ByteTable, Normalized, explicit_provable_type]
 
   completeness := by
     rintro i0 env x_var _ ⟨ x0, x1, x2, x3 ⟩ h_eval _as
-    simp_all [CircuitType.eval_var, main, circuit_norm, ByteTable, Normalized, explicit_provable_type]
+    simp_all [main, circuit_norm, ByteTable, Normalized, explicit_provable_type]
 
 end U32.AssertNormalized
 

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -215,7 +215,7 @@ lemma value_of_literal' (a b c d : field (F p)) :
 
 omit p_large_enough in
 @[circuit_norm]
-lemma eval_of_literal (env : Environment (F p)) (a b c d : Var field (F p)) :
+lemma eval_of_literal (env : Environment (F p)) (a b c d : Expression (F p)) :
     eval env (U32.mk a b c d) =
     U32.mk (eval env a) (eval env b) (eval env c) (eval env d) := by
   simp only [explicit_provable_type, circuit_norm]
@@ -332,11 +332,12 @@ lemma toLimbs_map {α β : Type} (x : U32 α) (f : α → β) :
 
 lemma getElem_eval_toLimbs {F} [Field F] {env : Environment F} {x : U32 (Expression F)} {i : ℕ} (hi : i < 4) :
     Expression.eval env x.toLimbs[i] = (eval env x).toLimbs[i] := by
-  simp only [toLimbs, eval, size, toVars, ProvableType.toElements_fromElements, Vector.getElem_map]
+  simp only [circuit_norm]
+  simp only [toLimbs, ProvableType.eval, size, toVars, ProvableType.toElements_fromElements, Vector.getElem_map]
 
 lemma eval_fromLimbs {F} [Field F] {env : Environment F} {v : Vector (Expression F) 4} :
     eval env (U32.fromLimbs v) = .fromLimbs (v.map env) := by
-  simp only [U32.fromLimbs, ProvableType.eval_fromElements]
+  simp only [circuit_norm, U32.fromLimbs, ProvableType.eval_fromElements]
 end ByteVector
 
 -- Bitwise operations on U32

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -216,7 +216,7 @@ lemma value_of_literal' (a b c d : field (F p)) :
 omit p_large_enough in
 @[circuit_norm]
 lemma eval_of_literal (env : Environment (F p)) (a b c d : Expression (F p)) :
-    ProvableType.eval env (U32.mk a b c d) =
+    ProvableType.eval' env (U32.mk a b c d) =
     U32.mk (a.eval env) (b.eval env) (c.eval env) (d.eval env) := by
   simp only [explicit_provable_type, circuit_norm]
 
@@ -331,11 +331,11 @@ lemma toLimbs_map {α β : Type} (x : U32 α) (f : α → β) :
   simp [toLimbs, toElements, map]
 
 lemma getElem_eval_toLimbs {F} [Field F] {env : Environment F} {x : U32 (Expression F)} {i : ℕ} (hi : i < 4) :
-    Expression.eval env x.toLimbs[i] = (ProvableType.eval env x).toLimbs[i] := by
-  simp only [toLimbs, ProvableType.eval, size, toVars, ProvableType.toElements_fromElements, Vector.getElem_map]
+    Expression.eval env x.toLimbs[i] = (ProvableType.eval' env x).toLimbs[i] := by
+  simp only [toLimbs, ProvableType.eval', size, toVars, ProvableType.toElements_fromElements, Vector.getElem_map]
 
 lemma eval_fromLimbs {F} [Field F] {env : Environment F} {v : Vector (Expression F) 4} :
-    ProvableType.eval env (U32.fromLimbs v) = .fromLimbs (v.map env) := by
+    ProvableType.eval' env (U32.fromLimbs v) = .fromLimbs (v.map env) := by
   simp only [circuit_norm, U32.fromLimbs, ProvableType.eval_fromElements]
 end ByteVector
 

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -218,7 +218,7 @@ omit p_large_enough in
 lemma eval_of_literal (env : Environment (F p)) (a b c d : Expression (F p)) :
     eval env (U32.mk a b c d) =
     U32.mk (a.eval env) (b.eval env) (c.eval env) (d.eval env) := by
-  simp only [explicit_provable_type, circuit_norm]
+  simp only [CircuitType.eval_var, explicit_provable_type, circuit_norm]
 
 omit p_large_enough in
 omit [Fact (Nat.Prime p)] in
@@ -281,11 +281,11 @@ def circuit : FormalAssertion (F p) U32 where
 
   soundness := by
     rintro i0 env x_var ⟨ x0, x1, x2, x3 ⟩ h_eval _as
-    simp_all [main, circuit_norm, ByteTable, Normalized, explicit_provable_type]
+    simp_all [CircuitType.eval_var, main, circuit_norm, ByteTable, Normalized, explicit_provable_type]
 
   completeness := by
     rintro i0 env x_var _ ⟨ x0, x1, x2, x3 ⟩ h_eval _as
-    simp_all [main, circuit_norm, ByteTable, Normalized, explicit_provable_type]
+    simp_all [CircuitType.eval_var, main, circuit_norm, ByteTable, Normalized, explicit_provable_type]
 
 end U32.AssertNormalized
 
@@ -331,11 +331,11 @@ lemma toLimbs_map {α β : Type} (x : U32 α) (f : α → β) :
   simp [toLimbs, toElements, map]
 
 lemma getElem_eval_toLimbs {F} [Field F] {env : Environment F} {x : U32 (Expression F)} {i : ℕ} (hi : i < 4) :
-    Expression.eval env x.toLimbs[i] = (ProvableType.eval' env x).toLimbs[i] := by
-  simp only [toLimbs, ProvableType.eval', size, toVars, ProvableType.toElements_fromElements, Vector.getElem_map]
+    Expression.eval env x.toLimbs[i] = (eval env x).toLimbs[i] := by
+  exact ProvableType.getElem_eval_toElements x i hi
 
 lemma eval_fromLimbs {F} [Field F] {env : Environment F} {v : Vector (Expression F) 4} :
-    ProvableType.eval' env (U32.fromLimbs v) = .fromLimbs (v.map env) := by
+    eval env (U32.fromLimbs v) = .fromLimbs (v.map env) := by
   simp only [circuit_norm, U32.fromLimbs, ProvableType.eval_fromElements]
 end ByteVector
 

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -216,7 +216,7 @@ lemma value_of_literal' (a b c d : field (F p)) :
 omit p_large_enough in
 @[circuit_norm]
 lemma eval_of_literal (env : Environment (F p)) (a b c d : Expression (F p)) :
-    ProvableType.eval' env (U32.mk a b c d) =
+    eval env (U32.mk a b c d) =
     U32.mk (a.eval env) (b.eval env) (c.eval env) (d.eval env) := by
   simp only [explicit_provable_type, circuit_norm]
 

--- a/Clean/Types/U32.lean
+++ b/Clean/Types/U32.lean
@@ -216,8 +216,8 @@ lemma value_of_literal' (a b c d : field (F p)) :
 omit p_large_enough in
 @[circuit_norm]
 lemma eval_of_literal (env : Environment (F p)) (a b c d : Expression (F p)) :
-    eval env (U32.mk a b c d) =
-    U32.mk (eval env a) (eval env b) (eval env c) (eval env d) := by
+    ProvableType.eval env (U32.mk a b c d) =
+    U32.mk (a.eval env) (b.eval env) (c.eval env) (d.eval env) := by
   simp only [explicit_provable_type, circuit_norm]
 
 omit p_large_enough in
@@ -331,12 +331,11 @@ lemma toLimbs_map {α β : Type} (x : U32 α) (f : α → β) :
   simp [toLimbs, toElements, map]
 
 lemma getElem_eval_toLimbs {F} [Field F] {env : Environment F} {x : U32 (Expression F)} {i : ℕ} (hi : i < 4) :
-    Expression.eval env x.toLimbs[i] = (eval env x).toLimbs[i] := by
-  simp only [circuit_norm]
+    Expression.eval env x.toLimbs[i] = (ProvableType.eval env x).toLimbs[i] := by
   simp only [toLimbs, ProvableType.eval, size, toVars, ProvableType.toElements_fromElements, Vector.getElem_map]
 
 lemma eval_fromLimbs {F} [Field F] {env : Environment F} {v : Vector (Expression F) 4} :
-    eval env (U32.fromLimbs v) = .fromLimbs (v.map env) := by
+    ProvableType.eval env (U32.fromLimbs v) = .fromLimbs (v.map env) := by
   simp only [circuit_norm, U32.fromLimbs, ProvableType.eval_fromElements]
 end ByteVector
 

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -276,11 +276,11 @@ lemma toLimbs_map {α β : Type} (x : U64 α) (f : α → β) :
   simp [toLimbs, toElements, map]
 
 lemma getElem_eval_toLimbs {F} [Field F] {env : Environment F} {x : U64 (Expression F)} {i : ℕ} (hi : i < 8) :
-    Expression.eval env x.toLimbs[i] = (ProvableType.eval' env x).toLimbs[i] := by
-  simp only [toLimbs, ProvableType.eval', size, toVars, ProvableType.toElements_fromElements, Vector.getElem_map]
+    Expression.eval env x.toLimbs[i] = (eval env x).toLimbs[i] := by
+  exact ProvableType.getElem_eval_toElements x i hi
 
 lemma eval_fromLimbs {F} [Field F] {env : Environment F} {v : Vector (Expression F) 8} :
-    ProvableType.eval' env (U64.fromLimbs v) = .fromLimbs (v.map env) := by
+    eval env (U64.fromLimbs v) = .fromLimbs (v.map env) := by
   simp only [circuit_norm, U64.fromLimbs, ProvableType.eval_fromElements]
 end ByteVector
 end U64

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -276,11 +276,11 @@ lemma toLimbs_map {α β : Type} (x : U64 α) (f : α → β) :
   simp [toLimbs, toElements, map]
 
 lemma getElem_eval_toLimbs {F} [Field F] {env : Environment F} {x : U64 (Expression F)} {i : ℕ} (hi : i < 8) :
-    Expression.eval env x.toLimbs[i] = (ProvableType.eval env x).toLimbs[i] := by
-  simp only [toLimbs, ProvableType.eval, size, toVars, ProvableType.toElements_fromElements, Vector.getElem_map]
+    Expression.eval env x.toLimbs[i] = (ProvableType.eval' env x).toLimbs[i] := by
+  simp only [toLimbs, ProvableType.eval', size, toVars, ProvableType.toElements_fromElements, Vector.getElem_map]
 
 lemma eval_fromLimbs {F} [Field F] {env : Environment F} {v : Vector (Expression F) 8} :
-    ProvableType.eval env (U64.fromLimbs v) = .fromLimbs (v.map env) := by
+    ProvableType.eval' env (U64.fromLimbs v) = .fromLimbs (v.map env) := by
   simp only [circuit_norm, U64.fromLimbs, ProvableType.eval_fromElements]
 end ByteVector
 end U64

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -277,10 +277,11 @@ lemma toLimbs_map {α β : Type} (x : U64 α) (f : α → β) :
 
 lemma getElem_eval_toLimbs {F} [Field F] {env : Environment F} {x : U64 (Expression F)} {i : ℕ} (hi : i < 8) :
     Expression.eval env x.toLimbs[i] = (eval env x).toLimbs[i] := by
-  simp only [toLimbs, eval, size, toVars, ProvableType.toElements_fromElements, Vector.getElem_map]
+  simp only [circuit_norm]
+  simp only [toLimbs, ProvableType.eval, size, toVars, ProvableType.toElements_fromElements, Vector.getElem_map]
 
 lemma eval_fromLimbs {F} [Field F] {env : Environment F} {v : Vector (Expression F) 8} :
     eval env (U64.fromLimbs v) = .fromLimbs (v.map env) := by
-  simp only [U64.fromLimbs, ProvableType.eval_fromElements]
+  simp only [circuit_norm, U64.fromLimbs, ProvableType.eval_fromElements]
 end ByteVector
 end U64

--- a/Clean/Types/U64.lean
+++ b/Clean/Types/U64.lean
@@ -276,12 +276,11 @@ lemma toLimbs_map {α β : Type} (x : U64 α) (f : α → β) :
   simp [toLimbs, toElements, map]
 
 lemma getElem_eval_toLimbs {F} [Field F] {env : Environment F} {x : U64 (Expression F)} {i : ℕ} (hi : i < 8) :
-    Expression.eval env x.toLimbs[i] = (eval env x).toLimbs[i] := by
-  simp only [circuit_norm]
+    Expression.eval env x.toLimbs[i] = (ProvableType.eval env x).toLimbs[i] := by
   simp only [toLimbs, ProvableType.eval, size, toVars, ProvableType.toElements_fromElements, Vector.getElem_map]
 
 lemma eval_fromLimbs {F} [Field F] {env : Environment F} {v : Vector (Expression F) 8} :
-    eval env (U64.fromLimbs v) = .fromLimbs (v.map env) := by
+    ProvableType.eval env (U64.fromLimbs v) = .fromLimbs (v.map env) := by
   simp only [circuit_norm, U64.fromLimbs, ProvableType.eval_fromElements]
 end ByteVector
 end U64

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -1,6 +1,7 @@
 import Mathlib.Algebra.Field.ZMod
 import Mathlib.Algebra.Order.Star.Basic
 import Mathlib.Analysis.Normed.Ring.Lemmas
+import Clean.Circuit.SimpGadget
 
 -- main field definition
 def F p := ZMod p
@@ -104,6 +105,19 @@ theorem val_of_natToField_eq {n : ℕ} (lt : n < p) : (natToField n lt).val = n 
 def less_than_p (x : F p) : x.val < p := by
   rcases p with _ | n; cases p_ne_zero rfl
   exact x.is_lt
+
+@[circuit_norm, grind =]
+lemma natCast_val (a : F p) : (a.val : F p) = a := ZMod.natCast_zmod_val _
+
+@[circuit_norm, grind .]
+lemma fin_val_natCast_val_lt {p : ℕ} {n : ℕ} (x : Fin n) : (x.val : F p).val < n := by
+  grw [ZMod.val_natCast, Nat.mod_le]
+  exact x.isLt
+
+@[grind =]
+lemma fin_val_natCast_val_eq_of_lt {p : ℕ} {n : ℕ} (x : Fin n) (hn : n < p) : (x.val : F p).val = x.val := by
+  rw [ZMod.val_natCast_of_lt (a := x.val)]
+  linarith [hn, x.isLt]
 
 def mod (x : F p) (c : ℕ+) (lt : c < p) : F p :=
   FieldUtils.natToField (x.val % c) (by linarith [Nat.mod_lt x.val c.pos, lt])

--- a/Clean/Utils/Tactics/CircuitProofStart.lean
+++ b/Clean/Utils/Tactics/CircuitProofStart.lean
@@ -18,10 +18,12 @@ partial def circuitProofStartCore : TacticM Unit := do
     let headConst? := goalType.getAppFn.constName?
     let isSoundness := headConst? == some ``Soundness ||
                        headConst? == some ``FormalAssertion.Soundness ||
-                       headConst? == some ``GeneralFormalCircuit.Soundness
+                       headConst? == some ``GeneralFormalCircuit.Soundness ||
+                       headConst? == some ``GeneralFormalCircuit.WithHint.Soundness
     let isCompleteness := headConst? == some ``Completeness ||
                           headConst? == some ``FormalAssertion.Completeness ||
-                          headConst? == some ``GeneralFormalCircuit.Completeness
+                          headConst? == some ``GeneralFormalCircuit.Completeness ||
+                          headConst? == some ``GeneralFormalCircuit.WithHint.Completeness
 
     if isSoundness then
       match headConst? with
@@ -37,6 +39,11 @@ partial def circuitProofStartCore : TacticM Unit := do
           evalTactic (← `(tactic| intro $(mkIdent name):ident))
       | some ``GeneralFormalCircuit.Soundness =>
         evalTactic (← `(tactic| unfold GeneralFormalCircuit.Soundness))
+        let names := [`i₀, `env, `input_var, `input, `h_input, `h_assumptions, `h_holds]
+        for name in names do
+          evalTactic (← `(tactic| intro $(mkIdent name):ident))
+      | some ``GeneralFormalCircuit.WithHint.Soundness =>
+        evalTactic (← `(tactic| unfold GeneralFormalCircuit.WithHint.Soundness))
         let names := [`i₀, `env, `input_var, `input, `h_input, `h_assumptions, `h_holds]
         for name in names do
           evalTactic (← `(tactic| intro $(mkIdent name):ident))
@@ -57,6 +64,11 @@ partial def circuitProofStartCore : TacticM Unit := do
           evalTactic (← `(tactic| intro $(mkIdent name):ident))
       | some ``GeneralFormalCircuit.Completeness =>
         evalTactic (← `(tactic| unfold GeneralFormalCircuit.Completeness))
+        let names := [`i₀, `env, `input_var, `h_env, `input, `h_input, `h_assumptions]
+        for name in names do
+          evalTactic (← `(tactic| intro $(mkIdent name):ident))
+      | some ``GeneralFormalCircuit.WithHint.Completeness =>
+        evalTactic (← `(tactic| unfold GeneralFormalCircuit.WithHint.Completeness))
         let names := [`i₀, `env, `input_var, `h_env, `input, `h_input, `h_assumptions]
         for name in names do
           evalTactic (← `(tactic| intro $(mkIdent name):ident))

--- a/Clean/Utils/Tactics/CircuitProofStart.lean
+++ b/Clean/Utils/Tactics/CircuitProofStart.lean
@@ -107,6 +107,7 @@ elab_rules : tactic
   circuitProofStartCore
   try (evalTactic (← `(tactic| simp only [circuit_norm] at $(mkIdent `input_var):ident))) catch _ => pure ()
   try (evalTactic (← `(tactic| simp only [circuit_norm] at $(mkIdent `input):ident))) catch _ => pure ()
+  try (evalTactic (← `(tactic| simp only [circuit_norm] at $(mkIdent `h_input):ident))) catch _ => pure ()
 
   -- try to unfold main, Assumptions and Spec as local definitions
   evalTactic (← `(tactic| try dsimp only [$(mkIdent `Assumptions):ident] at *))

--- a/Clean/Utils/Tactics/CircuitProofStart.lean
+++ b/Clean/Utils/Tactics/CircuitProofStart.lean
@@ -105,6 +105,8 @@ elab_rules : tactic
   | `(tactic| circuit_proof_start $[[$terms:term,*]]?) => do
   -- intro all hypotheses
   circuitProofStartCore
+  try (evalTactic (← `(tactic| simp only [circuit_norm] at $(mkIdent `input_var):ident))) catch _ => pure ()
+  try (evalTactic (← `(tactic| simp only [circuit_norm] at $(mkIdent `input):ident))) catch _ => pure ()
 
   -- try to unfold main, Assumptions and Spec as local definitions
   evalTactic (← `(tactic| try dsimp only [$(mkIdent `Assumptions):ident] at *))

--- a/Clean/Utils/Tactics/ProvableTacticUtils.lean
+++ b/Clean/Utils/Tactics/ProvableTacticUtils.lean
@@ -48,9 +48,9 @@ def hasProvableStructInstance (type : Expr) : MetaM Bool := do
     catch _ => return false
   | _ => return false
 
-/-- Check if expression contains eval pattern (ProvableType.eval', Expression.eval, or ProvableStruct.eval) -/
+/-- Check if expression contains eval pattern (ProvableType.eval, Expression.eval, or ProvableStruct.eval) -/
 def hasEvalPattern (e : Expr) : Bool :=
-  e.isAppOf ``eval || e.isAppOf ``ProvableType.eval' || e.isAppOf ``Expression.eval || e.isAppOf ``ProvableStruct.eval
+  e.isAppOf ``eval || e.isAppOf ``ProvableType.eval || e.isAppOf ``Expression.eval || e.isAppOf ``ProvableStruct.eval
 
 /-- Extract type map candidates from a type for ProvableType/ProvableStruct checking -/
 def extractTypeMapCandidates (type : Expr) : MetaM (List Expr) := do

--- a/Clean/Utils/Tactics/ProvableTacticUtils.lean
+++ b/Clean/Utils/Tactics/ProvableTacticUtils.lean
@@ -1,5 +1,6 @@
 import Lean
 import Clean.Circuit.CircuitType
+import Clean.Circuit.Provable
 
 open Lean Meta Elab Tactic
 

--- a/Clean/Utils/Tactics/ProvableTacticUtils.lean
+++ b/Clean/Utils/Tactics/ProvableTacticUtils.lean
@@ -45,7 +45,7 @@ def hasProvableStructInstance (type : Expr) : MetaM Bool := do
 
 /-- Check if expression contains eval pattern (ProvableType.eval, Expression.eval, or ProvableStruct.eval) -/
 def hasEvalPattern (e : Expr) : Bool :=
-  e.isAppOf ``eval' || e.isAppOf ``ProvableType.eval || e.isAppOf ``Expression.eval || e.isAppOf ``ProvableStruct.eval
+  e.isAppOf ``eval || e.isAppOf ``ProvableType.eval || e.isAppOf ``Expression.eval || e.isAppOf ``ProvableStruct.eval
 
 /-- Extract type map candidates from a type for ProvableType/ProvableStruct checking -/
 def extractTypeMapCandidates (type : Expr) : MetaM (List Expr) := do

--- a/Clean/Utils/Tactics/ProvableTacticUtils.lean
+++ b/Clean/Utils/Tactics/ProvableTacticUtils.lean
@@ -4,10 +4,15 @@ import Clean.Circuit.Provable
 
 open Lean Meta Elab Tactic
 
-/-- Check if an expression is a constructor application (ends with .mk) -/
+/-- Check if an expression is a constructor application (ends with .mk).
+
+This intentionally does not unfold the expression. The struct tactics use this as
+a cheap syntactic guard before splitting constructor equalities; unfolding here
+can expand `eval` terms appearing in unrelated hypotheses and make the tactic
+far too expensive.
+-/
 def isMkConstructor (e : Expr) : MetaM Bool := do
-  let e' ← withTransparency .all (whnf e)
-  match e'.getAppFn with
+  match e.consumeMData.getAppFn with
   | .const name _ =>
     -- Check if it's a constructor (ends with .mk)
     return name.components.getLast? == some `mk

--- a/Clean/Utils/Tactics/ProvableTacticUtils.lean
+++ b/Clean/Utils/Tactics/ProvableTacticUtils.lean
@@ -43,9 +43,9 @@ def hasProvableStructInstance (type : Expr) : MetaM Bool := do
     catch _ => return false
   | _ => return false
 
-/-- Check if expression contains eval pattern (ProvableType.eval, Expression.eval, or ProvableStruct.eval) -/
+/-- Check if expression contains eval pattern (ProvableType.eval', Expression.eval, or ProvableStruct.eval) -/
 def hasEvalPattern (e : Expr) : Bool :=
-  e.isAppOf ``eval || e.isAppOf ``ProvableType.eval || e.isAppOf ``Expression.eval || e.isAppOf ``ProvableStruct.eval
+  e.isAppOf ``eval || e.isAppOf ``ProvableType.eval' || e.isAppOf ``Expression.eval || e.isAppOf ``ProvableStruct.eval
 
 /-- Extract type map candidates from a type for ProvableType/ProvableStruct checking -/
 def extractTypeMapCandidates (type : Expr) : MetaM (List Expr) := do

--- a/Clean/Utils/Tactics/ProvableTacticUtils.lean
+++ b/Clean/Utils/Tactics/ProvableTacticUtils.lean
@@ -1,5 +1,5 @@
 import Lean
-import Clean.Circuit.Provable
+import Clean.Circuit.CircuitType
 
 open Lean Meta Elab Tactic
 
@@ -44,7 +44,7 @@ def hasProvableStructInstance (type : Expr) : MetaM Bool := do
 
 /-- Check if expression contains eval pattern (ProvableType.eval, Expression.eval, or ProvableStruct.eval) -/
 def hasEvalPattern (e : Expr) : Bool :=
-  e.isAppOf ``ProvableType.eval || e.isAppOf ``Expression.eval || e.isAppOf ``ProvableStruct.eval
+  e.isAppOf ``eval' || e.isAppOf ``ProvableType.eval || e.isAppOf ``Expression.eval || e.isAppOf ``ProvableStruct.eval
 
 /-- Extract type map candidates from a type for ProvableType/ProvableStruct checking -/
 def extractTypeMapCandidates (type : Expr) : MetaM (List Expr) := do

--- a/Clean/Utils/Tactics/SimplifyProvableStructEval.lean
+++ b/Clean/Utils/Tactics/SimplifyProvableStructEval.lean
@@ -17,6 +17,13 @@ private def isStructLiteral (e : Expr) : MetaM Bool := do
       return false
   catch _ => return false
 
+/-- Extract the value being evaluated from supported `eval` forms. -/
+private def evalArg? (e : Expr) : Option Expr :=
+  if e.isAppOf ``eval || e.isAppOf ``ProvableType.eval' then
+    e.getAppArgs.back?
+  else
+    none
+
 /-- Check if an expression contains a struct eval equality pattern, including inside conjunctions.
     Returns the struct expression being evaluated if a pattern is found. -/
 private partial def collectStructEvalPattern (e : Expr) : MetaM (List Expr) := do
@@ -40,22 +47,22 @@ private partial def collectStructEvalPattern (e : Expr) : MetaM (List Expr) := d
 
           -- Check if other side is a struct literal
           let otherIsLiteral ← if otherSideIsEval then
-              if let some otherExpr := otherSide.getArg? 5 then
+              if let some otherExpr := evalArg? otherSide then
                 isStructLiteral otherExpr
               else
                 pure false
             else
               isStructLiteral otherSide
           if otherIsLiteral then
-            -- Extract the struct expression being evaluated (last argument of ProvableType.eval')
-            if let some structExpr := evalSide.getArg? 5 then
+            -- Extract the struct expression being evaluated.
+            if let some structExpr := evalArg? evalSide then
               return [structExpr]
             else
               return []
 
           -- If other side is just a variable, check if eval side has a struct literal
           -- Extract the argument of eval (the struct being evaluated)
-          if let some evalArg := evalSide.getArg? 5 /- very specific to ProvableType.eval' -/ then
+          if let some evalArg := evalArg? evalSide then
             let isLit ← isStructLiteral evalArg
             if isLit then
               return [evalArg]
@@ -108,6 +115,8 @@ elab "simplify_provable_struct_eval" : tactic => do
       let castStructSyntax ← `(($structSyntax : $typeSyntax))
       let evalLemma ← `(Lean.Parser.Tactic.simpLemma| ProvableStruct.eval_eq_eval (x := $castStructSyntax))
       simpArgs := simpArgs.push evalLemma
+      let evalProverLemma ← `(Lean.Parser.Tactic.simpLemma| ProvableStruct.eval_eq_eval_prover (x := $castStructSyntax))
+      simpArgs := simpArgs.push evalProverLemma
 
     -- Add the other simp lemmas
     simpArgs := simpArgs.push (← `(Lean.Parser.Tactic.simpLemma| ProvableStruct.eval))
@@ -116,6 +125,11 @@ elab "simplify_provable_struct_eval" : tactic => do
     simpArgs := simpArgs.push (← `(Lean.Parser.Tactic.simpLemma| ProvableStruct.toComponents))
     simpArgs := simpArgs.push (← `(Lean.Parser.Tactic.simpLemma| ProvableStruct.eval.go))
     simpArgs := simpArgs.push (← `(Lean.Parser.Tactic.simpLemma| ProvableType.eval_field))
+    simpArgs := simpArgs.push (← `(Lean.Parser.Tactic.simpLemma| CircuitType.eval_var_prover_to_verifier))
+    simpArgs := simpArgs.push (← `(Lean.Parser.Tactic.simpLemma| CircuitType.eval_var_field))
+    simpArgs := simpArgs.push (← `(Lean.Parser.Tactic.simpLemma| CircuitType.eval_var_field_prover))
+    simpArgs := simpArgs.push (← `(Lean.Parser.Tactic.simpLemma| CircuitType.eval_expr))
+    simpArgs := simpArgs.push (← `(Lean.Parser.Tactic.simpLemma| CircuitType.eval_expr_prover))
 
     -- Apply simp to this hypothesis
     let hypIdent := mkIdent hypName

--- a/Clean/Utils/Tactics/SimplifyProvableStructEval.lean
+++ b/Clean/Utils/Tactics/SimplifyProvableStructEval.lean
@@ -26,7 +26,7 @@ private def hasProvableStructType (e : Expr) : MetaM Bool := do
 
 /-- Extract the value being evaluated from supported `eval` forms. -/
 private def evalArg? (e : Expr) : Option Expr :=
-  if e.isAppOf ``eval || e.isAppOf ``ProvableType.eval' then
+  if e.isAppOf ``eval || e.isAppOf ``ProvableType.eval then
     e.getAppArgs.back?
   else
     none

--- a/Clean/Utils/Tactics/SimplifyProvableStructEval.lean
+++ b/Clean/Utils/Tactics/SimplifyProvableStructEval.lean
@@ -17,6 +17,13 @@ private def isStructLiteral (e : Expr) : MetaM Bool := do
       return false
   catch _ => return false
 
+/-- Check whether an expression has a type backed by `ProvableStruct`. -/
+private def hasProvableStructType (e : Expr) : MetaM Bool := do
+  try
+    let type ← inferType e
+    hasProvableStructInstance type
+  catch _ => return false
+
 /-- Extract the value being evaluated from supported `eval` forms. -/
 private def evalArg? (e : Expr) : Option Expr :=
   if e.isAppOf ``eval || e.isAppOf ``ProvableType.eval' then
@@ -59,6 +66,16 @@ private partial def collectStructEvalPattern (e : Expr) : MetaM (List Expr) := d
               return [structExpr]
             else
               return []
+
+          -- If the other side is a plain struct variable, unfold the eval side
+          -- so that `split_provable_struct_eq` can turn the resulting
+          -- constructor equality into field-wise equalities.
+          if !otherSideIsEval then
+            if ← hasProvableStructType otherSide then
+              if let some structExpr := evalArg? evalSide then
+                return [structExpr]
+              else
+                return []
 
           -- If other side is just a variable, check if eval side has a struct literal
           -- Extract the argument of eval (the struct being evaluated)
@@ -131,7 +148,23 @@ elab "simplify_provable_struct_eval" : tactic => do
     simpArgs := simpArgs.push (← `(Lean.Parser.Tactic.simpLemma| CircuitType.eval_expr))
     simpArgs := simpArgs.push (← `(Lean.Parser.Tactic.simpLemma| CircuitType.eval_expr_prover))
 
-    -- Apply simp to this hypothesis
-    let hypIdent := mkIdent hypName
-    let tac ← `(tactic| simp only [$[$simpArgs],*] at $hypIdent:ident)
-    evalTactic tac
+    -- Apply the targeted eval simplification throughout the local context. A
+    -- struct eval equality often feeds other hypotheses containing projections
+    -- of the same `eval env struct`, so simplifying only the equality itself is
+    -- not enough.
+    withMainContext do
+      let ctx ← getLCtx
+      for localDecl in ctx do
+        if localDecl.isImplementationDetail then
+          continue
+        try
+          let hypIdent := mkIdent localDecl.userName
+          let tac ← `(tactic| simp only [$[$simpArgs],*] at $hypIdent:ident)
+          evalTactic tac
+        catch _ =>
+          continue
+      try
+        let tac ← `(tactic| simp only [$[$simpArgs],*])
+        evalTactic tac
+      catch _ =>
+        pure ()

--- a/Clean/Utils/Tactics/SimplifyProvableStructEval.lean
+++ b/Clean/Utils/Tactics/SimplifyProvableStructEval.lean
@@ -47,7 +47,7 @@ private partial def collectStructEvalPattern (e : Expr) : MetaM (List Expr) := d
             else
               isStructLiteral otherSide
           if otherIsLiteral then
-            -- Extract the struct expression being evaluated (last argument of ProvableType.eval)
+            -- Extract the struct expression being evaluated (last argument of ProvableType.eval')
             if let some structExpr := evalSide.getArg? 5 then
               return [structExpr]
             else
@@ -55,7 +55,7 @@ private partial def collectStructEvalPattern (e : Expr) : MetaM (List Expr) := d
 
           -- If other side is just a variable, check if eval side has a struct literal
           -- Extract the argument of eval (the struct being evaluated)
-          if let some evalArg := evalSide.getArg? 5 /- very specific to ProvableType.eval -/ then
+          if let some evalArg := evalSide.getArg? 5 /- very specific to ProvableType.eval' -/ then
             let isLit ← isStructLiteral evalArg
             if isLit then
               return [evalArg]

--- a/Clean/Utils/Tactics/SplitProvableStructEq.lean
+++ b/Clean/Utils/Tactics/SplitProvableStructEq.lean
@@ -59,6 +59,16 @@ def findStructVarsInEqualities : TacticM (List FVarId) := do
 -/
 def splitProvableStructEq : TacticM Unit := do
   withMainContext do
+    -- Struct equalities sometimes have a wrapper equality type such as
+    -- `Value MyStruct F` or `ProverValue MyStruct F`. Normalize those type
+    -- wrappers before looking for constructor equalities, so generated
+    -- `MyStruct.mk.injEq` lemmas can match.
+    try
+      evalTactic (← `(tactic|
+        simp only [CircuitType.value_of_provableType, CircuitType.proverValue_of_provableType] at *))
+    catch _ =>
+      pure ()
+
     -- First, find and apply cases on struct variables in equalities
     let varsToCase ← findStructVarsInEqualities
 

--- a/Clean/Utils/Test/TestCircuitProofStart.lean
+++ b/Clean/Utils/Test/TestCircuitProofStart.lean
@@ -80,7 +80,7 @@ example {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [Prov
   have : Environment F := env
   have : Input (Expression F) := input_var
   have : Input F := input
-  have : ProvableType.eval' env input_var = input := h_input
+  have : eval env input_var = input := h_input
   have : Assumptions input := h_assumptions
   have : ConstraintsHold.Soundness env (circuit.main input_var i₀).2 := h_holds
   sorry

--- a/Clean/Utils/Test/TestCircuitProofStart.lean
+++ b/Clean/Utils/Test/TestCircuitProofStart.lean
@@ -80,7 +80,7 @@ example {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [Prov
   have : Environment F := env
   have : Input (Expression F) := input_var
   have : Input F := input
-  have : ProvableType.eval env input_var = input := h_input
+  have : ProvableType.eval' env input_var = input := h_input
   have : Assumptions input := h_assumptions
   have : ConstraintsHold.Soundness env (circuit.main input_var i₀).2 := h_holds
   sorry

--- a/Clean/Utils/Test/TestCircuitProofStart.lean
+++ b/Clean/Utils/Test/TestCircuitProofStart.lean
@@ -80,7 +80,7 @@ example {F : Type} [Field F] {Input Output : TypeMap} [ProvableType Input] [Prov
   have : Environment F := env
   have : Input (Expression F) := input_var
   have : Input F := input
-  have : eval env input_var = input := h_input
+  have : ProvableType.eval env input_var = input := h_input
   have : Assumptions input := h_assumptions
   have : ConstraintsHold.Soundness env (circuit.main input_var i₀).2 := h_holds
   sorry
@@ -120,7 +120,7 @@ def Spec (input : unit (F p)) (output : unit (F p)) : Prop :=
   TestSpec input output
 
 def testCircuit : ElaboratedCircuit (F p) unit unit :=
-  { main := fun _ => pure (), output := fun _ _ => (), localLength := 0, output_eq := by simp }
+  { main := fun _ => pure (), output := fun _ _ => (), localLength := 0, output_eq _ _ := rfl }
 
 example : Soundness (F p) testCircuit Assumptions Spec := by
   circuit_proof_start
@@ -144,7 +144,7 @@ def Spec (input : unit (F p)) (output : unit (F p)) : Prop :=
   TestSpec input output
 
 def testCircuit : ElaboratedCircuit (F p) unit unit :=
-  { main := fun _ => pure (), output := fun _ _ => (), localLength := 0, output_eq := by simp }
+  { main := fun _ => pure (), output := fun _ _ => (), localLength := 0, output_eq _ _ := rfl }
 
 example : Soundness (F p) testCircuit Assumptions Spec := by
   circuit_proof_start
@@ -157,7 +157,7 @@ end UnfoldTest2
 namespace UnfoldTest3
 -- Test that elaborated definition is unfolded
 def testCircuit : ElaboratedCircuit (F p) unit unit :=
-  { main := fun _ => pure (), output := fun _ _ => (), localLength := 0, output_eq := by simp }
+  { main := fun _ => pure (), output := fun _ _ => (), localLength := 0, output_eq _ _ := rfl }
 
 def elaborated : ElaboratedCircuit (F p) unit unit :=
   testCircuit

--- a/Clean/Utils/Test/TestSimplifyProvableStructEval.lean
+++ b/Clean/Utils/Test/TestSimplifyProvableStructEval.lean
@@ -19,7 +19,7 @@ deriving ProvableStruct
 -- Test eval with struct literal on RHS
 lemma test_eval_eq_struct_literal {F : Type} [Field F] (env : ProverEnvironment F)
     (x_var y_var z_var : Var field F)
-    (h : eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3) :
+    (h : ProvableType.eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3) :
     Expression.eval env x_var = 1 ∧ Expression.eval env y_var = 2 ∧ Expression.eval env z_var = 3 := by
   fail_if_no_progress simplify_provable_struct_eval
   -- Now h should be literal = literal
@@ -29,7 +29,7 @@ lemma test_eval_eq_struct_literal {F : Type} [Field F] (env : ProverEnvironment 
 -- Test eval with struct literal on LHS
 theorem test_struct_literal_eq_eval {F : Type} [Field F] (env : ProverEnvironment F)
     (x_var y_var z_var : Var field F)
-    (h : TestInputs.mk 1 2 3 = eval env (TestInputs.mk x_var y_var z_var)) :
+    (h : TestInputs.mk 1 2 3 = ProvableType.eval env (TestInputs.mk x_var y_var z_var)) :
     1 = Expression.eval env x_var ∧ 2 = Expression.eval env y_var ∧ 3 = Expression.eval env z_var := by
   fail_if_no_progress simplify_provable_struct_eval
   -- Now h should be literal = literal
@@ -39,7 +39,7 @@ theorem test_struct_literal_eq_eval {F : Type} [Field F] (env : ProverEnvironmen
 -- Test eval with struct variable
 theorem test_eval_eq_struct_variable {F : Type} [Field F] (env : ProverEnvironment F) (input : TestInputs F)
     (x_var y_var z_var : Var field F)
-    (h : eval env (TestInputs.mk x_var y_var z_var) = input) :
+    (h : ProvableType.eval env (TestInputs.mk x_var y_var z_var) = input) :
     TestInputs.mk (Expression.eval env x_var) (Expression.eval env y_var) (Expression.eval env z_var) = input := by
   -- determine if should succeed or fail
   simplify_provable_struct_eval
@@ -49,7 +49,7 @@ theorem test_eval_eq_struct_variable {F : Type} [Field F] (env : ProverEnvironme
 -- Test eval inside conjunctions
 theorem test_eval_in_conjunction {F : Type} [Field F] (env : ProverEnvironment F) (x : F)
     (x_var y_var z_var : Var field F)
-    (h : eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) :
+    (h : ProvableType.eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) :
     Expression.eval env x_var = 1 ∧ Expression.eval env y_var = 2 ∧ Expression.eval env z_var = 3 ∧ x = 7 := by
   simplify_provable_struct_eval
   -- now h should be literal = literal
@@ -65,8 +65,8 @@ theorem test_eval_in_conjunction {F : Type} [Field F] (env : ProverEnvironment F
 -- Test nested conjunctions with eval
 theorem test_nested_conjunctions_with_eval {F : Type} [Field F] (env : ProverEnvironment F) (x : F)
     (x_var y_var z_var a_var b_var : Var field F)
-    (h : (eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) ∧
-         eval env (SimpleStruct.mk a_var b_var) = SimpleStruct.mk 8 9) :
+    (h : (ProvableType.eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) ∧
+         ProvableType.eval env (SimpleStruct.mk a_var b_var) = SimpleStruct.mk 8 9) :
     Expression.eval env x_var = 1 ∧ Expression.eval env a_var = 8 := by
   simplify_provable_struct_eval
   -- now h should be a conjunction of literal = literal
@@ -79,8 +79,8 @@ theorem test_nested_conjunctions_with_eval {F : Type} [Field F] (env : ProverEnv
 -- Test multiple eval expressions
 theorem test_multiple_eval_expressions {F : Type} [Field F] (env1 env2 : ProverEnvironment F)
     (x1_var y1_var z1_var : Var field F) (a2_var b2_var : Var field F)
-    (h1 : eval env1 (TestInputs.mk x1_var y1_var z1_var) = TestInputs.mk 1 2 3)
-    (h2 : eval env2 (SimpleStruct.mk a2_var b2_var) = SimpleStruct.mk 4 5) :
+    (h1 : ProvableType.eval env1 (TestInputs.mk x1_var y1_var z1_var) = TestInputs.mk 1 2 3)
+    (h2 : ProvableType.eval env2 (SimpleStruct.mk a2_var b2_var) = SimpleStruct.mk 4 5) :
     Expression.eval env1 x1_var = 1 ∧ Expression.eval env2 b2_var = 5 := by
   simplify_provable_struct_eval
   -- now h should be a conjunction of literal = literal
@@ -93,7 +93,7 @@ theorem test_multiple_eval_expressions {F : Type} [Field F] (env1 env2 : ProverE
 -- Test with complex eval expressions
 theorem test_complex_eval {F : Type} [Field F] (env : ProverEnvironment F)
     (a_var b_var c_var d_var e_var : Var field F)
-    (h : eval env (TestInputs.mk (a_var + b_var) (c_var * d_var) e_var) = TestInputs.mk 5 6 7) :
+    (h : ProvableType.eval env (TestInputs.mk (a_var + b_var) (c_var * d_var) e_var) = TestInputs.mk 5 6 7) :
     Expression.eval env (a_var + b_var) = 5 ∧
     Expression.eval env (c_var * d_var) = 6 ∧
     Expression.eval env e_var = 7 := by
@@ -106,13 +106,13 @@ theorem test_complex_eval {F : Type} [Field F] (env : ProverEnvironment F)
 -- Test conjunction with an eval to be decomposed and another eval not to be decomposed
 theorem test_conjunction_with_base_and_non_base {F : Type} [Field F] (env : ProverEnvironment F) (x : F)
     (x_var y_var z_var : Var field F) (s1 s2 : Var SimpleStruct F)
-    (h : (eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) ∧
-         eval env s1 = eval env s2) :
+    (h : (ProvableType.eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) ∧
+         ProvableType.eval env s1 = ProvableType.eval env s2) :
     Expression.eval env x_var = 1 := by
   simplify_provable_struct_eval
-  -- eval env s1 = eval env s2 should be intact
+  -- ProvableType.eval env s1 = ProvableType.eval env s2 should be intact
   simp only [TestInputs.mk.injEq] at h
-  -- Since eval env s1 = eval env s2 should be intact, this simplification should fail
+  -- Since ProvableType.eval env s1 = ProvableType.eval env s2 should be intact, this simplification should fail
   fail_if_success simp only [SimpleStruct.mk.injEq] at h
   -- Both eval equalities should be simplified
   exact h.1.1.1

--- a/Clean/Utils/Test/TestSimplifyProvableStructEval.lean
+++ b/Clean/Utils/Test/TestSimplifyProvableStructEval.lean
@@ -19,7 +19,7 @@ deriving ProvableStruct
 -- Test eval with struct literal on RHS
 lemma test_eval_eq_struct_literal {F : Type} [Field F] (env : ProverEnvironment F)
     (x_var y_var z_var : Var field F)
-    (h : ProvableType.eval' env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3) :
+    (h : eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3) :
     Expression.eval env x_var = 1 ∧ Expression.eval env y_var = 2 ∧ Expression.eval env z_var = 3 := by
   fail_if_no_progress simplify_provable_struct_eval
   -- Now h should be literal = literal
@@ -29,7 +29,7 @@ lemma test_eval_eq_struct_literal {F : Type} [Field F] (env : ProverEnvironment 
 -- Test eval with struct literal on LHS
 theorem test_struct_literal_eq_eval {F : Type} [Field F] (env : ProverEnvironment F)
     (x_var y_var z_var : Var field F)
-    (h : TestInputs.mk 1 2 3 = ProvableType.eval' env (TestInputs.mk x_var y_var z_var)) :
+    (h : TestInputs.mk 1 2 3 = eval env (TestInputs.mk x_var y_var z_var)) :
     1 = Expression.eval env x_var ∧ 2 = Expression.eval env y_var ∧ 3 = Expression.eval env z_var := by
   fail_if_no_progress simplify_provable_struct_eval
   -- Now h should be literal = literal
@@ -39,7 +39,7 @@ theorem test_struct_literal_eq_eval {F : Type} [Field F] (env : ProverEnvironmen
 -- Test eval with struct variable
 theorem test_eval_eq_struct_variable {F : Type} [Field F] (env : ProverEnvironment F) (input : TestInputs F)
     (x_var y_var z_var : Var field F)
-    (h : ProvableType.eval' env (TestInputs.mk x_var y_var z_var) = input) :
+    (h : eval env (TestInputs.mk x_var y_var z_var) = input) :
     TestInputs.mk (Expression.eval env x_var) (Expression.eval env y_var) (Expression.eval env z_var) = input := by
   -- determine if should succeed or fail
   simplify_provable_struct_eval
@@ -49,7 +49,7 @@ theorem test_eval_eq_struct_variable {F : Type} [Field F] (env : ProverEnvironme
 -- Test eval inside conjunctions
 theorem test_eval_in_conjunction {F : Type} [Field F] (env : ProverEnvironment F) (x : F)
     (x_var y_var z_var : Var field F)
-    (h : ProvableType.eval' env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) :
+    (h : eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) :
     Expression.eval env x_var = 1 ∧ Expression.eval env y_var = 2 ∧ Expression.eval env z_var = 3 ∧ x = 7 := by
   simplify_provable_struct_eval
   -- now h should be literal = literal
@@ -65,8 +65,8 @@ theorem test_eval_in_conjunction {F : Type} [Field F] (env : ProverEnvironment F
 -- Test nested conjunctions with eval
 theorem test_nested_conjunctions_with_eval {F : Type} [Field F] (env : ProverEnvironment F) (x : F)
     (x_var y_var z_var a_var b_var : Var field F)
-    (h : (ProvableType.eval' env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) ∧
-         ProvableType.eval' env (SimpleStruct.mk a_var b_var) = SimpleStruct.mk 8 9) :
+    (h : (eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) ∧
+         eval env (SimpleStruct.mk a_var b_var) = SimpleStruct.mk 8 9) :
     Expression.eval env x_var = 1 ∧ Expression.eval env a_var = 8 := by
   simplify_provable_struct_eval
   -- now h should be a conjunction of literal = literal
@@ -79,8 +79,8 @@ theorem test_nested_conjunctions_with_eval {F : Type} [Field F] (env : ProverEnv
 -- Test multiple eval expressions
 theorem test_multiple_eval_expressions {F : Type} [Field F] (env1 env2 : ProverEnvironment F)
     (x1_var y1_var z1_var : Var field F) (a2_var b2_var : Var field F)
-    (h1 : ProvableType.eval' env1 (TestInputs.mk x1_var y1_var z1_var) = TestInputs.mk 1 2 3)
-    (h2 : ProvableType.eval' env2 (SimpleStruct.mk a2_var b2_var) = SimpleStruct.mk 4 5) :
+    (h1 : eval env1 (TestInputs.mk x1_var y1_var z1_var) = TestInputs.mk 1 2 3)
+    (h2 : eval env2 (SimpleStruct.mk a2_var b2_var) = SimpleStruct.mk 4 5) :
     Expression.eval env1 x1_var = 1 ∧ Expression.eval env2 b2_var = 5 := by
   simplify_provable_struct_eval
   -- now h should be a conjunction of literal = literal
@@ -93,7 +93,7 @@ theorem test_multiple_eval_expressions {F : Type} [Field F] (env1 env2 : ProverE
 -- Test with complex eval expressions
 theorem test_complex_eval {F : Type} [Field F] (env : ProverEnvironment F)
     (a_var b_var c_var d_var e_var : Var field F)
-    (h : ProvableType.eval' env (TestInputs.mk (a_var + b_var) (c_var * d_var) e_var) = TestInputs.mk 5 6 7) :
+    (h : eval env (TestInputs.mk (a_var + b_var) (c_var * d_var) e_var) = TestInputs.mk 5 6 7) :
     Expression.eval env (a_var + b_var) = 5 ∧
     Expression.eval env (c_var * d_var) = 6 ∧
     Expression.eval env e_var = 7 := by
@@ -106,13 +106,13 @@ theorem test_complex_eval {F : Type} [Field F] (env : ProverEnvironment F)
 -- Test conjunction with an eval to be decomposed and another eval not to be decomposed
 theorem test_conjunction_with_base_and_non_base {F : Type} [Field F] (env : ProverEnvironment F) (x : F)
     (x_var y_var z_var : Var field F) (s1 s2 : Var SimpleStruct F)
-    (h : (ProvableType.eval' env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) ∧
-         ProvableType.eval' env s1 = ProvableType.eval' env s2) :
+    (h : (eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) ∧
+         eval env s1 = eval env s2) :
     Expression.eval env x_var = 1 := by
   simplify_provable_struct_eval
-  -- ProvableType.eval' env s1 = ProvableType.eval' env s2 should be intact
+  -- eval env s1 = eval env s2 should be intact
   simp only [TestInputs.mk.injEq] at h
-  -- Since ProvableType.eval' env s1 = ProvableType.eval' env s2 should be intact, this simplification should fail
+  -- Since eval env s1 = eval env s2 should be intact, this simplification should fail
   fail_if_success simp only [SimpleStruct.mk.injEq] at h
   -- Both eval equalities should be simplified
   exact h.1.1.1

--- a/Clean/Utils/Test/TestSimplifyProvableStructEval.lean
+++ b/Clean/Utils/Test/TestSimplifyProvableStructEval.lean
@@ -19,7 +19,7 @@ deriving ProvableStruct
 -- Test eval with struct literal on RHS
 lemma test_eval_eq_struct_literal {F : Type} [Field F] (env : ProverEnvironment F)
     (x_var y_var z_var : Var field F)
-    (h : ProvableType.eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3) :
+    (h : ProvableType.eval' env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3) :
     Expression.eval env x_var = 1 ∧ Expression.eval env y_var = 2 ∧ Expression.eval env z_var = 3 := by
   fail_if_no_progress simplify_provable_struct_eval
   -- Now h should be literal = literal
@@ -29,7 +29,7 @@ lemma test_eval_eq_struct_literal {F : Type} [Field F] (env : ProverEnvironment 
 -- Test eval with struct literal on LHS
 theorem test_struct_literal_eq_eval {F : Type} [Field F] (env : ProverEnvironment F)
     (x_var y_var z_var : Var field F)
-    (h : TestInputs.mk 1 2 3 = ProvableType.eval env (TestInputs.mk x_var y_var z_var)) :
+    (h : TestInputs.mk 1 2 3 = ProvableType.eval' env (TestInputs.mk x_var y_var z_var)) :
     1 = Expression.eval env x_var ∧ 2 = Expression.eval env y_var ∧ 3 = Expression.eval env z_var := by
   fail_if_no_progress simplify_provable_struct_eval
   -- Now h should be literal = literal
@@ -39,7 +39,7 @@ theorem test_struct_literal_eq_eval {F : Type} [Field F] (env : ProverEnvironmen
 -- Test eval with struct variable
 theorem test_eval_eq_struct_variable {F : Type} [Field F] (env : ProverEnvironment F) (input : TestInputs F)
     (x_var y_var z_var : Var field F)
-    (h : ProvableType.eval env (TestInputs.mk x_var y_var z_var) = input) :
+    (h : ProvableType.eval' env (TestInputs.mk x_var y_var z_var) = input) :
     TestInputs.mk (Expression.eval env x_var) (Expression.eval env y_var) (Expression.eval env z_var) = input := by
   -- determine if should succeed or fail
   simplify_provable_struct_eval
@@ -49,7 +49,7 @@ theorem test_eval_eq_struct_variable {F : Type} [Field F] (env : ProverEnvironme
 -- Test eval inside conjunctions
 theorem test_eval_in_conjunction {F : Type} [Field F] (env : ProverEnvironment F) (x : F)
     (x_var y_var z_var : Var field F)
-    (h : ProvableType.eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) :
+    (h : ProvableType.eval' env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) :
     Expression.eval env x_var = 1 ∧ Expression.eval env y_var = 2 ∧ Expression.eval env z_var = 3 ∧ x = 7 := by
   simplify_provable_struct_eval
   -- now h should be literal = literal
@@ -65,8 +65,8 @@ theorem test_eval_in_conjunction {F : Type} [Field F] (env : ProverEnvironment F
 -- Test nested conjunctions with eval
 theorem test_nested_conjunctions_with_eval {F : Type} [Field F] (env : ProverEnvironment F) (x : F)
     (x_var y_var z_var a_var b_var : Var field F)
-    (h : (ProvableType.eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) ∧
-         ProvableType.eval env (SimpleStruct.mk a_var b_var) = SimpleStruct.mk 8 9) :
+    (h : (ProvableType.eval' env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) ∧
+         ProvableType.eval' env (SimpleStruct.mk a_var b_var) = SimpleStruct.mk 8 9) :
     Expression.eval env x_var = 1 ∧ Expression.eval env a_var = 8 := by
   simplify_provable_struct_eval
   -- now h should be a conjunction of literal = literal
@@ -79,8 +79,8 @@ theorem test_nested_conjunctions_with_eval {F : Type} [Field F] (env : ProverEnv
 -- Test multiple eval expressions
 theorem test_multiple_eval_expressions {F : Type} [Field F] (env1 env2 : ProverEnvironment F)
     (x1_var y1_var z1_var : Var field F) (a2_var b2_var : Var field F)
-    (h1 : ProvableType.eval env1 (TestInputs.mk x1_var y1_var z1_var) = TestInputs.mk 1 2 3)
-    (h2 : ProvableType.eval env2 (SimpleStruct.mk a2_var b2_var) = SimpleStruct.mk 4 5) :
+    (h1 : ProvableType.eval' env1 (TestInputs.mk x1_var y1_var z1_var) = TestInputs.mk 1 2 3)
+    (h2 : ProvableType.eval' env2 (SimpleStruct.mk a2_var b2_var) = SimpleStruct.mk 4 5) :
     Expression.eval env1 x1_var = 1 ∧ Expression.eval env2 b2_var = 5 := by
   simplify_provable_struct_eval
   -- now h should be a conjunction of literal = literal
@@ -93,7 +93,7 @@ theorem test_multiple_eval_expressions {F : Type} [Field F] (env1 env2 : ProverE
 -- Test with complex eval expressions
 theorem test_complex_eval {F : Type} [Field F] (env : ProverEnvironment F)
     (a_var b_var c_var d_var e_var : Var field F)
-    (h : ProvableType.eval env (TestInputs.mk (a_var + b_var) (c_var * d_var) e_var) = TestInputs.mk 5 6 7) :
+    (h : ProvableType.eval' env (TestInputs.mk (a_var + b_var) (c_var * d_var) e_var) = TestInputs.mk 5 6 7) :
     Expression.eval env (a_var + b_var) = 5 ∧
     Expression.eval env (c_var * d_var) = 6 ∧
     Expression.eval env e_var = 7 := by
@@ -106,13 +106,13 @@ theorem test_complex_eval {F : Type} [Field F] (env : ProverEnvironment F)
 -- Test conjunction with an eval to be decomposed and another eval not to be decomposed
 theorem test_conjunction_with_base_and_non_base {F : Type} [Field F] (env : ProverEnvironment F) (x : F)
     (x_var y_var z_var : Var field F) (s1 s2 : Var SimpleStruct F)
-    (h : (ProvableType.eval env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) ∧
-         ProvableType.eval env s1 = ProvableType.eval env s2) :
+    (h : (ProvableType.eval' env (TestInputs.mk x_var y_var z_var) = TestInputs.mk 1 2 3 ∧ x = 7) ∧
+         ProvableType.eval' env s1 = ProvableType.eval' env s2) :
     Expression.eval env x_var = 1 := by
   simplify_provable_struct_eval
-  -- ProvableType.eval env s1 = ProvableType.eval env s2 should be intact
+  -- ProvableType.eval' env s1 = ProvableType.eval' env s2 should be intact
   simp only [TestInputs.mk.injEq] at h
-  -- Since ProvableType.eval env s1 = ProvableType.eval env s2 should be intact, this simplification should fail
+  -- Since ProvableType.eval' env s1 = ProvableType.eval' env s2 should be intact, this simplification should fail
   fail_if_success simp only [SimpleStruct.mk.injEq] at h
   -- Both eval equalities should be simplified
   exact h.1.1.1

--- a/Clean/Utils/Test/TestSimplifyProvableStructEval.lean
+++ b/Clean/Utils/Test/TestSimplifyProvableStructEval.lean
@@ -16,6 +16,11 @@ structure SimpleStruct (F : Type) where
   b : F
 deriving ProvableStruct
 
+structure VectorStruct (F : Type) where
+  xs : Vector F 2
+  y : F
+deriving ProvableStruct
+
 -- Test eval with struct literal on RHS
 lemma test_eval_eq_struct_literal {F : Type} [Field F] (env : ProverEnvironment F)
     (x_var y_var z_var : Var field F)
@@ -45,6 +50,48 @@ theorem test_eval_eq_struct_variable {F : Type} [Field F] (env : ProverEnvironme
   simplify_provable_struct_eval
   -- This should simplify the eval expression
   exact h
+
+-- Test eval with a struct variable on both sides, where projections force decomposition.
+theorem test_eval_eq_decomposed_struct_variable {F : Type} [Field F] (env : ProverEnvironment F)
+    (input_var : TestInputs (Expression F)) (input : TestInputs F)
+    (h : eval env input_var = input) :
+    eval env input_var.x = input.x := by
+  provable_struct_simp
+  exact h.1
+
+-- Test the same decomposition when the input is written through the public `Var` alias.
+theorem test_eval_eq_decomposed_var_struct {F : Type} [Field F] (env : ProverEnvironment F)
+    (input_var : Var TestInputs F) (input : TestInputs F)
+    (h : eval env input_var = input) :
+    eval env input_var.x = input.x := by
+  provable_struct_simp
+  exact h.1
+
+-- Test splitting the constructor equality produced by simplifying eval on a struct variable.
+theorem test_eval_eq_decomposed_struct_variable_conjunction {F : Type} [Field F] (env : ProverEnvironment F)
+    (input_var : TestInputs (Expression F)) (input : TestInputs F)
+    (h : eval env input_var = input ∧ True) :
+    eval env input_var.y = input.y := by
+  provable_struct_simp
+  exact h.1.2.1
+
+-- Test the same decomposition when a field is itself a provable vector.
+theorem test_eval_eq_decomposed_vector_struct {F : Type} [Field F] (env : ProverEnvironment F)
+    (input_var : VectorStruct (Expression F)) (input : VectorStruct F)
+    (h : eval env input_var = input ∧ True) :
+    eval env input_var.y = input.y := by
+  provable_struct_simp
+  exact h.1.2
+
+-- Test that projected whole-struct evals are reduced to component evals after decomposition.
+theorem test_eval_projection_uses_decomposed_struct_eq {F : Type} [Field F] (env : Environment F)
+    (input_var : VectorStruct (Expression F)) (input : VectorStruct F)
+    (h : eval env input_var = input)
+    (hh : (eval env input_var).y = 1) :
+    input.y = 1 := by
+  provable_struct_simp
+  simp only [h] at hh ⊢
+  exact hh
 
 -- Test eval inside conjunctions
 theorem test_eval_in_conjunction {F : Type} [Field F] (env : ProverEnvironment F) (x : F)


### PR DESCRIPTION
Make prover hints a first-class circuit input. This unlocks a pattern used in some production circuit libraries that, so far, clean couldn't represent in an idiomatic way.

```lean
/--
  A circuit that witnesses a boolean field element using a prover hint.

  The hint callback tells the prover which boolean value to witness.
  The circuit constrains the output to be boolean (0 or 1).
-/
def witnessBool : GeneralFormalCircuit.WithHint (F p) (Unconstrained Bool) field where
  main (hint : ProverEnvironment (F p) → Bool) := do
    let b ← witness fun env => if hint env then 1 else 0
    assertBool b
    return b

  Assumptions (_ : Unit) _ := True
  Spec (_ : Unit) (output : F p) _ := IsBool output

  ProverAssumptions (hint : Bool) _ _ := True
  ProverSpec (hint : Bool) (b : F p) _ := b = if hint then 1 else 0

structure Input (F : Type) where
  x : F
  y : F
deriving ProvableStruct

/--
  A circuit that computes the AND of two boolean inputs.

  This is a plain `FormalCircuit` (no hint input). It creates the hint
  internally from its inputs and passes it to `witnessBool`.
-/
def booleanAnd : FormalCircuit (F p) Input field where
  main | ⟨x, y⟩ => do
    -- Use witnessBool as a subcircuit with a hint synthesized from the inputs
    let z ← witnessBool fun env => eval env x = 1 ∧ eval env y = 1
    -- Constrain result = x * y (multiplication is AND for booleans)
    z === x * y
    return z

  Assumptions | ⟨x, y⟩ => IsBool x ∧ IsBool y
  Spec | ⟨x, y⟩, z => IsBool z ∧ z.val = x.val &&& y.val
```