### PR TITLE
[codex] Fix bench command acknowledgement comment

### DIFF
--- a/.github/workflows/bench-command.yml
+++ b/.github/workflows/bench-command.yml
@@ -16,6 +16,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: read
+      statuses: write
 
     steps:
       - name: Resolve PR head
@@ -42,10 +43,23 @@ jobs:
             -f sha="${{ steps.pr.outputs.sha }}" \
             -f head_repo="${{ steps.pr.outputs.head_repo }}"
 
+      - name: Mark benchmark queued
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.sha }}" \
+            -f state=pending \
+            -f context=bench \
+            -f description="Build benchmark queued" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/workflows/bench.yml"
+
       - name: Acknowledge command
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr comment "${{ steps.pr.outputs.number }}" \
-            --repo "${{ github.repository }}" \
-            --body "Queued build benchmark for \`${{ steps.pr.outputs.sha }}\` against baseline \`${{ steps.pr.outputs.base_sha }}\`."
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/issues/${{ steps.pr.outputs.number }}/comments" \
+            -f body="Queued build benchmark for \`${{ steps.pr.outputs.sha }}\` against baseline \`${{ steps.pr.outputs.base_sha }}\`."

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -23,8 +23,20 @@ jobs:
       contents: read
       pull-requests: read
       issues: write
+      statuses: write
 
     steps:
+      - name: Mark benchmark running
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/statuses/${{ inputs.sha }}" \
+            -f state=pending \
+            -f context=bench \
+            -f description="Build benchmark running" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: Check out benchmark scripts
         uses: actions/checkout@v4
         with:
@@ -89,3 +101,30 @@ jobs:
             current.jsonl
             benchmark-report.md
           if-no-files-found: warn
+      - name: Mark benchmark complete
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          case "$JOB_STATUS" in
+            success)
+              state=success
+              description="Build benchmark completed"
+              ;;
+            cancelled)
+              state=error
+              description="Build benchmark cancelled"
+              ;;
+            *)
+              state=failure
+              description="Build benchmark failed"
+              ;;
+          esac
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/statuses/${{ inputs.sha }}" \
+            -f state="$state" \
+            -f context=bench \
+            -f description="$description" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Summary

Improves the `/bench` command visibility on pull requests.

Changes:

- Switch the acknowledgement comment from `gh pr comment` to the REST issue comments endpoint. The old command dispatched the benchmark successfully but failed afterwards with `GraphQL: Resource not accessible by integration (addComment)`.
- Publish an optional `bench` commit status on the PR head SHA:
  - `pending` when the command queues the benchmark
  - `pending` with a direct run link when the benchmark starts
  - `success`, `failure`, or `error` when the benchmark job completes

This makes the benchmark visible in the PR checks area without turning it into a required merge gate.

## Validation

- Confirmed `/bench` on PR #375 created a `Bench Command` issue_comment run and dispatched a `Bench` workflow run.
- Confirmed the `Bench Command` run failed only at the acknowledgement step, after successful dispatch.
- Parsed `.github/workflows/bench-command.yml` and `.github/workflows/bench.yml` as YAML locally.