### PR TITLE
foldlRange extension

### DIFF
--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -882,6 +882,32 @@ lemma foldlRange.output_eq :
   congr! 6
   rw [constant.localLength_eq (_, _)]
 
+/--
+Variant of `foldlRange.output_eq` for bodies whose output is independent of their
+input pair (`ConstantOutput`). Mirrors `foldl.output_eq`: the output collapses to a
+single application of `body` at the last index, eliminating the residual `Fin.foldl`.
+Users must supply the `ConstantOutput` proof explicitly because `foldlRange`, unlike
+`foldl`, does not bundle it in its definition.
+-/
+lemma foldlRange.output_eq_of_constantOutput [NeZero m]
+    (h_const_out : ConstantOutput fun (t : β × Fin m) => body t.1 t.2) :
+  (foldlRange m init body constant).output n =
+    (body default ⟨m - 1, Nat.pred_lt (NeZero.ne m)⟩).output
+      (n + (m - 1) * (body default default).localLength) := by
+  rw [foldlRange, FoldlM.output_eq (constant:=constant)]
+  unfold FoldlM.prod
+  rw [constant.localLength_eq (default, default) 0]
+  set k := constant.localLength
+  have hm1 : m - 1 < m := Nat.pred_lt (NeZero.ne m)
+  simp only [Vector.getElem_finRange, Fin.eta]
+  -- Convert the RHS body argument ⟨m-1, _⟩ to default via h_const_out.
+  rw [h_const_out (default, ⟨m - 1, hm1⟩) _]
+  -- Convert each LHS body application to use default default via h_const_out.
+  conv => lhs; lhs; intro acc i; rw [h_const_out (acc, _)]
+  rcases m with _ | m
+  · nomatch hm1
+  simp only [Fin.foldl_const, Fin.val_last, add_tsub_cancel_right]
+
 lemma foldlRange.operations_eq :
   (foldlRange m init body constant).operations n =
     (List.ofFn fun i =>


### PR DESCRIPTION
References https://github.com/tachyon-zcash/ragu/pull/710#pullrequestreview-4317615259 which doesn't currently seem feasible without upstream changes.

Adds a `ConstantOutput`-collapsed variant of `foldlRange.output_eq` in `Clean/Circuit/Loops.lean`.

### Motivation

`Circuit.foldl` already exposes a single-application output via `foldl.output_eq`, because it bundles `ConstantOutput` in its signature. `Circuit.foldlRange` doesn't bundle it, so `foldlRange.output_eq` produces a residual `Fin.foldl m step init` term — even when the body's output is acc-independent (and thus reducible via `Fin.foldl_const`).

This PR adds the analogous lemma:

```lean
lemma foldlRange.output_eq_of_constantOutput [NeZero m]
    (h_const_out : ConstantOutput fun (t : β × Fin m) => body t.1 t.2) :
  (foldlRange m init body constant).output n =
    (body default ⟨m - 1, Nat.pred_lt (NeZero.ne m)⟩).output
      (n + (m - 1) * (body default default).localLength)
```

Callers supply `h_const_out` (typically dischargeable by `intros; rfl` for bodies that allocate fresh wires and don't reuse the accumulator in the returned expression).

### Downstream use case

For example, the Ragu FV pipeline rewriting `Element::enforce_root_of_unity` as a polymorphic-in-`k` reimpl with `Circuit.foldlRange`: the formal-instance `same_output` proof needs the symbolic output to match an extracted flat-trace expression `var ⟨n+3k-1⟩`. With the existing `foldlRange.output_eq` alone, the goal stalls on `Fin.foldl k (fun acc _ => …) init`. The new lemma discharges it in one step.

### Proof

Mirrors `foldl.output_eq`: unfold via `FoldlM.output_eq`, normalize the `finRange` indexing, rewrite each step's body via the supplied `h_const_out`, then `Fin.foldl_const_succ` collapses to the last application.

### Tests

Full `lake build` passes (1771 jobs).