### PR TITLE
Fix stale benchmark reports

### DIFF
--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -17,7 +17,13 @@ jobs:
         with:
           ref: main
           path: bench-control
+      - name: Clear benchmark outputs
+        run: |
+          rm -f baseline.jsonl benchmark-report.md benchmark-modules.md
+          rm -rf "$GITHUB_WORKSPACE/bench-output/${{ github.run_id }}"
+          mkdir -p "$GITHUB_WORKSPACE/bench-output/${{ github.run_id }}"
       - name: Run benchmark in container
+        id: benchmark
         working-directory: bench-control
         env:
           BENCH_BASELINE_ONLY: "1"
@@ -25,16 +31,16 @@ jobs:
           BENCH_HEAD_REPO: ${{ github.repository }}
           BENCH_REPOSITORY: ${{ github.repository }}
           BENCH_RUN_ID: ${{ github.run_id }}
-          BENCH_OUTPUT_DIR: ${{ github.workspace }}/bench-output
+          BENCH_OUTPUT_DIR: ${{ github.workspace }}/bench-output/${{ github.run_id }}
         run: scripts/bench/runner/run-in-docker.sh
       - name: Copy measurements
         if: always()
         run: |
-          if [ -f "$GITHUB_WORKSPACE/bench-output/baseline.jsonl" ]; then
-            cp "$GITHUB_WORKSPACE/bench-output/baseline.jsonl" baseline.jsonl
+          if [ -f "$GITHUB_WORKSPACE/bench-output/${{ github.run_id }}/baseline.jsonl" ]; then
+            cp "$GITHUB_WORKSPACE/bench-output/${{ github.run_id }}/baseline.jsonl" baseline.jsonl
           fi
       - name: Render benchmark report
-        if: always() && hashFiles('baseline.jsonl') != ''
+        if: steps.benchmark.outcome == 'success' && hashFiles('baseline.jsonl') != ''
         run: |
           bench-control/scripts/bench/report.py baseline.jsonl --limit 10 > benchmark-report.md
           bench-control/scripts/bench/report.py baseline.jsonl --all-modules > benchmark-modules.md

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -42,7 +42,13 @@ jobs:
         with:
           ref: main
           path: bench-control
+      - name: Clear benchmark outputs
+        run: |
+          rm -f baseline.jsonl current.jsonl benchmark-report.md benchmark-modules.md
+          rm -rf "$GITHUB_WORKSPACE/bench-output/${{ github.run_id }}"
+          mkdir -p "$GITHUB_WORKSPACE/bench-output/${{ github.run_id }}"
       - name: Run benchmark in container
+        id: benchmark
         working-directory: bench-control
         env:
           BENCH_PR: ${{ inputs.pr }}
@@ -51,19 +57,19 @@ jobs:
           BENCH_HEAD_REPO: ${{ inputs.head_repo }}
           BENCH_REPOSITORY: ${{ github.repository }}
           BENCH_RUN_ID: ${{ github.run_id }}
-          BENCH_OUTPUT_DIR: ${{ github.workspace }}/bench-output
+          BENCH_OUTPUT_DIR: ${{ github.workspace }}/bench-output/${{ github.run_id }}
         run: scripts/bench/runner/run-in-docker.sh
       - name: Copy measurements
         if: always()
         run: |
-          if [ -f "$GITHUB_WORKSPACE/bench-output/baseline.jsonl" ]; then
-            cp "$GITHUB_WORKSPACE/bench-output/baseline.jsonl" baseline.jsonl
+          if [ -f "$GITHUB_WORKSPACE/bench-output/${{ github.run_id }}/baseline.jsonl" ]; then
+            cp "$GITHUB_WORKSPACE/bench-output/${{ github.run_id }}/baseline.jsonl" baseline.jsonl
           fi
-          if [ -f "$GITHUB_WORKSPACE/bench-output/current.jsonl" ]; then
-            cp "$GITHUB_WORKSPACE/bench-output/current.jsonl" current.jsonl
+          if [ -f "$GITHUB_WORKSPACE/bench-output/${{ github.run_id }}/current.jsonl" ]; then
+            cp "$GITHUB_WORKSPACE/bench-output/${{ github.run_id }}/current.jsonl" current.jsonl
           fi
       - name: Render benchmark report
-        if: always() && hashFiles('current.jsonl') != ''
+        if: steps.benchmark.outcome == 'success' && hashFiles('current.jsonl') != ''
         run: |
           if [ -f baseline.jsonl ]; then
             bench-control/scripts/bench/report.py current.jsonl baseline.jsonl --limit 10 > benchmark-report.md
@@ -74,7 +80,7 @@ jobs:
           fi
           cat benchmark-report.md >> "$GITHUB_STEP_SUMMARY"
       - name: Comment on PR
-        if: always() && hashFiles('benchmark-report.md') != ''
+        if: steps.benchmark.outcome == 'success' && hashFiles('benchmark-report.md') != ''
         uses: actions/github-script@v7
         with:
           script: |

--- a/scripts/bench/runner/run-in-docker.sh
+++ b/scripts/bench/runner/run-in-docker.sh
@@ -23,8 +23,6 @@ WORK_DIR="$RUN_DIR/work"
 BASELINE_CACHE_DIR="$CACHE_DIR/baselines"
 LOCK_DIR="$CACHE_DIR/locks"
 
-mkdir -p "$CACHE_DIR/elan" "$BASELINE_CACHE_DIR" "$LOCK_DIR" "$WORK_DIR" "$BENCH_OUTPUT_DIR"
-
 cleanup() {
   rm -rf "$RUN_DIR" 2>/dev/null && return
   docker run --rm \
@@ -38,6 +36,40 @@ cleanup() {
 trap cleanup EXIT
 
 docker build -t "$IMAGE" -f scripts/bench/runner/Dockerfile scripts/bench/runner
+
+prepare_runner_dirs() {
+  local uid
+  local gid
+  uid="$(id -u)"
+  gid="$(id -g)"
+
+  mkdir -p "$BENCH_OUTPUT_DIR"
+  docker run --rm \
+    --network none \
+    --security-opt no-new-privileges \
+    -v "$ROOT:$ROOT" \
+    "$IMAGE" \
+    bash -lc '
+      set -euo pipefail
+      mkdir -p "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9"
+      find "$1" -mindepth 1 -maxdepth 4 -type d -exec chown "${10}:${11}" {} +
+      find "$4" -mindepth 1 -maxdepth 1 -type f -exec chown "${10}:${11}" {} +
+      chown "${10}:${11}" "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9"
+    ' bash \
+      "$CACHE_DIR" \
+      "$CACHE_DIR/elan" \
+      "$BASELINE_CACHE_DIR" \
+      "$LOCK_DIR" \
+      "$WORK_DIR" \
+      "$CACHE_DIR/lake-packages" \
+      "$CACHE_DIR/mathlib-cache" \
+      "$CACHE_DIR/lake-build" \
+      "$CACHE_DIR/pr-lake-build" \
+      "$uid" \
+      "$gid"
+}
+
+prepare_runner_dirs
 
 prune_pr_build_caches() {
   local root="$CACHE_DIR/pr-lake-build"


### PR DESCRIPTION
## Summary

Fixes two failure modes from #392:

- Use a per-run benchmark output directory (`bench-output/<run_id>`) and clear root-level report files before each benchmark job.
- Only render/comment benchmark reports when the benchmark step itself succeeds, so partial or stale JSONL files cannot produce a misleading PR comment.
- Prepare persistent runner cache directories from inside Docker and chown them back to the host runner user before host-side cache writes, avoiding baseline cache permission failures caused by stale root-owned directories.

## Validation

- `bash -n scripts/bench/runner/run-in-docker.sh`
- `git diff --check`

Closes #392.
