### PR TITLE
CircuitType with properties

### DIFF
--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -491,25 +491,28 @@ export Circuit (witnessVar witnessField witnessVars witnessVector assertZero loo
 
 -- general `witness` method
 
-class Witnessable (F : Type) [Field F] (value : outParam TypeMap) (var : TypeMap) [ProvableType value] where
-  witness : (ProverEnvironment F → value F) → Circuit F (var F)
-  var_eq : var F = value (Expression F) := by rfl
+class Witnessable (F : Type) [Field F] (value : outParam TypeMap) (var : Type) [ProvableType value] where
+  witness : (ProverEnvironment F → value F) → Circuit F var
+  var_eq : var = value (Expression F) := by rfl
   witness_eq (compute : ProverEnvironment F → value F) :
     witness compute = var_eq ▸ ProvableType.witness compute := by intros; rfl
 
 export Witnessable (witness)
 
-instance : Witnessable F field Expression where
+instance : Witnessable F field (Expression F) where
   witness := witnessField
 
-instance {m : ℕ} : Witnessable F (Vector · m) (fun F => Vector (Expression F) m) where
+instance {m : ℕ} : Witnessable F (Vector · m) (Vector (Expression F) m) where
   witness := witnessVector m
 
-instance (α : TypeMap) [ProvableType α] : Witnessable F α (Var α) where
+instance (α : TypeMap) [ProvableType α] : Witnessable F α (Var α F) where
+  witness := ProvableType.witness
+
+instance (α : TypeMap) [ProvableType α] : Witnessable F α (α (Expression F)) where
   witness := ProvableType.witness
 
 instance {m : ℕ} (α : TypeMap) [NonEmptyProvableType α] :
-    Witnessable F (ProvableVector α m) (Var (ProvableVector α m)) where
+    Witnessable F (ProvableVector α m) (Var (ProvableVector α m) F) where
   witness := ProvableVector.witness m
 
 -- witness generation
@@ -605,7 +608,7 @@ macro_rules
     try ac_rfl))
 
 example :
-  let add (x : Expression F) := do
+  let add (x : Expression F) : Circuit F (Expression F) := do
     let y : Expression F ← witness fun _ => 1
     let z ← witness fun eval => eval (x + y)
     assertZero (x + y - z)

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -1,12 +1,15 @@
 import Clean.Circuit.Expression
 
+universe u v w x
+
 /--
 _Circuit types_ are usually just structured collections of field elements.
 
- We represent them as types generic over a single type argument (the field element),
- i.e. `Type → Type`.
+ We represent them as sorts generic over a single type argument (the field element),
+ i.e. `Type → Sort u`. This permits proof-valued circuit metadata such as
+ `Unconstrained someProp`.
 -/
-abbrev TypeMap := Type → Type
+abbrev TypeMap := Type → Sort u
 
 variable {F : Type} [Field F] {M : TypeMap}
 
@@ -16,7 +19,7 @@ to a `Value` (concrete value in the field), in a given environment.
 
 Generalizes verifier evaluation and prover evaluation for both provable types and prover hints.
 -/
-class Eval (Env : Type) (Var : Type) (Value : outParam Type) where
+class Eval (Env : Type) (Var : Sort u) (Value : outParam (Sort v)) where
   eval : Env → Var → Value
 
 /-
@@ -31,11 +34,11 @@ export Eval (eval)
 
 /-- Verifier evaluation is `Eval` specialized to `Environment F`. -/
 @[circuit_norm]
-abbrev VerifierEval (F : Type) Var (Value : outParam Type) := Eval (Environment F) Var Value
+abbrev VerifierEval (F : Type) Var (Value : outParam (Sort v)) := Eval (Environment F) Var Value
 
 /-- Prover evaluation is `Eval` specialized to `ProverEnvironment F`. -/
 @[circuit_norm]
-abbrev ProverEval (F : Type) Var (Value : outParam Type) := Eval (ProverEnvironment F) Var Value
+abbrev ProverEval (F : Type) Var (Value : outParam (Sort v)) := Eval (ProverEnvironment F) Var Value
 
 /--
 Explicit verifier view: even on a `ProverEnvironment`, this forces the verifier
@@ -56,18 +59,18 @@ and two eval functions that map the variable form to the two value forms
 For fully provable schemas (no hint fields), the verifier- and prover-value forms
 coincide; see the default instance in `Provable.lean`.
 -/
-class CircuitType (M : TypeMap) where
+class CircuitType (M : TypeMap.{u}) where
   /--
   An element of `Var M F` represents a `M F` that's polynomially dependent
   on the environment. More concretely, an element of `Var M F` is a value of `M F`
   with missing holes, and each hole contains a polynomial that can refer to fixed
   positions of the environment.
   -/
-  Var : TypeMap
+  Var : TypeMap.{v}
   /-- Verifier value: hint fields are erased to `Unit`. -/
-  Value : TypeMap
+  Value : TypeMap.{w}
   /-- Prover value: hint fields carry their underlying type. -/
-  ProverValue : TypeMap
+  ProverValue : TypeMap.{x}
   evalVerifier : ∀ {F : Type} [Field F], Environment F → Var F → Value F
   evalProver   : ∀ {F : Type} [Field F], ProverEnvironment F → Var F → ProverValue F
 
@@ -104,10 +107,10 @@ end CircuitType
 /--
 `Unconstrained` acts as a type marker for circuit inputs that should only be hints to the prover.
 -/
-structure Unconstrained (Hint : Type) (F : Type) where
+structure Unconstrained (Hint : Sort u) (F : Type) where
   value : Hint
 
-variable {Hint : Type}
+variable {Hint : Sort u}
 
 instance Unconstrained.toCircuitType : CircuitType (Unconstrained Hint) where
   Var F := ProverEnvironment F → Hint
@@ -117,11 +120,11 @@ instance Unconstrained.toCircuitType : CircuitType (Unconstrained Hint) where
   evalProver env v := v env
 
 namespace CircuitType
-@[circuit_norm] lemma var_of_unconstrained (Hint F) :
+@[circuit_norm] lemma var_of_unconstrained {F} :
   Var (Unconstrained Hint) F = (ProverEnvironment F → Hint) := rfl
-@[circuit_norm] lemma proverValue_of_unconstrained (Hint F) :
+@[circuit_norm] lemma proverValue_of_unconstrained {F} :
   ProverValue (Unconstrained Hint) F = Hint := rfl
-@[circuit_norm] lemma value_of_unconstrained (Hint F) :
+@[circuit_norm] lemma value_of_unconstrained {F} :
   Value (Unconstrained Hint) F = Unit := rfl
 
 /- forwarding instances to help instance search get through defeq -/

--- a/Clean/Circuit/CircuitType.lean
+++ b/Clean/Circuit/CircuitType.lean
@@ -1,15 +1,15 @@
 import Clean.Circuit.Expression
 
-universe u v w x
-
 /--
 _Circuit types_ are usually just structured collections of field elements.
 
- We represent them as sorts generic over a single type argument (the field element),
- i.e. `Type → Sort u`. This permits proof-valued circuit metadata such as
- `Unconstrained someProp`.
+We represent them as types generic over a single type argument (the field element),
+i.e. `Type → Type`.
 -/
-abbrev TypeMap := Type → Sort u
+abbrev TypeMap := Type → Type
+
+/-- Field-aware maps used for concrete verifier/prover views of a `CircuitType`. -/
+abbrev FieldTypeMap := (F : Type) → [Field F] → Type
 
 variable {F : Type} [Field F] {M : TypeMap}
 
@@ -19,7 +19,7 @@ to a `Value` (concrete value in the field), in a given environment.
 
 Generalizes verifier evaluation and prover evaluation for both provable types and prover hints.
 -/
-class Eval (Env : Type) (Var : Sort u) (Value : outParam (Sort v)) where
+class Eval (Env : Type) (Var : Type) (Value : outParam Type) where
   eval : Env → Var → Value
 
 /-
@@ -34,11 +34,11 @@ export Eval (eval)
 
 /-- Verifier evaluation is `Eval` specialized to `Environment F`. -/
 @[circuit_norm]
-abbrev VerifierEval (F : Type) Var (Value : outParam (Sort v)) := Eval (Environment F) Var Value
+abbrev VerifierEval (F : Type) Var (Value : outParam Type) := Eval (Environment F) Var Value
 
 /-- Prover evaluation is `Eval` specialized to `ProverEnvironment F`. -/
 @[circuit_norm]
-abbrev ProverEval (F : Type) Var (Value : outParam (Sort v)) := Eval (ProverEnvironment F) Var Value
+abbrev ProverEval (F : Type) Var (Value : outParam Type) := Eval (ProverEnvironment F) Var Value
 
 /--
 Explicit verifier view: even on a `ProverEnvironment`, this forces the verifier
@@ -59,20 +59,20 @@ and two eval functions that map the variable form to the two value forms
 For fully provable schemas (no hint fields), the verifier- and prover-value forms
 coincide; see the default instance in `Provable.lean`.
 -/
-class CircuitType (M : TypeMap.{u}) where
+class CircuitType (M : TypeMap) where
   /--
   An element of `Var M F` represents a `M F` that's polynomially dependent
   on the environment. More concretely, an element of `Var M F` is a value of `M F`
   with missing holes, and each hole contains a polynomial that can refer to fixed
   positions of the environment.
   -/
-  Var : TypeMap.{v}
+  Var : FieldTypeMap
   /-- Verifier value: hint fields are erased to `Unit`. -/
-  Value : TypeMap.{w}
+  Value : FieldTypeMap
   /-- Prover value: hint fields carry their underlying type. -/
-  ProverValue : TypeMap.{x}
-  evalVerifier : ∀ {F : Type} [Field F], Environment F → Var F → Value F
-  evalProver   : ∀ {F : Type} [Field F], ProverEnvironment F → Var F → ProverValue F
+  ProverValue : FieldTypeMap
+  evalVerifier {F : Type} [Field F] : Environment F → Var F → Value F
+  evalProver {F : Type} [Field F] : ProverEnvironment F → Var F → ProverValue F
 
 export CircuitType (Var Value ProverValue)
 
@@ -107,10 +107,10 @@ end CircuitType
 /--
 `Unconstrained` acts as a type marker for circuit inputs that should only be hints to the prover.
 -/
-structure Unconstrained (Hint : Sort u) (F : Type) where
+structure Unconstrained (Hint : Type) (F : Type) where
   value : Hint
 
-variable {Hint : Sort u}
+variable {Hint : Type}
 
 instance Unconstrained.toCircuitType : CircuitType (Unconstrained Hint) where
   Var F := ProverEnvironment F → Hint
@@ -120,11 +120,11 @@ instance Unconstrained.toCircuitType : CircuitType (Unconstrained Hint) where
   evalProver env v := v env
 
 namespace CircuitType
-@[circuit_norm] lemma var_of_unconstrained {F} :
+@[circuit_norm] lemma var_of_unconstrained :
   Var (Unconstrained Hint) F = (ProverEnvironment F → Hint) := rfl
-@[circuit_norm] lemma proverValue_of_unconstrained {F} :
+@[circuit_norm] lemma proverValue_of_unconstrained :
   ProverValue (Unconstrained Hint) F = Hint := rfl
-@[circuit_norm] lemma value_of_unconstrained {F} :
+@[circuit_norm] lemma value_of_unconstrained :
   Value (Unconstrained Hint) F = Unit := rfl
 
 /- forwarding instances to help instance search get through defeq -/
@@ -138,4 +138,18 @@ instance : ProverEval F (ProverEnvironment F → Hint) Hint := proverEval (Uncon
     eval env v = v env := by
   rw [eval_prover (M := Unconstrained Hint)]
   rfl
+
+-- we can also allow any structures with `Prop`s to act as a `CircuitType`!
+-- (this is just an example. similar incorporation of `Prop` fields happens in the `CircuitType` deriver)
+
+private structure WrappedProp (P : Prop) (F : Type) : Type where
+  prop : P
+
+example {P : Prop} : CircuitType (WrappedProp P) where
+  Var F := WrappedProp (ProverEnvironment F → P) F
+  ProverValue _ := WrappedProp P F
+  Value _ := Unit
+  evalVerifier _ _ := ()
+  evalProver env v := ⟨ v.prop env ⟩
+
 end CircuitType

--- a/Clean/Circuit/Explicit.lean
+++ b/Clean/Circuit/Explicit.lean
@@ -126,12 +126,12 @@ instance {k : ℕ} {c : ProverEnvironment F → Vector F k} : ExplicitCircuit (w
   localLength _ := k
   operations n := [.witness k c]
 
-instance {α : TypeMap} [ProvableType α] : ExplicitCircuits (ProvableType.witness (α:=α) (F:=F)) where
-  output _ n := varFromOffset α n
-  localLength _ _ := size α
-  operations c n := [.witness (size α) (toElements ∘ c)]
+instance {M : TypeMap} [ProvableType M] : ExplicitCircuits (ProvableType.witness (α:=M) (F:=F)) where
+  output _ n := varFromOffset M n
+  localLength _ _ := size M
+  operations c n := [.witness (size M) (toElements ∘ c)]
 
-instance {value var : TypeMap} [ProvableType value] [inst : Witnessable F value var] :
+instance {value : TypeMap} {var : Type} [ProvableType value] [inst : Witnessable F value var] :
     ExplicitCircuits (witness (F:=F) (value:=value) (var:=var)) where
   output _ n := inst.var_eq ▸ varFromOffset value n
   output_eq c n := by
@@ -213,7 +213,7 @@ section
 example : ExplicitCircuit (witness fun _ => (0 : F) : Circuit F (Expression F)) := by infer_explicit_circuit
 
 example :
-  let add := do
+  let add : Circuit F (Expression F) := do
     let x : Expression F ← witness fun _ => 0
     let y ← witness fun _ => 1
     let z ← witness fun eval => eval (x + y)
@@ -226,7 +226,7 @@ example :
 example : ExplicitCircuits (witnessField (F:=F)) := by infer_explicit_circuits
 
 example :
-  let add (x : Expression F) := do
+  let add (x : Expression F) : Circuit F (Expression F) := do
     let y : Expression F ← witness fun _ => 1
     let z ← witness fun eval => eval (x + y)
     assertZero (x + y - z)

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -9,7 +9,7 @@ variable {F : Type} [Field F]
 Class of types that can be used inside a circuit,
 because they can be flattened into a vector of (field) elements.
 -/
-class ProvableType (M : TypeMap.{1}) where
+class ProvableType (M : TypeMap) where
   size : ℕ
   toElements {F : Type} : M F -> Vector F size
   fromElements {F : Type} : Vector F size -> M F
@@ -31,7 +31,7 @@ class ProvableType (M : TypeMap.{1}) where
   fromElements_toElements {F : Type} : ∀ x : M F, fromElements (toElements x) = x
     := by intros; rfl
 
-class NonEmptyProvableType (M : TypeMap.{1}) extends ProvableType M where
+class NonEmptyProvableType (M : TypeMap) extends ProvableType M where
   nonempty : size > 0 := by try simp only [size]; try norm_num
 
 export ProvableType (size toElements fromElements)
@@ -43,10 +43,10 @@ attribute [circuit_norm] size ProvableType.toElements_fromElements ProvableType.
 -- to explicitly unfold provable type definitions
 attribute [explicit_provable_type low] toElements fromElements
 
-variable {M : TypeMap.{1}} [ProvableType M]
+variable {M : TypeMap} [ProvableType M]
 
 namespace ProvableType
-variable {α β γ: TypeMap.{1}} [ProvableType α] [ProvableType β] [ProvableType γ]
+variable {α β γ: TypeMap} [ProvableType α] [ProvableType β] [ProvableType γ]
 
 /--
 Evaluate a variable in the given environment.
@@ -67,10 +67,10 @@ with the input type, and `Var` is `M ∘ Expression`.
 The instance lives in `Provable.lean`, after `ProvableType` is defined, to keep
 `CircuitType.lean` below `Provable.lean` in the import graph.
 -/
-instance toCircuitType {M : TypeMap.{1}} [ProvableType M] : CircuitType M where
+instance toCircuitType {M : TypeMap} [ProvableType M] : CircuitType M where
   Var F := M (Expression F)
-  ProverValue := M
-  Value := M
+  ProverValue F := M F
+  Value F := M F
   evalVerifier env v := ProvableType.eval env v
   evalProver env v := ProvableType.eval env.toEnvironment v
 
@@ -90,7 +90,7 @@ instance [Field F] : Inhabited (M (Expression F)) where
 
 -- TODO this should be simply called `var`, analogous to `const`
 @[explicit_provable_type]
-def varFromOffset (M : TypeMap.{1}) [ProvableType M] (offset : ℕ) : M (Expression F) :=
+def varFromOffset (M : TypeMap) [ProvableType M] (offset : ℕ) : M (Expression F) :=
   let vars := Vector.mapRange (size M) fun i => var ⟨offset + i⟩
   fromElements vars
 
@@ -120,11 +120,11 @@ then elaborate as `@eval _ (M (Expression F)) (M F) ...` and can be applied by
 ordinary simplification.
 -/
 
-@[circuit_norm] lemma var_of_provableType (F) :
+@[circuit_norm] lemma var_of_provableType :
   Var M F = M (Expression F) := rfl
-@[circuit_norm] lemma proverValue_of_provableType (F) :
+@[circuit_norm] lemma proverValue_of_provableType :
   ProverValue M F = M F := rfl
-@[circuit_norm] lemma value_of_provableType (F) :
+@[circuit_norm] lemma value_of_provableType :
   Value M F = M F := rfl
 
 instance : VerifierEval F (Var M F) (M F) := verifierEval M
@@ -298,12 +298,12 @@ end CircuitType
 
 namespace ProvableStruct
 structure WithProvableType where
-  type : TypeMap.{1}
+  type : TypeMap
   provableType : ProvableType type := by infer_instance
 
 instance {c : WithProvableType} : ProvableType c.type := c.provableType
 
-instance {α : TypeMap.{1}} [ProvableType α] : CoeDep TypeMap.{1} (α) WithProvableType where
+instance {α : TypeMap} [ProvableType α] : CoeDep TypeMap (α) WithProvableType where
   coe := { type := α }
 
 -- custom heterogeneous list
@@ -316,7 +316,7 @@ end ProvableStruct
 
 -- if we can split a type into components that are provable types, then this gives us a provable type
 open ProvableStruct in
-class ProvableStruct (α : TypeMap.{1}) where
+class ProvableStruct (α : TypeMap) where
   components : List WithProvableType
   toComponents {F : Type} : α F → ProvableTypeList F components
   fromComponents {F : Type} : ProvableTypeList F components → α F

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -9,7 +9,7 @@ variable {F : Type} [Field F]
 Class of types that can be used inside a circuit,
 because they can be flattened into a vector of (field) elements.
 -/
-class ProvableType (M : TypeMap) where
+class ProvableType (M : TypeMap.{1}) where
   size : ℕ
   toElements {F : Type} : M F -> Vector F size
   fromElements {F : Type} : Vector F size -> M F
@@ -31,7 +31,7 @@ class ProvableType (M : TypeMap) where
   fromElements_toElements {F : Type} : ∀ x : M F, fromElements (toElements x) = x
     := by intros; rfl
 
-class NonEmptyProvableType (M : TypeMap) extends ProvableType M where
+class NonEmptyProvableType (M : TypeMap.{1}) extends ProvableType M where
   nonempty : size > 0 := by try simp only [size]; try norm_num
 
 export ProvableType (size toElements fromElements)
@@ -43,10 +43,10 @@ attribute [circuit_norm] size ProvableType.toElements_fromElements ProvableType.
 -- to explicitly unfold provable type definitions
 attribute [explicit_provable_type low] toElements fromElements
 
-variable {M : TypeMap} [ProvableType M]
+variable {M : TypeMap.{1}} [ProvableType M]
 
 namespace ProvableType
-variable {α β γ: TypeMap} [ProvableType α] [ProvableType β] [ProvableType γ]
+variable {α β γ: TypeMap.{1}} [ProvableType α] [ProvableType β] [ProvableType γ]
 
 /--
 Evaluate a variable in the given environment.
@@ -67,7 +67,7 @@ with the input type, and `Var` is `M ∘ Expression`.
 The instance lives in `Provable.lean`, after `ProvableType` is defined, to keep
 `CircuitType.lean` below `Provable.lean` in the import graph.
 -/
-instance toCircuitType {M : TypeMap} [ProvableType M] : CircuitType M where
+instance toCircuitType {M : TypeMap.{1}} [ProvableType M] : CircuitType M where
   Var F := M (Expression F)
   ProverValue := M
   Value := M
@@ -90,7 +90,7 @@ instance [Field F] : Inhabited (M (Expression F)) where
 
 -- TODO this should be simply called `var`, analogous to `const`
 @[explicit_provable_type]
-def varFromOffset (M : TypeMap) [ProvableType M] (offset : ℕ) : M (Expression F) :=
+def varFromOffset (M : TypeMap.{1}) [ProvableType M] (offset : ℕ) : M (Expression F) :=
   let vars := Vector.mapRange (size M) fun i => var ⟨offset + i⟩
   fromElements vars
 
@@ -298,12 +298,12 @@ end CircuitType
 
 namespace ProvableStruct
 structure WithProvableType where
-  type : TypeMap
+  type : TypeMap.{1}
   provableType : ProvableType type := by infer_instance
 
 instance {c : WithProvableType} : ProvableType c.type := c.provableType
 
-instance {α : TypeMap} [ProvableType α] : CoeDep TypeMap (α) WithProvableType where
+instance {α : TypeMap.{1}} [ProvableType α] : CoeDep TypeMap.{1} (α) WithProvableType where
   coe := { type := α }
 
 -- custom heterogeneous list
@@ -316,7 +316,7 @@ end ProvableStruct
 
 -- if we can split a type into components that are provable types, then this gives us a provable type
 open ProvableStruct in
-class ProvableStruct (α : TypeMap) where
+class ProvableStruct (α : TypeMap.{1}) where
   components : List WithProvableType
   toComponents {F : Type} : α F → ProvableTypeList F components
   fromComponents {F : Type} : ProvableTypeList F components → α F

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -100,7 +100,7 @@ on prover knowledge, because we don't surface a way to reason about the environm
 assuming honest prover witness generation.
 
 For example, it is not possible to implement `HasAssignEq`:
-we can prove the `isBool` property for the copied variable.
+we cannot prove the `isBool` property for the copied variable.
 
 So, as it stands, this pattern is less useful than the code below suggests.
 -/

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -93,6 +93,52 @@ example (input : MixedInput.ProverValue (F p)) : U32 (F p) × Bool :=
 example (input : MixedInput.Value (F p)) : U32 (F p) × Unit :=
   (input.someElement, input.someHint)
 
+structure CircuitBool (F : Type) where
+  bool : F
+  isBool [Field F] : IsBool bool
+deriving CircuitType
+
+example (input : CircuitBool.Var (F p)) : ∀ env : ProverEnvironment (F p),
+    IsBool (eval env input.bool) := by
+  intro env; exact input.isBool env
+
+example (env : Environment (F p)) (input : CircuitBool.Var (F p)) :
+    (eval env input).bool = eval env input.bool := by
+  simp only [CircuitType.eval_verifier (M := CircuitBool), circuit_norm]
+
+namespace CircuitBool
+variable {F : Type} [Field F]
+
+-- this seems generally useful: whenever we allow `eval` to be rewritten to a concrete `CircuitType` instance,
+-- we can immediately unfold it with `circuit_norm`!
+attribute [circuit_norm] CircuitType.evalVerifier CircuitType.evalProver
+
+-- this seems like useful simp infrastructure for any derived CircuitType
+@[circuit_norm] lemma eval_verifier (env : Environment F) (input : CircuitType.Var CircuitBool F) :
+    eval env input = CircuitType.evalVerifier env input :=
+  CircuitType.eval_verifier env input
+@[circuit_norm] lemma eval_verifier_structvar (env : Environment F) (input : Var F) :
+    eval env input = CircuitType.evalVerifier (M := CircuitBool) env input :=
+  CircuitType.eval_verifier (M := CircuitBool) env input
+@[circuit_norm] lemma eval_prover (env : ProverEnvironment F) (input : CircuitType.Var CircuitBool F) :
+    eval env input = CircuitType.evalProver (M := CircuitBool) env input :=
+  CircuitType.eval_prover env input
+@[circuit_norm] lemma eval_prover_structvar (env : ProverEnvironment F) (input : Var F) :
+    eval env input = CircuitType.evalProver (M := CircuitBool) env input :=
+  CircuitType.eval_prover (M := CircuitBool) env input
+
+def toBool [DecidableEq F] (x : CircuitBool F) : Bool := x.bool = 1
+
+def Value.toBool [DecidableEq F] (x : CircuitBool.Value F) : Bool := x.bool = 1
+
+def negate (input : CircuitBool.Var F) : CircuitBool.Var F where
+  bool := (1 : F) - input.bool
+  isBool env := by
+    have h_input := input.isBool env
+    simp only [circuit_norm, IsBool] at h_input ⊢
+    grind
+end CircuitBool
+
 /--
   A circuit with both ordinary provable input data and a prover-only hint.
 
@@ -100,56 +146,27 @@ example (input : MixedInput.Value (F p)) : U32 (F p) × Unit :=
   soundness statement. The prover still sees the hint in completeness and uses it
   to choose the witnessed boolean.
 -/
-def witnessMixedHint : GeneralFormalCircuit.WithHint (F p) MixedInput field where
-  main (input : MixedInput.Var (F p)) := do
-    let b ← witness fun env => if input.someHint env then 1 else 0
-    assertBool b
-    return b
+def boolNegate : GeneralFormalCircuit.WithHint (F p) CircuitBool CircuitBool where
+  main (input : CircuitBool.Var (F p)) := do
+    return CircuitBool.negate input
 
-  localLength _ := 1
-  output _ i := var ⟨i⟩
+  localLength _ := 0
+  output input _ := CircuitBool.negate input
 
-  Assumptions _ _ := True
-  Spec _ (output : F p) _ := IsBool output
-
-  ProverAssumptions _ _ _ := True
-  ProverSpec input (output : F p) _ := output = if input.someHint then 1 else 0
+  Assumptions input _ := IsBool input.bool
+  Spec input output _ := IsBool output.bool ∧
+    output.toBool = ¬ input.toBool
 
   soundness := by
-    circuit_proof_all [assertBool, IsBool.iff_mul_sub_one, sub_eq_add_neg]
+    circuit_proof_start [CircuitBool.Value.toBool, CircuitBool.negate, IsBool]
+    -- TODO do this automatically for circuit inputs
+    rcases input with ⟨ bool, h_bool ⟩
+    -- TODO why doesn't this work with simp only?
+    rw [CircuitBool.Value.mk.injEq] at h_input
+    simp_all only
+    grind
 
   completeness := by
-    circuit_proof_start [assertBool, IsBool.iff_mul_sub_one, sub_eq_add_neg]
-    have h_hint : input.someHint = input_var.someHint env := by
-      have h := congrArg MixedInput.ProverValue.someHint h_input
-      rw [CircuitType.eval_prover] at h
-      change eval env input_var.someHint = input.someHint at h
-      rw [CircuitType.eval_hint_prover] at h
-      exact h.symm
-    cases input_var.someHint env <;> simp_all
-
-structure InputWithProp (F : Type) where
-  bool : F
-  isBool : Unconstrained (∀ [Zero F] [One F], IsBool bool) F
-deriving CircuitType
-
--- set_option trace.Meta.synthInstance true
-
-#check InputWithProp.Value
-
-abbrev InputWithProp.Value' (F : Type) := [inst: Field F] → @InputWithProp.Value F inst
-
-#check InputWithProp.Value'
-
-instance : CircuitType Examples.HintExample.InputWithProp where
-  Var := InputWithProp.Var
-  Value F := [Field F] → InputWithProp.Value F
-  ProverValue F := [Field F] → InputWithProp.ProverValue F
-  evalVerifier env input := fun [_] => (InputWithProp.Value.mk (eval env input.bool)) ()
-  evalProver env input := fun [_] => (InputWithProp.ProverValue.mk (eval env input.bool)) (input.isBool env)
-
-example (input : InputWithProp.Var (F p)) : ∀ env : ProverEnvironment (F p),
-    IsBool (eval env input.bool) := by
-  intro env; exact input.isBool env
+    circuit_proof_all
 
 end Examples.HintExample

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -113,10 +113,6 @@ example (input : CircuitBool.Var (F p)) : ∀ env : ProverEnvironment (F p),
     IsBool (eval env input.bool) := by
   intro env; exact input.isBool env
 
-example (env : Environment (F p)) (input : CircuitBool.Var (F p)) :
-    (eval env input).bool = eval env input.bool := by
-  simp only [CircuitType.eval_verifier (M := CircuitBool), circuit_norm]
-
 namespace CircuitBool
 variable {F : Type} [Field F]
 

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -150,13 +150,6 @@ def Var.negate (input : CircuitBool.Var F) : CircuitBool.Var F where
     grind
 end CircuitBool
 
-/--
-  A circuit with both ordinary provable input data and a prover-only hint.
-
-  The verifier sees `someElement`, but `someHint` is erased to `Unit` in the
-  soundness statement. The prover still sees the hint in completeness and uses it
-  to choose the witnessed boolean.
--/
 def boolNegate : GeneralFormalCircuit.WithHint (F p) CircuitBool CircuitBool where
   main (input : CircuitBool.Var (F p)) := do
     let c := input.negate

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -128,4 +128,28 @@ def witnessMixedHint : GeneralFormalCircuit.WithHint (F p) MixedInput field wher
       exact h.symm
     cases input_var.someHint env <;> simp_all
 
+structure InputWithProp (F : Type) where
+  bool : F
+  isBool : Unconstrained (∀ [Zero F] [One F], IsBool bool) F
+deriving CircuitType
+
+-- set_option trace.Meta.synthInstance true
+
+#check InputWithProp.Value
+
+abbrev InputWithProp.Value' (F : Type) := [inst: Field F] → @InputWithProp.Value F inst
+
+#check InputWithProp.Value'
+
+instance : CircuitType Examples.HintExample.InputWithProp where
+  Var := InputWithProp.Var
+  Value F := [Field F] → InputWithProp.Value F
+  ProverValue F := [Field F] → InputWithProp.ProverValue F
+  evalVerifier env input := fun [_] => (InputWithProp.Value.mk (eval env input.bool)) ()
+  evalProver env input := fun [_] => (InputWithProp.ProverValue.mk (eval env input.bool)) (input.isBool env)
+
+example (input : InputWithProp.Var (F p)) : ∀ env : ProverEnvironment (F p),
+    IsBool (eval env input.bool) := by
+  intro env; exact input.isBool env
+
 end Examples.HintExample

--- a/Clean/Examples/HintExample.lean
+++ b/Clean/Examples/HintExample.lean
@@ -93,6 +93,17 @@ example (input : MixedInput.ProverValue (F p)) : U32 (F p) × Bool :=
 example (input : MixedInput.Value (F p)) : U32 (F p) × Unit :=
   (input.someElement, input.someHint)
 
+/--
+The following seems like a cool experiment at first glance.
+The main problem is that it's not possible to generate `CircuitBool` values in a circuit based
+on prover knowledge, because we don't surface a way to reason about the environment
+assuming honest prover witness generation.
+
+For example, it is not possible to implement `HasAssignEq`:
+we can prove the `isBool` property for the copied variable.
+
+So, as it stands, this pattern is less useful than the code below suggests.
+-/
 structure CircuitBool (F : Type) where
   bool : F
   isBool [Field F] : IsBool bool
@@ -131,11 +142,11 @@ def toBool [DecidableEq F] (x : CircuitBool F) : Bool := x.bool = 1
 
 def Value.toBool [DecidableEq F] (x : CircuitBool.Value F) : Bool := x.bool = 1
 
-def negate (input : CircuitBool.Var F) : CircuitBool.Var F where
+def Var.negate (input : CircuitBool.Var F) : CircuitBool.Var F where
   bool := (1 : F) - input.bool
   isBool env := by
-    have h_input := input.isBool env
-    simp only [circuit_norm, IsBool] at h_input ⊢
+    have h_bool := input.isBool env
+    simp only [circuit_norm, IsBool] at h_bool ⊢
     grind
 end CircuitBool
 
@@ -148,17 +159,22 @@ end CircuitBool
 -/
 def boolNegate : GeneralFormalCircuit.WithHint (F p) CircuitBool CircuitBool where
   main (input : CircuitBool.Var (F p)) := do
-    return CircuitBool.negate input
+    let c := input.negate
+    -- unnecessary constraint, just there to show that completeness is automatic
+    assertBool c.bool
+    return c
 
   localLength _ := 0
-  output input _ := CircuitBool.negate input
+  output input _ := input.negate
 
+  -- we don't need any completeness statements! these are already captured by the
+  -- `CircuitBool.isBool` property
   Assumptions input _ := IsBool input.bool
   Spec input output _ := IsBool output.bool ∧
     output.toBool = ¬ input.toBool
 
   soundness := by
-    circuit_proof_start [CircuitBool.Value.toBool, CircuitBool.negate, IsBool]
+    circuit_proof_start [CircuitBool.Value.toBool, CircuitBool.Var.negate, IsBool]
     -- TODO do this automatically for circuit inputs
     rcases input with ⟨ bool, h_bool ⟩
     -- TODO why doesn't this work with simp only?
@@ -167,6 +183,10 @@ def boolNegate : GeneralFormalCircuit.WithHint (F p) CircuitBool CircuitBool whe
     grind
 
   completeness := by
-    circuit_proof_all
+    circuit_proof_start [CircuitBool.Value.toBool, CircuitBool.Var.negate, IsBool]
+    rcases input with ⟨ bool, h_bool ⟩
+    rw [CircuitBool.ProverValue.mk.injEq] at h_input
+    simp_all only [IsBool]
+    grind
 
 end Examples.HintExample

--- a/Clean/Utils/Tactics/ProvableStructDeriving.lean
+++ b/Clean/Utils/Tactics/ProvableStructDeriving.lean
@@ -141,6 +141,20 @@ def matchUnconstrainedField? (fieldType typeParamFVar : Expr) : Option Expr :=
   else
     none
 
+def matchProofOnlyField? (fieldType typeParamFVar : Expr) : MetaM (Option Expr) := do
+  match matchUnconstrainedField? fieldType typeParamFVar with
+  | some hintType => return some hintType
+  | none =>
+      if ← isProp fieldType then
+        return some fieldType
+      else
+        return none
+
+def isRawPropField (fieldType typeParamFVar : Expr) : MetaM Bool := do
+  if (matchUnconstrainedField? fieldType typeParamFVar).isSome then
+    return false
+  isProp fieldType
+
 partial def containsProjectionFrom (structName : Name) (e : Expr) : Bool :=
   let (fn, _) := e.getAppFnArgs
   if structName.isPrefixOf fn then
@@ -157,15 +171,30 @@ partial def containsProjectionFrom (structName : Name) (e : Expr) : Bool :=
     | .proj _ _ b => containsProjectionFrom structName b
     | _ => false
 
+partial def containsAnyFVar (fvars : Array Expr) (e : Expr) : Bool :=
+  if fvars.any (· == e) then
+    true
+  else
+    match e with
+    | .app f a => containsAnyFVar fvars f || containsAnyFVar fvars a
+    | .lam _ t b _ => containsAnyFVar fvars t || containsAnyFVar fvars b
+    | .forallE _ t b _ => containsAnyFVar fvars t || containsAnyFVar fvars b
+    | .letE _ t v b _ =>
+        containsAnyFVar fvars t || containsAnyFVar fvars v || containsAnyFVar fvars b
+    | .mdata _ b => containsAnyFVar fvars b
+    | .proj _ _ b => containsAnyFVar fvars b
+    | _ => false
+
 partial def dependentCircuitExprToSyntax (structName : Name) (typeParamFVar : Expr)
     (fieldNames : Array Name) (fieldKinds : Array CircuitFieldKind) (fieldTypes : Array Expr)
-    (fieldLimit : Nat) (mode : Name) (e : Expr) : MetaM (TSyntax `term) := do
+    (sourceFieldFVars : Array Expr) (fieldLimit : Nat) (mode : Name) (e : Expr) :
+    MetaM (TSyntax `term) := do
   let proverEnvType := mkApp (mkConst ``ProverEnvironment) typeParamFVar
   let expressionType := mkApp (mkConst ``Expression) typeParamFVar
 
   let fieldViewType (idx : Nat) : MetaM Expr := do
     let fieldType := fieldTypes[idx]!
-    match matchUnconstrainedField? fieldType typeParamFVar with
+    match ← matchProofOnlyField? fieldType typeParamFVar with
     | some hintType =>
         if mode == `var then
           return ← mkArrow proverEnvType hintType
@@ -197,8 +226,7 @@ partial def dependentCircuitExprToSyntax (structName : Name) (typeParamFVar : Ex
       withLocalDecl `inst .instImplicit fieldInstType fun instFVar =>
         withNewLocalInstances #[instFVar] 0 do
           withFieldDecls 0 #[] fun fieldFVars => do
-            let bodyStx ← delabTransformed (some envFVar) fieldFVars
-            `(∀ [inst : Field F], $bodyStx)
+            delabTransformed (some envFVar) fieldFVars
   else
     withFieldDecls 0 #[] fun fieldFVars =>
       delabTransformed none fieldFVars
@@ -206,6 +234,18 @@ where
   fieldIdentOfProjection? (e : Expr) : Option Name :=
     let (fn, _) := e.getAppFnArgs
     fieldNames.find? fun fieldName => fn == structName ++ fieldName
+
+  fieldIdentOfSourceFVar? (e : Expr) : Option Name :=
+    Id.run do
+      for i in [:sourceFieldFVars.size] do
+        if sourceFieldFVars[i]! == e then
+          return some fieldNames[i]!
+      return none
+
+  fieldIdentOfReference? (e : Expr) : Option Name :=
+    match fieldIdentOfProjection? e with
+    | some fieldName => some fieldName
+    | none => fieldIdentOfSourceFVar? e
 
   fieldIndex? (name : Name) : Option Nat :=
     Id.run do
@@ -224,20 +264,23 @@ where
         | throwError "missing prover environment while translating dependent Var field"
       let fieldType := fieldTypes[idx]!
       let valueType ←
-        match matchUnconstrainedField? fieldType typeParamFVar with
+        match ← matchProofOnlyField? fieldType typeParamFVar with
         | some hintType => pure hintType
         | none => pure fieldType
-      let envType ← inferType env
-      let varType ← inferType fieldFVar
-      let evalInstType ← mkAppOptM ``Eval #[envType, varType, valueType]
-      let evalInst ← mkFreshExprMVar (some evalInstType)
-      mkAppOptM ``Eval.eval #[envType, varType, valueType, evalInst, env, fieldFVar]
+      if ← isRawPropField fieldType typeParamFVar then
+        return mkApp fieldFVar env
+      else
+        let envType ← inferType env
+        let varType ← inferType fieldFVar
+        let evalInstType ← mkAppOptM ``Eval #[envType, varType, valueType]
+        let evalInst ← mkFreshExprMVar (some evalInstType)
+        mkAppOptM ``Eval.eval #[envType, varType, valueType, evalInst, env, fieldFVar]
     else
       return fieldFVar
 
   matchStructProjection? (env? : Option Expr) (fieldFVars : Array Expr) (e : Expr) :
       MetaM (Option Expr) := do
-    let some fieldName := fieldIdentOfProjection? e
+    let some fieldName := fieldIdentOfReference? e
       | return none
     return some (← replaceField env? fieldFVars fieldName)
 
@@ -246,7 +289,7 @@ where
     let (fn, args) := e.getAppFnArgs
     unless fn == ``Unconstrained.value && args.size == 3 do
       return none
-    let some fieldName := fieldIdentOfProjection? args[2]!
+    let some fieldName := fieldIdentOfReference? args[2]!
       | return none
     unless fieldKindFor fieldNames fieldKinds fieldName == .unconstrained do
       return none
@@ -563,6 +606,7 @@ initialize registerDerivingHandler ``ProvableStruct provableStructDerivingHandle
   derived `CircuitType`.
 -/
 def mkCircuitViewStruct (viewName : Name) (paramInfos : Array ParamInfo)
+    (includeFieldBinder : Bool)
     (fieldNameIdents : Array (TSyntax `ident)) (fieldTypes : Array (TSyntax `term))
     (viewType : TSyntax `term → CommandElabM (TSyntax `term)) : CommandElabM Unit := do
   let mut binderSyntaxes : Array (TSyntax ``bracketedBinder) := #[]
@@ -587,6 +631,9 @@ def mkCircuitViewStruct (viewName : Name) (paramInfos : Array ParamInfo)
   let fIdent := mkIdent `F
   let fBinder ← `(bracketedBinderF| ($fIdent : Type))
   binderSyntaxes := binderSyntaxes.push fBinder
+  if includeFieldBinder then
+    let fieldBinder ← `(bracketedBinderF| [Field $fIdent])
+    binderSyntaxes := binderSyntaxes.push fieldBinder
 
   let mut fieldSyntaxes : Array (TSyntax ``Lean.Parser.Command.structSimpleBinder) := #[]
   for h : i in [:fieldNameIdents.size] do
@@ -603,12 +650,54 @@ def mkCircuitViewStruct (viewName : Name) (paramInfos : Array ParamInfo)
   )
   elabCommand cmd
 
+def mkCircuitEvalForwardingInstances (paramInfos : Array ParamInfo) (circuitType : TSyntax `term)
+    (varType valueType proverValueType : TSyntax `term) : CommandElabM Unit := do
+  let mut binderSyntaxes : Array (TSyntax ``bracketedBinder) := #[]
+  for info in paramInfos do
+    match info with
+    | .natural n =>
+      let nIdent := mkIdent n
+      let binder ← `(bracketedBinderF| {$nIdent : ℕ})
+      binderSyntaxes := binderSyntaxes.push binder
+    | .typeMap m =>
+      let mIdent := mkIdent m
+      let typeBinder ← `(bracketedBinderF| {$mIdent : TypeMap})
+      let instBinder ← `(bracketedBinderF| [CircuitType $mIdent])
+      binderSyntaxes := binderSyntaxes.push typeBinder
+      binderSyntaxes := binderSyntaxes.push instBinder
+    | .other n ty =>
+      let nIdent := mkIdent n
+      let tySyntax ← liftTermElabM <| PrettyPrinter.delab ty
+      let binder ← `(bracketedBinderF| {$nIdent : $tySyntax})
+      binderSyntaxes := binderSyntaxes.push binder
+
+  let fIdent := mkIdent `F
+  let fBinder ← `(bracketedBinderF| { $fIdent : Type })
+  let fieldBinder ← `(bracketedBinderF| [Field $fIdent])
+  binderSyntaxes := binderSyntaxes.push fBinder
+  binderSyntaxes := binderSyntaxes.push fieldBinder
+
+  let cmd ← `(
+    instance $binderSyntaxes:bracketedBinder* : VerifierEval $fIdent ($varType $fIdent) ($valueType $fIdent) :=
+      CircuitType.verifierEval $circuitType
+
+    instance $binderSyntaxes:bracketedBinder* : ProverEval $fIdent ($varType $fIdent) ($proverValueType $fIdent) :=
+      CircuitType.proverEval $circuitType
+  )
+  elabCommand cmd
+
 def mkDependentCircuitTypeInstance? (structName : Name) : CommandElabM Bool := do
   let env ← getEnv
   let some structInfo := getStructureInfo? env structName
     | throwError "failed to get structure info for {structName}"
   let some (.inductInfo indInfo) := env.find? structName
     | throwError "{structName} not found in environment"
+  let ctorName ←
+    match indInfo.ctors with
+    | [ctorName] => pure ctorName
+    | _ => throwError "{structName} should have exactly one constructor"
+  let some (.ctorInfo ctorInfo) := env.find? ctorName
+    | throwError "constructor {ctorName} not found"
   let numParams := indInfo.numParams
   if numParams != 1 then
     return false
@@ -618,31 +707,34 @@ def mkDependentCircuitTypeInstance? (structName : Name) : CommandElabM Bool := d
     return false
 
   let resultOpt ← liftTermElabM do
-    forallTelescope indInfo.type fun args _ => do
+    forallTelescope ctorInfo.type fun args _ => do
+      if args.size < numParams + fieldNames.size then
+        throwError "constructor {ctorName} has unexpected arity: {args.size}"
       let typeParamFVar := args[0]!
+      let sourceFieldFVars : Array Expr :=
+        Id.run do
+          let mut result := #[]
+          for i in [:fieldNames.size] do
+            result := result.push args[numParams + i]!
+          return result
       let mut fieldTypes : Array Expr := #[]
       let mut fieldKinds : Array CircuitFieldKind := #[]
-      let mut hasDependentUnconstrained := false
+      let mut hasDependentProofOnly := false
 
-      for fname in fieldNames do
-        let projFnName := structName ++ fname
-        let some (.defnInfo projInfo) := env.find? projFnName
-          | throwError "projection {projFnName} not found"
-        let fieldType ← forallTelescope projInfo.type fun projArgs projBody => do
-          if projArgs.size != 2 then
-            throwError "projection {projFnName} has unexpected arity: {projArgs.size} vs expected 2"
-          return projBody.replaceFVar projArgs[0]! typeParamFVar
-
+      for i in [:fieldNames.size] do
+        let fieldType ← inferType sourceFieldFVars[i]!
         fieldTypes := fieldTypes.push fieldType
-        match matchUnconstrainedField? fieldType typeParamFVar with
+        match ← matchProofOnlyField? fieldType typeParamFVar with
         | some hintType =>
             fieldKinds := fieldKinds.push .unconstrained
-            if containsProjectionFrom structName hintType then
-              hasDependentUnconstrained := true
+            if ← isRawPropField fieldType typeParamFVar then
+              hasDependentProofOnly := true
+            if containsProjectionFrom structName hintType || containsAnyFVar sourceFieldFVars hintType then
+              hasDependentProofOnly := true
         | none =>
             fieldKinds := fieldKinds.push .regular
 
-      unless hasDependentUnconstrained do
+      unless hasDependentProofOnly do
         return none
 
       let mut varFieldTypes : Array (TSyntax `term) := #[]
@@ -655,14 +747,17 @@ def mkDependentCircuitTypeInstance? (structName : Name) : CommandElabM Bool := d
         let fname := fieldNames[i]!
         let fieldIdent := mkIdent fname
         let fieldType := fieldTypes[i]!
-        match matchUnconstrainedField? fieldType typeParamFVar with
+        match ← matchProofOnlyField? fieldType typeParamFVar with
         | some hintType =>
-            if containsProjectionFrom structName hintType then
+            let isRawProp ← isRawPropField fieldType typeParamFVar
+            if containsProjectionFrom structName hintType || containsAnyFVar sourceFieldFVars hintType then
               let hVar ← withLeadingFieldInstanceForallStripped typeParamFVar hintType fun hintType =>
-                dependentCircuitExprToSyntax structName typeParamFVar fieldNames fieldKinds fieldTypes i
+                dependentCircuitExprToSyntax structName typeParamFVar fieldNames fieldKinds fieldTypes
+                  sourceFieldFVars i
                   `var hintType
               let hProver ← withLeadingFieldInstanceForallStripped typeParamFVar hintType fun hintType =>
-                dependentCircuitExprToSyntax structName typeParamFVar fieldNames fieldKinds fieldTypes i
+                dependentCircuitExprToSyntax structName typeParamFVar fieldNames fieldKinds fieldTypes
+                  sourceFieldFVars i
                   `prover hintType
               let envIdent := mkIdent `env
               varFieldTypes := varFieldTypes.push (← `(∀ ($envIdent : ProverEnvironment F), $hVar))
@@ -677,7 +772,10 @@ def mkDependentCircuitTypeInstance? (structName : Name) : CommandElabM Bool := d
               valueFieldTypes := valueFieldTypes.push (← `(Unit))
               proverFieldTypes := proverFieldTypes.push hintTerm
               verifierArgs := verifierArgs.push (← `(()))
-              proverArgs := proverArgs.push (← `(eval env input.$fieldIdent:ident))
+              if isRawProp then
+                proverArgs := proverArgs.push (← `(input.$fieldIdent:ident env))
+              else
+                proverArgs := proverArgs.push (← `(eval env input.$fieldIdent:ident))
         | none =>
             if fieldType == typeParamFVar then
               varFieldTypes := varFieldTypes.push (← `(Expression F))
@@ -725,7 +823,7 @@ def mkDependentCircuitTypeInstance? (structName : Name) : CommandElabM Bool := d
     logInfo m!"generated dependent CircuitType struct:\n{cmd}"
     elabCommand cmd
 
-  mkStruct varStructName #[fBinder] varFieldTypes
+  mkStruct varStructName #[fBinder, fieldBinder] varFieldTypes
   mkStruct valueStructName #[fBinder, fieldBinder] valueFieldTypes
   mkStruct proverValueStructName #[fBinder, fieldBinder] proverFieldTypes
 
@@ -746,15 +844,16 @@ def mkDependentCircuitTypeInstance? (structName : Name) : CommandElabM Bool := d
   let envIdent := mkIdent `env
   let inputIdent := mkIdent `input
   let instanceCmd ← `(
-    instance : CircuitType.{1, 1, 1, 1} $structIdent where
+    instance : CircuitType $structIdent where
       Var := $varIdent
-      Value F := [Field F] → $valueIdent F
-      ProverValue F := [Field F] → $proverValueIdent F
-      evalVerifier := fun $envIdent $inputIdent => fun [_] => $verifierBody
-      evalProver := fun $envIdent $inputIdent => fun [_] => $proverBody
+      Value := $valueIdent
+      ProverValue := $proverValueIdent
+      evalVerifier := fun $envIdent $inputIdent => $verifierBody
+      evalProver := fun $envIdent $inputIdent => $proverBody
   )
   logInfo m!"generated dependent CircuitType instance:\n{instanceCmd}"
   elabCommand instanceCmd
+  mkCircuitEvalForwardingInstances #[] structIdent varIdent valueIdent proverValueIdent
   return true
 
 /--
@@ -822,11 +921,11 @@ def mkCircuitTypeInstance (structName : Name) : CommandElabM Unit := do
   let proverValueStructName := structName ++ `ProverValue
 
   let fIdent := mkIdent `F
-  mkCircuitViewStruct varStructName paramInfos fieldNameIdents componentSyntaxes
+  mkCircuitViewStruct varStructName paramInfos true fieldNameIdents componentSyntaxes
     (fun component => `(CircuitType.Var $component $fIdent))
-  mkCircuitViewStruct valueStructName paramInfos fieldNameIdents componentSyntaxes
+  mkCircuitViewStruct valueStructName paramInfos true fieldNameIdents componentSyntaxes
     (fun component => `(CircuitType.Value $component $fIdent))
-  mkCircuitViewStruct proverValueStructName paramInfos fieldNameIdents componentSyntaxes
+  mkCircuitViewStruct proverValueStructName paramInfos true fieldNameIdents componentSyntaxes
     (fun component => `(CircuitType.ProverValue $component $fIdent))
 
   let structIdent := mkIdent structName
@@ -907,6 +1006,7 @@ def mkCircuitTypeInstance (structName : Name) : CommandElabM Unit := do
       )
 
   elabCommand cmd
+  mkCircuitEvalForwardingInstances paramInfos appliedStructType varType valueType proverValueType
 
 /-- The deriving handler for record-shaped `CircuitType`s. -/
 def circuitTypeDerivingHandler (declNames : Array Name) : CommandElabM Bool := do

--- a/Clean/Utils/Tactics/ProvableStructDeriving.lean
+++ b/Clean/Utils/Tactics/ProvableStructDeriving.lean
@@ -100,6 +100,186 @@ def ParamInfo.name : ParamInfo → Name
   | .typeMap n => n
   | .other n _ => n
 
+inductive CircuitFieldKind where
+  | regular
+  | unconstrained
+deriving Inhabited, BEq
+
+def fieldKindFor (fieldNames : Array Name) (fieldKinds : Array CircuitFieldKind) (name : Name) :
+    CircuitFieldKind :=
+  Id.run do
+    for i in [:fieldNames.size] do
+      if fieldNames[i]! == name then
+        return fieldKinds[i]!
+    return .regular
+
+partial def eraseMacroScopesSyntax : Syntax → Syntax
+  | .missing => .missing
+  | .atom info val => .atom info val
+  | .ident info rawVal val preresolved => .ident info rawVal val.eraseMacroScopes preresolved
+  | .node info kind args => .node info kind (args.map eraseMacroScopesSyntax)
+
+def eraseMacroScopesTerm (stx : TSyntax `term) : TSyntax `term :=
+  ⟨eraseMacroScopesSyntax stx.raw⟩
+
+def withLeadingFieldInstanceForallStripped {α : Type} (fieldParamFVar hintType : Expr)
+    (k : Expr → MetaM α) : MetaM α :=
+  match hintType with
+  | .forallE name binderTy body .instImplicit =>
+      let (fn, args) := binderTy.getAppFnArgs
+      if fn == ``Field && args.size == 1 && args[0]! == fieldParamFVar then
+        withLocalDecl name .instImplicit binderTy fun fvar =>
+          k (body.instantiate1 fvar)
+      else
+        k hintType
+  | _ => k hintType
+
+def matchUnconstrainedField? (fieldType typeParamFVar : Expr) : Option Expr :=
+  let (fn, args) := fieldType.getAppFnArgs
+  if fn == ``Unconstrained && args.size == 2 && args[1]! == typeParamFVar then
+    some args[0]!
+  else
+    none
+
+partial def containsProjectionFrom (structName : Name) (e : Expr) : Bool :=
+  let (fn, _) := e.getAppFnArgs
+  if structName.isPrefixOf fn then
+    true
+  else
+    match e with
+    | .app f a => containsProjectionFrom structName f || containsProjectionFrom structName a
+    | .lam _ t b _ => containsProjectionFrom structName t || containsProjectionFrom structName b
+    | .forallE _ t b _ => containsProjectionFrom structName t || containsProjectionFrom structName b
+    | .letE _ t v b _ =>
+        containsProjectionFrom structName t || containsProjectionFrom structName v ||
+          containsProjectionFrom structName b
+    | .mdata _ b => containsProjectionFrom structName b
+    | .proj _ _ b => containsProjectionFrom structName b
+    | _ => false
+
+partial def dependentCircuitExprToSyntax (structName : Name) (typeParamFVar : Expr)
+    (fieldNames : Array Name) (fieldKinds : Array CircuitFieldKind) (fieldTypes : Array Expr)
+    (fieldLimit : Nat) (mode : Name) (e : Expr) : MetaM (TSyntax `term) := do
+  let proverEnvType := mkApp (mkConst ``ProverEnvironment) typeParamFVar
+  let expressionType := mkApp (mkConst ``Expression) typeParamFVar
+
+  let fieldViewType (idx : Nat) : MetaM Expr := do
+    let fieldType := fieldTypes[idx]!
+    match matchUnconstrainedField? fieldType typeParamFVar with
+    | some hintType =>
+        if mode == `var then
+          return ← mkArrow proverEnvType hintType
+        else
+          withLeadingFieldInstanceForallStripped typeParamFVar hintType pure
+    | none =>
+        if fieldType == typeParamFVar && mode == `var then
+          return expressionType
+        return fieldType
+
+  let rec withFieldDecls {α : Type} (idx : Nat) (fieldFVars : Array Expr) (k : Array Expr → MetaM α) :
+      MetaM α := do
+    if idx < fieldLimit then
+      let fieldName := fieldNames[idx]!
+      let fieldType ← fieldViewType idx
+      withLocalDecl fieldName .default fieldType fun fieldFVar =>
+        withFieldDecls (idx + 1) (fieldFVars.push fieldFVar) k
+    else
+      k fieldFVars
+
+  let delabTransformed (env? : Option Expr) (fieldFVars : Array Expr) : MetaM (TSyntax `term) := do
+    let body ← transform env? fieldFVars e
+    let stx ← PrettyPrinter.delab body
+    return eraseMacroScopesTerm ⟨stx.raw⟩
+
+  if mode == `var then
+    let fieldInstType := mkApp (mkConst ``Field) typeParamFVar
+    withLocalDecl `env .default proverEnvType fun envFVar =>
+      withLocalDecl `inst .instImplicit fieldInstType fun instFVar =>
+        withNewLocalInstances #[instFVar] 0 do
+          withFieldDecls 0 #[] fun fieldFVars => do
+            let bodyStx ← delabTransformed (some envFVar) fieldFVars
+            `(∀ [inst : Field F], $bodyStx)
+  else
+    withFieldDecls 0 #[] fun fieldFVars =>
+      delabTransformed none fieldFVars
+where
+  fieldIdentOfProjection? (e : Expr) : Option Name :=
+    let (fn, _) := e.getAppFnArgs
+    fieldNames.find? fun fieldName => fn == structName ++ fieldName
+
+  fieldIndex? (name : Name) : Option Nat :=
+    Id.run do
+      for i in [:fieldNames.size] do
+        if fieldNames[i]! == name then
+          return some i
+      return none
+
+  replaceField (env? : Option Expr) (fieldFVars : Array Expr) (fieldName : Name) :
+      MetaM Expr := do
+    let some idx := fieldIndex? fieldName
+      | throwError "unknown dependent field {fieldName}"
+    let fieldFVar := fieldFVars[idx]!
+    if mode == `var then
+      let some env := env?
+        | throwError "missing prover environment while translating dependent Var field"
+      let fieldType := fieldTypes[idx]!
+      let valueType ←
+        match matchUnconstrainedField? fieldType typeParamFVar with
+        | some hintType => pure hintType
+        | none => pure fieldType
+      let envType ← inferType env
+      let varType ← inferType fieldFVar
+      let evalInstType ← mkAppOptM ``Eval #[envType, varType, valueType]
+      let evalInst ← mkFreshExprMVar (some evalInstType)
+      mkAppOptM ``Eval.eval #[envType, varType, valueType, evalInst, env, fieldFVar]
+    else
+      return fieldFVar
+
+  matchStructProjection? (env? : Option Expr) (fieldFVars : Array Expr) (e : Expr) :
+      MetaM (Option Expr) := do
+    let some fieldName := fieldIdentOfProjection? e
+      | return none
+    return some (← replaceField env? fieldFVars fieldName)
+
+  matchUnconstrainedValue? (env? : Option Expr) (fieldFVars : Array Expr) (e : Expr) :
+      MetaM (Option Expr) := do
+    let (fn, args) := e.getAppFnArgs
+    unless fn == ``Unconstrained.value && args.size == 3 do
+      return none
+    let some fieldName := fieldIdentOfProjection? args[2]!
+      | return none
+    unless fieldKindFor fieldNames fieldKinds fieldName == .unconstrained do
+      return none
+    return some (← replaceField env? fieldFVars fieldName)
+
+  transform (env? : Option Expr) (fieldFVars : Array Expr) (e : Expr) : MetaM Expr := do
+    if let some replacement ← matchUnconstrainedValue? env? fieldFVars e then
+      return replacement
+    if let some replacement ← matchStructProjection? env? fieldFVars e then
+      return replacement
+    match e with
+    | .app f arg =>
+        return mkApp (← transform env? fieldFVars f) (← transform env? fieldFVars arg)
+    | .lam name type body binderInfo =>
+        let type' ← transform env? fieldFVars type
+        withLocalDecl name binderInfo type' fun fvar => do
+          let body' ← transform env? fieldFVars (body.instantiate1 fvar)
+          return .lam name type' (body'.abstract #[fvar]) binderInfo
+    | .forallE name type body binderInfo =>
+        let type' ← transform env? fieldFVars type
+        withLocalDecl name binderInfo type' fun fvar => do
+          let body' ← transform env? fieldFVars (body.instantiate1 fvar)
+          return .forallE name type' (body'.abstract #[fvar]) binderInfo
+    | .letE name type value body nondep =>
+        let type' ← transform env? fieldFVars type
+        let value' ← transform env? fieldFVars value
+        withLocalDecl name .default type' fun fvar => do
+          let body' ← transform env? fieldFVars (body.instantiate1 fvar)
+          return .letE name type' value' (body'.abstract #[fvar]) nondep
+    | .mdata data body => return .mdata data (← transform env? fieldFVars body)
+    | .proj typeName idx struct => return .proj typeName idx (← transform env? fieldFVars struct)
+    | _ => return e
+
 /--
   Analyze a field type to determine its TypeMap.
   `numParams` is the total number of parameters (including F)
@@ -423,6 +603,160 @@ def mkCircuitViewStruct (viewName : Name) (paramInfos : Array ParamInfo)
   )
   elabCommand cmd
 
+def mkDependentCircuitTypeInstance? (structName : Name) : CommandElabM Bool := do
+  let env ← getEnv
+  let some structInfo := getStructureInfo? env structName
+    | throwError "failed to get structure info for {structName}"
+  let some (.inductInfo indInfo) := env.find? structName
+    | throwError "{structName} not found in environment"
+  let numParams := indInfo.numParams
+  if numParams != 1 then
+    return false
+
+  let fieldNames := structInfo.fieldNames
+  if fieldNames.isEmpty then
+    return false
+
+  let resultOpt ← liftTermElabM do
+    forallTelescope indInfo.type fun args _ => do
+      let typeParamFVar := args[0]!
+      let mut fieldTypes : Array Expr := #[]
+      let mut fieldKinds : Array CircuitFieldKind := #[]
+      let mut hasDependentUnconstrained := false
+
+      for fname in fieldNames do
+        let projFnName := structName ++ fname
+        let some (.defnInfo projInfo) := env.find? projFnName
+          | throwError "projection {projFnName} not found"
+        let fieldType ← forallTelescope projInfo.type fun projArgs projBody => do
+          if projArgs.size != 2 then
+            throwError "projection {projFnName} has unexpected arity: {projArgs.size} vs expected 2"
+          return projBody.replaceFVar projArgs[0]! typeParamFVar
+
+        fieldTypes := fieldTypes.push fieldType
+        match matchUnconstrainedField? fieldType typeParamFVar with
+        | some hintType =>
+            fieldKinds := fieldKinds.push .unconstrained
+            if containsProjectionFrom structName hintType then
+              hasDependentUnconstrained := true
+        | none =>
+            fieldKinds := fieldKinds.push .regular
+
+      unless hasDependentUnconstrained do
+        return none
+
+      let mut varFieldTypes : Array (TSyntax `term) := #[]
+      let mut valueFieldTypes : Array (TSyntax `term) := #[]
+      let mut proverFieldTypes : Array (TSyntax `term) := #[]
+      let mut verifierArgs : Array (TSyntax `term) := #[]
+      let mut proverArgs : Array (TSyntax `term) := #[]
+
+      for i in [:fieldNames.size] do
+        let fname := fieldNames[i]!
+        let fieldIdent := mkIdent fname
+        let fieldType := fieldTypes[i]!
+        match matchUnconstrainedField? fieldType typeParamFVar with
+        | some hintType =>
+            if containsProjectionFrom structName hintType then
+              let hVar ← withLeadingFieldInstanceForallStripped typeParamFVar hintType fun hintType =>
+                dependentCircuitExprToSyntax structName typeParamFVar fieldNames fieldKinds fieldTypes i
+                  `var hintType
+              let hProver ← withLeadingFieldInstanceForallStripped typeParamFVar hintType fun hintType =>
+                dependentCircuitExprToSyntax structName typeParamFVar fieldNames fieldKinds fieldTypes i
+                  `prover hintType
+              let envIdent := mkIdent `env
+              varFieldTypes := varFieldTypes.push (← `(∀ ($envIdent : ProverEnvironment F), $hVar))
+              valueFieldTypes := valueFieldTypes.push (← `(Unit))
+              proverFieldTypes := proverFieldTypes.push hProver
+              verifierArgs := verifierArgs.push (← `(()))
+              proverArgs := proverArgs.push (← `(input.$fieldIdent:ident env))
+            else
+              let hintTypeStx ← PrettyPrinter.delab hintType
+              let hintTerm : TSyntax `term := ⟨hintTypeStx.raw⟩
+              varFieldTypes := varFieldTypes.push (← `(ProverEnvironment F → $hintTerm))
+              valueFieldTypes := valueFieldTypes.push (← `(Unit))
+              proverFieldTypes := proverFieldTypes.push hintTerm
+              verifierArgs := verifierArgs.push (← `(()))
+              proverArgs := proverArgs.push (← `(eval env input.$fieldIdent:ident))
+        | none =>
+            if fieldType == typeParamFVar then
+              varFieldTypes := varFieldTypes.push (← `(Expression F))
+              valueFieldTypes := valueFieldTypes.push (← `(F))
+              proverFieldTypes := proverFieldTypes.push (← `(F))
+            else
+              let component ← analyzeFieldType numParams args fieldType
+              varFieldTypes := varFieldTypes.push (← `(CircuitType.Var $component F))
+              valueFieldTypes := valueFieldTypes.push (← `(CircuitType.Value $component F))
+              proverFieldTypes := proverFieldTypes.push (← `(CircuitType.ProverValue $component F))
+            verifierArgs := verifierArgs.push (← `(eval env input.$fieldIdent:ident))
+            proverArgs := proverArgs.push (← `(eval env input.$fieldIdent:ident))
+
+      return some (fieldKinds, varFieldTypes, valueFieldTypes, proverFieldTypes, verifierArgs, proverArgs)
+
+  let some (_, varFieldTypes, valueFieldTypes, proverFieldTypes, verifierArgs, proverArgs) := resultOpt
+    | return false
+  let varFieldTypes := varFieldTypes.map eraseMacroScopesTerm
+  let valueFieldTypes := valueFieldTypes.map eraseMacroScopesTerm
+  let proverFieldTypes := proverFieldTypes.map eraseMacroScopesTerm
+  let verifierArgs := verifierArgs.map eraseMacroScopesTerm
+  let proverArgs := proverArgs.map eraseMacroScopesTerm
+  let fieldNameIdents : Array (TSyntax `ident) := fieldNames.map mkIdent
+
+  let varStructName := structName ++ `Var
+  let valueStructName := structName ++ `Value
+  let proverValueStructName := structName ++ `ProverValue
+
+  let fIdent := mkIdent `F
+  let fBinder ← `(bracketedBinderF| ($fIdent : Type))
+  let fieldBinder ← `(bracketedBinderF| [Field $fIdent])
+
+  let mkStruct (name : Name) (binders : Array (TSyntax ``bracketedBinder))
+      (fieldTypes : Array (TSyntax `term)) : CommandElabM Unit := do
+    let mut fieldSyntaxes : Array (TSyntax ``Lean.Parser.Command.structSimpleBinder) := #[]
+    for i in [:fieldNameIdents.size] do
+      let fname := fieldNameIdents[i]!
+      let ty := fieldTypes[i]!
+      fieldSyntaxes := fieldSyntaxes.push (← `(Lean.Parser.Command.structSimpleBinder| $fname:ident : $ty))
+    let nameIdent := mkIdent (← relativeToCurrentNamespace name)
+    let cmd ← `(
+      structure $nameIdent $binders:bracketedBinder* where
+        $fieldSyntaxes:structSimpleBinder*
+    )
+    logInfo m!"generated dependent CircuitType struct:\n{cmd}"
+    elabCommand cmd
+
+  mkStruct varStructName #[fBinder] varFieldTypes
+  mkStruct valueStructName #[fBinder, fieldBinder] valueFieldTypes
+  mkStruct proverValueStructName #[fBinder, fieldBinder] proverFieldTypes
+
+  let structIdent := mkIdent structName
+  let varIdent := mkIdent (← relativeToCurrentNamespace varStructName)
+  let valueIdent := mkIdent (← relativeToCurrentNamespace valueStructName)
+  let proverValueIdent := mkIdent (← relativeToCurrentNamespace proverValueStructName)
+  let valueMk := mkIdent (← relativeToCurrentNamespace (valueStructName ++ `mk))
+  let proverMk := mkIdent (← relativeToCurrentNamespace (proverValueStructName ++ `mk))
+
+  let mut verifierBody : TSyntax `term := valueMk
+  for arg in verifierArgs do
+    verifierBody ← `($verifierBody $arg)
+  let mut proverBody : TSyntax `term := proverMk
+  for arg in proverArgs do
+    proverBody ← `($proverBody $arg)
+
+  let envIdent := mkIdent `env
+  let inputIdent := mkIdent `input
+  let instanceCmd ← `(
+    instance : CircuitType.{1, 1, 1, 1} $structIdent where
+      Var := $varIdent
+      Value F := [Field F] → $valueIdent F
+      ProverValue F := [Field F] → $proverValueIdent F
+      evalVerifier := fun $envIdent $inputIdent => fun [_] => $verifierBody
+      evalProver := fun $envIdent $inputIdent => fun [_] => $proverBody
+  )
+  logInfo m!"generated dependent CircuitType instance:\n{instanceCmd}"
+  elabCommand instanceCmd
+  return true
+
 /--
   Generate the CircuitType instance declaration.
 -/
@@ -431,6 +765,9 @@ def mkCircuitTypeInstance (structName : Name) : CommandElabM Unit := do
 
   unless isStructure env structName do
     throwError "{structName} is not a structure"
+
+  if (← mkDependentCircuitTypeInstance? structName) then
+    return
 
   let some structInfo := getStructureInfo? env structName
     | throwError "failed to get structure info for {structName}"

--- a/Clean/Utils/Tactics/ProvableStructDeriving.lean
+++ b/Clean/Utils/Tactics/ProvableStructDeriving.lean
@@ -820,7 +820,6 @@ def mkDependentCircuitTypeInstance? (structName : Name) : CommandElabM Bool := d
       structure $nameIdent $binders:bracketedBinder* where
         $fieldSyntaxes:structSimpleBinder*
     )
-    logInfo m!"generated dependent CircuitType struct:\n{cmd}"
     elabCommand cmd
 
   mkStruct varStructName #[fBinder, fieldBinder] varFieldTypes
@@ -851,7 +850,6 @@ def mkDependentCircuitTypeInstance? (structName : Name) : CommandElabM Bool := d
       evalVerifier := fun $envIdent $inputIdent => $verifierBody
       evalProver := fun $envIdent $inputIdent => $proverBody
   )
-  logInfo m!"generated dependent CircuitType instance:\n{instanceCmd}"
   elabCommand instanceCmd
   mkCircuitEvalForwardingInstances #[] structIdent varIdent valueIdent proverValueIdent
   return true

--- a/Clean/Utils/Test/TestCircuitStructDeriving.lean
+++ b/Clean/Utils/Test/TestCircuitStructDeriving.lean
@@ -41,7 +41,7 @@ example {F : Type} [Field F] (env : ProverEnvironment F) (input : Var Inputs F) 
 structure InputWithProp (F : Type) where
   bool : F
   hint : Unconstrained Bool F
-  same_content : Unconstrained (∀ [Field F], bool = if hint.value then 1 else 0) F
+  same_content [Field F] : bool = if hint.value then 1 else 0
 deriving CircuitType
 
 example : CircuitType InputWithProp := by infer_instance
@@ -53,5 +53,16 @@ example {F : Type} [Field F] (input : InputWithProp.Var F) (env : ProverEnvironm
 example {F : Type} [Field F] (input : InputWithProp.ProverValue F) :
     input.bool = if input.hint then 1 else 0 :=
   input.same_content
+
+structure InputWithPlainProp (F : Type) where
+  bool : F
+  always : True
+deriving CircuitType
+
+example : CircuitType InputWithPlainProp := by infer_instance
+
+example {F : Type} [Field F] (input : InputWithPlainProp.ProverValue F) :
+    True :=
+  input.always
 
 end TestCircuitStructDeriving

--- a/Clean/Utils/Test/TestCircuitStructDeriving.lean
+++ b/Clean/Utils/Test/TestCircuitStructDeriving.lean
@@ -38,4 +38,20 @@ example {F : Type} [Field F] (env : ProverEnvironment F) (input : Var Inputs F) 
   rw [CircuitType.eval_prover]
   rfl
 
+structure InputWithProp (F : Type) where
+  bool : F
+  hint : Unconstrained Bool F
+  same_content : Unconstrained (∀ [Field F], bool = if hint.value then 1 else 0) F
+deriving CircuitType
+
+example : CircuitType InputWithProp := by infer_instance
+
+example {F : Type} [Field F] (input : InputWithProp.Var F) (env : ProverEnvironment F) :
+    eval env input.bool = if eval env input.hint then 1 else 0 :=
+  input.same_content env
+
+example {F : Type} [Field F] (input : InputWithProp.ProverValue F) :
+    input.bool = if input.hint then 1 else 0 :=
+  input.same_content
+
 end TestCircuitStructDeriving


### PR DESCRIPTION
This is an experimental follow-up for `CircuitType` deriving. It extends the derived `CircuitType` path to handle structures with dependent prop fields, that could capture properties of the circuit type:

```lean
structure CircuitBool (F : Type) where
  bool : F
  isBool [Field F] : IsBool bool
deriving CircuitType

example (input : CircuitBool.Var (F p)) : ∀ env : ProverEnvironment (F p),
    IsBool (eval env input.bool) := by
  intro env; exact input.isBool env
```

## Why This Is Draft

The comment above `CircuitBool` captures the main issue: proof-carrying circuit inputs look attractive, but they do not compose well with values generated inside circuits from prover knowledge.

For expressions built from existing variables, the proof field can be transported syntactically. But for witnessed values, the invariant usually follows from honest witness generation, constraints, or a circuit spec. We currently do not surface that reasoning in a way that lets us construct the proof field of the generated `Var`.

For example, it is impossible to implement the simple `HasAssignEq` class for `CircuitBool`.