### PR TITLE
[codex] Use Lean heartbeats as benchmark module metric

### DIFF
--- a/.github/workflows/bench-command.yml
+++ b/.github/workflows/bench-command.yml
@@ -64,7 +64,7 @@ jobs:
           printf -v body '%s\n\n%s\n\n%s' \
             'Benchmark queued! ⏱️' \
             "We are comparing the PR HEAD against the base: [$compare_url_tail]($compare_url)." \
-            'Expect this to take ~10 minutes to complete.'
+            'Expect this to take ~30 minutes to complete.'
           gh api \
             --method POST \
             "repos/${{ github.repository }}/issues/${{ steps.pr.outputs.number }}/comments" \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -52,6 +52,7 @@ jobs:
           BENCH_REPOSITORY: ${{ github.repository }}
           BENCH_RUN_ID: ${{ github.run_id }}
           BENCH_OUTPUT_DIR: ${{ github.workspace }}/bench-output
+          BENCH_HEARTBEATS: "1"
         run: scripts/bench/runner/run-in-docker.sh
       - name: Copy measurements
         if: always()

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -15,7 +15,7 @@ Run only the build benchmark:
 scripts/bench/build/run
 ```
 
-The build benchmark records whole-build resource metrics and per-module instruction counts. Instruction counts are the preferred regression signal because wall-clock time is noisy on shared CI runners.
+The build benchmark records whole-build resource metrics and per-module instruction counts. When `BENCH_HEARTBEATS=1` is set, it also records deterministic per-module frontend heartbeat counts.
 
 Render a report from one run:
 
@@ -36,6 +36,8 @@ When heartbeat measurements are available, render the module tables by heartbeat
 ```bash
 scripts/bench/report.py current.jsonl baseline.jsonl --module-metric heartbeats
 ```
+
+Set `BENCH_HEARTBEATS=1` when running the benchmark to collect heartbeat measurements.
 
 ## Maintainer-triggered PR benchmarks
 

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -31,6 +31,12 @@ scripts/bench/report.py current.jsonl baseline.jsonl
 
 Comparison reports show the whole-build summary plus the top 10 module instruction regressions, top 10 module instruction improvements, and top 10 longest-running modules.
 
+When heartbeat measurements are available, render the module tables by heartbeats instead of instructions:
+
+```bash
+scripts/bench/report.py current.jsonl baseline.jsonl --module-metric heartbeats
+```
+
 ## Maintainer-triggered PR benchmarks
 
 After the benchmark workflows are present on the default branch, maintainers can comment on a pull request with:

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -15,7 +15,7 @@ Run only the build benchmark:
 scripts/bench/build/run
 ```
 
-The build benchmark records whole-build resource metrics and per-module instruction counts. When `BENCH_HEARTBEATS=1` is set, it also records deterministic per-module frontend heartbeat counts.
+The build benchmark records whole-build resource metrics and per-module instruction counts. When `BENCH_HEARTBEATS=1` is set, it also records deterministic per-module frontend heartbeat counts. The maintainer-triggered PR workflow enables heartbeat collection by default.
 
 Render a report from one run:
 
@@ -29,12 +29,12 @@ Compare a current run against a baseline:
 scripts/bench/report.py current.jsonl baseline.jsonl
 ```
 
-Comparison reports show the whole-build summary plus the top 10 module instruction regressions, top 10 module instruction improvements, and top 10 longest-running modules.
+Comparison reports show the whole-build summary plus the top 10 module heartbeat regressions, top 10 module heartbeat improvements, and top 10 highest-heartbeat modules.
 
-When heartbeat measurements are available, render the module tables by heartbeats instead of instructions:
+Render the module tables by instructions instead of heartbeats:
 
 ```bash
-scripts/bench/report.py current.jsonl baseline.jsonl --module-metric heartbeats
+scripts/bench/report.py current.jsonl baseline.jsonl --module-metric instructions
 ```
 
 Set `BENCH_HEARTBEATS=1` when running the benchmark to collect heartbeat measurements.

--- a/scripts/bench/build/HeartbeatCheck.lean
+++ b/scripts/bench/build/HeartbeatCheck.lean
@@ -1,0 +1,154 @@
+import Lean
+import Lean.Elab.Frontend
+import Lean.Elab.Import
+import Mathlib.Util.CountHeartbeats
+
+open Lean System Elab Command
+
+structure CommandHeartbeat where
+  name : String
+  heartbeats : Nat
+
+structure Args where
+  file : String := ""
+  setup? : Option FilePath := none
+  jsonOutput : Bool := false
+  opts : Options := {}
+
+def parseD (opts : Options) (arg : String) : IO Options := do
+  let pos := arg.find '='
+  if h : pos.IsAtEnd then
+    throw <| IO.userError s!"invalid -D argument {arg}"
+  else
+    let name := arg.sliceTo pos |>.toName
+    let val := arg.sliceFrom (pos.next h) |>.copy
+    if let some decl := (← getOptionDecls).find? name then
+      Language.Lean.setOption opts decl name val
+    else
+      return opts.set name val
+
+partial def parseArgs (args : List String) (acc : Args := {}) : IO Args := do
+  match args with
+  | [] => return acc
+  | "--json" :: xs => parseArgs xs { acc with jsonOutput := true }
+  | "--setup" :: x :: xs => parseArgs xs { acc with setup? := some x }
+  | "-D" :: x :: xs => parseArgs xs { acc with opts := (← parseD acc.opts x) }
+  | x :: xs =>
+      if x.startsWith "-D" then
+        parseArgs xs { acc with opts := (← parseD acc.opts (x.drop 2).toString) }
+      else if x == "-o" || x == "--o" || x == "-i" || x == "--i" || x == "-c" || x == "--c" then
+        match xs with
+        | _ :: ys => parseArgs ys acc
+        | [] => parseArgs [] acc
+      else if acc.file == "" then
+        parseArgs xs { acc with file := x }
+      else
+        parseArgs xs acc
+
+def commandName (stx : Syntax) : String :=
+  match stx.find? (·.isOfKind ``Parser.Command.declId) with
+  | some decl => toString decl[0].getId
+  | none => toString stx.getKind
+
+def runCommandElabM
+    (inputCtx : Parser.InputContext)
+    (cmdPos : String.Pos.Raw)
+    (x : CommandElabM α)
+    (state : State) : IO (α × State) := do
+  let cmdCtx : Context := {
+    cmdPos
+    fileName := inputCtx.fileName
+    fileMap := inputCtx.fileMap
+    snap? := none
+    cancelTk? := none
+  }
+  match ← EIO.toIO' ((x cmdCtx).run state) with
+  | Except.error e => throw <| IO.userError s!"unexpected internal error: {← e.toMessageData.toString}"
+  | Except.ok result => return result
+
+partial def processCommandsWithHeartbeats
+    (inputCtx : Parser.InputContext)
+    (parserState : Parser.ModuleParserState)
+    (commandState : State)
+    (acc : Array CommandHeartbeat := #[]) : IO (State × Array CommandHeartbeat) := do
+  let scope := commandState.scopes.head!
+  let pmctx := {
+    env := commandState.env
+    options := scope.opts
+    currNamespace := scope.currNamespace
+    openDecls := scope.openDecls
+  }
+  let (cmd, parserState, messages) :=
+    Parser.parseCommand inputCtx pmctx parserState commandState.messages
+  let commandState := { commandState with messages }
+
+  if Parser.isTerminalCommand cmd then
+    return (commandState, acc)
+
+  let (heartbeats, commandState) ←
+    runCommandElabM inputCtx parserState.pos
+      (Mathlib.CountHeartbeats.elabForHeartbeats ⟨cmd⟩)
+      commandState
+
+  let (_, commandState) ←
+    runCommandElabM inputCtx parserState.pos (elabCommandTopLevel cmd) commandState
+
+  processCommandsWithHeartbeats inputCtx parserState commandState
+    (acc.push { name := commandName cmd, heartbeats := heartbeats / 1000 })
+
+def runFrontendWithCommandHeartbeats
+    (input : String)
+    (opts : Options)
+    (fileName : String)
+    (mainModuleName : Name)
+    (setup? : Option ModuleSetup := none) :
+    IO (Option (Environment × Array CommandHeartbeat)) := do
+  let inputCtx := Parser.mkInputContext input fileName
+  let (header, parserState, messages) ← Parser.parseHeader inputCtx
+  let opts := Lean.internal.cmdlineSnapshots.setIfNotSet opts true
+  let opts := Elab.async.setIfNotSet opts true
+  let (imports, isModule, mainModuleName, package?, importArts, plugins, opts) ←
+    if let some setup := setup? then
+      setup.dynlibs.forM Lean.loadDynlib
+      pure (
+        setup.imports?.getD (Elab.HeaderSyntax.imports header),
+        strictOr setup.isModule (Elab.HeaderSyntax.isModule header),
+        setup.name,
+        setup.package?,
+        setup.importArts,
+        setup.plugins,
+        opts.mergeBy (fun _ _ hOpt => hOpt) setup.options.toOptions
+      )
+    else
+      pure (Elab.HeaderSyntax.imports header, Elab.HeaderSyntax.isModule header, mainModuleName, none, {}, #[], opts)
+  let (env, messages) ← Elab.processHeaderCore (leakEnv := true)
+    (Elab.HeaderSyntax.startPos header) imports isModule opts messages inputCtx 0 plugins mainModuleName package? importArts
+  if messages.hasErrors then
+    messages.forM fun msg => msg.toString >>= IO.eprintln
+    return none
+  let commandState := mkState env messages opts
+  let (commandState, heartbeats) ← processCommandsWithHeartbeats inputCtx parserState commandState
+  if commandState.messages.hasErrors then
+    commandState.messages.forM fun msg => msg.toString >>= IO.eprintln
+    return none
+  return some (commandState.env, heartbeats)
+
+def main (argv : List String) : IO UInt32 := do
+  unsafe Lean.enableInitializersExecution
+  let args ← parseArgs argv
+  if args.file == "" then
+    IO.eprintln "expected Lean file"
+    return 1
+  let contents ← IO.FS.readFile args.file
+  let setup? ← args.setup?.mapM ModuleSetup.load
+  let mainModuleName ←
+    if let some setup := setup? then pure setup.name else moduleNameOfFileName args.file none
+  let result? ← runFrontendWithCommandHeartbeats contents args.opts args.file mainModuleName setup?
+  let some (_, commandHeartbeats) := result?
+    | return 1
+  let total := commandHeartbeats.foldl (· + ·.heartbeats) 0
+  IO.println s!"HEARTBEATS {mainModuleName} {total}"
+  for row in commandHeartbeats do
+    if row.heartbeats > 0 then
+      IO.println s!"COMMAND_HEARTBEATS {mainModuleName} {row.name} {row.heartbeats}"
+  return 0

--- a/scripts/bench/build/HeartbeatCheck.lean
+++ b/scripts/bench/build/HeartbeatCheck.lean
@@ -106,7 +106,7 @@ def runFrontendWithCommandHeartbeats
   let inputCtx := Parser.mkInputContext input fileName
   let (header, parserState, messages) ← Parser.parseHeader inputCtx
   let opts := Lean.internal.cmdlineSnapshots.setIfNotSet opts true
-  let opts := Elab.async.setIfNotSet opts true
+  let opts := Elab.async.set opts false
   let (imports, isModule, mainModuleName, package?, importArts, plugins, opts) ←
     if let some setup := setup? then
       setup.dynlibs.forM Lean.loadDynlib

--- a/scripts/bench/build/README.md
+++ b/scripts/bench/build/README.md
@@ -23,4 +23,4 @@ Lean profile metrics, summed by downstream consumers when metric names repeat:
 
 The benchmark overrides the Lean executable that Lake uses, so module measurements come from the actual Lake build graph rather than a separate one-file-at-a-time pass.
 
-The heartbeat metric is experimental. It reruns Lean's frontend for each successfully built module, re-elaborates each command with Mathlib's heartbeat-counting helper before elaborating it for real, and records the sum of user-facing heartbeat counts.
+The heartbeat metric reruns Lean's frontend for each successfully built module, re-elaborates each command with Mathlib's heartbeat-counting helper before elaborating it for real, and records the sum of user-facing heartbeat counts.

--- a/scripts/bench/build/README.md
+++ b/scripts/bench/build/README.md
@@ -23,4 +23,4 @@ Lean profile metrics, summed by downstream consumers when metric names repeat:
 
 The benchmark overrides the Lean executable that Lake uses, so module measurements come from the actual Lake build graph rather than a separate one-file-at-a-time pass.
 
-The heartbeat metric is experimental. It enables Lean's heartbeat profiler and sums top-level profiler events for each module invocation.
+The heartbeat metric is experimental. It reruns Lean's frontend for each successfully built module, re-elaborates each command with Mathlib's heartbeat-counting helper before elaborating it for real, and records the sum of user-facing heartbeat counts.

--- a/scripts/bench/build/README.md
+++ b/scripts/bench/build/README.md
@@ -15,9 +15,12 @@ Per-module metrics:
 
 - `build/module/<module>//instructions`
 - `build/module/<module>//lines`
+- `build/module/<module>//heartbeats` when `BENCH_HEARTBEATS=1`
 
 Lean profile metrics, summed by downstream consumers when metric names repeat:
 
 - `build/profile/<name>//wall-clock`
 
 The benchmark overrides the Lean executable that Lake uses, so module measurements come from the actual Lake build graph rather than a separate one-file-at-a-time pass.
+
+The heartbeat metric is experimental. It enables Lean's heartbeat profiler and sums top-level profiler events for each module invocation.

--- a/scripts/bench/build/fake-root/bin/lean
+++ b/scripts/bench/build/fake-root/bin/lean
@@ -6,7 +6,6 @@ import os
 import re
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 NAME = "build"
@@ -60,17 +59,6 @@ def save_profile_metrics_from_lines(lines) -> None:
         save_result(f"{NAME}/profile/{name}//wall-clock", seconds, "s")
 
 
-def save_heartbeat_metrics_from_lines(lines, module: str) -> None:
-    heartbeats = 0
-    for line in lines:
-        line = line.rstrip("\n")
-        match = re.fullmatch(r"\[.*\] \[([\d.]+)\].*", line)
-        if not match:
-            continue
-        heartbeats += round(float(match.group(1)))
-    save_result(f"{NAME}/module/{module}//heartbeats", heartbeats, "heartbeats")
-
-
 def run_lean(module: str) -> None:
     _, stderr = measure.main(
         cmd=["lean", "--profile", "-Dprofiler.threshold=9999999", *sys.argv[1:]],
@@ -83,62 +71,29 @@ def run_lean(module: str) -> None:
     save_profile_metrics(stderr)
 
 
-def run_lean_with_heartbeats(module: str) -> None:
-    with tempfile.NamedTemporaryFile() as perf_file, tempfile.NamedTemporaryFile(
-        "w+", encoding="utf-8"
-    ) as stdout_file, tempfile.NamedTemporaryFile("w+", encoding="utf-8") as stderr_file:
-        env = os.environ.copy()
-        env["LC_ALL"] = "C"
-        command = [
-            "perf",
-            "stat",
-            "-j",
-            "-o",
-            perf_file.name,
-            "-e",
-            "instructions:u",
-            "--",
-            "env",
-            f"PATH={env['PATH']}",
-            "lean",
-            "--profile",
-            "-Dprofiler.threshold=9999999",
-            "-Dtrace.profiler=true",
-            "-Dtrace.profiler.useHeartbeats=true",
-            "-Dtrace.profiler.threshold=0",
+def run_heartbeat_frontend(module: str) -> None:
+    result = subprocess.run(
+        [
+            os.environ.get("BENCH_HEARTBEAT_LEAN", "lean"),
+            "--run",
+            str(BENCH / "build" / "HeartbeatCheck.lean"),
             *sys.argv[1:],
-        ]
-        result = subprocess.run(
-            command,
-            env=env,
-            stdout=stdout_file,
-            stderr=stderr_file,
-            encoding="utf-8",
-        )
+        ],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        print(result.stdout, end="", file=sys.stdout)
+        print(result.stderr, end="", file=sys.stderr)
+        sys.exit(result.returncode)
 
-        stdout_file.seek(0)
-        stderr_file.seek(0)
-        if result.returncode != 0:
-            stdout = stdout_file.read()
-            stderr = stderr_file.read()
-            print(stdout, end="", file=sys.stdout)
-            print(stderr, end="", file=sys.stderr)
-            sys.exit(result.returncode)
+    match = re.search(rf"^HEARTBEATS {re.escape(module)} (\d+)$", result.stdout, re.MULTILINE)
+    if not match:
+        print(result.stdout, end="", file=sys.stdout)
+        print(result.stderr, end="", file=sys.stderr)
+        raise SystemExit(f"heartbeat frontend did not report heartbeats for {module}")
 
-        perf_file.seek(0)
-        perf = {}
-        for line in perf_file:
-            data = json.loads(line)
-            if data.get("event") == "instructions:u" and "counter-value" in data:
-                perf["instructions:u"] = float(data["counter-value"])
-        if "instructions:u" not in perf:
-            raise SystemExit("perf did not report supported data for event 'instructions:u'")
-
-        save_result(f"{NAME}/module/{module}//instructions", perf["instructions:u"])
-        stderr_file.seek(0)
-        save_profile_metrics_from_lines(stderr_file)
-        stderr_file.seek(0)
-        save_heartbeat_metrics_from_lines(stderr_file, module)
+    save_result(f"{NAME}/module/{module}//heartbeats", float(match.group(1)), "heartbeats")
 
 
 def main() -> None:
@@ -157,10 +112,9 @@ def main() -> None:
 
     module = get_module(args.setup)
     count_lines(module, args.lean)
+    run_lean(module)
     if os.environ.get("BENCH_HEARTBEATS") == "1":
-        run_lean_with_heartbeats(module)
-    else:
-        run_lean(module)
+        run_heartbeat_frontend(module)
 
 
 if __name__ == "__main__":

--- a/scripts/bench/build/fake-root/bin/lean
+++ b/scripts/bench/build/fake-root/bin/lean
@@ -2,9 +2,11 @@
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 NAME = "build"
@@ -41,6 +43,34 @@ def count_lines(module: str, path: Path) -> None:
     save_result(f"{NAME}/module/{module}//lines", lines)
 
 
+def save_profile_metrics(stderr: str) -> None:
+    save_profile_metrics_from_lines(stderr.splitlines())
+
+
+def save_profile_metrics_from_lines(lines) -> None:
+    for line in lines:
+        line = line.rstrip("\n")
+        match = re.fullmatch(r"\t(.*) ([\d.]+)(m?s)", line)
+        if not match:
+            continue
+        name = match.group(1)
+        seconds = float(match.group(2))
+        if match.group(3) == "ms":
+            seconds = seconds / 1000
+        save_result(f"{NAME}/profile/{name}//wall-clock", seconds, "s")
+
+
+def save_heartbeat_metrics_from_lines(lines, module: str) -> None:
+    heartbeats = 0
+    for line in lines:
+        line = line.rstrip("\n")
+        match = re.fullmatch(r"\[.*\] \[([\d.]+)\].*", line)
+        if not match:
+            continue
+        heartbeats += round(float(match.group(1)))
+    save_result(f"{NAME}/module/{module}//heartbeats", heartbeats, "heartbeats")
+
+
 def run_lean(module: str) -> None:
     _, stderr = measure.main(
         cmd=["lean", "--profile", "-Dprofiler.threshold=9999999", *sys.argv[1:]],
@@ -50,16 +80,65 @@ def run_lean(module: str) -> None:
         append=True,
         capture=True,
     )
+    save_profile_metrics(stderr)
 
-    for line in stderr.splitlines():
-        match = re.fullmatch(r"\t(.*) ([\d.]+)(m?s)", line)
-        if not match:
-            continue
-        name = match.group(1)
-        seconds = float(match.group(2))
-        if match.group(3) == "ms":
-            seconds = seconds / 1000
-        save_result(f"{NAME}/profile/{name}//wall-clock", seconds, "s")
+
+def run_lean_with_heartbeats(module: str) -> None:
+    with tempfile.NamedTemporaryFile() as perf_file, tempfile.NamedTemporaryFile(
+        "w+", encoding="utf-8"
+    ) as stdout_file, tempfile.NamedTemporaryFile("w+", encoding="utf-8") as stderr_file:
+        env = os.environ.copy()
+        env["LC_ALL"] = "C"
+        command = [
+            "perf",
+            "stat",
+            "-j",
+            "-o",
+            perf_file.name,
+            "-e",
+            "instructions:u",
+            "--",
+            "env",
+            f"PATH={env['PATH']}",
+            "lean",
+            "--profile",
+            "-Dprofiler.threshold=9999999",
+            "-Dtrace.profiler=true",
+            "-Dtrace.profiler.useHeartbeats=true",
+            "-Dtrace.profiler.threshold=0",
+            *sys.argv[1:],
+        ]
+        result = subprocess.run(
+            command,
+            env=env,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            encoding="utf-8",
+        )
+
+        stdout_file.seek(0)
+        stderr_file.seek(0)
+        if result.returncode != 0:
+            stdout = stdout_file.read()
+            stderr = stderr_file.read()
+            print(stdout, end="", file=sys.stdout)
+            print(stderr, end="", file=sys.stderr)
+            sys.exit(result.returncode)
+
+        perf_file.seek(0)
+        perf = {}
+        for line in perf_file:
+            data = json.loads(line)
+            if data.get("event") == "instructions:u" and "counter-value" in data:
+                perf["instructions:u"] = float(data["counter-value"])
+        if "instructions:u" not in perf:
+            raise SystemExit("perf did not report supported data for event 'instructions:u'")
+
+        save_result(f"{NAME}/module/{module}//instructions", perf["instructions:u"])
+        stderr_file.seek(0)
+        save_profile_metrics_from_lines(stderr_file)
+        stderr_file.seek(0)
+        save_heartbeat_metrics_from_lines(stderr_file, module)
 
 
 def main() -> None:
@@ -78,7 +157,10 @@ def main() -> None:
 
     module = get_module(args.setup)
     count_lines(module, args.lean)
-    run_lean(module)
+    if os.environ.get("BENCH_HEARTBEATS") == "1":
+        run_lean_with_heartbeats(module)
+    else:
+        run_lean(module)
 
 
 if __name__ == "__main__":

--- a/scripts/bench/report.py
+++ b/scripts/bench/report.py
@@ -86,6 +86,10 @@ def fmt_instructions_bn(value: float) -> str:
     return f"{value / 1_000_000_000:,.0f}"
 
 
+def fmt_heartbeats_k(value: float) -> str:
+    return f"{value / 1_000:,.0f}"
+
+
 def fmt_signed_int(value: float | None) -> str:
     if value is None:
         return "new"
@@ -96,6 +100,15 @@ def fmt_signed_instructions_bn(value: float | None) -> str:
     if value is None:
         return "new"
     rounded = round(value / 1_000_000_000)
+    if rounded == 0:
+        return "0"
+    return f"{rounded:+,}"
+
+
+def fmt_signed_heartbeats_k(value: float | None) -> str:
+    if value is None:
+        return "new"
+    rounded = round(value / 1_000)
     if rounded == 0:
         return "0"
     return f"{rounded:+,}"
@@ -120,7 +133,7 @@ def fmt_metric(metric: str, value: float) -> str:
     if metric.endswith("//instructions"):
         return fmt_instructions_bn(value)
     if metric.endswith("//heartbeats"):
-        return fmt_int(value)
+        return fmt_heartbeats_k(value)
     if metric.endswith("//wall-clock") or metric.endswith("//task-clock"):
         return fmt_seconds(value)
     if metric.endswith("//maxrss"):
@@ -134,7 +147,7 @@ def fmt_delta(metric: str, value: float | None) -> str:
     if metric.endswith("//instructions"):
         return fmt_signed_instructions_bn(value)
     if metric.endswith("//heartbeats"):
-        return fmt_signed_int(value)
+        return fmt_signed_heartbeats_k(value)
     if metric.endswith("//wall-clock") or metric.endswith("//task-clock"):
         return f"{value:+,.2f}s"
     if metric.endswith("//maxrss"):
@@ -146,7 +159,7 @@ def fmt_delta(metric: str, value: float | None) -> str:
 def print_summary(current: Measurements, baseline: Measurements | None) -> None:
     metrics = [
         ("Build instructions (bn)", "build//instructions"),
-        ("Build heartbeats", "build//heartbeats"),
+        ("Build heartbeats (k)", "build//heartbeats"),
         ("Wall time", "build//wall-clock"),
         ("Task clock", "build//task-clock"),
         ("Max RSS", "build//maxrss"),
@@ -216,6 +229,8 @@ def print_module_table(
 
     if metric_name == "instructions":
         print("| Delta (bn) | Delta % | Current (bn) | Baseline (bn) | Module |")
+    elif metric_name == "heartbeats":
+        print("| Delta (k) | Delta % | Current (k) | Baseline (k) | Module |")
     else:
         print("| Delta | Delta % | Current | Baseline | Module |")
     print("| ---: | ---: | ---: | ---: | --- |")
@@ -298,7 +313,7 @@ def main() -> None:
     parser.add_argument(
         "--module-metric",
         choices=sorted(MODULE_METRICS),
-        default="instructions",
+        default="heartbeats",
         help="metric to use in the module top lists",
     )
     args = parser.parse_args()

--- a/scripts/bench/report.py
+++ b/scripts/bench/report.py
@@ -6,6 +6,17 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
+MODULE_METRICS = {
+    "instructions": {
+        "singular": "Instruction",
+        "plural": "Instructions",
+    },
+    "heartbeats": {
+        "singular": "Heartbeat",
+        "plural": "Heartbeats",
+    },
+}
+
 
 @dataclass
 class Measurements:
@@ -44,16 +55,27 @@ def load(path: Path) -> Measurements:
     return Measurements(by_metric=by_metric)
 
 
-def module_metric(module: str) -> str:
-    return f"build/module/{module}//instructions"
+def module_metric(module: str, metric_name: str) -> str:
+    return f"build/module/{module}//{metric_name}"
 
 
-def module_from_metric(metric: str) -> str | None:
+def module_from_metric(metric: str, metric_name: str) -> str | None:
     prefix = "build/module/"
-    suffix = "//instructions"
+    suffix = f"//{metric_name}"
     if not metric.startswith(prefix) or not metric.endswith(suffix):
         return None
     return metric[len(prefix) : -len(suffix)]
+
+
+def build_heartbeats(measurements: Measurements) -> float | None:
+    total = sum(
+        value
+        for metric, value in measurements.by_metric.items()
+        if module_from_metric(metric, "heartbeats") is not None
+    )
+    if total == 0:
+        return None
+    return total
 
 
 def fmt_int(value: float) -> str:
@@ -97,6 +119,8 @@ def fmt_bytes(value: float) -> str:
 def fmt_metric(metric: str, value: float) -> str:
     if metric.endswith("//instructions"):
         return fmt_instructions_bn(value)
+    if metric.endswith("//heartbeats"):
+        return fmt_int(value)
     if metric.endswith("//wall-clock") or metric.endswith("//task-clock"):
         return fmt_seconds(value)
     if metric.endswith("//maxrss"):
@@ -109,6 +133,8 @@ def fmt_delta(metric: str, value: float | None) -> str:
         return "new"
     if metric.endswith("//instructions"):
         return fmt_signed_instructions_bn(value)
+    if metric.endswith("//heartbeats"):
+        return fmt_signed_int(value)
     if metric.endswith("//wall-clock") or metric.endswith("//task-clock"):
         return f"{value:+,.2f}s"
     if metric.endswith("//maxrss"):
@@ -120,6 +146,7 @@ def fmt_delta(metric: str, value: float | None) -> str:
 def print_summary(current: Measurements, baseline: Measurements | None) -> None:
     metrics = [
         ("Build instructions (bn)", "build//instructions"),
+        ("Build heartbeats", "build//heartbeats"),
         ("Wall time", "build//wall-clock"),
         ("Task clock", "build//task-clock"),
         ("Max RSS", "build//maxrss"),
@@ -130,8 +157,12 @@ def print_summary(current: Measurements, baseline: Measurements | None) -> None:
     print("| Metric | Current | Baseline | Delta | Delta % |")
     print("| --- | ---: | ---: | ---: | ---: |")
     for label, metric in metrics:
-        current_value = current.by_metric.get(metric)
-        baseline_value = baseline.by_metric.get(metric) if baseline else None
+        if metric == "build//heartbeats":
+            current_value = build_heartbeats(current)
+            baseline_value = build_heartbeats(baseline) if baseline else None
+        else:
+            current_value = current.by_metric.get(metric)
+            baseline_value = baseline.by_metric.get(metric) if baseline else None
         if current_value is None:
             continue
         delta = None if baseline_value is None else current_value - baseline_value
@@ -145,15 +176,19 @@ def print_summary(current: Measurements, baseline: Measurements | None) -> None:
     print()
 
 
-def get_module_rows(current: Measurements, baseline: Measurements | None) -> list[ModuleRow]:
+def get_module_rows(
+    current: Measurements,
+    baseline: Measurements | None,
+    metric_name: str,
+) -> list[ModuleRow]:
     modules = sorted(
         module
         for metric in current.by_metric
-        if (module := module_from_metric(metric)) is not None
+        if (module := module_from_metric(metric, metric_name)) is not None
     )
     rows = []
     for module in modules:
-        metric = module_metric(module)
+        metric = module_metric(module, metric_name)
         rows.append(
             ModuleRow(
                 module=module,
@@ -169,6 +204,7 @@ def print_module_table(
     rows: Iterable[ModuleRow],
     limit: int,
     empty_message: str,
+    metric_name: str,
 ) -> None:
     rows = list(rows)[:limit]
     print(f"## {title}")
@@ -178,26 +214,37 @@ def print_module_table(
         print()
         return
 
-    print("| Delta (bn) | Delta % | Current (bn) | Baseline (bn) | Module |")
+    if metric_name == "instructions":
+        print("| Delta (bn) | Delta % | Current (bn) | Baseline (bn) | Module |")
+    else:
+        print("| Delta | Delta % | Current | Baseline | Module |")
     print("| ---: | ---: | ---: | ---: | --- |")
     for row in rows:
-        baseline_text = "-" if row.baseline is None else fmt_instructions_bn(row.baseline)
+        metric = module_metric(row.module, metric_name)
+        baseline_text = "-" if row.baseline is None else fmt_metric(metric, row.baseline)
         print(
-            f"| {fmt_signed_instructions_bn(row.delta)} | {fmt_pct(row.delta_pct)} | "
-            f"{fmt_instructions_bn(row.current)} | {baseline_text} | `{row.module}` |"
+            f"| {fmt_delta(metric, row.delta)} | {fmt_pct(row.delta_pct)} | "
+            f"{fmt_metric(metric, row.current)} | {baseline_text} | `{row.module}` |"
         )
     print()
 
 
-def print_modules(current: Measurements, baseline: Measurements | None, limit: int) -> None:
-    rows = get_module_rows(current, baseline)
+def print_modules(
+    current: Measurements,
+    baseline: Measurements | None,
+    limit: int,
+    metric_name: str,
+) -> None:
+    rows = get_module_rows(current, baseline, metric_name)
+    metric_labels = MODULE_METRICS[metric_name]
 
     if baseline is None:
         print_module_table(
-            "Longest-Running Modules By Instructions",
+            f"Longest-Running Modules By {metric_labels['plural']}",
             sorted(rows, key=lambda row: row.current, reverse=True),
             limit,
-            "No module instruction measurements found.",
+            f"No module {metric_labels['singular'].lower()} measurements found.",
+            metric_name,
         )
         return
 
@@ -208,22 +255,25 @@ def print_modules(current: Measurements, baseline: Measurements | None, limit: i
         return row.delta is not None and row.delta < 0
 
     print_module_table(
-        "Top Module Instruction Regressions",
+        f"Top Module {metric_labels['singular']} Regressions",
         sorted(filter(is_regression, rows), key=regression_key, reverse=True),
         limit,
-        "No module instruction regressions found.",
+        f"No module {metric_labels['singular'].lower()} regressions found.",
+        metric_name,
     )
     print_module_table(
-        "Top Module Instruction Improvements",
+        f"Top Module {metric_labels['singular']} Improvements",
         sorted(filter(is_improvement, rows), key=lambda row: row.delta or 0),
         limit,
-        "No module instruction improvements found.",
+        f"No module {metric_labels['singular'].lower()} improvements found.",
+        metric_name,
     )
     print_module_table(
-        "Longest-Running Modules By Instructions",
+        f"Longest-Running Modules By {metric_labels['plural']}",
         sorted(rows, key=lambda row: row.current, reverse=True),
         limit,
-        "No module instruction measurements found.",
+        f"No module {metric_labels['singular'].lower()} measurements found.",
+        metric_name,
     )
 
 
@@ -245,12 +295,18 @@ def main() -> None:
     parser.add_argument("current", type=Path)
     parser.add_argument("baseline", type=Path, nargs="?")
     parser.add_argument("--limit", type=positive_int, default=10)
+    parser.add_argument(
+        "--module-metric",
+        choices=sorted(MODULE_METRICS),
+        default="instructions",
+        help="metric to use in the module top lists",
+    )
     args = parser.parse_args()
 
     current = load(args.current)
     baseline = load(args.baseline) if args.baseline else None
     print_summary(current, baseline)
-    print_modules(current, baseline, args.limit)
+    print_modules(current, baseline, args.limit, args.module_metric)
 
 
 if __name__ == "__main__":

--- a/scripts/bench/runner/run-in-docker.sh
+++ b/scripts/bench/runner/run-in-docker.sh
@@ -86,6 +86,7 @@ run_benchmark() {
     --network bridge \
     -e XDG_CACHE_HOME=/workspace/xdg-cache \
     -e ELAN_HOME=/workspace/elan-home \
+    -e BENCH_HEARTBEATS="${BENCH_HEARTBEATS:-}" \
     -e BENCH_OUTPUT_FILE="/bench-output/$label.jsonl" \
     -v "$checkout:/workspace/clean" \
     -v "$package_cache:/workspace/clean/.lake/packages" \


### PR DESCRIPTION
## Summary

Makes Lean heartbeat counts the default module-level metric for the maintainer-triggered build benchmark.

The benchmark wrapper can now collect deterministic per-module heartbeat totals by rerunning Lean's frontend for each successfully built module and summing Mathlib's command-level heartbeat measurements. PR reports still include whole-build instruction count, wall time, task clock, and max RSS in the top-level summary, but the top module regression/improvement tables now default to heartbeats.

The `/bench` workflow enables heartbeat collection by default with `BENCH_HEARTBEATS=1`. Instruction-based module tables remain available with:

```bash
scripts/bench/report.py current.jsonl baseline.jsonl --module-metric instructions
```

## Notes

This intentionally keeps the current conservative clean rebuild behavior. Cache/runtime optimizations for a heartbeat-only future are tracked separately in #389.

## Validation

- `python3 -m py_compile scripts/bench/report.py scripts/bench/build/fake-root/bin/lean`
- `lake env lean scripts/bench/build/HeartbeatCheck.lean`
- `git diff --check`
- Re-rendered `/tmp/clean-command-heartbeat-main-vs-autoelaborate/report.md` from saved main-vs-autoelaborate measurements and confirmed heartbeat tables are used by default.