### PR TITLE
[codex] Add Lean build benchmark suite

### DIFF
--- a/.github/workflows/bench-command.yml
+++ b/.github/workflows/bench-command.yml
@@ -1,0 +1,49 @@
+name: Bench Command
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  dispatch:
+    if: >
+      github.event.issue.pull_request &&
+      (github.event.comment.body == '/bench' || startsWith(github.event.comment.body, '/bench ')) &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Resolve PR head
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          data="$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER")"
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "sha=$(jq -r .head.sha <<<"$data")" >> "$GITHUB_OUTPUT"
+          echo "head_repo=$(jq -r .head.repo.full_name <<<"$data")" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch benchmark
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run bench.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f pr="${{ steps.pr.outputs.number }}" \
+            -f sha="${{ steps.pr.outputs.sha }}" \
+            -f head_repo="${{ steps.pr.outputs.head_repo }}"
+
+      - name: Acknowledge command
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ steps.pr.outputs.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "Queued build benchmark for \`${{ steps.pr.outputs.sha }}\`."

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -21,8 +21,6 @@ jobs:
         run: |
           sudo sysctl -w kernel.perf_event_paranoid=0
           perf stat -e instructions -- true
-      - name: Fetch dependency cache
-        run: lake exe cache get
       - name: Run build benchmark
         run: scripts/bench/build/run
       - name: Render benchmark report

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,37 @@
+name: Bench
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: leanprover/lean-action@v1.5.0
+        with:
+          build: false
+          test: false
+          lint: false
+      - name: Enable perf counters
+        run: |
+          sudo sysctl -w kernel.perf_event_paranoid=0
+          perf stat -e instructions -- true
+      - name: Fetch dependency cache
+        run: lake exe cache get
+      - name: Run build benchmark
+        run: scripts/bench/build/run
+      - name: Render benchmark report
+        if: always() && hashFiles('measurements.jsonl') != ''
+        run: scripts/bench/report.py measurements.jsonl >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload benchmark measurements
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: bench-measurements
+          path: measurements.jsonl
+          if-no-files-found: warn

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,7 +14,7 @@ on:
         required: true
 
 jobs:
-  build:
+  bench:
     runs-on: [self-hosted, linux, x64, clean-bench]
     permissions:
       contents: read

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,35 +1,79 @@
 name: Bench
 
 on:
-  push:
-    branches: ["main"]
-  pull_request:
   workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number to report results to"
+        required: true
+      sha:
+        description: "Exact commit SHA to benchmark"
+        required: true
+      head_repo:
+        description: "owner/repo containing the commit SHA"
+        required: true
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, clean-bench]
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: leanprover/lean-action@v1.5.0
+      - name: Check out benchmark scripts
+        uses: actions/checkout@v4
         with:
-          build: false
-          test: false
-          lint: false
-      - name: Enable perf counters
+          ref: main
+          path: bench-control
+      - name: Run benchmark in container
+        working-directory: bench-control
+        env:
+          BENCH_PR: ${{ inputs.pr }}
+          BENCH_SHA: ${{ inputs.sha }}
+          BENCH_HEAD_REPO: ${{ inputs.head_repo }}
+          BENCH_REPOSITORY: ${{ github.repository }}
+          BENCH_RUN_ID: ${{ github.run_id }}
+          BENCH_OUTPUT_DIR: ${{ github.workspace }}/bench-output
+        run: scripts/bench/runner/run-in-docker.sh
+      - name: Copy measurements
+        if: always()
         run: |
-          sudo sysctl -w kernel.perf_event_paranoid=0
-          perf stat -e instructions -- true
-      - name: Run build benchmark
-        run: scripts/bench/build/run
+          if [ -f "$GITHUB_WORKSPACE/bench-output/measurements.jsonl" ]; then
+            cp "$GITHUB_WORKSPACE/bench-output/measurements.jsonl" measurements.jsonl
+          fi
       - name: Render benchmark report
         if: always() && hashFiles('measurements.jsonl') != ''
-        run: scripts/bench/report.py measurements.jsonl >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          bench-control/scripts/bench/report.py measurements.jsonl > benchmark-report.md
+          cat benchmark-report.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Comment on PR
+        if: always() && hashFiles('benchmark-report.md') != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('benchmark-report.md', 'utf8');
+            const body = [
+              '<!-- clean-build-benchmark -->',
+              '',
+              'Benchmark for `${{ inputs.sha }}`:',
+              '',
+              report,
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number('${{ inputs.pr }}'),
+              body,
+            });
       - name: Upload benchmark measurements
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: bench-measurements
-          path: measurements.jsonl
+          path: |
+            measurements.jsonl
+            benchmark-report.md
           if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .codex
 backends/plonky3/target
 backends/plonky3/tests/fixtures/output
+measurements.jsonl

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -28,3 +28,23 @@ Compare a current run against a baseline:
 ```bash
 scripts/bench/report.py measurements.jsonl baseline-measurements.jsonl
 ```
+
+## Maintainer-triggered PR benchmarks
+
+After the benchmark workflows are present on the default branch, maintainers can comment on a pull request with:
+
+```text
+/bench
+```
+
+The command workflow verifies that the commenter is an owner, member, or collaborator, then dispatches the benchmark workflow for the pull request's exact head commit.
+
+The benchmark workflow expects a self-hosted runner with labels:
+
+```text
+self-hosted, linux, x64, clean-bench
+```
+
+The workflow runs pull request code inside a Docker container. Persistent Lean toolchain state lives under `/var/lib/clean-bench/cache/elan`, while each pull request checkout and writable cache directory uses a per-run workspace that is removed after the benchmark. The persistent Lean toolchain cache is mounted read-only when pull request code runs.
+
+The host must provide working userspace `perf` instruction counters. In practice this means configuring the host so `perf stat -e instructions:u -- true` reports a numeric count for the runner environment. The container is run without host networking, without privileged mode, and without the Docker socket mounted.

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -1,0 +1,30 @@
+# Benchmark Suite
+
+This directory contains benchmarks for tracking Lean build regressions.
+The format follows the mathlib4 benchmark suite: each benchmark appends JSON Lines records to `measurements.jsonl`.
+
+Run the full suite from the repository root:
+
+```bash
+scripts/bench/run
+```
+
+Run only the build benchmark:
+
+```bash
+scripts/bench/build/run
+```
+
+The build benchmark records whole-build resource metrics and per-module instruction counts. Instruction counts are the preferred regression signal because wall-clock time is noisy on shared CI runners.
+
+Render a report from one run:
+
+```bash
+scripts/bench/report.py measurements.jsonl
+```
+
+Compare a current run against a baseline:
+
+```bash
+scripts/bench/report.py measurements.jsonl baseline-measurements.jsonl
+```

--- a/scripts/bench/build/README.md
+++ b/scripts/bench/build/README.md
@@ -1,0 +1,21 @@
+# Build Benchmark
+
+This benchmark runs a clean `lake build --no-cache` and records build metrics in `measurements.jsonl`.
+
+Whole-build metrics:
+
+- `build//instructions`
+- `build//maxrss`
+- `build//task-clock`
+- `build//wall-clock`
+
+Per-module metrics:
+
+- `build/module/<module>//instructions`
+- `build/module/<module>//lines`
+
+Lean profile metrics, summed by downstream consumers when metric names repeat:
+
+- `build/profile/<name>//wall-clock`
+
+The benchmark overrides the Lean executable that Lake uses, so module measurements come from the actual Lake build graph rather than a separate one-file-at-a-time pass.

--- a/scripts/bench/build/fake-root/bin/lean
+++ b/scripts/bench/build/fake-root/bin/lean
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+NAME = "build"
+REPO = Path()
+BENCH = REPO / "scripts" / "bench"
+OUTFILE = REPO / "measurements.jsonl"
+
+sys.path.append(str(BENCH))
+import measure  # noqa: E402
+
+
+def save_result(metric: str, value: float, unit: str | None = None) -> None:
+    data: dict[str, str | float] = {"metric": metric, "value": value}
+    if unit is not None:
+        data["unit"] = unit
+    with OUTFILE.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(data) + "\n")
+
+
+def run(*command: str) -> None:
+    result = subprocess.run(command)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+def get_module(setup: Path) -> str:
+    with setup.open(encoding="utf-8") as handle:
+        return json.load(handle)["name"]
+
+
+def count_lines(module: str, path: Path) -> None:
+    with path.open(encoding="utf-8") as handle:
+        lines = sum(1 for _ in handle)
+    save_result(f"{NAME}/module/{module}//lines", lines)
+
+
+def run_lean(module: str) -> None:
+    _, stderr = measure.main(
+        cmd=["lean", "--profile", "-Dprofiler.threshold=9999999", *sys.argv[1:]],
+        output=OUTFILE,
+        topics=[f"{NAME}/module/{module}"],
+        metrics={"instructions"},
+        append=True,
+        capture=True,
+    )
+
+    for line in stderr.splitlines():
+        match = re.fullmatch(r"\t(.*) ([\d.]+)(m?s)", line)
+        if not match:
+            continue
+        name = match.group(1)
+        seconds = float(match.group(2))
+        if match.group(3) == "ms":
+            seconds = seconds / 1000
+        save_result(f"{NAME}/profile/{name}//wall-clock", seconds, "s")
+
+
+def main() -> None:
+    if sys.argv[1:] == ["--print-prefix"]:
+        print(Path(__file__).resolve().parent.parent)
+        return
+
+    if sys.argv[1:] == ["--githash"]:
+        run("lean", "--githash")
+        return
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("lean", type=Path)
+    parser.add_argument("--setup", type=Path, required=True)
+    args, _ = parser.parse_known_args()
+
+    module = get_module(args.setup)
+    count_lines(module, args.lean)
+    run_lean(module)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/build/run
+++ b/scripts/bench/build/run
@@ -3,7 +3,7 @@ set -euo pipefail
 
 BENCH="scripts/bench"
 
-if ! perf stat -e instructions -- true >/dev/null 2>&1; then
+if ! perf stat -e instructions:u -- true >/dev/null 2>&1; then
   cat >&2 <<'EOF'
 error: perf instruction counters are unavailable.
 

--- a/scripts/bench/build/run
+++ b/scripts/bench/build/run
@@ -16,6 +16,7 @@ fi
 
 rm -f measurements.jsonl
 lake clean
+lake exe cache get
 
 LAKE_OVERRIDE_LEAN=true LEAN="$(realpath "$BENCH/build/fake-root/bin/lean")" \
   "$BENCH/measure.py" --append --topic build --default-metrics -- \

--- a/scripts/bench/build/run
+++ b/scripts/bench/build/run
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BENCH="scripts/bench"
+
+if ! perf stat -e instructions -- true >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+error: perf instruction counters are unavailable.
+
+The build benchmark uses instruction counts as its primary regression signal.
+Enable perf for this runner, for example by lowering perf_event_paranoid or
+running in an environment with CAP_PERFMON access.
+EOF
+  exit 1
+fi
+
+rm -f measurements.jsonl
+lake clean
+
+LAKE_OVERRIDE_LEAN=true LEAN="$(realpath "$BENCH/build/fake-root/bin/lean")" \
+  "$BENCH/measure.py" --append --topic build --default-metrics -- \
+  lake build --no-cache

--- a/scripts/bench/measure.py
+++ b/scripts/bench/measure.py
@@ -42,8 +42,8 @@ class Result:
 PERF_METRICS = {
     "task-clock": PerfMetric("task-clock", factor=1e-9, unit="s"),
     "wall-clock": PerfMetric("duration_time", factor=1e-9, unit="s"),
-    "instructions": PerfMetric("instructions"),
-    "cycles": PerfMetric("cycles"),
+    "instructions": PerfMetric("instructions:u"),
+    "cycles": PerfMetric("cycles:u"),
 }
 
 PERF_UNITS = {
@@ -122,10 +122,11 @@ def measure_perf(cmd: list[str], events: set[str], capture: bool) -> MeasureResu
         for line in tmp:
             data = json.loads(line)
             if "event" in data and "counter-value" in data:
-                perf[data["event"]] = PerfResult(
-                    value=float(data["counter-value"]),
-                    unit=data["unit"],
-                )
+                try:
+                    value = float(data["counter-value"])
+                except ValueError:
+                    continue
+                perf[data["event"]] = PerfResult(value=value, unit=data["unit"])
 
         return MeasureResult(
             perf=perf,
@@ -136,10 +137,9 @@ def measure_perf(cmd: list[str], events: set[str], capture: bool) -> MeasureResu
 
 def get_perf_result(perf: PerfResults, metric: str) -> Result:
     info = PERF_METRICS[metric]
-    if info.event in perf:
-        result = perf[info.event]
-    else:
-        result = perf[f"{info.event}:u"]
+    if info.event not in perf:
+        raise SystemExit(f"perf did not report supported data for event {info.event!r}")
+    result = perf[info.event]
     value = result.value * PERF_UNITS.get(result.unit, info.factor)
     return Result(category=metric, value=value, unit=info.unit)
 

--- a/scripts/bench/measure.py
+++ b/scripts/bench/measure.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import resource
+import subprocess
+import sys
+import tempfile
+from argparse import Namespace
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class PerfMetric:
+    event: str
+    factor: float = 1
+    unit: str | None = None
+
+
+@dataclass
+class RusageMetric:
+    name: str
+    factor: float = 1
+    unit: str | None = None
+
+
+@dataclass
+class Result:
+    category: str
+    value: float
+    unit: str | None
+
+    def fmt(self, topic: str) -> str:
+        data: dict[str, str | float] = {"metric": f"{topic}//{self.category}", "value": self.value}
+        if self.unit is not None:
+            data["unit"] = self.unit
+        return json.dumps(data)
+
+
+PERF_METRICS = {
+    "task-clock": PerfMetric("task-clock", factor=1e-9, unit="s"),
+    "wall-clock": PerfMetric("duration_time", factor=1e-9, unit="s"),
+    "instructions": PerfMetric("instructions"),
+    "cycles": PerfMetric("cycles"),
+}
+
+PERF_UNITS = {
+    "msec": 1e-3,
+    "ns": 1e-9,
+}
+
+RUSAGE_METRICS = {
+    "maxrss": RusageMetric("ru_maxrss", factor=1000, unit="B"),
+}
+
+ALL_METRICS = {**PERF_METRICS, **RUSAGE_METRICS}
+DEFAULT_METRICS = {"instructions", "maxrss", "task-clock", "wall-clock"}
+
+
+@dataclass
+class PerfResult:
+    value: float
+    unit: str
+
+
+PerfResults = dict[str, PerfResult]
+
+
+@dataclass
+class MeasureResult:
+    perf: PerfResults
+    stdout: str
+    stderr: str
+
+
+def resolve_metrics(metrics: set[str]) -> tuple[set[str], set[str]]:
+    perf = set()
+    rusage = set()
+    unknown = set()
+
+    for metric in metrics:
+        if metric in PERF_METRICS:
+            perf.add(metric)
+        elif metric in RUSAGE_METRICS:
+            rusage.add(metric)
+        else:
+            unknown.add(metric)
+
+    if unknown:
+        raise SystemExit(f"unknown metrics: {', '.join(sorted(unknown))}")
+
+    return perf, rusage
+
+
+def measure_perf(cmd: list[str], events: set[str], capture: bool) -> MeasureResult:
+    with tempfile.NamedTemporaryFile() as tmp:
+        env = os.environ.copy()
+        env["LC_ALL"] = "C"
+        command = [
+            "perf",
+            "stat",
+            "-j",
+            "-o",
+            tmp.name,
+            *(arg for event in sorted(events) for arg in ["-e", event]),
+            "--",
+            "env",
+            f"PATH={env['PATH']}",
+            *cmd,
+        ]
+
+        result = subprocess.run(command, env=env, capture_output=capture, encoding="utf-8")
+        if result.returncode != 0:
+            if capture:
+                print(result.stdout, end="", file=sys.stdout)
+                print(result.stderr, end="", file=sys.stderr)
+            raise SystemExit(result.returncode)
+
+        perf: PerfResults = {}
+        for line in tmp:
+            data = json.loads(line)
+            if "event" in data and "counter-value" in data:
+                perf[data["event"]] = PerfResult(
+                    value=float(data["counter-value"]),
+                    unit=data["unit"],
+                )
+
+        return MeasureResult(
+            perf=perf,
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+        )
+
+
+def get_perf_result(perf: PerfResults, metric: str) -> Result:
+    info = PERF_METRICS[metric]
+    if info.event in perf:
+        result = perf[info.event]
+    else:
+        result = perf[f"{info.event}:u"]
+    value = result.value * PERF_UNITS.get(result.unit, info.factor)
+    return Result(category=metric, value=value, unit=info.unit)
+
+
+def get_rusage_result(rusage: resource.struct_rusage, metric: str) -> Result:
+    info = RUSAGE_METRICS[metric]
+    value = getattr(rusage, info.name) * info.factor
+    return Result(category=metric, value=value, unit=info.unit)
+
+
+def main(
+    cmd: list[str],
+    output: Path,
+    topics: list[str],
+    metrics: set[str],
+    append: bool = True,
+    capture: bool = False,
+) -> tuple[str, str]:
+    perf_metrics, rusage_metrics = resolve_metrics(metrics)
+    perf_events = {PERF_METRICS[metric].event for metric in perf_metrics}
+
+    measured = measure_perf(cmd, perf_events, capture=capture)
+    rusage = resource.getrusage(resource.RUSAGE_CHILDREN)
+
+    results = [get_perf_result(measured.perf, metric) for metric in perf_metrics]
+    results.extend(get_rusage_result(rusage, metric) for metric in rusage_metrics)
+
+    with output.open("a" if append else "w", encoding="utf-8") as handle:
+        for result in results:
+            for topic in topics:
+                handle.write(result.fmt(topic) + "\n")
+
+    return measured.stdout, measured.stderr
+
+
+@dataclass
+class Args(Namespace):
+    topic: list[str]
+    metric: list[str]
+    default_metrics: bool
+    output: Path
+    append: bool
+    cmd: str
+    args: list[str]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Measure command resource usage using perf and rusage.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--topic", "-t", action="append", default=[], help="metric topic prefix")
+    parser.add_argument(
+        "--metric",
+        "-m",
+        action="append",
+        default=[],
+        help=f"metric to record; available metrics: {', '.join(sorted(ALL_METRICS))}",
+    )
+    parser.add_argument(
+        "--default-metrics",
+        "-d",
+        action="store_true",
+        help=f"record the default metric set: {', '.join(sorted(DEFAULT_METRICS))}",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=Path("measurements.jsonl"),
+        help="JSON Lines output file",
+    )
+    parser.add_argument("--append", "-a", action="store_true", help="append to output")
+    parser.add_argument("cmd", help="command to measure")
+    parser.add_argument("args", nargs="*", default=[], help="arguments for command")
+    args = parser.parse_args(namespace=Args)
+
+    metrics = set(args.metric)
+    if args.default_metrics:
+        metrics |= DEFAULT_METRICS
+
+    if not args.topic:
+        raise SystemExit("at least one --topic is required")
+
+    main(
+        cmd=[args.cmd] + args.args,
+        output=args.output,
+        topics=args.topic,
+        metrics=metrics,
+        append=args.append,
+    )

--- a/scripts/bench/report.py
+++ b/scripts/bench/report.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Measurements:
+    by_metric: dict[str, float]
+
+
+def load(path: Path) -> Measurements:
+    by_metric: dict[str, float] = {}
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            metric = record["metric"]
+            value = float(record["value"])
+            by_metric[metric] = by_metric.get(metric, 0) + value
+    return Measurements(by_metric=by_metric)
+
+
+def module_metric(module: str) -> str:
+    return f"build/module/{module}//instructions"
+
+
+def module_from_metric(metric: str) -> str | None:
+    prefix = "build/module/"
+    suffix = "//instructions"
+    if not metric.startswith(prefix) or not metric.endswith(suffix):
+        return None
+    return metric[len(prefix) : -len(suffix)]
+
+
+def fmt_int(value: float) -> str:
+    return f"{value:,.0f}"
+
+
+def fmt_pct(value: float) -> str:
+    return f"{value:+.2f}%"
+
+
+def print_summary(current: Measurements, baseline: Measurements | None) -> None:
+    current_total = current.by_metric.get("build//instructions")
+    baseline_total = baseline.by_metric.get("build//instructions") if baseline else None
+
+    print("# Build Benchmark Report")
+    print()
+    if current_total is None:
+        print("No whole-build instruction count found.")
+    elif baseline_total is None:
+        print(f"- Build instructions: `{fmt_int(current_total)}`")
+    else:
+        delta = current_total - baseline_total
+        pct = (delta / baseline_total * 100) if baseline_total else 0
+        print(f"- Build instructions: `{fmt_int(current_total)}` ({fmt_int(delta)} / {fmt_pct(pct)})")
+    print()
+
+
+def print_modules(current: Measurements, baseline: Measurements | None, limit: int) -> None:
+    modules = sorted(
+        module
+        for metric in current.by_metric
+        if (module := module_from_metric(metric)) is not None
+    )
+
+    if baseline is None:
+        rows = sorted(
+            ((current.by_metric[module_metric(module)], module) for module in modules),
+            reverse=True,
+        )[:limit]
+        print(f"## Slowest Modules By Instructions")
+        print()
+        print("| Instructions | Module |")
+        print("| ---: | --- |")
+        for instructions, module in rows:
+            print(f"| {fmt_int(instructions)} | `{module}` |")
+        return
+
+    rows = []
+    for module in modules:
+        metric = module_metric(module)
+        current_value = current.by_metric[metric]
+        baseline_value = baseline.by_metric.get(metric)
+        if baseline_value is None:
+            rows.append((current_value, 100.0, current_value, baseline_value, module))
+            continue
+        delta = current_value - baseline_value
+        pct = (delta / baseline_value * 100) if baseline_value else 0
+        rows.append((delta, pct, current_value, baseline_value, module))
+
+    rows.sort(key=lambda row: row[0], reverse=True)
+    print(f"## Largest Module Instruction Regressions")
+    print()
+    print("| Delta | Delta % | Current | Baseline | Module |")
+    print("| ---: | ---: | ---: | ---: | --- |")
+    for delta, pct, current_value, baseline_value, module in rows[:limit]:
+        baseline_text = "-" if baseline_value is None else fmt_int(baseline_value)
+        print(
+            f"| {fmt_int(delta)} | {fmt_pct(pct)} | {fmt_int(current_value)} | "
+            f"{baseline_text} | `{module}` |"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render build benchmark measurements.")
+    parser.add_argument("current", type=Path)
+    parser.add_argument("baseline", type=Path, nargs="?")
+    parser.add_argument("--limit", type=int, default=20)
+    args = parser.parse_args()
+
+    current = load(args.current)
+    baseline = load(args.baseline) if args.baseline else None
+    print_summary(current, baseline)
+    print_modules(current, baseline, args.limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/run
+++ b/scripts/bench/run
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BENCH="scripts/bench"
+
+echo "Running benchmark: build"
+"$BENCH/build/run"

--- a/scripts/bench/runner/Dockerfile
+++ b/scripts/bench/runner/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH=/root/.elan/bin:$PATH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    jq \
+    linux-tools-generic \
+    python3 \
+    xz-utils \
+    zstd \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+  | sh -s -- -y --default-toolchain none
+
+WORKDIR /workspace/clean

--- a/scripts/bench/runner/run-in-docker.sh
+++ b/scripts/bench/runner/run-in-docker.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${BENCH_PR:?BENCH_PR is required}"
+: "${BENCH_SHA:?BENCH_SHA is required}"
+: "${BENCH_HEAD_REPO:?BENCH_HEAD_REPO is required}"
+: "${BENCH_REPOSITORY:?BENCH_REPOSITORY is required}"
+: "${BENCH_RUN_ID:?BENCH_RUN_ID is required}"
+: "${BENCH_OUTPUT_DIR:?BENCH_OUTPUT_DIR is required}"
+
+ROOT="${BENCH_ROOT:-/var/lib/clean-bench}"
+IMAGE="${BENCH_IMAGE:-clean-bench-runner:latest}"
+RUN_DIR="$ROOT/runs/$BENCH_RUN_ID"
+CACHE_DIR="$ROOT/cache"
+WORK_DIR="$RUN_DIR/work"
+
+mkdir -p "$CACHE_DIR/elan" "$WORK_DIR" "$RUN_DIR/xdg-cache" "$BENCH_OUTPUT_DIR"
+rm -rf "$WORK_DIR/clean"
+
+docker build -t "$IMAGE" -f scripts/bench/runner/Dockerfile scripts/bench/runner
+
+git clone --filter=blob:none "https://github.com/$BENCH_HEAD_REPO.git" "$WORK_DIR/clean"
+git -C "$WORK_DIR/clean" fetch --no-tags "https://github.com/$BENCH_HEAD_REPO.git" "$BENCH_SHA"
+git -C "$WORK_DIR/clean" checkout --detach "$BENCH_SHA"
+
+TOOLCHAIN="$(sed -n '1p' "$WORK_DIR/clean/lean-toolchain")"
+docker run --rm \
+  --network bridge \
+  -e ELAN_HOME=/bench-cache/elan \
+  -v "$CACHE_DIR/elan:/bench-cache/elan" \
+  "$IMAGE" \
+  elan toolchain install "$TOOLCHAIN"
+
+PERF_MOUNTS=()
+if [ -x /usr/bin/perf ]; then
+  PERF_MOUNTS+=(-v /usr/bin/perf:/usr/local/bin/perf:ro)
+fi
+if [ -d /usr/lib/linux-tools ]; then
+  PERF_MOUNTS+=(-v /usr/lib/linux-tools:/usr/lib/linux-tools:ro)
+fi
+
+docker run --rm \
+  --cap-add PERFMON \
+  --security-opt seccomp=unconfined \
+  --security-opt no-new-privileges \
+  --network bridge \
+  -e XDG_CACHE_HOME=/workspace/xdg-cache \
+  -e ELAN_HOME=/bench-cache/elan \
+  -v "$WORK_DIR/clean:/workspace/clean" \
+  -v "$CACHE_DIR/elan:/bench-cache/elan:ro" \
+  -v "$RUN_DIR/xdg-cache:/workspace/xdg-cache" \
+  -v "$BENCH_OUTPUT_DIR:/bench-output" \
+  "${PERF_MOUNTS[@]}" \
+  "$IMAGE" \
+  bash -lc 'scripts/bench/build/run && cp measurements.jsonl /bench-output/measurements.jsonl'
+
+rm -rf "$RUN_DIR"

--- a/scripts/bench/runner/run-in-docker.sh
+++ b/scripts/bench/runner/run-in-docker.sh
@@ -32,11 +32,16 @@ docker run --rm \
   elan toolchain install "$TOOLCHAIN"
 
 PERF_MOUNTS=()
-if [ -x /usr/bin/perf ]; then
-  PERF_MOUNTS+=(-v /usr/bin/perf:/usr/local/bin/perf:ro)
+HOST_PERF=""
+if [ -x "/usr/lib/linux-tools/$(uname -r)/perf" ]; then
+  HOST_PERF="/usr/lib/linux-tools/$(uname -r)/perf"
+elif [ -x "/usr/lib/linux-tools-$(uname -r | sed 's/-generic$//')/perf" ]; then
+  HOST_PERF="/usr/lib/linux-tools-$(uname -r | sed 's/-generic$//')/perf"
+elif [ -x /usr/bin/perf ]; then
+  HOST_PERF="/usr/bin/perf"
 fi
-if [ -d /usr/lib/linux-tools ]; then
-  PERF_MOUNTS+=(-v /usr/lib/linux-tools:/usr/lib/linux-tools:ro)
+if [ -n "$HOST_PERF" ]; then
+  PERF_MOUNTS+=(-v "$HOST_PERF:/usr/local/bin/perf:ro")
 fi
 
 docker run --rm \


### PR DESCRIPTION
## Summary

Adds a mathlib-style Lean build benchmark suite for tracking build regressions with instruction counts instead of noisy wall-clock timings.

## Changes

- Adds `scripts/bench/measure.py` for JSONL metric capture using `perf` and rusage.
- Adds a build benchmark that runs Lake with `LAKE_OVERRIDE_LEAN` and a Lean wrapper, so per-module measurements come from the actual Lake build graph.
- Records whole-build metrics, per-module instruction counts, per-module line counts, and Lean profile buckets.
- Adds `scripts/bench/report.py` for current and baseline-vs-current benchmark summaries.
- Adds a `Bench` GitHub Actions workflow that enables perf counters, runs the benchmark, renders a summary, and uploads `measurements.jsonl`.

## Validation

- `python3 -m py_compile scripts/bench/measure.py scripts/bench/report.py scripts/bench/build/fake-root/bin/lean`
- `bash -n scripts/bench/run scripts/bench/build/run`
- Synthetic JSONL smoke test for `scripts/bench/report.py`

I did not run the full benchmark locally because this machine has `perf_event_paranoid=4`; the benchmark preflight exits before `lake clean` or `lake build` in that case.