### PR TITLE
[codex] Fix bench PR comment permissions

### DIFF
--- a/.github/workflows/bench-command.yml
+++ b/.github/workflows/bench-command.yml
@@ -15,7 +15,7 @@ jobs:
       actions: write
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
 
     steps:
@@ -56,6 +56,7 @@ jobs:
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/workflows/bench.yml"
 
       - name: Acknowledge command
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/bench-command.yml
+++ b/.github/workflows/bench-command.yml
@@ -56,7 +56,6 @@ jobs:
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/workflows/bench.yml"
 
       - name: Acknowledge command
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -73,7 +73,6 @@ jobs:
           cat benchmark-report.md >> "$GITHUB_STEP_SUMMARY"
       - name: Comment on PR
         if: always() && hashFiles('benchmark-report.md') != ''
-        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, clean-bench]
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
       statuses: write
 
@@ -73,6 +73,7 @@ jobs:
           cat benchmark-report.md >> "$GITHUB_STEP_SUMMARY"
       - name: Comment on PR
         if: always() && hashFiles('benchmark-report.md') != ''
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary

Follow-up for the `/bench` PR visibility workflow.

The status integration is working, but on PR #382 GitHub rejected the acknowledgement comment even through the REST issue-comment endpoint:

```text
gh: Resource not accessible by integration (HTTP 403)
```

This PR keeps comment failures as hard failures and requests `pull-requests: write` in addition to `issues: write`, so the workflow has the permissions GitHub may require for writing to PR conversations.

## Validation

- Confirmed `/bench` on PR #382 created the `bench` pending status and dispatched the benchmark run.
- Confirmed the command workflow failed while creating the acknowledgement comment.
- Parsed both benchmark workflow YAML files locally.