### PR TITLE
Add CircuitType deriving for record inputs

### DIFF
--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -128,11 +128,53 @@ namespace CircuitType
 instance : VerifierEval F (ProverEnvironment F → Hint) Unit := verifierEval (Unconstrained Hint)
 instance : ProverEval F (ProverEnvironment F → Hint) Hint := proverEval (Unconstrained Hint)
 
-@[circuit_norm] lemma eval_hint (env : Environment F) (v : ProverEnvironment F → Hint) :
+@[circuit_norm] lemma eval_unconstrained (env : Environment F) (v : ProverEnvironment F → Hint) :
   eval env v = () := by rfl
 
-@[circuit_norm] lemma eval_hint_prover (env : ProverEnvironment F) (v : ProverEnvironment F → Hint) :
+@[circuit_norm] lemma eval_unconstrained_prover (env : ProverEnvironment F)
+    (v : ProverEnvironment F → Hint) :
     eval env v = v env := by
   rw [eval_prover (M := Unconstrained Hint)]
+  rfl
+end CircuitType
+
+/--
+`UnconstrainedDep` is the field-dependent version of `Unconstrained`.
+Use it when the prover-only hint itself mentions the circuit field type.
+-/
+structure UnconstrainedDep (Hint : TypeMap) (F : Type) where
+  value : Hint F
+
+variable {HintMap : TypeMap}
+
+instance UnconstrainedDep.toCircuitType : CircuitType (UnconstrainedDep HintMap) where
+  Var F := ProverEnvironment F → HintMap F
+  ProverValue F := HintMap F
+  Value _ := Unit
+  evalVerifier _ _ := ()
+  evalProver env v := v env
+
+namespace CircuitType
+@[circuit_norm] lemma var_of_unconstrainedDep (Hint F) :
+  Var (UnconstrainedDep Hint) F = (ProverEnvironment F → Hint F) := rfl
+@[circuit_norm] lemma proverValue_of_unconstrainedDep (Hint F) :
+  ProverValue (UnconstrainedDep Hint) F = Hint F := rfl
+@[circuit_norm] lemma value_of_unconstrainedDep (Hint F) :
+  Value (UnconstrainedDep Hint) F = Unit := rfl
+
+/- forwarding instances to help instance search get through defeq -/
+instance : VerifierEval F (ProverEnvironment F → HintMap F) Unit :=
+  verifierEval (UnconstrainedDep HintMap)
+instance : ProverEval F (ProverEnvironment F → HintMap F) (HintMap F) :=
+  proverEval (UnconstrainedDep HintMap)
+
+@[circuit_norm] lemma eval_unconstrainedDep (env : Environment F)
+    (v : ProverEnvironment F → HintMap F) :
+  eval env v = () := by rfl
+
+@[circuit_norm] lemma eval_unconstrainedDep_prover (env : ProverEnvironment F)
+    (v : ProverEnvironment F → HintMap F) :
+    eval env v = v env := by
+  rw [eval_prover (M := UnconstrainedDep HintMap)]
   rfl
 end CircuitType

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -74,6 +74,9 @@ instance toCircuitType {M : TypeMap} [ProvableType M] : CircuitType M where
   evalVerifier env v := ProvableType.eval env v
   evalProver env v := ProvableType.eval env.toEnvironment v
 
+instance {M : TypeMap} [ProvableType M] : ProvableType (Value M) :=
+  inferInstanceAs (ProvableType M)
+
 def const (x : M F) : M (Expression F) :=
   let values : Vector F _ := toElements x
   fromElements (values.map .const)
@@ -187,6 +190,12 @@ instance : ProvableType unit where
   size := 0
   toElements _ := #v[]
   fromElements _ := ()
+
+instance {Hint : Type} : ProvableType (Value (Unconstrained Hint)) :=
+  inferInstanceAs (ProvableType unit)
+
+instance {Hint : TypeMap} : ProvableType (Value (UnconstrainedDep Hint)) :=
+  inferInstanceAs (ProvableType unit)
 
 abbrev field : TypeMap := id
 

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -9,6 +9,7 @@ and constrains it to be boolean.
 -/
 import Clean.Circuit
 import Clean.Gadgets.Boolean
+import Clean.Types.U32
 
 variable {p : ℕ} [Fact p.Prime] [Fact (p > 2)]
 
@@ -79,5 +80,52 @@ def booleanAnd : FormalCircuit (F p) Input field where
     simp_all
     rcases h_assumptions with ⟨ x | notx, y | noty ⟩
       <;> simp_all
+
+structure MixedInput (F : Type) where
+  someElement : U32 F
+  someHint : Unconstrained Bool F
+deriving CircuitType
+
+example (input : MixedInput.Var (F p)) : U32 (Expression (F p)) × (ProverEnvironment (F p) → Bool) :=
+  (input.someElement, input.someHint)
+example (input : MixedInput.ProverValue (F p)) : U32 (F p) × Bool :=
+  (input.someElement, input.someHint)
+example (input : MixedInput.Value (F p)) : U32 (F p) × Unit :=
+  (input.someElement, input.someHint)
+
+/--
+  A circuit with both ordinary provable input data and a prover-only hint.
+
+  The verifier sees `someElement`, but `someHint` is erased to `Unit` in the
+  soundness statement. The prover still sees the hint in completeness and uses it
+  to choose the witnessed boolean.
+-/
+def witnessMixedHint : GeneralFormalCircuit.WithHint (F p) MixedInput field where
+  main (input : MixedInput.Var (F p)) := do
+    let b ← witness fun env => if input.someHint env then 1 else 0
+    assertBool b
+    return b
+
+  localLength _ := 1
+  output _ i := var ⟨i⟩
+
+  Assumptions _ _ := True
+  Spec _ (output : F p) _ := IsBool output
+
+  ProverAssumptions _ _ _ := True
+  ProverSpec input (output : F p) _ := output = if input.someHint then 1 else 0
+
+  soundness := by
+    circuit_proof_all [assertBool, IsBool.iff_mul_sub_one, sub_eq_add_neg]
+
+  completeness := by
+    circuit_proof_start [assertBool, IsBool.iff_mul_sub_one, sub_eq_add_neg]
+    have h_hint : input.someHint = input_var.someHint env := by
+      have h := congrArg MixedInput.ProverValue.someHint h_input
+      rw [CircuitType.eval_prover] at h
+      change eval env input_var.someHint = input.someHint at h
+      rw [CircuitType.eval_hint_prover] at h
+      exact h.symm
+    cases input_var.someHint env <;> simp_all
 
 end Examples.HintExample

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -92,4 +92,23 @@ example (input : MixedInput.ProverValue (F p)) : U32 (F p) × Bool :=
   (input.someElement, input.someHint)
 example (input : MixedInput.Value (F p)) : U32 (F p) × Unit :=
   (input.someElement, input.someHint)
+
+/--
+  This captures the field-dependent hint case: the prover-only data mentions the
+  circuit field type, so `Unconstrained Bool` is not expressive enough.
+-/
+structure InputWithFieldHint (F : Type) where
+  publicInput : F
+  hinted : UnconstrainedDep field F
+deriving CircuitType
+
+example (input : InputWithFieldHint.Var (F p)) :
+    Expression (F p) × (ProverEnvironment (F p) → F p) :=
+  (input.publicInput, input.hinted)
+example (input : InputWithFieldHint.ProverValue (F p)) : F p × F p :=
+  (input.publicInput, input.hinted)
+example (input : InputWithFieldHint.Value (F p)) : F p × Unit :=
+  (input.publicInput, input.hinted)
+
+example : ProvableType (Value InputWithFieldHint) := inferInstance
 end Examples.HintExample

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -92,40 +92,4 @@ example (input : MixedInput.ProverValue (F p)) : U32 (F p) × Bool :=
   (input.someElement, input.someHint)
 example (input : MixedInput.Value (F p)) : U32 (F p) × Unit :=
   (input.someElement, input.someHint)
-
-/--
-  A circuit with both ordinary provable input data and a prover-only hint.
-
-  The verifier sees `someElement`, but `someHint` is erased to `Unit` in the
-  soundness statement. The prover still sees the hint in completeness and uses it
-  to choose the witnessed boolean.
--/
-def witnessMixedHint : GeneralFormalCircuit.WithHint (F p) MixedInput field where
-  main (input : MixedInput.Var (F p)) := do
-    let b ← witness fun env => if input.someHint env then 1 else 0
-    assertBool b
-    return b
-
-  localLength _ := 1
-  output _ i := var ⟨i⟩
-
-  Assumptions _ _ := True
-  Spec _ (output : F p) _ := IsBool output
-
-  ProverAssumptions _ _ _ := True
-  ProverSpec input (output : F p) _ := output = if input.someHint then 1 else 0
-
-  soundness := by
-    circuit_proof_all [assertBool, IsBool.iff_mul_sub_one, sub_eq_add_neg]
-
-  completeness := by
-    circuit_proof_start [assertBool, IsBool.iff_mul_sub_one, sub_eq_add_neg]
-    have h_hint : input.someHint = input_var.someHint env := by
-      have h := congrArg MixedInput.ProverValue.someHint h_input
-      rw [CircuitType.eval_prover] at h
-      change eval env input_var.someHint = input.someHint at h
-      rw [CircuitType.eval_hint_prover] at h
-      exact h.symm
-    cases input_var.someHint env <;> simp_all
-
 end Examples.HintExample

--- a/Clean/Test.lean
+++ b/Clean/Test.lean
@@ -3,3 +3,4 @@ import Clean.Utils.Test.TestDecomposeProvableStruct
 import Clean.Utils.Test.TestSplitProvableStructEq
 import Clean.Utils.Test.TestCircuitProofStart
 import Clean.Utils.Test.TestSimplifyProvableStructEval
+import Clean.Utils.Test.TestCircuitStructDeriving

--- a/Clean/Utils/Tactics/CircuitProofStart.lean
+++ b/Clean/Utils/Tactics/CircuitProofStart.lean
@@ -124,6 +124,8 @@ elab_rules : tactic
   -- try to unfold main, Assumptions and Spec as local definitions
   evalTactic (← `(tactic| try dsimp only [$(mkIdent `Assumptions):ident] at *))
   evalTactic (← `(tactic| try dsimp only [$(mkIdent `Spec):ident] at *))
+  evalTactic (← `(tactic| try dsimp only [$(mkIdent `ProverAssumptions):ident] at *))
+  evalTactic (← `(tactic| try dsimp only [$(mkIdent `ProverSpec):ident] at *))
   evalTactic (← `(tactic| try dsimp only [$(mkIdent `elaborated):ident] at *)) -- sometimes `main` is hidden behind `elaborated`
   evalTactic (← `(tactic| try dsimp only [$(mkIdent `main):ident] at *))
 

--- a/Clean/Utils/Tactics/ProvableStructDeriving.lean
+++ b/Clean/Utils/Tactics/ProvableStructDeriving.lean
@@ -1,4 +1,5 @@
 import Lean
+import Lean.Elab.Deriving.Util
 import Clean.Circuit.Provable
 
 /-!
@@ -131,6 +132,13 @@ def ParamInfo.name : ParamInfo → Name
   | .natural n => n
   | .typeMap n => n
   | .other n _ => n
+
+def mkAppliedInductiveWithoutFieldParam (indInfo : InductiveVal) (paramInfos : Array ParamInfo) :
+    CommandElabM (TSyntax `term) := do
+  if paramInfos.isEmpty then
+    return mkIdent indInfo.name
+  liftTermElabM do
+    Lean.Elab.Deriving.mkInductiveApp indInfo (paramInfos.map ParamInfo.name)
 
 /--
   Analyze a field type to determine its TypeMap.
@@ -326,9 +334,6 @@ def mkProvableStructInstance (structName : Name) : CommandElabM Unit := do
     let fname := fieldNameIdents[idx]!
     fromCompPat ← `(.cons $fname $fromCompPat)
 
-  -- Build the struct literal with fields
-  let structIdent := mkIdent structName
-
   -- For fromComponents, we build the struct constructor explicitly: StructName.mk f1 f2 f3
   let structMk := mkIdent (structName ++ `mk)
   let mkAppSyntax ← fieldNameIdents.foldlM (init := (structMk : TSyntax `term)) fun acc fname =>
@@ -341,13 +346,7 @@ def mkProvableStructInstance (structName : Name) : CommandElabM Unit := do
 
   -- Build the applied structure type if there are extra parameters
   -- e.g., Inputs n M for structure Inputs (n : ℕ) (M : TypeMap) (F : Type)
-  let appliedStructType : TSyntax `term ←
-    if paramInfos.isEmpty then
-      `($structIdent)
-    else
-      let paramIdents := paramInfos.map (fun p => mkIdent p.name)
-      paramIdents.foldlM (init := (structIdent : TSyntax `term)) fun acc paramIdent =>
-        `($acc $paramIdent)
+  let appliedStructType ← mkAppliedInductiveWithoutFieldParam indInfo paramInfos
 
   -- Build the instance binders for extra parameters using bracketedBinderF
   -- e.g., {n : ℕ} {M : TypeMap} [ProvableType M]
@@ -524,14 +523,7 @@ def mkCircuitTypeInstance (structName : Name) : CommandElabM Unit := do
   mkCircuitViewStruct proverValueStructName paramInfos fieldNameIdents componentSyntaxes
     (fun component => `(CircuitType.ProverValue $component $fIdent))
 
-  let structIdent := mkIdent structName
-  let appliedStructType : TSyntax `term ←
-    if paramInfos.isEmpty then
-      `($structIdent)
-    else
-      let paramIdents := paramInfos.map (fun p => mkIdent p.name)
-      paramIdents.foldlM (init := (structIdent : TSyntax `term)) fun acc paramIdent =>
-        `($acc $paramIdent)
+  let appliedStructType ← mkAppliedInductiveWithoutFieldParam indInfo paramInfos
 
   let viewTypeApp (viewName : Name) : CommandElabM (TSyntax `term) := do
     let viewIdent := mkIdent (← relativeToCurrentNamespace viewName)

--- a/Clean/Utils/Tactics/ProvableStructDeriving.lean
+++ b/Clean/Utils/Tactics/ProvableStructDeriving.lean
@@ -194,7 +194,7 @@ def analyzeFieldType (numParams : Nat) (paramFVars : Array Expr) (fieldType : Ex
         else
           throwError "field type argument is not the type parameter: {fieldType}"
     | _ =>
-      throwError "unsupported field type for ProvableStruct: {fieldType}. Expected either F, M F, Vector F n, or Vector (M F) n where F is the type parameter."
+      throwError "unsupported field type for ProvableStruct or CircuitType: {fieldType}. Expected either F, M F, Vector F n, or Vector (M F) n where F is the type parameter."
 where
   /-- Convert an expression to syntax, handling fvars that reference other parameters -/
   exprToSyntax (paramFVars : Array Expr) (e : Expr) : MetaM (TSyntax `term) := do

--- a/Clean/Utils/Tactics/ProvableStructDeriving.lean
+++ b/Clean/Utils/Tactics/ProvableStructDeriving.lean
@@ -2,11 +2,18 @@ import Lean
 import Clean.Circuit.Provable
 
 /-!
-  # Deriving handler for ProvableStruct
+  # Deriving handlers for ProvableStruct and CircuitType
 
-  This macro generates `ProvableStruct` instances for structures where all fields
+  This file defines deriving handlers for record-shaped circuit data.
+
+  The `ProvableStruct` macro generates `ProvableStruct` instances for structures where all fields
   are of the form `M F` where `M : TypeMap` (i.e., `M : Type → Type`), and each `M`
   must have a `ProvableType M` instance.
+
+  The `CircuitType` macro generates companion `Var`, `Value`, and `ProverValue`
+  structures, plus a `CircuitType` instance, for structures whose fields implement
+  `CircuitType`. This allows circuit inputs to mix ordinary provable data with
+  prover-only hints such as `Unconstrained`.
 
   ## Basic usage
 
@@ -24,6 +31,31 @@ import Clean.Circuit.Provable
     components := [field, field, field]
     toComponents := fun ⟨pc, ap, fp⟩ => .cons pc (.cons ap (.cons fp .nil))
     fromComponents := fun (.cons pc (.cons ap (.cons fp .nil))) => MyState.mk pc ap fp
+  ```
+
+  For `CircuitType`:
+
+  ```lean
+  structure Inputs (F : Type) where
+    someElement : U32 F
+    someHint : Unconstrained Bool F
+  deriving CircuitType
+  ```
+
+  Generates companion views equivalent to:
+
+  ```lean
+  structure Inputs.Var (F : Type) where
+    someElement : Var U32 F
+    someHint : ProverEnvironment F → Bool
+
+  structure Inputs.Value (F : Type) where
+    someElement : Value U32 F
+    someHint : Unit
+
+  structure Inputs.ProverValue (F : Type) where
+    someElement : ProverValue U32 F
+    someHint : Bool
   ```
 
   ## Extra type parameters

--- a/Clean/Utils/Tactics/ProvableStructDeriving.lean
+++ b/Clean/Utils/Tactics/ProvableStructDeriving.lean
@@ -79,6 +79,13 @@ open Lean Meta Elab Term Command Parser.Term
 
 namespace ProvableStructDeriving
 
+/-- Use a declaration name relative to the current namespace when generating commands. -/
+def relativeToCurrentNamespace (name : Name) : CommandElabM Name := do
+  let ns ← getCurrNamespace
+  if ns != .anonymous && ns.isPrefixOf name then
+    return name.replacePrefix ns .anonymous
+  return name
+
 /--
   Information about a structure parameter (other than the final F : Type parameter)
 -/
@@ -370,5 +377,215 @@ def provableStructDerivingHandler (declNames : Array Name) : CommandElabM Bool :
 
 -- Register the deriving handler
 initialize registerDerivingHandler ``ProvableStruct provableStructDerivingHandler
+
+/--
+  Generate a companion structure for one of the `CircuitType` views of a
+  derived `CircuitType`.
+-/
+def mkCircuitViewStruct (viewName : Name) (paramInfos : Array ParamInfo)
+    (fieldNameIdents : Array (TSyntax `ident)) (fieldTypes : Array (TSyntax `term))
+    (viewType : TSyntax `term → CommandElabM (TSyntax `term)) : CommandElabM Unit := do
+  let mut binderSyntaxes : Array (TSyntax ``bracketedBinder) := #[]
+  for info in paramInfos do
+    match info with
+    | .natural n =>
+      let nIdent := mkIdent n
+      let binder ← `(bracketedBinderF| ($nIdent : ℕ))
+      binderSyntaxes := binderSyntaxes.push binder
+    | .typeMap m =>
+      let mIdent := mkIdent m
+      let typeBinder ← `(bracketedBinderF| ($mIdent : TypeMap))
+      let instBinder ← `(bracketedBinderF| [CircuitType $mIdent])
+      binderSyntaxes := binderSyntaxes.push typeBinder
+      binderSyntaxes := binderSyntaxes.push instBinder
+    | .other n ty =>
+      let nIdent := mkIdent n
+      let tySyntax ← liftTermElabM <| PrettyPrinter.delab ty
+      let binder ← `(bracketedBinderF| ($nIdent : $tySyntax))
+      binderSyntaxes := binderSyntaxes.push binder
+
+  let fIdent := mkIdent `F
+  let fBinder ← `(bracketedBinderF| ($fIdent : Type))
+  binderSyntaxes := binderSyntaxes.push fBinder
+
+  let mut fieldSyntaxes : Array (TSyntax ``Lean.Parser.Command.structSimpleBinder) := #[]
+  for h : i in [:fieldNameIdents.size] do
+    let fname := fieldNameIdents[i]
+    let component := fieldTypes[i]!
+    let ty ← viewType component
+    let field ← `(Lean.Parser.Command.structSimpleBinder| $fname:ident : $ty)
+    fieldSyntaxes := fieldSyntaxes.push field
+
+  let viewIdent := mkIdent (← relativeToCurrentNamespace viewName)
+  let cmd ← `(
+    structure $viewIdent $binderSyntaxes:bracketedBinder* where
+      $fieldSyntaxes:structSimpleBinder*
+  )
+  elabCommand cmd
+
+/--
+  Generate the CircuitType instance declaration.
+-/
+def mkCircuitTypeInstance (structName : Name) : CommandElabM Unit := do
+  let env ← getEnv
+
+  unless isStructure env structName do
+    throwError "{structName} is not a structure"
+
+  let some structInfo := getStructureInfo? env structName
+    | throwError "failed to get structure info for {structName}"
+
+  let some (.inductInfo indInfo) := env.find? structName
+    | throwError "{structName} not found in environment"
+
+  let numParams := indInfo.numParams
+
+  if numParams < 1 then
+    throwError "CircuitType deriving requires at least one type parameter (F : Type), but {structName} has {numParams}"
+
+  let fieldNames := structInfo.fieldNames
+
+  if fieldNames.isEmpty then
+    throwError "CircuitType deriving requires at least one field"
+
+  let (paramInfos, componentSyntaxes) ← liftTermElabM do
+    forallTelescope indInfo.type fun args _ => do
+      let mut infos : Array ParamInfo := #[]
+      for i in [:numParams - 1] do
+        let paramFVar := args[i]!
+        let paramName ← paramFVar.fvarId!.getUserName
+        let paramType ← inferType paramFVar
+        let info ← analyzeParam paramName paramType
+        infos := infos.push info
+
+      let mut components : Array (TSyntax `term) := #[]
+      for fname in fieldNames do
+        let projFnName := structName ++ fname
+        let some (.defnInfo projInfo) := env.find? projFnName
+          | throwError "projection {projFnName} not found"
+
+        let fieldType ← forallTelescope projInfo.type fun projArgs projBody => do
+          if projArgs.size != numParams + 1 then
+            throwError "projection {projFnName} has unexpected arity: {projArgs.size} vs expected {numParams + 1}"
+
+          let mut result := projBody
+          for i in [:numParams] do
+            result := result.replaceFVar projArgs[i]! args[i]!
+          return result
+
+        let componentSyntax ← analyzeFieldType numParams args fieldType
+        components := components.push componentSyntax
+
+      return (infos, components)
+
+  let fieldNameIdents : Array (TSyntax `ident) := fieldNames.map mkIdent
+
+  let varStructName := structName ++ `Var
+  let valueStructName := structName ++ `Value
+  let proverValueStructName := structName ++ `ProverValue
+
+  let fIdent := mkIdent `F
+  mkCircuitViewStruct varStructName paramInfos fieldNameIdents componentSyntaxes
+    (fun component => `(CircuitType.Var $component $fIdent))
+  mkCircuitViewStruct valueStructName paramInfos fieldNameIdents componentSyntaxes
+    (fun component => `(CircuitType.Value $component $fIdent))
+  mkCircuitViewStruct proverValueStructName paramInfos fieldNameIdents componentSyntaxes
+    (fun component => `(CircuitType.ProverValue $component $fIdent))
+
+  let structIdent := mkIdent structName
+  let appliedStructType : TSyntax `term ←
+    if paramInfos.isEmpty then
+      `($structIdent)
+    else
+      let paramIdents := paramInfos.map (fun p => mkIdent p.name)
+      paramIdents.foldlM (init := (structIdent : TSyntax `term)) fun acc paramIdent =>
+        `($acc $paramIdent)
+
+  let viewTypeApp (viewName : Name) : CommandElabM (TSyntax `term) := do
+    let viewIdent := mkIdent (← relativeToCurrentNamespace viewName)
+    if paramInfos.isEmpty then
+      `($viewIdent)
+    else
+      let paramIdents := paramInfos.map (fun p => mkIdent p.name)
+      paramIdents.foldlM (init := (viewIdent : TSyntax `term)) fun acc paramIdent =>
+        `($acc $paramIdent)
+
+  let varType ← viewTypeApp varStructName
+  let valueType ← viewTypeApp valueStructName
+  let proverValueType ← viewTypeApp proverValueStructName
+
+  let mut instanceBinders : Array (TSyntax ``bracketedBinder) := #[]
+  for info in paramInfos do
+    match info with
+    | .natural n =>
+      let nIdent := mkIdent n
+      let binder ← `(bracketedBinderF| {$nIdent : ℕ})
+      instanceBinders := instanceBinders.push binder
+    | .typeMap m =>
+      let mIdent := mkIdent m
+      let typeBinder ← `(bracketedBinderF| {$mIdent : TypeMap})
+      let instBinder ← `(bracketedBinderF| [CircuitType $mIdent])
+      instanceBinders := instanceBinders.push typeBinder
+      instanceBinders := instanceBinders.push instBinder
+    | .other n ty =>
+      let nIdent := mkIdent n
+      let tySyntax ← liftTermElabM <| PrettyPrinter.delab ty
+      let binder ← `(bracketedBinderF| {$nIdent : $tySyntax})
+      instanceBinders := instanceBinders.push binder
+
+  let inputIdent := mkIdent `input
+  let envIdent := mkIdent `env
+  let valueMk := mkIdent (← relativeToCurrentNamespace (valueStructName ++ `mk))
+  let proverValueMk := mkIdent (← relativeToCurrentNamespace (proverValueStructName ++ `mk))
+
+  let mut verifierBody : TSyntax `term := valueMk
+  let mut proverBody : TSyntax `term := proverValueMk
+  for fname in fieldNameIdents do
+    let verifierField ← `($inputIdent.$fname:ident)
+    let verifierEval ← `(Eval.eval $envIdent $verifierField)
+    verifierBody ← `($verifierBody $verifierEval)
+
+    let proverField ← `($inputIdent.$fname:ident)
+    let proverEval ← `(Eval.eval $envIdent $proverField)
+    proverBody ← `($proverBody $proverEval)
+
+  let cmd ←
+    if instanceBinders.isEmpty then
+      `(
+        instance : CircuitType $appliedStructType where
+          Var := $varType
+          Value := $valueType
+          ProverValue := $proverValueType
+          evalVerifier := fun $envIdent $inputIdent => $verifierBody
+          evalProver := fun $envIdent $inputIdent => $proverBody
+      )
+    else
+      `(
+        instance $instanceBinders:bracketedBinder* : CircuitType $appliedStructType where
+          Var := $varType
+          Value := $valueType
+          ProverValue := $proverValueType
+          evalVerifier := fun $envIdent $inputIdent => $verifierBody
+          evalProver := fun $envIdent $inputIdent => $proverBody
+      )
+
+  elabCommand cmd
+
+/-- The deriving handler for record-shaped `CircuitType`s. -/
+def circuitTypeDerivingHandler (declNames : Array Name) : CommandElabM Bool := do
+  if declNames.size != 1 then
+    return false
+  let declName := declNames[0]!
+  let env ← getEnv
+  unless isStructure env declName do
+    return false
+  try
+    mkCircuitTypeInstance declName
+    return true
+  catch e =>
+    logError m!"Failed to derive CircuitType for {declName}: {e.toMessageData}"
+    return false
+
+initialize registerDerivingHandler ``CircuitType circuitTypeDerivingHandler
 
 end ProvableStructDeriving

--- a/Clean/Utils/Tactics/ProvableStructDeriving.lean
+++ b/Clean/Utils/Tactics/ProvableStructDeriving.lean
@@ -455,6 +455,89 @@ def mkCircuitViewStruct (viewName : Name) (paramInfos : Array ParamInfo)
   elabCommand cmd
 
 /--
+  Generate a `ProvableStruct` instance for the verifier `Value` companion of a
+  derived `CircuitType`.
+
+  We generate this from the original field components instead of asking the
+  ordinary `ProvableStruct` deriver to rediscover them from fields like
+  `CircuitType.Value M F`. The latter loses the semantic context that these are
+  verifier values and can get stuck on generated typeclass arguments.
+-/
+def mkCircuitValueProvableStructInstance (valueStructName : Name) (paramInfos : Array ParamInfo)
+    (fieldNameIdents : Array (TSyntax `ident)) (componentSyntaxes : Array (TSyntax `term)) :
+    CommandElabM Unit := do
+  let valueComponents ← componentSyntaxes.mapM fun component =>
+    `(CircuitType.Value $component)
+  let componentsListSyntax ← `([$[$valueComponents],*])
+
+  let mut toCompBody : TSyntax `term ← `(.nil)
+  for i in [:fieldNameIdents.size] do
+    let idx := fieldNameIdents.size - 1 - i
+    let fname := fieldNameIdents[idx]!
+    toCompBody ← `(.cons $fname $toCompBody)
+
+  let mut fromCompPat : TSyntax `term ← `(.nil)
+  for i in [:fieldNameIdents.size] do
+    let idx := fieldNameIdents.size - 1 - i
+    let fname := fieldNameIdents[idx]!
+    fromCompPat ← `(.cons $fname $fromCompPat)
+
+  let valueStructIdent := mkIdent (← relativeToCurrentNamespace valueStructName)
+  let valueStructMk := mkIdent (← relativeToCurrentNamespace (valueStructName ++ `mk))
+  let mkAppSyntax ← fieldNameIdents.foldlM (init := (valueStructMk : TSyntax `term)) fun acc fname =>
+    `($acc $fname)
+
+  let structPatFields := fieldNameIdents.map (TSyntax.mk ·.raw)
+  let structPat ← `(⟨$[$structPatFields],*⟩)
+
+  let appliedValueStructType : TSyntax `term ←
+    if paramInfos.isEmpty then
+      `($valueStructIdent)
+    else
+      let paramIdents := paramInfos.map (fun p => mkIdent p.name)
+      paramIdents.foldlM (init := (valueStructIdent : TSyntax `term)) fun acc paramIdent =>
+        `($acc $paramIdent)
+
+  let mut binderSyntaxes : Array (TSyntax ``bracketedBinder) := #[]
+  for info in paramInfos do
+    match info with
+    | .natural n =>
+      let nIdent := mkIdent n
+      let binder ← `(bracketedBinderF| {$nIdent : ℕ})
+      binderSyntaxes := binderSyntaxes.push binder
+    | .typeMap m =>
+      let mIdent := mkIdent m
+      let typeBinder ← `(bracketedBinderF| {$mIdent : TypeMap})
+      let circuitBinder ← `(bracketedBinderF| [CircuitType $mIdent])
+      let provableValueBinder ← `(bracketedBinderF| [ProvableType (CircuitType.Value $mIdent)])
+      binderSyntaxes := binderSyntaxes.push typeBinder
+      binderSyntaxes := binderSyntaxes.push circuitBinder
+      binderSyntaxes := binderSyntaxes.push provableValueBinder
+    | .other n ty =>
+      let nIdent := mkIdent n
+      let tySyntax ← liftTermElabM <| PrettyPrinter.delab ty
+      let binder ← `(bracketedBinderF| {$nIdent : $tySyntax})
+      binderSyntaxes := binderSyntaxes.push binder
+
+  let cmd ←
+    if binderSyntaxes.isEmpty then
+      `(
+        instance : ProvableStruct $appliedValueStructType where
+          components := $componentsListSyntax
+          toComponents := fun $structPat => $toCompBody
+          fromComponents := fun ($fromCompPat) => $mkAppSyntax
+      )
+    else
+      `(
+        instance $binderSyntaxes:bracketedBinder* : ProvableStruct $appliedValueStructType where
+          components := $componentsListSyntax
+          toComponents := fun $structPat => $toCompBody
+          fromComponents := fun ($fromCompPat) => $mkAppSyntax
+      )
+
+  elabCommand cmd
+
+/--
   Generate the CircuitType instance declaration.
 -/
 def mkCircuitTypeInstance (structName : Name) : CommandElabM Unit := do
@@ -522,6 +605,7 @@ def mkCircuitTypeInstance (structName : Name) : CommandElabM Unit := do
     (fun component => `(CircuitType.Value $component $fIdent))
   mkCircuitViewStruct proverValueStructName paramInfos fieldNameIdents componentSyntaxes
     (fun component => `(CircuitType.ProverValue $component $fIdent))
+  mkCircuitValueProvableStructInstance valueStructName paramInfos fieldNameIdents componentSyntaxes
 
   let appliedStructType ← mkAppliedInductiveWithoutFieldParam indInfo paramInfos
 

--- a/Clean/Utils/Test/TestCircuitStructDeriving.lean
+++ b/Clean/Utils/Test/TestCircuitStructDeriving.lean
@@ -1,0 +1,41 @@
+import Clean.Circuit
+import Clean.Types.U32
+
+namespace TestCircuitStructDeriving
+
+structure Inputs (F : Type) where
+  someElement : U32 F
+  someHint : Unconstrained Bool F
+deriving CircuitType
+
+example : CircuitType Inputs := inferInstance
+
+example {F : Type} [Field F] (input : Var Inputs F) : Var U32 F :=
+  input.someElement
+
+example {F : Type} [Field F] (input : Var Inputs F) : ProverEnvironment F → Bool :=
+  input.someHint
+
+example {F : Type} [Field F] (input : Value Inputs F) : U32 F :=
+  input.someElement
+
+example {F : Type} [Field F] (input : Value Inputs F) : Unit :=
+  input.someHint
+
+example {F : Type} [Field F] (input : ProverValue Inputs F) : U32 F :=
+  input.someElement
+
+example {F : Type} [Field F] (input : ProverValue Inputs F) : Bool :=
+  input.someHint
+
+example {F : Type} [Field F] (env : Environment F) (input : Var Inputs F) :
+    eval env input = Inputs.Value.mk (eval env input.someElement) () := by
+  rw [CircuitType.eval_verifier]
+  rfl
+
+example {F : Type} [Field F] (env : ProverEnvironment F) (input : Var Inputs F) :
+    eval env input = Inputs.ProverValue.mk (eval env input.someElement) (eval env input.someHint) := by
+  rw [CircuitType.eval_prover]
+  rfl
+
+end TestCircuitStructDeriving


### PR DESCRIPTION
follow up to #363 

- Add `deriving CircuitType` support for record-like circuit input structures whose fields implement `CircuitType`.
- Generate companion `Var`, `Value`, and `ProverValue` structures and the corresponding `CircuitType` instance.
- Add focused deriver tests and a mixed provable/unconstrained input example.