### PR TITLE
[codex] Add maintainer-triggered Lean build benchmarks

### DIFF
--- a/.github/workflows/bench-command.yml
+++ b/.github/workflows/bench-command.yml
@@ -1,0 +1,49 @@
+name: Bench Command
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  dispatch:
+    if: >
+      github.event.issue.pull_request &&
+      (github.event.comment.body == '/bench' || startsWith(github.event.comment.body, '/bench ')) &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Resolve PR head
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          data="$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER")"
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "sha=$(jq -r .head.sha <<<"$data")" >> "$GITHUB_OUTPUT"
+          echo "head_repo=$(jq -r .head.repo.full_name <<<"$data")" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch benchmark
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run bench.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f pr="${{ steps.pr.outputs.number }}" \
+            -f sha="${{ steps.pr.outputs.sha }}" \
+            -f head_repo="${{ steps.pr.outputs.head_repo }}"
+
+      - name: Acknowledge command
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ steps.pr.outputs.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "Queued build benchmark for \`${{ steps.pr.outputs.sha }}\`."

--- a/.github/workflows/bench-command.yml
+++ b/.github/workflows/bench-command.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           data="$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER")"
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$(jq -r .base.sha <<<"$data")" >> "$GITHUB_OUTPUT"
           echo "sha=$(jq -r .head.sha <<<"$data")" >> "$GITHUB_OUTPUT"
           echo "head_repo=$(jq -r .head.repo.full_name <<<"$data")" >> "$GITHUB_OUTPUT"
 
@@ -37,6 +38,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --ref main \
             -f pr="${{ steps.pr.outputs.number }}" \
+            -f base_sha="${{ steps.pr.outputs.base_sha }}" \
             -f sha="${{ steps.pr.outputs.sha }}" \
             -f head_repo="${{ steps.pr.outputs.head_repo }}"
 
@@ -46,4 +48,4 @@ jobs:
         run: |
           gh pr comment "${{ steps.pr.outputs.number }}" \
             --repo "${{ github.repository }}" \
-            --body "Queued build benchmark for \`${{ steps.pr.outputs.sha }}\`."
+            --body "Queued build benchmark for \`${{ steps.pr.outputs.sha }}\` against baseline \`${{ steps.pr.outputs.base_sha }}\`."

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,6 +6,9 @@ on:
       pr:
         description: "Pull request number to report results to"
         required: true
+      base_sha:
+        description: "Exact base commit SHA to compare against"
+        required: true
       sha:
         description: "Exact commit SHA to benchmark"
         required: true
@@ -31,6 +34,7 @@ jobs:
         working-directory: bench-control
         env:
           BENCH_PR: ${{ inputs.pr }}
+          BENCH_BASE_SHA: ${{ inputs.base_sha }}
           BENCH_SHA: ${{ inputs.sha }}
           BENCH_HEAD_REPO: ${{ inputs.head_repo }}
           BENCH_REPOSITORY: ${{ github.repository }}
@@ -40,13 +44,20 @@ jobs:
       - name: Copy measurements
         if: always()
         run: |
-          if [ -f "$GITHUB_WORKSPACE/bench-output/measurements.jsonl" ]; then
-            cp "$GITHUB_WORKSPACE/bench-output/measurements.jsonl" measurements.jsonl
+          if [ -f "$GITHUB_WORKSPACE/bench-output/baseline.jsonl" ]; then
+            cp "$GITHUB_WORKSPACE/bench-output/baseline.jsonl" baseline.jsonl
+          fi
+          if [ -f "$GITHUB_WORKSPACE/bench-output/current.jsonl" ]; then
+            cp "$GITHUB_WORKSPACE/bench-output/current.jsonl" current.jsonl
           fi
       - name: Render benchmark report
-        if: always() && hashFiles('measurements.jsonl') != ''
+        if: always() && hashFiles('current.jsonl') != ''
         run: |
-          bench-control/scripts/bench/report.py measurements.jsonl > benchmark-report.md
+          if [ -f baseline.jsonl ]; then
+            bench-control/scripts/bench/report.py current.jsonl baseline.jsonl --limit 10 > benchmark-report.md
+          else
+            bench-control/scripts/bench/report.py current.jsonl --limit 10 > benchmark-report.md
+          fi
           cat benchmark-report.md >> "$GITHUB_STEP_SUMMARY"
       - name: Comment on PR
         if: always() && hashFiles('benchmark-report.md') != ''
@@ -58,7 +69,7 @@ jobs:
             const body = [
               '<!-- clean-build-benchmark -->',
               '',
-              'Benchmark for `${{ inputs.sha }}`:',
+              'Benchmark for `${{ inputs.sha }}` against baseline `${{ inputs.base_sha }}`:',
               '',
               report,
             ].join('\n');
@@ -74,6 +85,7 @@ jobs:
         with:
           name: bench-measurements
           path: |
-            measurements.jsonl
+            baseline.jsonl
+            current.jsonl
             benchmark-report.md
           if-no-files-found: warn

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,79 @@
+name: Bench
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number to report results to"
+        required: true
+      sha:
+        description: "Exact commit SHA to benchmark"
+        required: true
+      head_repo:
+        description: "owner/repo containing the commit SHA"
+        required: true
+
+jobs:
+  bench:
+    runs-on: [self-hosted, linux, x64, clean-bench]
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+
+    steps:
+      - name: Check out benchmark scripts
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: bench-control
+      - name: Run benchmark in container
+        working-directory: bench-control
+        env:
+          BENCH_PR: ${{ inputs.pr }}
+          BENCH_SHA: ${{ inputs.sha }}
+          BENCH_HEAD_REPO: ${{ inputs.head_repo }}
+          BENCH_REPOSITORY: ${{ github.repository }}
+          BENCH_RUN_ID: ${{ github.run_id }}
+          BENCH_OUTPUT_DIR: ${{ github.workspace }}/bench-output
+        run: scripts/bench/runner/run-in-docker.sh
+      - name: Copy measurements
+        if: always()
+        run: |
+          if [ -f "$GITHUB_WORKSPACE/bench-output/measurements.jsonl" ]; then
+            cp "$GITHUB_WORKSPACE/bench-output/measurements.jsonl" measurements.jsonl
+          fi
+      - name: Render benchmark report
+        if: always() && hashFiles('measurements.jsonl') != ''
+        run: |
+          bench-control/scripts/bench/report.py measurements.jsonl > benchmark-report.md
+          cat benchmark-report.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Comment on PR
+        if: always() && hashFiles('benchmark-report.md') != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('benchmark-report.md', 'utf8');
+            const body = [
+              '<!-- clean-build-benchmark -->',
+              '',
+              'Benchmark for `${{ inputs.sha }}`:',
+              '',
+              report,
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number('${{ inputs.pr }}'),
+              body,
+            });
+      - name: Upload benchmark measurements
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: bench-measurements
+          path: |
+            measurements.jsonl
+            benchmark-report.md
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .codex
 backends/plonky3/target
 backends/plonky3/tests/fixtures/output
+measurements.jsonl

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -39,7 +39,7 @@ After the benchmark workflows are present on the default branch, maintainers can
 
 The command workflow verifies that the commenter is an owner, member, or collaborator, then dispatches the benchmark workflow for the pull request's exact head commit.
 
-The benchmark workflow expects a self-hosted runner with labels:
+The benchmark workflow expects a repo-scoped self-hosted runner with labels:
 
 ```text
 self-hosted, linux, x64, clean-bench

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -49,6 +49,6 @@ The benchmark workflow expects a repo-scoped self-hosted runner with labels:
 self-hosted, linux, x64, clean-bench
 ```
 
-The workflow runs checked-out code inside a Docker container. Persistent Lean toolchain state lives under `/var/lib/clean-bench/cache/elan`, while each baseline/current checkout and writable cache directory uses a per-run workspace that is removed after the benchmark. The persistent Lean toolchain cache is mounted read-only when benchmarked code runs.
+The workflow runs checked-out code inside a Docker container. Persistent Lean toolchain state lives under `/var/lib/clean-bench/cache/elan`, and persistent Lake dependency package caches live under `/var/lib/clean-bench/cache/lake-packages`, keyed by `lean-toolchain` plus `lake-manifest.json`. Each baseline/current checkout and writable non-dependency cache directory uses a per-run workspace that is removed after the benchmark. The persistent Lean toolchain cache is mounted read-only when benchmarked code runs.
 
 The host must provide working userspace `perf` instruction counters. In practice this means configuring the host so `perf stat -e instructions:u -- true` reports a numeric count for the runner environment. The container is run without host networking, without privileged mode, and without the Docker socket mounted.

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -1,0 +1,50 @@
+# Benchmark Suite
+
+This directory contains benchmarks for tracking Lean build regressions.
+The format follows the mathlib4 benchmark suite: each benchmark appends JSON Lines records to `measurements.jsonl`.
+
+Run the full suite from the repository root:
+
+```bash
+scripts/bench/run
+```
+
+Run only the build benchmark:
+
+```bash
+scripts/bench/build/run
+```
+
+The build benchmark records whole-build resource metrics and per-module instruction counts. Instruction counts are the preferred regression signal because wall-clock time is noisy on shared CI runners.
+
+Render a report from one run:
+
+```bash
+scripts/bench/report.py measurements.jsonl
+```
+
+Compare a current run against a baseline:
+
+```bash
+scripts/bench/report.py measurements.jsonl baseline-measurements.jsonl
+```
+
+## Maintainer-triggered PR benchmarks
+
+After the benchmark workflows are present on the default branch, maintainers can comment on a pull request with:
+
+```text
+/bench
+```
+
+The command workflow verifies that the commenter is an owner, member, or collaborator, then dispatches the benchmark workflow for the pull request's exact head commit.
+
+The benchmark workflow expects a self-hosted runner with labels:
+
+```text
+self-hosted, linux, x64, clean-bench
+```
+
+The workflow runs pull request code inside a Docker container. Persistent Lean toolchain state lives under `/var/lib/clean-bench/cache/elan`, while each pull request checkout and writable cache directory uses a per-run workspace that is removed after the benchmark. The persistent Lean toolchain cache is mounted read-only when pull request code runs.
+
+The host must provide working userspace `perf` instruction counters. In practice this means configuring the host so `perf stat -e instructions:u -- true` reports a numeric count for the runner environment. The container is run without host networking, without privileged mode, and without the Docker socket mounted.

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -26,8 +26,10 @@ scripts/bench/report.py measurements.jsonl
 Compare a current run against a baseline:
 
 ```bash
-scripts/bench/report.py measurements.jsonl baseline-measurements.jsonl
+scripts/bench/report.py current.jsonl baseline.jsonl
 ```
+
+Comparison reports show the whole-build summary plus the top 10 module instruction regressions, top 10 module instruction improvements, and top 10 longest-running modules.
 
 ## Maintainer-triggered PR benchmarks
 
@@ -37,7 +39,9 @@ After the benchmark workflows are present on the default branch, maintainers can
 /bench
 ```
 
-The command workflow verifies that the commenter is an owner, member, or collaborator, then dispatches the benchmark workflow for the pull request's exact head commit.
+The command workflow verifies that the commenter is an owner, member, or collaborator, then dispatches the benchmark workflow for the pull request's exact base and head commits. The benchmark job runs the base commit first and the pull request commit second on the same runner, then comments on the pull request with a comparison report.
+
+The benchmark scripts themselves are checked out from the default branch and overlaid onto each measured checkout before running. This keeps the reporting machinery stable and lets the baseline commit be measured even when it predates the benchmark suite.
 
 The benchmark workflow expects a repo-scoped self-hosted runner with labels:
 
@@ -45,6 +49,6 @@ The benchmark workflow expects a repo-scoped self-hosted runner with labels:
 self-hosted, linux, x64, clean-bench
 ```
 
-The workflow runs pull request code inside a Docker container. Persistent Lean toolchain state lives under `/var/lib/clean-bench/cache/elan`, while each pull request checkout and writable cache directory uses a per-run workspace that is removed after the benchmark. The persistent Lean toolchain cache is mounted read-only when pull request code runs.
+The workflow runs checked-out code inside a Docker container. Persistent Lean toolchain state lives under `/var/lib/clean-bench/cache/elan`, while each baseline/current checkout and writable cache directory uses a per-run workspace that is removed after the benchmark. The persistent Lean toolchain cache is mounted read-only when benchmarked code runs.
 
 The host must provide working userspace `perf` instruction counters. In practice this means configuring the host so `perf stat -e instructions:u -- true` reports a numeric count for the runner environment. The container is run without host networking, without privileged mode, and without the Docker socket mounted.

--- a/scripts/bench/build/README.md
+++ b/scripts/bench/build/README.md
@@ -1,6 +1,8 @@
 # Build Benchmark
 
-This benchmark removes the local package `.lake/build` directory, runs `lake exe cache get`, then runs `lake build --no-cache` and records build metrics in `measurements.jsonl`.
+This benchmark removes the local `.lake/build` directory, runs `lake exe cache get`, then runs `lake build --no-cache` and records build metrics in `measurements.jsonl`.
+
+It deliberately preserves `.lake/packages`, so dependency source trees and downloaded dependency build artifacts can be reused by the runner cache while the project itself is rebuilt from scratch.
 
 Whole-build metrics:
 

--- a/scripts/bench/build/README.md
+++ b/scripts/bench/build/README.md
@@ -1,6 +1,6 @@
 # Build Benchmark
 
-This benchmark runs a clean `lake build --no-cache` and records build metrics in `measurements.jsonl`.
+This benchmark removes the local package `.lake/build` directory, runs `lake exe cache get`, then runs `lake build --no-cache` and records build metrics in `measurements.jsonl`.
 
 Whole-build metrics:
 

--- a/scripts/bench/build/README.md
+++ b/scripts/bench/build/README.md
@@ -1,0 +1,21 @@
+# Build Benchmark
+
+This benchmark runs a clean `lake build --no-cache` and records build metrics in `measurements.jsonl`.
+
+Whole-build metrics:
+
+- `build//instructions`
+- `build//maxrss`
+- `build//task-clock`
+- `build//wall-clock`
+
+Per-module metrics:
+
+- `build/module/<module>//instructions`
+- `build/module/<module>//lines`
+
+Lean profile metrics, summed by downstream consumers when metric names repeat:
+
+- `build/profile/<name>//wall-clock`
+
+The benchmark overrides the Lean executable that Lake uses, so module measurements come from the actual Lake build graph rather than a separate one-file-at-a-time pass.

--- a/scripts/bench/build/fake-root/bin/lean
+++ b/scripts/bench/build/fake-root/bin/lean
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+NAME = "build"
+REPO = Path()
+BENCH = REPO / "scripts" / "bench"
+OUTFILE = REPO / "measurements.jsonl"
+
+sys.path.append(str(BENCH))
+import measure  # noqa: E402
+
+
+def save_result(metric: str, value: float, unit: str | None = None) -> None:
+    data: dict[str, str | float] = {"metric": metric, "value": value}
+    if unit is not None:
+        data["unit"] = unit
+    with OUTFILE.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(data) + "\n")
+
+
+def run(*command: str) -> None:
+    result = subprocess.run(command)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+def get_module(setup: Path) -> str:
+    with setup.open(encoding="utf-8") as handle:
+        return json.load(handle)["name"]
+
+
+def count_lines(module: str, path: Path) -> None:
+    with path.open(encoding="utf-8") as handle:
+        lines = sum(1 for _ in handle)
+    save_result(f"{NAME}/module/{module}//lines", lines)
+
+
+def run_lean(module: str) -> None:
+    _, stderr = measure.main(
+        cmd=["lean", "--profile", "-Dprofiler.threshold=9999999", *sys.argv[1:]],
+        output=OUTFILE,
+        topics=[f"{NAME}/module/{module}"],
+        metrics={"instructions"},
+        append=True,
+        capture=True,
+    )
+
+    for line in stderr.splitlines():
+        match = re.fullmatch(r"\t(.*) ([\d.]+)(m?s)", line)
+        if not match:
+            continue
+        name = match.group(1)
+        seconds = float(match.group(2))
+        if match.group(3) == "ms":
+            seconds = seconds / 1000
+        save_result(f"{NAME}/profile/{name}//wall-clock", seconds, "s")
+
+
+def main() -> None:
+    if sys.argv[1:] == ["--print-prefix"]:
+        print(Path(__file__).resolve().parent.parent)
+        return
+
+    if sys.argv[1:] == ["--githash"]:
+        run("lean", "--githash")
+        return
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("lean", type=Path)
+    parser.add_argument("--setup", type=Path, required=True)
+    args, _ = parser.parse_known_args()
+
+    module = get_module(args.setup)
+    count_lines(module, args.lean)
+    run_lean(module)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/build/run
+++ b/scripts/bench/build/run
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BENCH="scripts/bench"
+
+if ! perf stat -e instructions:u -- true >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+error: perf instruction counters are unavailable.
+
+The build benchmark uses instruction counts as its primary regression signal.
+Enable perf for this runner, for example by lowering perf_event_paranoid or
+running in an environment with CAP_PERFMON access.
+EOF
+  exit 1
+fi
+
+rm -f measurements.jsonl
+lake clean
+lake exe cache get
+
+LAKE_OVERRIDE_LEAN=true LEAN="$(realpath "$BENCH/build/fake-root/bin/lean")" \
+  "$BENCH/measure.py" --append --topic build --default-metrics -- \
+  lake build --no-cache

--- a/scripts/bench/build/run
+++ b/scripts/bench/build/run
@@ -15,7 +15,7 @@ EOF
 fi
 
 rm -f measurements.jsonl
-lake clean
+rm -rf .lake/build
 lake exe cache get
 
 LAKE_OVERRIDE_LEAN=true LEAN="$(realpath "$BENCH/build/fake-root/bin/lean")" \

--- a/scripts/bench/measure.py
+++ b/scripts/bench/measure.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import resource
+import subprocess
+import sys
+import tempfile
+from argparse import Namespace
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class PerfMetric:
+    event: str
+    factor: float = 1
+    unit: str | None = None
+
+
+@dataclass
+class RusageMetric:
+    name: str
+    factor: float = 1
+    unit: str | None = None
+
+
+@dataclass
+class Result:
+    category: str
+    value: float
+    unit: str | None
+
+    def fmt(self, topic: str) -> str:
+        data: dict[str, str | float] = {"metric": f"{topic}//{self.category}", "value": self.value}
+        if self.unit is not None:
+            data["unit"] = self.unit
+        return json.dumps(data)
+
+
+PERF_METRICS = {
+    "task-clock": PerfMetric("task-clock", factor=1e-9, unit="s"),
+    "wall-clock": PerfMetric("duration_time", factor=1e-9, unit="s"),
+    "instructions": PerfMetric("instructions:u"),
+    "cycles": PerfMetric("cycles:u"),
+}
+
+PERF_UNITS = {
+    "msec": 1e-3,
+    "ns": 1e-9,
+}
+
+RUSAGE_METRICS = {
+    "maxrss": RusageMetric("ru_maxrss", factor=1000, unit="B"),
+}
+
+ALL_METRICS = {**PERF_METRICS, **RUSAGE_METRICS}
+DEFAULT_METRICS = {"instructions", "maxrss", "task-clock", "wall-clock"}
+
+
+@dataclass
+class PerfResult:
+    value: float
+    unit: str
+
+
+PerfResults = dict[str, PerfResult]
+
+
+@dataclass
+class MeasureResult:
+    perf: PerfResults
+    stdout: str
+    stderr: str
+
+
+def resolve_metrics(metrics: set[str]) -> tuple[set[str], set[str]]:
+    perf = set()
+    rusage = set()
+    unknown = set()
+
+    for metric in metrics:
+        if metric in PERF_METRICS:
+            perf.add(metric)
+        elif metric in RUSAGE_METRICS:
+            rusage.add(metric)
+        else:
+            unknown.add(metric)
+
+    if unknown:
+        raise SystemExit(f"unknown metrics: {', '.join(sorted(unknown))}")
+
+    return perf, rusage
+
+
+def measure_perf(cmd: list[str], events: set[str], capture: bool) -> MeasureResult:
+    with tempfile.NamedTemporaryFile() as tmp:
+        env = os.environ.copy()
+        env["LC_ALL"] = "C"
+        command = [
+            "perf",
+            "stat",
+            "-j",
+            "-o",
+            tmp.name,
+            *(arg for event in sorted(events) for arg in ["-e", event]),
+            "--",
+            "env",
+            f"PATH={env['PATH']}",
+            *cmd,
+        ]
+
+        result = subprocess.run(command, env=env, capture_output=capture, encoding="utf-8")
+        if result.returncode != 0:
+            if capture:
+                print(result.stdout, end="", file=sys.stdout)
+                print(result.stderr, end="", file=sys.stderr)
+            raise SystemExit(result.returncode)
+
+        perf: PerfResults = {}
+        for line in tmp:
+            data = json.loads(line)
+            if "event" in data and "counter-value" in data:
+                try:
+                    value = float(data["counter-value"])
+                except ValueError:
+                    continue
+                perf[data["event"]] = PerfResult(value=value, unit=data["unit"])
+
+        return MeasureResult(
+            perf=perf,
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+        )
+
+
+def get_perf_result(perf: PerfResults, metric: str) -> Result:
+    info = PERF_METRICS[metric]
+    if info.event not in perf:
+        raise SystemExit(f"perf did not report supported data for event {info.event!r}")
+    result = perf[info.event]
+    value = result.value * PERF_UNITS.get(result.unit, info.factor)
+    return Result(category=metric, value=value, unit=info.unit)
+
+
+def get_rusage_result(rusage: resource.struct_rusage, metric: str) -> Result:
+    info = RUSAGE_METRICS[metric]
+    value = getattr(rusage, info.name) * info.factor
+    return Result(category=metric, value=value, unit=info.unit)
+
+
+def main(
+    cmd: list[str],
+    output: Path,
+    topics: list[str],
+    metrics: set[str],
+    append: bool = True,
+    capture: bool = False,
+) -> tuple[str, str]:
+    perf_metrics, rusage_metrics = resolve_metrics(metrics)
+    perf_events = {PERF_METRICS[metric].event for metric in perf_metrics}
+
+    measured = measure_perf(cmd, perf_events, capture=capture)
+    rusage = resource.getrusage(resource.RUSAGE_CHILDREN)
+
+    results = [get_perf_result(measured.perf, metric) for metric in perf_metrics]
+    results.extend(get_rusage_result(rusage, metric) for metric in rusage_metrics)
+
+    with output.open("a" if append else "w", encoding="utf-8") as handle:
+        for result in results:
+            for topic in topics:
+                handle.write(result.fmt(topic) + "\n")
+
+    return measured.stdout, measured.stderr
+
+
+@dataclass
+class Args(Namespace):
+    topic: list[str]
+    metric: list[str]
+    default_metrics: bool
+    output: Path
+    append: bool
+    cmd: str
+    args: list[str]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Measure command resource usage using perf and rusage.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--topic", "-t", action="append", default=[], help="metric topic prefix")
+    parser.add_argument(
+        "--metric",
+        "-m",
+        action="append",
+        default=[],
+        help=f"metric to record; available metrics: {', '.join(sorted(ALL_METRICS))}",
+    )
+    parser.add_argument(
+        "--default-metrics",
+        "-d",
+        action="store_true",
+        help=f"record the default metric set: {', '.join(sorted(DEFAULT_METRICS))}",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=Path("measurements.jsonl"),
+        help="JSON Lines output file",
+    )
+    parser.add_argument("--append", "-a", action="store_true", help="append to output")
+    parser.add_argument("cmd", help="command to measure")
+    parser.add_argument("args", nargs="*", default=[], help="arguments for command")
+    args = parser.parse_args(namespace=Args)
+
+    metrics = set(args.metric)
+    if args.default_metrics:
+        metrics |= DEFAULT_METRICS
+
+    if not args.topic:
+        raise SystemExit("at least one --topic is required")
+
+    main(
+        cmd=[args.cmd] + args.args,
+        output=args.output,
+        topics=args.topic,
+        metrics=metrics,
+        append=args.append,
+    )

--- a/scripts/bench/report.py
+++ b/scripts/bench/report.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Measurements:
+    by_metric: dict[str, float]
+
+
+def load(path: Path) -> Measurements:
+    by_metric: dict[str, float] = {}
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            metric = record["metric"]
+            value = float(record["value"])
+            by_metric[metric] = by_metric.get(metric, 0) + value
+    return Measurements(by_metric=by_metric)
+
+
+def module_metric(module: str) -> str:
+    return f"build/module/{module}//instructions"
+
+
+def module_from_metric(metric: str) -> str | None:
+    prefix = "build/module/"
+    suffix = "//instructions"
+    if not metric.startswith(prefix) or not metric.endswith(suffix):
+        return None
+    return metric[len(prefix) : -len(suffix)]
+
+
+def fmt_int(value: float) -> str:
+    return f"{value:,.0f}"
+
+
+def fmt_pct(value: float) -> str:
+    return f"{value:+.2f}%"
+
+
+def print_summary(current: Measurements, baseline: Measurements | None) -> None:
+    current_total = current.by_metric.get("build//instructions")
+    baseline_total = baseline.by_metric.get("build//instructions") if baseline else None
+
+    print("# Build Benchmark Report")
+    print()
+    if current_total is None:
+        print("No whole-build instruction count found.")
+    elif baseline_total is None:
+        print(f"- Build instructions: `{fmt_int(current_total)}`")
+    else:
+        delta = current_total - baseline_total
+        pct = (delta / baseline_total * 100) if baseline_total else 0
+        print(f"- Build instructions: `{fmt_int(current_total)}` ({fmt_int(delta)} / {fmt_pct(pct)})")
+    print()
+
+
+def print_modules(current: Measurements, baseline: Measurements | None, limit: int) -> None:
+    modules = sorted(
+        module
+        for metric in current.by_metric
+        if (module := module_from_metric(metric)) is not None
+    )
+
+    if baseline is None:
+        rows = sorted(
+            ((current.by_metric[module_metric(module)], module) for module in modules),
+            reverse=True,
+        )[:limit]
+        print(f"## Slowest Modules By Instructions")
+        print()
+        print("| Instructions | Module |")
+        print("| ---: | --- |")
+        for instructions, module in rows:
+            print(f"| {fmt_int(instructions)} | `{module}` |")
+        return
+
+    rows = []
+    for module in modules:
+        metric = module_metric(module)
+        current_value = current.by_metric[metric]
+        baseline_value = baseline.by_metric.get(metric)
+        if baseline_value is None:
+            rows.append((current_value, 100.0, current_value, baseline_value, module))
+            continue
+        delta = current_value - baseline_value
+        pct = (delta / baseline_value * 100) if baseline_value else 0
+        rows.append((delta, pct, current_value, baseline_value, module))
+
+    rows.sort(key=lambda row: row[0], reverse=True)
+    print(f"## Largest Module Instruction Regressions")
+    print()
+    print("| Delta | Delta % | Current | Baseline | Module |")
+    print("| ---: | ---: | ---: | ---: | --- |")
+    for delta, pct, current_value, baseline_value, module in rows[:limit]:
+        baseline_text = "-" if baseline_value is None else fmt_int(baseline_value)
+        print(
+            f"| {fmt_int(delta)} | {fmt_pct(pct)} | {fmt_int(current_value)} | "
+            f"{baseline_text} | `{module}` |"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render build benchmark measurements.")
+    parser.add_argument("current", type=Path)
+    parser.add_argument("baseline", type=Path, nargs="?")
+    parser.add_argument("--limit", type=int, default=20)
+    args = parser.parse_args()
+
+    current = load(args.current)
+    baseline = load(args.baseline) if args.baseline else None
+    print_summary(current, baseline)
+    print_modules(current, baseline, args.limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/report.py
+++ b/scripts/bench/report.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -9,6 +10,25 @@ from pathlib import Path
 @dataclass
 class Measurements:
     by_metric: dict[str, float]
+
+
+@dataclass
+class ModuleRow:
+    module: str
+    current: float
+    baseline: float | None
+
+    @property
+    def delta(self) -> float | None:
+        if self.baseline is None:
+            return None
+        return self.current - self.baseline
+
+    @property
+    def delta_pct(self) -> float | None:
+        if self.baseline in (None, 0):
+            return None
+        return (self.current - self.baseline) / self.baseline * 100
 
 
 def load(path: Path) -> Measurements:
@@ -40,77 +60,174 @@ def fmt_int(value: float) -> str:
     return f"{value:,.0f}"
 
 
-def fmt_pct(value: float) -> str:
+def fmt_signed_int(value: float | None) -> str:
+    if value is None:
+        return "new"
+    return f"{value:+,.0f}"
+
+
+def fmt_pct(value: float | None) -> str:
+    if value is None:
+        return "-"
     return f"{value:+.2f}%"
 
 
+def fmt_seconds(value: float) -> str:
+    return f"{value:,.2f}s"
+
+
+def fmt_bytes(value: float) -> str:
+    mib = value / 1024 / 1024
+    return f"{mib:,.1f} MiB"
+
+
+def fmt_metric(metric: str, value: float) -> str:
+    if metric.endswith("//wall-clock") or metric.endswith("//task-clock"):
+        return fmt_seconds(value)
+    if metric.endswith("//maxrss"):
+        return fmt_bytes(value)
+    return fmt_int(value)
+
+
+def fmt_delta(metric: str, value: float | None) -> str:
+    if value is None:
+        return "new"
+    if metric.endswith("//wall-clock") or metric.endswith("//task-clock"):
+        return f"{value:+,.2f}s"
+    if metric.endswith("//maxrss"):
+        sign = "+" if value >= 0 else "-"
+        return f"{sign}{fmt_bytes(abs(value))}"
+    return fmt_signed_int(value)
+
+
 def print_summary(current: Measurements, baseline: Measurements | None) -> None:
-    current_total = current.by_metric.get("build//instructions")
-    baseline_total = baseline.by_metric.get("build//instructions") if baseline else None
+    metrics = [
+        ("Build instructions", "build//instructions"),
+        ("Wall time", "build//wall-clock"),
+        ("Task clock", "build//task-clock"),
+        ("Max RSS", "build//maxrss"),
+    ]
 
     print("# Build Benchmark Report")
     print()
-    if current_total is None:
-        print("No whole-build instruction count found.")
-    elif baseline_total is None:
-        print(f"- Build instructions: `{fmt_int(current_total)}`")
-    else:
-        delta = current_total - baseline_total
-        pct = (delta / baseline_total * 100) if baseline_total else 0
-        print(f"- Build instructions: `{fmt_int(current_total)}` ({fmt_int(delta)} / {fmt_pct(pct)})")
+    print("| Metric | Current | Baseline | Delta | Delta % |")
+    print("| --- | ---: | ---: | ---: | ---: |")
+    for label, metric in metrics:
+        current_value = current.by_metric.get(metric)
+        baseline_value = baseline.by_metric.get(metric) if baseline else None
+        if current_value is None:
+            continue
+        delta = None if baseline_value is None else current_value - baseline_value
+        pct = None if baseline_value in (None, 0) else delta / baseline_value * 100
+        baseline_text = "-" if baseline_value is None else fmt_metric(metric, baseline_value)
+        delta_text = "-" if baseline_value is None else fmt_delta(metric, delta)
+        print(
+            f"| {label} | {fmt_metric(metric, current_value)} | {baseline_text} | "
+            f"{delta_text} | {fmt_pct(pct)} |"
+        )
     print()
 
 
-def print_modules(current: Measurements, baseline: Measurements | None, limit: int) -> None:
+def get_module_rows(current: Measurements, baseline: Measurements | None) -> list[ModuleRow]:
     modules = sorted(
         module
         for metric in current.by_metric
         if (module := module_from_metric(metric)) is not None
     )
-
-    if baseline is None:
-        rows = sorted(
-            ((current.by_metric[module_metric(module)], module) for module in modules),
-            reverse=True,
-        )[:limit]
-        print(f"## Slowest Modules By Instructions")
-        print()
-        print("| Instructions | Module |")
-        print("| ---: | --- |")
-        for instructions, module in rows:
-            print(f"| {fmt_int(instructions)} | `{module}` |")
-        return
-
     rows = []
     for module in modules:
         metric = module_metric(module)
-        current_value = current.by_metric[metric]
-        baseline_value = baseline.by_metric.get(metric)
-        if baseline_value is None:
-            rows.append((current_value, 100.0, current_value, baseline_value, module))
-            continue
-        delta = current_value - baseline_value
-        pct = (delta / baseline_value * 100) if baseline_value else 0
-        rows.append((delta, pct, current_value, baseline_value, module))
+        rows.append(
+            ModuleRow(
+                module=module,
+                current=current.by_metric[metric],
+                baseline=baseline.by_metric.get(metric) if baseline else None,
+            )
+        )
+    return rows
 
-    rows.sort(key=lambda row: row[0], reverse=True)
-    print(f"## Largest Module Instruction Regressions")
+
+def print_module_table(
+    title: str,
+    rows: Iterable[ModuleRow],
+    limit: int,
+    empty_message: str,
+) -> None:
+    rows = list(rows)[:limit]
+    print(f"## {title}")
     print()
+    if not rows:
+        print(empty_message)
+        print()
+        return
+
     print("| Delta | Delta % | Current | Baseline | Module |")
     print("| ---: | ---: | ---: | ---: | --- |")
-    for delta, pct, current_value, baseline_value, module in rows[:limit]:
-        baseline_text = "-" if baseline_value is None else fmt_int(baseline_value)
+    for row in rows:
+        baseline_text = "-" if row.baseline is None else fmt_int(row.baseline)
         print(
-            f"| {fmt_int(delta)} | {fmt_pct(pct)} | {fmt_int(current_value)} | "
-            f"{baseline_text} | `{module}` |"
+            f"| {fmt_signed_int(row.delta)} | {fmt_pct(row.delta_pct)} | "
+            f"{fmt_int(row.current)} | {baseline_text} | `{row.module}` |"
         )
+    print()
+
+
+def print_modules(current: Measurements, baseline: Measurements | None, limit: int) -> None:
+    rows = get_module_rows(current, baseline)
+
+    if baseline is None:
+        print_module_table(
+            "Longest-Running Modules By Instructions",
+            sorted(rows, key=lambda row: row.current, reverse=True),
+            limit,
+            "No module instruction measurements found.",
+        )
+        return
+
+    def is_regression(row: ModuleRow) -> bool:
+        return row.delta is None or row.delta > 0
+
+    def is_improvement(row: ModuleRow) -> bool:
+        return row.delta is not None and row.delta < 0
+
+    print_module_table(
+        "Top Module Instruction Regressions",
+        sorted(filter(is_regression, rows), key=regression_key, reverse=True),
+        limit,
+        "No module instruction regressions found.",
+    )
+    print_module_table(
+        "Top Module Instruction Improvements",
+        sorted(filter(is_improvement, rows), key=lambda row: row.delta or 0),
+        limit,
+        "No module instruction improvements found.",
+    )
+    print_module_table(
+        "Longest-Running Modules By Instructions",
+        sorted(rows, key=lambda row: row.current, reverse=True),
+        limit,
+        "No module instruction measurements found.",
+    )
+
+
+def regression_key(row: ModuleRow) -> float:
+    if row.delta is None:
+        return row.current
+    return row.delta
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Render build benchmark measurements.")
     parser.add_argument("current", type=Path)
     parser.add_argument("baseline", type=Path, nargs="?")
-    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--limit", type=positive_int, default=10)
     args = parser.parse_args()
 
     current = load(args.current)

--- a/scripts/bench/report.py
+++ b/scripts/bench/report.py
@@ -60,10 +60,23 @@ def fmt_int(value: float) -> str:
     return f"{value:,.0f}"
 
 
+def fmt_instructions_bn(value: float) -> str:
+    return f"{value / 1_000_000_000:,.0f}"
+
+
 def fmt_signed_int(value: float | None) -> str:
     if value is None:
         return "new"
     return f"{value:+,.0f}"
+
+
+def fmt_signed_instructions_bn(value: float | None) -> str:
+    if value is None:
+        return "new"
+    rounded = round(value / 1_000_000_000)
+    if rounded == 0:
+        return "0"
+    return f"{rounded:+,}"
 
 
 def fmt_pct(value: float | None) -> str:
@@ -82,6 +95,8 @@ def fmt_bytes(value: float) -> str:
 
 
 def fmt_metric(metric: str, value: float) -> str:
+    if metric.endswith("//instructions"):
+        return fmt_instructions_bn(value)
     if metric.endswith("//wall-clock") or metric.endswith("//task-clock"):
         return fmt_seconds(value)
     if metric.endswith("//maxrss"):
@@ -92,6 +107,8 @@ def fmt_metric(metric: str, value: float) -> str:
 def fmt_delta(metric: str, value: float | None) -> str:
     if value is None:
         return "new"
+    if metric.endswith("//instructions"):
+        return fmt_signed_instructions_bn(value)
     if metric.endswith("//wall-clock") or metric.endswith("//task-clock"):
         return f"{value:+,.2f}s"
     if metric.endswith("//maxrss"):
@@ -102,7 +119,7 @@ def fmt_delta(metric: str, value: float | None) -> str:
 
 def print_summary(current: Measurements, baseline: Measurements | None) -> None:
     metrics = [
-        ("Build instructions", "build//instructions"),
+        ("Build instructions (bn)", "build//instructions"),
         ("Wall time", "build//wall-clock"),
         ("Task clock", "build//task-clock"),
         ("Max RSS", "build//maxrss"),
@@ -161,13 +178,13 @@ def print_module_table(
         print()
         return
 
-    print("| Delta | Delta % | Current | Baseline | Module |")
+    print("| Delta (bn) | Delta % | Current (bn) | Baseline (bn) | Module |")
     print("| ---: | ---: | ---: | ---: | --- |")
     for row in rows:
-        baseline_text = "-" if row.baseline is None else fmt_int(row.baseline)
+        baseline_text = "-" if row.baseline is None else fmt_instructions_bn(row.baseline)
         print(
-            f"| {fmt_signed_int(row.delta)} | {fmt_pct(row.delta_pct)} | "
-            f"{fmt_int(row.current)} | {baseline_text} | `{row.module}` |"
+            f"| {fmt_signed_instructions_bn(row.delta)} | {fmt_pct(row.delta_pct)} | "
+            f"{fmt_instructions_bn(row.current)} | {baseline_text} | `{row.module}` |"
         )
     print()
 

--- a/scripts/bench/run
+++ b/scripts/bench/run
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BENCH="scripts/bench"
+
+echo "Running benchmark: build"
+"$BENCH/build/run"

--- a/scripts/bench/runner/Dockerfile
+++ b/scripts/bench/runner/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH=/root/.elan/bin:$PATH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    jq \
+    linux-tools-generic \
+    python3 \
+    xz-utils \
+    zstd \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+  | sh -s -- -y --default-toolchain none
+
+WORKDIR /workspace/clean

--- a/scripts/bench/runner/run-in-docker.sh
+++ b/scripts/bench/runner/run-in-docker.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${BENCH_PR:?BENCH_PR is required}"
+: "${BENCH_SHA:?BENCH_SHA is required}"
+: "${BENCH_HEAD_REPO:?BENCH_HEAD_REPO is required}"
+: "${BENCH_REPOSITORY:?BENCH_REPOSITORY is required}"
+: "${BENCH_RUN_ID:?BENCH_RUN_ID is required}"
+: "${BENCH_OUTPUT_DIR:?BENCH_OUTPUT_DIR is required}"
+
+ROOT="${BENCH_ROOT:-/var/lib/clean-bench}"
+IMAGE="${BENCH_IMAGE:-clean-bench-runner:latest}"
+RUN_DIR="$ROOT/runs/$BENCH_RUN_ID"
+CACHE_DIR="$ROOT/cache"
+WORK_DIR="$RUN_DIR/work"
+
+mkdir -p "$CACHE_DIR/elan" "$WORK_DIR" "$RUN_DIR/xdg-cache" "$BENCH_OUTPUT_DIR"
+rm -rf "$WORK_DIR/clean"
+
+docker build -t "$IMAGE" -f scripts/bench/runner/Dockerfile scripts/bench/runner
+
+git clone --filter=blob:none "https://github.com/$BENCH_HEAD_REPO.git" "$WORK_DIR/clean"
+git -C "$WORK_DIR/clean" fetch --no-tags "https://github.com/$BENCH_HEAD_REPO.git" "$BENCH_SHA"
+git -C "$WORK_DIR/clean" checkout --detach "$BENCH_SHA"
+
+TOOLCHAIN="$(sed -n '1p' "$WORK_DIR/clean/lean-toolchain")"
+docker run --rm \
+  --network bridge \
+  -e ELAN_HOME=/bench-cache/elan \
+  -v "$CACHE_DIR/elan:/bench-cache/elan" \
+  "$IMAGE" \
+  elan toolchain install "$TOOLCHAIN"
+
+PERF_MOUNTS=()
+HOST_PERF=""
+if [ -x "/usr/lib/linux-tools/$(uname -r)/perf" ]; then
+  HOST_PERF="/usr/lib/linux-tools/$(uname -r)/perf"
+elif [ -x "/usr/lib/linux-tools-$(uname -r | sed 's/-generic$//')/perf" ]; then
+  HOST_PERF="/usr/lib/linux-tools-$(uname -r | sed 's/-generic$//')/perf"
+elif [ -x /usr/bin/perf ]; then
+  HOST_PERF="/usr/bin/perf"
+fi
+if [ -n "$HOST_PERF" ]; then
+  PERF_MOUNTS+=(-v "$HOST_PERF:/usr/local/bin/perf:ro")
+fi
+
+docker run --rm \
+  --cap-add PERFMON \
+  --security-opt seccomp=unconfined \
+  --security-opt no-new-privileges \
+  --network bridge \
+  -e XDG_CACHE_HOME=/workspace/xdg-cache \
+  -e ELAN_HOME=/bench-cache/elan \
+  -v "$WORK_DIR/clean:/workspace/clean" \
+  -v "$CACHE_DIR/elan:/bench-cache/elan:ro" \
+  -v "$RUN_DIR/xdg-cache:/workspace/xdg-cache" \
+  -v "$BENCH_OUTPUT_DIR:/bench-output" \
+  "${PERF_MOUNTS[@]}" \
+  "$IMAGE" \
+  bash -lc 'scripts/bench/build/run && cp measurements.jsonl /bench-output/measurements.jsonl'
+
+rm -rf "$RUN_DIR"

--- a/scripts/bench/runner/run-in-docker.sh
+++ b/scripts/bench/runner/run-in-docker.sh
@@ -66,7 +66,7 @@ run_benchmark() {
   package_cache_key="$(
     {
       printf '%s\n' "$toolchain"
-      sha256sum "$checkout/lake-manifest.json"
+      sha256sum "$checkout/lake-manifest.json" | cut -d' ' -f1
     } | sha256sum | cut -d' ' -f1
   )"
   local package_cache="$CACHE_DIR/lake-packages/$package_cache_key"

--- a/scripts/bench/runner/run-in-docker.sh
+++ b/scripts/bench/runner/run-in-docker.sh
@@ -38,9 +38,10 @@ run_benchmark() {
   local repo="$2"
   local sha="$3"
   local checkout="$WORK_DIR/$label/clean"
+  local elan_home="$RUN_DIR/elan-home/$label"
   local xdg_cache="$RUN_DIR/xdg-cache/$label"
 
-  mkdir -p "$xdg_cache"
+  mkdir -p "$elan_home" "$xdg_cache"
   git clone --filter=blob:none "https://github.com/$repo.git" "$checkout"
   git -C "$checkout" fetch --no-tags "https://github.com/$repo.git" "$sha"
   git -C "$checkout" checkout --detach "$sha"
@@ -50,12 +51,22 @@ run_benchmark() {
 
   local toolchain
   toolchain="$(sed -n '1p' "$checkout/lean-toolchain")"
+  local package_cache_key
+  package_cache_key="$(
+    {
+      printf '%s\n' "$toolchain"
+      sha256sum "$checkout/lake-manifest.json"
+    } | sha256sum | cut -d' ' -f1
+  )"
+  local package_cache="$CACHE_DIR/lake-packages/$package_cache_key"
+  mkdir -p "$checkout/.lake" "$package_cache"
+
   docker run --rm \
     --network bridge \
     -e ELAN_HOME=/bench-cache/elan \
     -v "$CACHE_DIR/elan:/bench-cache/elan" \
     "$IMAGE" \
-    elan toolchain install "$toolchain"
+    bash -lc 'elan toolchain install "$1" || elan toolchain list | grep -Fxq "$1"' bash "$toolchain"
 
   docker run --rm \
     --cap-add PERFMON \
@@ -63,10 +74,12 @@ run_benchmark() {
     --security-opt no-new-privileges \
     --network bridge \
     -e XDG_CACHE_HOME=/workspace/xdg-cache \
-    -e ELAN_HOME=/bench-cache/elan \
+    -e ELAN_HOME=/workspace/elan-home \
     -e BENCH_OUTPUT_FILE="/bench-output/$label.jsonl" \
     -v "$checkout:/workspace/clean" \
-    -v "$CACHE_DIR/elan:/bench-cache/elan:ro" \
+    -v "$package_cache:/workspace/clean/.lake/packages" \
+    -v "$elan_home:/workspace/elan-home" \
+    -v "$CACHE_DIR/elan/toolchains:/workspace/elan-home/toolchains:ro" \
     -v "$xdg_cache:/workspace/xdg-cache" \
     -v "$BENCH_OUTPUT_DIR:/bench-output" \
     "${PERF_MOUNTS[@]}" \

--- a/scripts/bench/runner/run-in-docker.sh
+++ b/scripts/bench/runner/run-in-docker.sh
@@ -16,7 +16,18 @@ CACHE_DIR="$ROOT/cache"
 WORK_DIR="$RUN_DIR/work"
 
 mkdir -p "$CACHE_DIR/elan" "$WORK_DIR" "$BENCH_OUTPUT_DIR"
-trap 'rm -rf "$RUN_DIR"' EXIT
+
+cleanup() {
+  rm -rf "$RUN_DIR" 2>/dev/null && return
+  docker run --rm \
+    --network none \
+    --security-opt no-new-privileges \
+    -v "$RUN_DIR:$RUN_DIR" \
+    "$IMAGE" \
+    rm -rf "$RUN_DIR" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
 
 docker build -t "$IMAGE" -f scripts/bench/runner/Dockerfile scripts/bench/runner
 

--- a/scripts/bench/runner/run-in-docker.sh
+++ b/scripts/bench/runner/run-in-docker.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 : "${BENCH_PR:?BENCH_PR is required}"
+: "${BENCH_BASE_SHA:?BENCH_BASE_SHA is required}"
 : "${BENCH_SHA:?BENCH_SHA is required}"
 : "${BENCH_HEAD_REPO:?BENCH_HEAD_REPO is required}"
 : "${BENCH_REPOSITORY:?BENCH_REPOSITORY is required}"
@@ -14,22 +15,10 @@ RUN_DIR="$ROOT/runs/$BENCH_RUN_ID"
 CACHE_DIR="$ROOT/cache"
 WORK_DIR="$RUN_DIR/work"
 
-mkdir -p "$CACHE_DIR/elan" "$WORK_DIR" "$RUN_DIR/xdg-cache" "$BENCH_OUTPUT_DIR"
-rm -rf "$WORK_DIR/clean"
+mkdir -p "$CACHE_DIR/elan" "$WORK_DIR" "$BENCH_OUTPUT_DIR"
+trap 'rm -rf "$RUN_DIR"' EXIT
 
 docker build -t "$IMAGE" -f scripts/bench/runner/Dockerfile scripts/bench/runner
-
-git clone --filter=blob:none "https://github.com/$BENCH_HEAD_REPO.git" "$WORK_DIR/clean"
-git -C "$WORK_DIR/clean" fetch --no-tags "https://github.com/$BENCH_HEAD_REPO.git" "$BENCH_SHA"
-git -C "$WORK_DIR/clean" checkout --detach "$BENCH_SHA"
-
-TOOLCHAIN="$(sed -n '1p' "$WORK_DIR/clean/lean-toolchain")"
-docker run --rm \
-  --network bridge \
-  -e ELAN_HOME=/bench-cache/elan \
-  -v "$CACHE_DIR/elan:/bench-cache/elan" \
-  "$IMAGE" \
-  elan toolchain install "$TOOLCHAIN"
 
 PERF_MOUNTS=()
 HOST_PERF=""
@@ -44,19 +33,46 @@ if [ -n "$HOST_PERF" ]; then
   PERF_MOUNTS+=(-v "$HOST_PERF:/usr/local/bin/perf:ro")
 fi
 
-docker run --rm \
-  --cap-add PERFMON \
-  --security-opt seccomp=unconfined \
-  --security-opt no-new-privileges \
-  --network bridge \
-  -e XDG_CACHE_HOME=/workspace/xdg-cache \
-  -e ELAN_HOME=/bench-cache/elan \
-  -v "$WORK_DIR/clean:/workspace/clean" \
-  -v "$CACHE_DIR/elan:/bench-cache/elan:ro" \
-  -v "$RUN_DIR/xdg-cache:/workspace/xdg-cache" \
-  -v "$BENCH_OUTPUT_DIR:/bench-output" \
-  "${PERF_MOUNTS[@]}" \
-  "$IMAGE" \
-  bash -lc 'scripts/bench/build/run && cp measurements.jsonl /bench-output/measurements.jsonl'
+run_benchmark() {
+  local label="$1"
+  local repo="$2"
+  local sha="$3"
+  local checkout="$WORK_DIR/$label/clean"
+  local xdg_cache="$RUN_DIR/xdg-cache/$label"
 
-rm -rf "$RUN_DIR"
+  mkdir -p "$xdg_cache"
+  git clone --filter=blob:none "https://github.com/$repo.git" "$checkout"
+  git -C "$checkout" fetch --no-tags "https://github.com/$repo.git" "$sha"
+  git -C "$checkout" checkout --detach "$sha"
+  rm -rf "$checkout/scripts/bench"
+  mkdir -p "$checkout/scripts"
+  cp -a scripts/bench "$checkout/scripts/bench"
+
+  local toolchain
+  toolchain="$(sed -n '1p' "$checkout/lean-toolchain")"
+  docker run --rm \
+    --network bridge \
+    -e ELAN_HOME=/bench-cache/elan \
+    -v "$CACHE_DIR/elan:/bench-cache/elan" \
+    "$IMAGE" \
+    elan toolchain install "$toolchain"
+
+  docker run --rm \
+    --cap-add PERFMON \
+    --security-opt seccomp=unconfined \
+    --security-opt no-new-privileges \
+    --network bridge \
+    -e XDG_CACHE_HOME=/workspace/xdg-cache \
+    -e ELAN_HOME=/bench-cache/elan \
+    -e BENCH_OUTPUT_FILE="/bench-output/$label.jsonl" \
+    -v "$checkout:/workspace/clean" \
+    -v "$CACHE_DIR/elan:/bench-cache/elan:ro" \
+    -v "$xdg_cache:/workspace/xdg-cache" \
+    -v "$BENCH_OUTPUT_DIR:/bench-output" \
+    "${PERF_MOUNTS[@]}" \
+    "$IMAGE" \
+    bash -lc 'scripts/bench/build/run && cp measurements.jsonl "$BENCH_OUTPUT_FILE"'
+}
+
+run_benchmark baseline "$BENCH_REPOSITORY" "$BENCH_BASE_SHA"
+run_benchmark current "$BENCH_HEAD_REPO" "$BENCH_SHA"


### PR DESCRIPTION
## Summary

Adds a maintainer-triggered Lean build benchmark flow for catching build-time regressions using instruction counts rather than noisy wall-clock timings.

## Changes

- Adds a mathlib-style benchmark suite under `scripts/bench`.
- Records whole-build resource metrics, per-module instruction counts, line counts, and Lean profile buckets as JSONL.
- Adds `scripts/bench/report.py` to render benchmark summaries.
- Adds `Bench Command`, where maintainers can comment `/bench` on a PR to dispatch a benchmark for the PR head SHA.
- Adds `Bench`, a `workflow_dispatch` workflow that targets the self-hosted `clean-bench` runner and runs PR code inside Docker.
- Adds a Docker wrapper that keeps the PR checkout per-run, preserves Lean toolchain cache under `/var/lib/clean-bench/cache/elan`, and mounts that cache read-only while PR code runs.

## Runner setup

A repo-scoped self-hosted runner has been set up on `kevin`:

- runner: `kevin-clean-bench`
- labels: `self-hosted`, `Linux`, `X64`, `clean-bench`
- service: `actions.runner.Verified-zkEVM-clean.kevin-clean-bench.service`
- runner user: `github-bench-runner`

The runner details were also documented on the host in `/root/bot/SYSTEM.md`.

## Validation

- `bash -n scripts/bench/run scripts/bench/build/run scripts/bench/runner/run-in-docker.sh`
- `python3 -m py_compile scripts/bench/measure.py scripts/bench/report.py scripts/bench/build/fake-root/bin/lean`
- YAML parse check for `.github/workflows/bench.yml` and `.github/workflows/bench-command.yml`
- `python3 scripts/check-consecutive-empty-lines.py`
- Host/container perf smoke test on `kevin` for `instructions:u`

This is a replacement for #383 to avoid stale required-check state from the earlier automatic benchmark workflow.