### PR TITLE
Refactor `channelsWithRequirements` to support pushes/pulls with a boolean `enabled` flag

### DIFF
--- a/Clean/Air/Balance.lean
+++ b/Clean/Air/Balance.lean
@@ -95,88 +95,92 @@ lemma balanceOf_eq_of_const_mult' {interactions : List (Interaction F)} {msg : A
     balanceOf interactions msg = mult * ↑(interactions.countP (·.msg = msg)) :=
   fun constant_mult => balanceOf_eq_of_const_mult (fun i hi _ => constant_mult i hi)
 
+lemma balanceOf_eq_of_const_zero {interactions : List (Interaction F)} {msg : Array F} :
+    (∀ i ∈ interactions, i.mult = 0) → balanceOf interactions msg = 0 := by
+  intro const_zero
+  rw [balanceOf_eq_of_const_mult' const_zero]
+  simp
+
+lemma balanceOf_eq_add_filter {interactions : List (Interaction F)} {msg : Array F} (p : F → Prop) [DecidablePred p] :
+    balanceOf interactions msg =
+      balanceOf (interactions.filter (fun i => decide (p i.mult))) msg
+      + balanceOf (interactions.filter (fun i => decide (¬p i.mult))) msg := by
+  simp only [balanceOf, List.filter_filter]
+  conv in _ && decide (p _) => rw [Bool.and_comm]
+  conv in _ && decide (¬ p _) => rw [Bool.and_comm]
+  simp_rw [← List.filter_filter]
+  rw [List.sum_map_filter_add_sum_map_filter_not]
+
+lemma balanceOf_eq_filter_ne_zero {interactions : List (Interaction F)} {msg : Array F} :
+    balanceOf interactions msg =
+      (interactions.filter (fun i => i.msg = msg && i.mult ≠ 0) |>.map (·.mult) |>.sum) := by
+  rw [balanceOf_eq_add_filter (· = 0)]
+  simp only [balanceOf, List.filter_filter, decide_not, ne_eq, add_eq_right]
+  simp_rw [←List.filter_filter]
+  set l := interactions.filter (·.mult = 0) with hl
+  show balanceOf l msg = 0
+  apply balanceOf_eq_of_const_zero
+  grind
+
 /--
 If every interaction for `msg` has multiplicity either nonzero `mult` or `0`, the
 balance is `mult` times the count of the `mult` interactions. This is the zero-padding
 variant of `balanceOf_eq_of_const_mult`.
 -/
-lemma balanceOf_eq_mult_countP_of_mult_or_zero
+lemma balanceOf_eq_of_mult_or_zero
     {interactions : List (Interaction F)} {msg : Array F} {mult : F} :
-    mult ≠ 0 →
-    (∀ i ∈ interactions, i.msg = msg → i.mult = mult ∨ i.mult = 0) →
+    (∀ i ∈ interactions, i.msg = msg → i.mult ≠ 0 → i.mult = mult) →
     balanceOf interactions msg =
-      mult * ↑(interactions.countP fun i => i.msg = msg && i.mult = mult) := by
-  intro mult_ne_zero h
-  induction interactions with
-  | nil => simp [balanceOf]
-  | cons a interactions ih =>
-    have h_tail : ∀ i ∈ interactions, i.msg = msg → i.mult = mult ∨ i.mult = 0 := by
-      intro i hi
-      exact h i (by simp [hi])
-    specialize ih h_tail
-    by_cases h_msg : a.msg = msg
-    · specialize h a (by simp) h_msg
-      rcases h with h_mult | h_zero
-      · calc
-          balanceOf (a :: interactions) msg = mult + balanceOf interactions msg := by
-            simp [balanceOf, h_msg, h_mult]
-          _ = mult + mult * ↑(interactions.countP fun i => i.msg = msg && i.mult = mult) := by
-            rw [ih]
-          _ = mult * ↑((a :: interactions).countP fun i => i.msg = msg && i.mult = mult) := by
-            simp [h_msg, h_mult, Nat.cast_add]
-            ring
-      · have h_a_mult_ne : ¬a.mult = mult := by
-          intro h_a_mult
-          exact mult_ne_zero (h_a_mult.symm.trans h_zero)
-        calc
-          balanceOf (a :: interactions) msg = balanceOf interactions msg := by
-            simp [balanceOf_cons, h_msg, h_zero]
-          _ = mult * ↑(interactions.countP fun i => i.msg = msg && i.mult = mult) := ih
-          _ = mult * ↑((a :: interactions).countP fun i => i.msg = msg && i.mult = mult) := by
-            simp [h_msg, h_a_mult_ne]
-    · simpa [balanceOf, h_msg] using ih
+      mult * ↑(interactions.countP fun i => i.msg = msg && i.mult ≠ 0) := by
+  intro constant_mult
+  set count : ℕ := interactions.countP fun i => i.msg = msg && i.mult ≠ 0
+  suffices (interactions.filter (fun i => i.msg = msg && i.mult ≠ 0)).map (·.mult) = List.replicate count mult by
+    rw [balanceOf_eq_filter_ne_zero]
+    convert (congrArg List.sum this)
+    simp [mul_comm]
+  apply List.ext_getElem
+  · simp [count, List.countP_eq_length_filter]
+  intro i hi hi'
+  simp only [List.getElem_map, List.getElem_replicate]
+  rw [List.length_map] at hi
+  set a := (interactions.filter (fun i ↦ decide (i.msg = msg) && decide (i.mult ≠ 0)))[i] with ha
+  have a_mem_filter : a ∈ interactions.filter (fun i ↦ decide (i.msg = msg) && decide (i.mult ≠ 0)) := by simp [a]
+  simp [List.mem_filter] at a_mem_filter
+  apply constant_mult a <;> simp_all
 
 /--
 If an interaction list is balanced, then for every pull there must be a corresponding "push",
 where "push" means an interaction with multiplicity neither `-1` nor `0`.
 -/
 theorem exists_push_of_pull (interactions : List (Interaction F)) (balance : BalancedInteractions interactions) :
-    ∀ a ∈ interactions, a.mult = -1 → ∃ b ∈ interactions, b.msg = a.msg ∧ b.mult ≠ -1 ∧ b.mult ≠ 0 := by
+    ∀ a ∈ interactions, a.mult = -1 → ∃ b ∈ interactions, b.msg = a.msg ∧ b.mult ≠ 0 ∧ b.mult ≠ -1 := by
   intro a h_mem_a h_pull
   set msg := a.msg
-  set count : ℕ := interactions.countP (·.msg = msg)
+  set count : ℕ := interactions.countP fun i => i.msg = msg && i.mult ≠ 0
   have count_lt_ringChar : count < ringChar F ∨ ringChar F = 0 := by
-    exact count_lt_ringChar_of_balancedInteractions balance
+    simp only [count]
+    grw [List.countP_le_length]
+    exact balance.1
   replace balance := balance.2 msg
   -- assuming no such push exists => all interactions with the same message have multiplicity -1 or 0
   -- this leads to a contradiction with the 0 balance + no overflow
-  by_contra! no_nonzero_push
-  have neg_one_or_zero : ∀ i ∈ interactions, i.msg = msg → i.mult = -1 ∨ i.mult = 0 := by
-    intro i hi h_msg
-    by_cases h_mult : i.mult = -1
-    · exact .inl h_mult
-    · exact .inr (no_nonzero_push i hi h_msg h_mult)
-  suffices interactions.countP (fun i => i.msg = msg && i.mult = -1) = 0 by
-    have h_zero : ∀ x ∈ interactions, (decide (x.msg = msg) && decide (x.mult = -1)) = false := by
-      simpa [List.countP_eq_zero] using this
-    have h_false := h_zero a h_mem_a
-    simp [msg, h_pull] at h_false
-  rw [balanceOf_eq_mult_countP_of_mult_or_zero (by simp) neg_one_or_zero] at balance
+  by_contra! const_minus_one
+  suffices count = 0 by
+    simp only [count, msg, List.countP_eq_zero, Bool.and_eq_true, decide_eq_true_eq, not_and] at this
+    apply this a h_mem_a rfl
+    show a.mult ≠ 0
+    rw [h_pull, ne_eq, neg_eq_zero]
+    exact one_ne_zero
+  rw [balanceOf_eq_of_mult_or_zero const_minus_one] at balance
   simp only [neg_mul, one_mul, neg_eq_zero] at balance
-  change (↑(interactions.countP fun i => i.msg = msg && i.mult = -1) : F) = 0 at balance
+  change (count : F) = 0 at balance
   rcases count_lt_ringChar with count_lt_ringChar | ringChar_zero
-  · have neg_one_count_lt_ringChar :
-        interactions.countP (fun i => i.msg = msg && i.mult = -1) < ringChar F := by
-      apply lt_of_le_of_lt _ count_lt_ringChar
-      unfold count
-      exact List.countP_and_left_le interactions (fun i => i.msg = msg) (fun i => i.mult = -1)
-    simp_all [Lean.Grind.IsCharP.natCast_eq_zero_iff_of_lt _ neg_one_count_lt_ringChar]
+  · simp_all [Lean.Grind.IsCharP.natCast_eq_zero_iff_of_lt _ count_lt_ringChar]
   · simp_all [CharP.ringChar_zero_iff_CharZero]
 
 /- ## Conditions on channels that strengthen the implications of interaction balance. -/
 
 namespace RawChannel
-
 /--
 We call a channel "consistent" if balancedness + requirements on all interacions
 imply guarantees on all interactions.
@@ -196,27 +200,22 @@ class Consistent (channel : RawChannel F) : Prop where
 A "normal" channel is one where
 - the requirements for a push interaction imply the guarantees of the corresponding pull interaction
 - only pull interactions cause guarantees to be added
-- only push interactions cause requirements to be added
 -/
 class Normal (channel : RawChannel F) : Prop where
-  grts_of_reqs : ∀ (msg : Vector F channel.arity) (mult : F) data, mult ≠ -1 → mult ≠ 0 →
+  grts_of_reqs : ∀ (msg : Vector F channel.arity) (mult : F) data, mult ≠ 0 → mult ≠ -1 →
     channel.Requirements mult msg data → channel.Guarantees (-1) msg data
   grts_of_ne_neg_one : ∀ (msg : Vector F channel.arity) (mult : F) data, mult ≠ -1 →
     channel.Guarantees mult msg data
-  reqs_neg_one : ∀ (msg : Vector F channel.arity) (data), channel.Requirements (-1) msg data
 
 /-- Typed `Channel`s are normal by definition! -/
 instance (channel : Channel F Message) : Normal channel.toRaw where
   grts_of_reqs := by
-    intro msg mult data mult_ne_neg_one mult_ne_zero reqs
-    simp [Channel.toRaw, mult_ne_neg_one, mult_ne_zero] at reqs ⊢
+    intro msg mult data mult_ne_zero mult_ne_neg_one reqs
+    simp [Channel.toRaw, mult_ne_zero, mult_ne_neg_one] at reqs ⊢
     exact reqs
   grts_of_ne_neg_one := by
     intro msg mult data mult_ne_neg_one
     simp [Channel.toRaw, mult_ne_neg_one]
-  reqs_neg_one := by
-    intro msg
-    simp [Channel.toRaw]
 
 /-- Normal channels are consistent, thanks to `exists_push_of_pull` -/
 theorem consistent_of_normal (channel : RawChannel F) [channel.Normal] :
@@ -254,8 +253,6 @@ only ever emit 1 or -1 multiplicities.
 
 See `Vm.lean` for a detailed motivation and application of the main theorem,
 `guarantees_of_requirements_of_requirements_of_guarantees`.
-
-TODO: extend to cover 0-padding.
 -/
 
 omit [DecidableEq F] in
@@ -276,6 +273,148 @@ lemma List.countP_eraseIdx {α : Type} {l : List α} {p : α → Bool} {i : ℕ}
       rw [← ih (Nat.lt_of_succ_lt_succ hi)]
       ring
 
+/--
+Assume you have a list of channel interactions that is made up of pairs (-1, pull_i), (1, push_i),
+where for each i, `Guarantees (-1, pull_i) → Requirements (1, push_i)`.
+We want to think of (pull_i → push_i) as the state transition of a VM circuit.
+
+Furthermore, assume the list is balanced and the channel is normal.
+
+Then, for any i, the **converse** is true: `Requirements (1, push_i) → Guarantees (-1, pull_i)`.
+
+The intuition is that when the requirements for a push hold unconditionally, we
+can "follow implications around the cycle" to show that _all_ the guarantees/requirements must hold
+(within that cycle, which contains both the push and its corresponding pull).
+
+By narrowing the conclusion to only the guarantees of the push, the formulation cleverly
+avoids talking about cycles at all, and achieves a comparatively simple proof by induction.
+-/
+theorem guarantees_of_requirements_of_requirements_of_guarantees [Fact (ringChar F ≠ 2)]
+    (channel : RawChannel F) [channel.Normal]
+    (pulls pushes : List (Interaction F))
+    (balance : BalancedInteractions (pulls ++ pushes)) (data : ProverData F)
+  -- same length
+  (n : ℕ) (len_pulls : pulls.length = n) (len_pushes : pushes.length = n)
+  -- all interactions are on the input channel
+  (pulls_channel : ∀ a ∈ pulls, a.channel = channel) (pushes_channel : ∀ b ∈ pushes, b.channel = channel)
+  -- the multiplicities are -1 for pulls and 1 for pushes
+  (pulls_mult : ∀ a ∈ pulls, a.mult = -1) (pushes_mult : ∀ b ∈ pushes, b.mult = 1) :
+    (∀ (i : ℕ) (hi : i < n), pulls[i].Guarantees data → pushes[i].Requirements data) →
+    ∀ (i : ℕ) (hi: i < n), pushes[i].Requirements data → pulls[i].Guarantees data := by
+  intro constraints
+  induction n generalizing pulls pushes with
+  | zero => intro i hi; nomatch hi
+  | succ n ih =>
+    -- first, a little inline version of `exists_push_of_pull`
+    have exists_push_of_pull : ∀ pull ∈ pulls, ∃ push ∈ pushes, push.msg = pull.msg := by
+      intro pull pull_mem
+      have pull_mem_append : pull ∈ pulls ++ pushes := by simp [pull_mem]
+      have ⟨ push, push_mem, push_msg_eq, push_mult_ne_neg_one, _ ⟩ := exists_push_of_pull (pulls ++ pushes)
+        balance pull pull_mem_append (pulls_mult pull pull_mem)
+      have push_mem : push ∈ pushes := by simp only [List.mem_append] at push_mem; tauto
+      exists push
+    -- we identify the "previous" transition (pulls[j], pushes[j]) in the chain, where pushes[j] = pulls[i]
+    intro i hi push_i_req
+    have ⟨ push', push'_mem, push_j_msg ⟩ := exists_push_of_pull pulls[i] (List.getElem_mem ..)
+    set msg := pulls[i].msg with pull_i_msg
+    have ⟨ j, hj, hpush' ⟩ := List.getElem_of_mem push'_mem
+    subst hpush'
+    rw [len_pushes] at hj
+    -- thanks to the channel being consistent, it suffices to show the requirements of pushes[j]
+    have push_j_imp_pull_i : pushes[j].Requirements data → pulls[i].Guarantees data := by
+      intro push_j_req
+      have pulls_i_channel := pulls_channel pulls[i] (List.getElem_mem ..)
+      have pushes_j_channel := pushes_channel pushes[j] (List.getElem_mem ..) |>.symm
+      have pulls_i_mult := pulls_mult pulls[i] (List.getElem_mem ..)
+      have pushes_j_mult := pushes_mult pushes[j] (List.getElem_mem ..) |>.symm
+      have msg_size : msg.size = channel.arity := by rw [pulls[i].same_size, pulls_i_channel]
+      suffices grt' : channel.Guarantees (-1) ⟨ msg, msg_size ⟩ data by
+        simp only [Interaction.Guarantees]
+        convert fun _ => grt'
+      apply RawChannel.Normal.grts_of_reqs ⟨ msg, msg_size ⟩ 1 data one_ne_zero one_ne_neg_one
+      simp only [Interaction.Requirements, Interaction.msgVector, push_j_msg] at push_j_req
+      convert push_j_req
+    -- if i = j, we're done
+    by_cases h_ij : j = i
+    · subst h_ij; exact push_j_imp_pull_i push_i_req
+    -- if i ≠ j, we can reduce our goal to a smaller list: the one where
+    -- (pulls[j], pushes[j]) and (pulls[i], pushes[i]) are replaced with the single pair (pulls[j], pushes[i]).
+    have pulls_j_imp_push_i : pulls[j].Guarantees data → pushes[i].Requirements data := fun j_grt =>
+      j_grt |> constraints j hj |> push_j_imp_pull_i |> constraints i hi
+    -- we remove (pulls[i], pushes[i]) and change pushes[j] to pushes[i]
+    let j' := if j < i then j else j - 1
+    let pulls' := pulls.eraseIdx i
+    let pushes' := pushes.eraseIdx i |>.set j' pushes[i]
+    have hj' : j' < n := by simp only [j']; split_ifs <;> omega
+    have pulls'_len : pulls'.length = n := by simp [pulls', List.length_eraseIdx, len_pulls, hi]
+    have pushes'_len : pushes'.length = n := by simp [pushes', List.length_eraseIdx, len_pushes, hi]
+    have pulls'_getElem : pulls'[j'] = pulls[j] := by
+      simp only [pulls', j', List.getElem_eraseIdx]
+      split_ifs
+      · simp
+      · omega
+      · simp [show j - 1 + 1 = j by omega]
+    have pushes'_getElem : pushes'[j'] = pushes[i] := by simp [pushes', j']
+    suffices push_i_imp_pull_j : pushes'[j'].Requirements data → pulls'[j'].Guarantees data by
+      simp only [pulls'_getElem, pushes'_getElem] at push_i_imp_pull_j
+      exact push_i_req |> push_i_imp_pull_j |> constraints j hj |> push_j_imp_pull_i
+    -- we need to re-check all assumptions about as', bs' for the induction hypothesis
+    -- most of these are straightforward
+    have pulls'_mult : ∀ a ∈ pulls', a.mult = -1 := by
+      simp only [pulls', List.forall_mem_iff_getElem, List.getElem_eraseIdx]
+      intros; split_ifs <;> simp [*]
+    have pushes'_mult : ∀ b ∈ pushes', b.mult = 1 := by
+      simp only [pushes', List.forall_mem_iff_getElem, List.getElem_eraseIdx, List.getElem_set]
+      intros; split_ifs <;> simp [*]
+    apply ih pulls' pushes' ?balance' pulls'_len pushes'_len ?pulls'_channel ?pushes'_channel pulls'_mult pushes'_mult ?constraints' j' hj'
+    <;> clear ih
+    case pulls'_channel | pushes'_channel =>
+      simp only [pulls', pushes', List.forall_mem_iff_getElem, List.getElem_set, List.getElem_eraseIdx]
+      intros; split_ifs <;> simp [*]
+    case constraints' : ∀ i' (hi' : i' < n), pulls'[i'].Guarantees data → pushes'[i'].Requirements data := by
+      intro i' hi'
+      by_cases h_ij' : j' = i'
+      · simp only [←h_ij', pulls'_getElem, pushes'_getElem]
+        exact pulls_j_imp_push_i
+      simp only [pulls', pushes', h_ij', List.getElem_eraseIdx, ne_eq, not_false_eq_true, List.getElem_set_ne]
+      split_ifs <;> exact constraints _ (by linarith)
+    -- it only remains to prove the balance condition for pulls' ++ pushes'.
+    -- at a high level, this is obvious because we removed two opposing elements with the same message
+    -- (pushes[j] and pulls[i]), so balance for any message is unaffected.
+    rcases balance with ⟨ lt_ringChar, balance ⟩
+    simp only [len_pulls, len_pushes, List.length_append] at lt_ringChar
+    constructor
+    · simp only [pulls'_len, pushes'_len, List.length_append]
+      rcases lt_ringChar with lt_ringChar | ringChar_zero
+      · left; linarith
+      · right; assumption
+    intro msg'
+    specialize balance msg'
+    simp only [balanceOf_append] at balance ⊢
+    rw [balanceOf_eq_of_const_mult' pulls_mult, balanceOf_eq_of_const_mult' pushes_mult] at balance
+    rw [balanceOf_eq_of_const_mult' pulls'_mult, balanceOf_eq_of_const_mult' pushes'_mult]
+    simp only [neg_mul, one_mul, neg_add_eq_zero] at balance ⊢
+    have count_eq : pulls.countP (·.msg = msg') = pushes.countP (·.msg = msg') := by
+      rcases lt_ringChar with lt_ringChar | ringChar_zero
+      · have a_lt_ringChar : pulls.countP (·.msg = msg') < ringChar F := by
+          grw [List.countP_le_length, len_pulls, Nat.le_add_right (n + 1) (n + 1)]
+          exact lt_ringChar
+        have b_lt_ringChar : pushes.countP (·.msg = msg') < ringChar F := by
+          grw [List.countP_le_length, len_pushes, Nat.le_add_right (n + 1) (n + 1)]
+          exact lt_ringChar
+        rw [Lean.Grind.IsCharP.natCast_eq_iff_of_lt _ a_lt_ringChar b_lt_ringChar] at balance
+        exact balance
+      · rw [CharP.ringChar_zero_iff_CharZero] at ringChar_zero
+        rw [Nat.cast_inj] at balance
+        exact balance
+    have pushes_eq : pushes' = (pushes.set j pushes[i]).eraseIdx i := by
+      simp [pushes', List.eraseIdx_set, j']
+      split_ifs <;> (simp_all; try omega)
+    simp only [pulls', pushes_eq]
+    rw [List.countP_eraseIdx (by linarith), ←pull_i_msg]
+    rw [List.countP_eraseIdx (by simp_all), List.countP_set (len_pushes ▸ hj), push_j_msg]
+    simp [h_ij, count_eq]
+
 def activeInteractions (interactions : List (Interaction F)) : List (Interaction F) :=
   interactions.filter (fun i => i.mult ≠ 0)
 
@@ -284,9 +423,10 @@ lemma activeInteractions_length_eq {pulls pushes : List (Interaction F)}
     (h_pair : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
       pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
     (activeInteractions pulls).length = (activeInteractions pushes).length := by
+  simp only [activeInteractions]
   induction pulls generalizing pushes with
   | nil =>
-    cases pushes <;> simp [activeInteractions] at h_len ⊢
+    cases pushes <;> simp at h_len ⊢
   | cons pull pulls ih =>
     cases pushes with
     | nil => simp at h_len
@@ -296,14 +436,11 @@ lemma activeInteractions_length_eq {pulls pushes : List (Interaction F)}
           pulls[i].mult = 0 ↔ pushes[i].mult = 0 := by
         intro i hpi hqi
         exact h_pair (i + 1) (by simpa) (by simpa)
-      have ih' := ih h_len h_pair_tail
-      by_cases h : pull.mult = 0
-      · have h_push : push.mult = 0 := (h_pair 0 (by simp) (by simp)).mp h
-        simpa [activeInteractions, h, h_push] using ih'
-      · have h_push : push.mult ≠ 0 := by
-          intro h_push
-          exact h ((h_pair 0 (by simp) (by simp)).mpr h_push)
-        simpa [activeInteractions, h, h_push] using congrArg Nat.succ ih'
+      specialize ih h_len h_pair_tail
+      simp only [ne_eq, decide_not] at ih
+      have h_pair_head : pull.mult = 0 ↔ push.mult = 0 := h_pair 0 (by simp) (by simp)
+      by_cases h_pull : pull.mult = 0
+      <;> simp [←h_pair_head, h_pull, ih]
 
 lemma activePair_mem_zip {pulls pushes : List (Interaction F)}
     (h_len : pulls.length = pushes.length)
@@ -404,157 +541,13 @@ lemma balancedInteractions_active_append {pulls pushes : List (Interaction F)}
     exact balance.2 msg
 
 /--
-Assume you have a list of channel interactions that is made up of pairs (-1, pull_i), (1, push_i),
-where for each i, `Guarantees (-1, pull_i) → Requirements (1, push_i)`.
-We want to think of (pull_i → push_i) as the state transition of a VM circuit.
-
-Furthermore, assume the list is balanced and the channel is normal.
-
-Then, for any i, the **converse** is true: `Requirements (1, push_i) → Guarantees (-1, pull_i)`.
-
-The intuition is that when the requirements for a push hold unconditionally, we
-can "follow implications around the cycle" to show that _all_ the guarantees/requirements must hold
-(within that cycle, which contains both the push and its corresponding pull).
-
-By narrowing the conclusion to only the guarantees of the push, the formulation cleverly
-avoids talking about cycles at all, and achieves a comparatively simple proof by induction.
--/
-theorem guarantees_of_requirements_of_requirements_of_guarantees [Fact (ringChar F ≠ 2)]
-    (channel : RawChannel F) [channel.Normal]
-    (pulls pushes : List (Interaction F))
-    (balance : BalancedInteractions (pulls ++ pushes)) (data : ProverData F)
-  -- same length
-  (n : ℕ) (len_pulls : pulls.length = n) (len_pushes : pushes.length = n)
-  -- all interactions are on the input channel
-  (pulls_channel : ∀ a ∈ pulls, a.channel = channel) (pushes_channel : ∀ b ∈ pushes, b.channel = channel)
-  -- the multiplicities are -1 for pulls and 1 for pushes
-  (pulls_mult : ∀ a ∈ pulls, a.mult = -1) (pushes_mult : ∀ b ∈ pushes, b.mult = 1) :
-    (∀ (i : ℕ) (hi : i < n), pulls[i].Guarantees data → pushes[i].Requirements data) →
-    ∀ (i : ℕ) (hi: i < n), pushes[i].Requirements data → pulls[i].Guarantees data := by
-  intro constraints
-  induction n generalizing pulls pushes with
-  | zero => intro i hi; nomatch hi
-  | succ n ih =>
-    -- first, a little inline version of `exists_push_of_pull`
-    have exists_push_of_pull : ∀ pull ∈ pulls, ∃ push ∈ pushes, push.msg = pull.msg := by
-      intro pull pull_mem
-      have pull_mem_append : pull ∈ pulls ++ pushes := by simp [pull_mem]
-      have ⟨ push, push_mem, push_msg_eq, push_mult_ne_neg_one, _push_mult_ne_zero ⟩ :=
-        exists_push_of_pull (pulls ++ pushes)
-        balance pull pull_mem_append (pulls_mult pull pull_mem)
-      have push_mem : push ∈ pushes := by simp only [List.mem_append] at push_mem; tauto
-      exists push
-    -- we identify the "previous" transition (pulls[j], pushes[j]) in the chain, where pushes[j] = pulls[i]
-    intro i hi push_i_req
-    have ⟨ push', push'_mem, push_j_msg ⟩ := exists_push_of_pull pulls[i] (List.getElem_mem ..)
-    set msg := pulls[i].msg with pull_i_msg
-    have ⟨ j, hj, hpush' ⟩ := List.getElem_of_mem push'_mem
-    subst hpush'
-    rw [len_pushes] at hj
-    -- thanks to the channel being consistent, it suffices to show the requirements of pushes[j]
-    have push_j_imp_pull_i : pushes[j].Requirements data → pulls[i].Guarantees data := by
-      intro push_j_req
-      have pulls_i_channel := pulls_channel pulls[i] (List.getElem_mem ..)
-      have pushes_j_channel := pushes_channel pushes[j] (List.getElem_mem ..) |>.symm
-      have pulls_i_mult := pulls_mult pulls[i] (List.getElem_mem ..)
-      have pushes_j_mult := pushes_mult pushes[j] (List.getElem_mem ..) |>.symm
-      have msg_size : msg.size = channel.arity := by rw [pulls[i].same_size, pulls_i_channel]
-      suffices grt' : channel.Guarantees (-1) ⟨ msg, msg_size ⟩ data by
-        simp only [Interaction.Guarantees]
-        convert fun _ => grt'
-      apply RawChannel.Normal.grts_of_reqs ⟨ msg, msg_size ⟩ 1 data one_ne_neg_one one_ne_zero
-      simp only [Interaction.Requirements, Interaction.msgVector, push_j_msg] at push_j_req
-      convert push_j_req
-    -- if i = j, we're done
-    by_cases h_ij : j = i
-    · subst h_ij; exact push_j_imp_pull_i push_i_req
-    -- if i ≠ j, we can reduce our goal to a smaller list: the one where
-    -- (pulls[j], pushes[j]) and (pulls[i], pushes[i]) are replaced with the single pair (pulls[j], pushes[i]).
-    have pulls_j_imp_push_i : pulls[j].Guarantees data → pushes[i].Requirements data := fun j_grt =>
-      j_grt |> constraints j hj |> push_j_imp_pull_i |> constraints i hi
-    -- we remove (pulls[i], pushes[i]) and change pushes[j] to pushes[i]
-    let j' := if j < i then j else j - 1
-    let pulls' := pulls.eraseIdx i
-    let pushes' := pushes.eraseIdx i |>.set j' pushes[i]
-    have hj' : j' < n := by simp only [j']; split_ifs <;> omega
-    have pulls'_len : pulls'.length = n := by simp [pulls', List.length_eraseIdx, len_pulls, hi]
-    have pushes'_len : pushes'.length = n := by simp [pushes', List.length_eraseIdx, len_pushes, hi]
-    have pulls'_getElem : pulls'[j'] = pulls[j] := by
-      simp only [pulls', j', List.getElem_eraseIdx]
-      split_ifs
-      · simp
-      · omega
-      · simp [show j - 1 + 1 = j by omega]
-    have pushes'_getElem : pushes'[j'] = pushes[i] := by simp [pushes', j']
-    suffices push_i_imp_pull_j : pushes'[j'].Requirements data → pulls'[j'].Guarantees data by
-      simp only [pulls'_getElem, pushes'_getElem] at push_i_imp_pull_j
-      exact push_i_req |> push_i_imp_pull_j |> constraints j hj |> push_j_imp_pull_i
-    -- we need to re-check all assumptions about as', bs' for the induction hypothesis
-    -- most of these are straightforward
-    have pulls'_mult : ∀ a ∈ pulls', a.mult = -1 := by
-      simp only [pulls', List.forall_mem_iff_getElem, List.getElem_eraseIdx]
-      intros; split_ifs <;> simp [*]
-    have pushes'_mult : ∀ b ∈ pushes', b.mult = 1 := by
-      simp only [pushes', List.forall_mem_iff_getElem, List.getElem_eraseIdx, List.getElem_set]
-      intros; split_ifs <;> simp [*]
-    apply ih pulls' pushes' ?balance' pulls'_len pushes'_len ?pulls'_channel ?pushes'_channel pulls'_mult pushes'_mult ?constraints' j' hj'
-    <;> clear ih
-    case pulls'_channel | pushes'_channel =>
-      simp only [pulls', pushes', List.forall_mem_iff_getElem, List.getElem_set, List.getElem_eraseIdx]
-      intros; split_ifs <;> simp [*]
-    case constraints' : ∀ i' (hi' : i' < n), pulls'[i'].Guarantees data → pushes'[i'].Requirements data := by
-      intro i' hi'
-      by_cases h_ij' : j' = i'
-      · simp only [←h_ij', pulls'_getElem, pushes'_getElem]
-        exact pulls_j_imp_push_i
-      simp only [pulls', pushes', h_ij', List.getElem_eraseIdx, ne_eq, not_false_eq_true, List.getElem_set_ne]
-      split_ifs <;> exact constraints _ (by linarith)
-    -- it only remains to prove the balance condition for pulls' ++ pushes'.
-    -- at a high level, this is obvious because we removed two opposing elements with the same message
-    -- (pushes[j] and pulls[i]), so balance for any message is unaffected.
-    rcases balance with ⟨ lt_ringChar, balance ⟩
-    simp only [len_pulls, len_pushes, List.length_append] at lt_ringChar
-    constructor
-    · simp only [pulls'_len, pushes'_len, List.length_append]
-      rcases lt_ringChar with lt_ringChar | ringChar_zero
-      · left; linarith
-      · right; assumption
-    intro msg'
-    specialize balance msg'
-    simp only [balanceOf_append] at balance ⊢
-    rw [balanceOf_eq_of_const_mult' pulls_mult, balanceOf_eq_of_const_mult' pushes_mult] at balance
-    rw [balanceOf_eq_of_const_mult' pulls'_mult, balanceOf_eq_of_const_mult' pushes'_mult]
-    simp only [neg_mul, one_mul, neg_add_eq_zero] at balance ⊢
-    have count_eq : pulls.countP (·.msg = msg') = pushes.countP (·.msg = msg') := by
-      rcases lt_ringChar with lt_ringChar | ringChar_zero
-      · have a_lt_ringChar : pulls.countP (·.msg = msg') < ringChar F := by
-          grw [List.countP_le_length, len_pulls, Nat.le_add_right (n + 1) (n + 1)]
-          exact lt_ringChar
-        have b_lt_ringChar : pushes.countP (·.msg = msg') < ringChar F := by
-          grw [List.countP_le_length, len_pushes, Nat.le_add_right (n + 1) (n + 1)]
-          exact lt_ringChar
-        rw [Lean.Grind.IsCharP.natCast_eq_iff_of_lt _ a_lt_ringChar b_lt_ringChar] at balance
-        exact balance
-      · rw [CharP.ringChar_zero_iff_CharZero] at ringChar_zero
-        rw [Nat.cast_inj] at balance
-        exact balance
-    have pushes_eq : pushes' = (pushes.set j pushes[i]).eraseIdx i := by
-      simp [pushes', List.eraseIdx_set, j']
-      split_ifs <;> (simp_all; try omega)
-    simp only [pulls', pushes_eq]
-    rw [List.countP_eraseIdx (by linarith), ←pull_i_msg]
-    rw [List.countP_eraseIdx (by simp_all), List.countP_set (len_pushes ▸ hj), push_j_msg]
-    simp [h_ij, count_eq]
-
-/--
-Zero-gated variant of `guarantees_of_requirements_of_requirements_of_guarantees`.
+Zero-padded variant of `guarantees_of_requirements_of_requirements_of_guarantees`.
 
 The input lists may contain padded pull/push pairs with multiplicity `0`. The active
 subsequence, where pull multiplicity is `-1` and push multiplicity is `1`, satisfies
-the original VM theorem. Disabled pairs are removed at this abstract layer because
-they do not affect balance.
+the original VM theorem. `0` multiplicities can be discarded as they don't affect balance.
 -/
-theorem guarantees_of_requirements_of_requirements_of_guarantees_gated [Fact (ringChar F ≠ 2)]
+theorem guarantees_of_requirements_of_requirements_of_guarantees_of_mult_zero_iff [Fact (ringChar F ≠ 2)]
     (channel : RawChannel F) [channel.Normal]
     (pulls pushes : List (Interaction F))
     (balance : BalancedInteractions (pulls ++ pushes)) (data : ProverData F)

--- a/Clean/Air/Balance.lean
+++ b/Clean/Air/Balance.lean
@@ -173,15 +173,6 @@ theorem exists_push_of_pull (interactions : List (Interaction F)) (balance : Bal
     simp_all [Lean.Grind.IsCharP.natCast_eq_zero_iff_of_lt _ neg_one_count_lt_ringChar]
   · simp_all [CharP.ringChar_zero_iff_CharZero]
 
-def InteractionsWellFormed (interactions : List (Interaction F)) : Prop :=
-  ∀ i ∈ interactions, i.assumeGuarantees = true → i.mult = -1 ∨ i.mult = 0
-
-omit [DecidableEq F] in
-theorem InteractionsWellFormed.of_perm {as bs : List (Interaction F)} :
-    InteractionsWellFormed as → as.Perm bs → InteractionsWellFormed bs := by
-  intro h perm i hi
-  exact h i (perm.mem_iff.mpr hi)
-
 /- ## Conditions on channels that strengthen the implications of interaction balance. -/
 
 namespace RawChannel
@@ -198,7 +189,6 @@ For `Channel` it holds by definition, see `NormalChannel` below.
 class Consistent (channel : RawChannel F) : Prop where
   consistent : ∀ (interactions : List (Interaction F)) (data : ProverData F),
     BalancedInteractions interactions →
-    InteractionsWellFormed interactions →
     (∀ i ∈ interactions, i.channel = channel ∧ i.Requirements data) →
     (∀ i ∈ interactions, i.Guarantees data)
 
@@ -232,7 +222,7 @@ instance (channel : Channel F Message) : Normal channel.toRaw where
 theorem consistent_of_normal (channel : RawChannel F) [channel.Normal] :
     channel.Consistent := by
   constructor
-  intro interactions data balance wellformed reqs a a_mem
+  intro interactions data balance reqs a a_mem
   simp only [Interaction.Guarantees, Interaction.Requirements, Interaction.msgVector] at reqs ⊢
   intro _
   have a_channel_eq := reqs a a_mem |>.left
@@ -249,15 +239,8 @@ theorem consistent_of_normal (channel : RawChannel F) [channel.Normal] :
   apply RawChannel.Normal.grts_of_reqs ⟨ a.msg, a_msg_size ⟩ b.mult data b_mult_ne_neg_one b_mult_ne_zero
   have ⟨ b_channel_eq, b_reqs ⟩ := reqs _ b_mem
   symm at b_channel_eq
-  have b_assume_false : b.assumeGuarantees = false := by
-    cases h : b.assumeGuarantees
-    · rfl
-    · have b_mult := wellformed b b_mem h
-      cases b_mult with
-      | inl h_mult => contradiction
-      | inr h_mult => contradiction
   simp only [b_msg_eq] at b_reqs
-  convert b_reqs b_assume_false
+  convert b_reqs
 
 instance (channel : RawChannel F) [channel.Normal] : channel.Consistent :=
   consistent_of_normal channel
@@ -445,8 +428,7 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees [Fact (ringChar
   -- all interactions are on the input channel
   (pulls_channel : ∀ a ∈ pulls, a.channel = channel) (pushes_channel : ∀ b ∈ pushes, b.channel = channel)
   -- the multiplicities are -1 for pulls and 1 for pushes
-  (pulls_mult : ∀ a ∈ pulls, a.mult = -1) (pushes_mult : ∀ b ∈ pushes, b.mult = 1)
-  (pushes_assumeRequirements : ∀ b ∈ pushes, b.assumeGuarantees = false) :
+  (pulls_mult : ∀ a ∈ pulls, a.mult = -1) (pushes_mult : ∀ b ∈ pushes, b.mult = 1) :
     (∀ (i : ℕ) (hi : i < n), pulls[i].Guarantees data → pushes[i].Requirements data) →
     ∀ (i : ℕ) (hi: i < n), pushes[i].Requirements data → pulls[i].Guarantees data := by
   intro constraints
@@ -482,7 +464,7 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees [Fact (ringChar
         convert fun _ => grt'
       apply RawChannel.Normal.grts_of_reqs ⟨ msg, msg_size ⟩ 1 data one_ne_neg_one one_ne_zero
       simp only [Interaction.Requirements, Interaction.msgVector, push_j_msg] at push_j_req
-      convert push_j_req (pushes_assumeRequirements pushes[j] (List.getElem_mem ..))
+      convert push_j_req
     -- if i = j, we're done
     by_cases h_ij : j = i
     · subst h_ij; exact push_j_imp_pull_i push_i_req
@@ -515,10 +497,7 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees [Fact (ringChar
     have pushes'_mult : ∀ b ∈ pushes', b.mult = 1 := by
       simp only [pushes', List.forall_mem_iff_getElem, List.getElem_eraseIdx, List.getElem_set]
       intros; split_ifs <;> simp [*]
-    have pushes'_assumeRequirements : ∀ b ∈ pushes', b.assumeGuarantees = false := by
-      simp only [pushes', List.forall_mem_iff_getElem, List.getElem_eraseIdx, List.getElem_set]
-      intros; split_ifs <;> simp [*]
-    apply ih pulls' pushes' ?balance' pulls'_len pushes'_len ?pulls'_channel ?pushes'_channel pulls'_mult pushes'_mult pushes'_assumeRequirements ?constraints' j' hj'
+    apply ih pulls' pushes' ?balance' pulls'_len pushes'_len ?pulls'_channel ?pushes'_channel pulls'_mult pushes'_mult ?constraints' j' hj'
     <;> clear ih
     case pulls'_channel | pushes'_channel =>
       simp only [pulls', pushes', List.forall_mem_iff_getElem, List.getElem_set, List.getElem_eraseIdx]
@@ -586,7 +565,6 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees_gated [Fact (ri
   -- pulls are either active `-1` pulls or disabled, pushes are either active `1` pushes or disabled
   (pulls_mult : ∀ a ∈ pulls, a.mult = -1 ∨ a.mult = 0)
   (pushes_mult : ∀ b ∈ pushes, b.mult = 1 ∨ b.mult = 0)
-  (pushes_assumeRequirements : ∀ b ∈ pushes, b.assumeGuarantees = false)
   -- a pair is disabled on one side iff it is disabled on the other
   (pair_zero : ∀ i (hi_p : i < pulls.length) (hi_q : i < pushes.length),
     pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
@@ -624,17 +602,12 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees_gated [Fact (ri
     rcases pushes_mult b hb.1 with h_mult | h_mult
     · exact h_mult
     · contradiction
-  have active_pushes_assumeRequirements : ∀ b ∈ active_pushes, b.assumeGuarantees = false := by
-    intro b hb
-    simp only [active_pushes, activeInteractions, List.mem_filter] at hb
-    exact pushes_assumeRequirements b hb.1
   have active_len : active_pulls.length = active_pushes.length := by
     simpa [active_pulls, active_pushes] using
       activeInteractions_length_eq len_pulls_pushes pair_zero
   have theorem_active := guarantees_of_requirements_of_requirements_of_guarantees
     channel active_pulls active_pushes active_balance data active_pulls.length rfl active_len.symm
     active_pulls_channel active_pushes_channel active_pulls_mult active_pushes_mult
-    active_pushes_assumeRequirements
   have constraints' : ∀ (i : ℕ) (hi : i < active_pulls.length),
       active_pulls[i].Guarantees data → (active_pushes[i]'(by rw [← active_len]; exact hi)).Requirements data := by
     simpa [active_pulls, active_pushes] using constraints

--- a/Clean/Air/Balance.lean
+++ b/Clean/Air/Balance.lean
@@ -293,11 +293,14 @@ lemma List.countP_eraseIdx {α : Type} {l : List α} {p : α → Bool} {i : ℕ}
       rw [← ih (Nat.lt_of_succ_lt_succ hi)]
       ring
 
-def activePulls (pulls : List (Interaction F)) : List (Interaction F) :=
-  pulls.filter (fun pull => pull.mult ≠ 0)
+def activeInteractions (interactions : List (Interaction F)) : List (Interaction F) :=
+  interactions.filter (fun i => i.mult ≠ 0)
 
-def activePushes (pushes : List (Interaction F)) : List (Interaction F) :=
-  pushes.filter (fun push => push.mult ≠ 0)
+abbrev activePulls : List (Interaction F) → List (Interaction F) :=
+  activeInteractions
+
+abbrev activePushes : List (Interaction F) → List (Interaction F) :=
+  activeInteractions
 
 lemma activePulls_length_eq_activePushes_length {pulls pushes : List (Interaction F)}
     (h_len : pulls.length = pushes.length)
@@ -306,7 +309,7 @@ lemma activePulls_length_eq_activePushes_length {pulls pushes : List (Interactio
     (activePulls pulls).length = (activePushes pushes).length := by
   induction pulls generalizing pushes with
   | nil =>
-    cases pushes <;> simp [activePulls, activePushes] at h_len ⊢
+    cases pushes <;> simp [activePulls, activePushes, activeInteractions] at h_len ⊢
   | cons pull pulls ih =>
     cases pushes with
     | nil => simp at h_len
@@ -319,76 +322,11 @@ lemma activePulls_length_eq_activePushes_length {pulls pushes : List (Interactio
       have ih' := ih h_len h_pair_tail
       by_cases h : pull.mult = 0
       · have h_push : push.mult = 0 := (h_pair 0 (by simp) (by simp)).mp h
-        simpa [activePulls, activePushes, h, h_push] using ih'
+        simpa [activePulls, activePushes, activeInteractions, h, h_push] using ih'
       · have h_push : push.mult ≠ 0 := by
           intro h_push
           exact h ((h_pair 0 (by simp) (by simp)).mpr h_push)
-        simpa [activePulls, activePushes, h, h_push] using congrArg Nat.succ ih'
-
-lemma activePulls_length_le_left (pulls : List (Interaction F)) :
-    (activePulls pulls).length ≤ pulls.length := by
-  induction pulls with
-  | nil => simp [activePulls]
-  | cons pull pulls ih =>
-    by_cases h : pull.mult = 0
-    · simp [activePulls, h]
-      simpa [activePulls] using ih.trans (Nat.le_succ _)
-    · simp [activePulls, h]
-      simpa [activePulls] using ih
-
-lemma activePushes_length_le_left (pushes : List (Interaction F)) :
-    (activePushes pushes).length ≤ pushes.length := by
-  induction pushes with
-  | nil => simp [activePushes]
-  | cons push pushes ih =>
-    by_cases h : push.mult = 0
-    · simp [activePushes, h]
-      simpa [activePushes] using ih.trans (Nat.le_succ _)
-    · simp [activePushes, h]
-      simpa [activePushes] using ih
-
-lemma activePulls_mult {pulls : List (Interaction F)}
-    (h : ∀ pull ∈ pulls, pull.mult = -1 ∨ pull.mult = 0) :
-    ∀ pull ∈ activePulls pulls, pull.mult = -1 := by
-  intro pull h_mem
-  simp only [activePulls, List.mem_filter] at h_mem
-  rcases h_mem with ⟨ h_mem, h_ne_zero ⟩
-  have h_ne_zero' : pull.mult ≠ 0 := by simpa using h_ne_zero
-  rcases h pull h_mem with h_mult | h_mult
-  · exact h_mult
-  · contradiction
-
-lemma activePushes_mult {pushes : List (Interaction F)}
-    (h_pushes : ∀ push ∈ pushes, push.mult = 1 ∨ push.mult = 0) :
-    ∀ push ∈ activePushes pushes, push.mult = 1 := by
-  intro push h_mem
-  simp only [activePushes, List.mem_filter] at h_mem
-  rcases h_mem with ⟨ h_mem, h_ne_zero ⟩
-  have h_ne_zero' : push.mult ≠ 0 := by simpa using h_ne_zero
-  rcases h_pushes push h_mem with h_mult | h_mult
-  · exact h_mult
-  · contradiction
-
-lemma activePulls_channel {channel : RawChannel F} {pulls : List (Interaction F)}
-    (h : ∀ pull ∈ pulls, pull.channel = channel) :
-    ∀ pull ∈ activePulls pulls, pull.channel = channel := by
-  intro pull h_mem
-  simp only [activePulls, List.mem_filter] at h_mem
-  exact h pull h_mem.1
-
-lemma activePushes_channel {channel : RawChannel F} {pushes : List (Interaction F)}
-    (h : ∀ push ∈ pushes, push.channel = channel) :
-    ∀ push ∈ activePushes pushes, push.channel = channel := by
-  intro push h_mem
-  simp only [activePushes, List.mem_filter] at h_mem
-  exact h push h_mem.1
-
-lemma activePushes_assumeRequirements {pushes : List (Interaction F)}
-    (h : ∀ push ∈ pushes, push.assumeGuarantees = false) :
-    ∀ push ∈ activePushes pushes, push.assumeGuarantees = false := by
-  intro push h_mem
-  simp only [activePushes, List.mem_filter] at h_mem
-  exact h push h_mem.1
+        simpa [activePulls, activePushes, activeInteractions, h, h_push] using congrArg Nat.succ ih'
 
 lemma activePair_mem_zip {pulls pushes : List (Interaction F)}
     (h_len : pulls.length = pushes.length)
@@ -399,7 +337,7 @@ lemma activePair_mem_zip {pulls pushes : List (Interaction F)}
       (activePushes pushes)[i]'(activePulls_length_eq_activePushes_length h_len h_pair ▸ hi))
       ∈ pulls.zip pushes := by
   induction pulls generalizing pushes i with
-  | nil => simp [activePulls] at hi
+  | nil => simp [activePulls, activeInteractions] at hi
   | cons pull pulls ih =>
     cases pushes with
     | nil => simp at h_len
@@ -411,22 +349,26 @@ lemma activePair_mem_zip {pulls pushes : List (Interaction F)}
         exact h_pair (i + 1) (by simpa) (by simpa)
       by_cases h_zero : pull.mult = 0
       · have h_push_zero : push.mult = 0 := (h_pair 0 (by simp) (by simp)).mp h_zero
-        simp [activePulls, activePushes, h_zero, h_push_zero] at hi ⊢
-        have hi' : i < (activePulls pulls).length := by simpa [activePulls] using hi
-        exact Or.inr (by simpa [activePulls, activePushes] using ih h_len h_pair_tail i hi')
+        simp [activePulls, activePushes, activeInteractions, h_zero, h_push_zero] at hi ⊢
+        have hi' : i < (activePulls pulls).length := by
+          simpa [activePulls, activeInteractions] using hi
+        exact Or.inr (by
+          simpa [activePulls, activePushes, activeInteractions] using ih h_len h_pair_tail i hi')
       · cases i with
         | zero =>
           have h_push_ne_zero : push.mult ≠ 0 := by
             intro h_push_zero
             exact h_zero ((h_pair 0 (by simp) (by simp)).mpr h_push_zero)
-          simp [activePulls, activePushes, h_zero, h_push_ne_zero]
+          simp [activePulls, activePushes, activeInteractions, h_zero, h_push_ne_zero]
         | succ i =>
           have h_push_ne_zero : push.mult ≠ 0 := by
             intro h_push_zero
             exact h_zero ((h_pair 0 (by simp) (by simp)).mpr h_push_zero)
-          simp [activePulls, activePushes, h_zero, h_push_ne_zero] at hi ⊢
-          have hi' : i < (activePulls pulls).length := by simpa [activePulls] using hi
-          exact Or.inr (by simpa [activePulls, activePushes] using ih h_len h_pair_tail i hi')
+          simp [activePulls, activePushes, activeInteractions, h_zero, h_push_ne_zero] at hi ⊢
+          have hi' : i < (activePulls pulls).length := by
+            simpa [activePulls, activeInteractions] using hi
+          exact Or.inr (by
+            simpa [activePulls, activePushes, activeInteractions] using ih h_len h_pair_tail i hi')
 
 lemma balanceOf_active_append_eq {pulls pushes : List (Interaction F)} {msg : Array F}
     (h_len : pulls.length = pushes.length)
@@ -436,7 +378,7 @@ lemma balanceOf_active_append_eq {pulls pushes : List (Interaction F)} {msg : Ar
       balanceOf (pulls ++ pushes) msg := by
   induction pulls generalizing pushes with
   | nil =>
-    cases pushes <;> simp [activePulls, activePushes, balanceOf] at h_len ⊢
+    cases pushes <;> simp [activePulls, activePushes, activeInteractions, balanceOf] at h_len ⊢
   | cons pull pulls ih =>
     cases pushes with
     | nil => simp at h_len
@@ -449,13 +391,13 @@ lemma balanceOf_active_append_eq {pulls pushes : List (Interaction F)} {msg : Ar
       have ih' := ih h_len h_pair_tail
       by_cases h_zero : pull.mult = 0
       · have h_push_zero : push.mult = 0 := (h_pair 0 (by simp) (by simp)).mp h_zero
-        simp [activePulls, activePushes, h_zero, h_push_zero, balanceOf_append,
+        simp [activePulls, activePushes, activeInteractions, h_zero, h_push_zero, balanceOf_append,
           balanceOf_cons] at ih' ⊢
         exact ih'
       · have h_push_ne_zero : push.mult ≠ 0 := by
           intro h_push_zero
           exact h_zero ((h_pair 0 (by simp) (by simp)).mpr h_push_zero)
-        simp [activePulls, activePushes, h_zero, h_push_ne_zero, balanceOf_append,
+        simp [activePulls, activePushes, activeInteractions, h_zero, h_push_ne_zero, balanceOf_append,
           balanceOf_cons] at ih' ⊢
         ring_nf at ih' ⊢
         exact congrArg (fun x => x + if push.msg = msg then push.mult else 0) ih'
@@ -469,8 +411,10 @@ lemma balancedInteractions_active_append {pulls pushes : List (Interaction F)}
   constructor
   · rcases balance.1 with h_lt | h_char
     · left
-      have h_len_pulls : (activePulls pulls).length ≤ pulls.length :=
-        activePulls_length_le_left pulls
+      have h_len_pulls : (activePulls pulls).length ≤ pulls.length := by
+        rw [activePulls, activeInteractions]
+        have h := pulls.length_eq_length_filter_add (fun i => i.mult ≠ 0)
+        omega
       have h_len_pushes : (activePushes pushes).length ≤ pushes.length := by
         rw [← activePulls_length_eq_activePushes_length h_len h_pair, ← h_len]
         exact h_len_pulls
@@ -665,15 +609,31 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees_gated [Fact (ri
     simpa [activePulls', activePushes'] using
       balancedInteractions_active_append balance len_pulls_pushes pair_zero
   have active_pulls_channel : ∀ a ∈ activePulls', a.channel = channel := by
-    simpa [activePulls'] using activePulls_channel pulls_channel
+    intro a ha
+    simp only [activePulls', activeInteractions, List.mem_filter] at ha
+    exact pulls_channel a ha.1
   have active_pushes_channel : ∀ b ∈ activePushes', b.channel = channel := by
-    simpa [activePushes'] using activePushes_channel pushes_channel
+    intro b hb
+    simp only [activePushes', activeInteractions, List.mem_filter] at hb
+    exact pushes_channel b hb.1
   have active_pulls_mult : ∀ a ∈ activePulls', a.mult = -1 := by
-    simpa [activePulls'] using activePulls_mult pulls_mult
+    intro a ha
+    simp only [activePulls', activeInteractions, List.mem_filter] at ha
+    have a_mult_ne_zero : a.mult ≠ 0 := by simpa using ha.2
+    rcases pulls_mult a ha.1 with h_mult | h_mult
+    · exact h_mult
+    · contradiction
   have active_pushes_mult : ∀ b ∈ activePushes', b.mult = 1 := by
-    simpa [activePushes'] using activePushes_mult pushes_mult
+    intro b hb
+    simp only [activePushes', activeInteractions, List.mem_filter] at hb
+    have b_mult_ne_zero : b.mult ≠ 0 := by simpa using hb.2
+    rcases pushes_mult b hb.1 with h_mult | h_mult
+    · exact h_mult
+    · contradiction
   have active_pushes_assumeRequirements : ∀ b ∈ activePushes', b.assumeGuarantees = false := by
-    simpa [activePushes'] using activePushes_assumeRequirements pushes_assumeRequirements
+    intro b hb
+    simp only [activePushes', activeInteractions, List.mem_filter] at hb
+    exact pushes_assumeRequirements b hb.1
   have active_len : activePulls'.length = activePushes'.length := by
     simpa [activePulls', activePushes'] using
       activePulls_length_eq_activePushes_length len_pulls_pushes pair_zero

--- a/Clean/Air/Balance.lean
+++ b/Clean/Air/Balance.lean
@@ -173,10 +173,6 @@ theorem exists_push_of_pull (interactions : List (Interaction F)) (balance : Bal
     simp_all [Lean.Grind.IsCharP.natCast_eq_zero_iff_of_lt _ neg_one_count_lt_ringChar]
   · simp_all [CharP.ringChar_zero_iff_CharZero]
 
-/- ## Conditions on channels that strengthen the implications of interaction balance. -/
-
-namespace RawChannel
-
 def InteractionsWellFormed (interactions : List (Interaction F)) : Prop :=
   ∀ i ∈ interactions, i.assumeGuarantees = true → i.mult = -1 ∨ i.mult = 0
 
@@ -185,6 +181,10 @@ theorem InteractionsWellFormed.of_perm {as bs : List (Interaction F)} :
     InteractionsWellFormed as → as.Perm bs → InteractionsWellFormed bs := by
   intro h perm i hi
   exact h i (perm.mem_iff.mpr hi)
+
+/- ## Conditions on channels that strengthen the implications of interaction balance. -/
+
+namespace RawChannel
 
 /--
 We call a channel "consistent" if balancedness + requirements on all interacions
@@ -293,172 +293,146 @@ lemma List.countP_eraseIdx {α : Type} {l : List α} {p : α → Bool} {i : ℕ}
       rw [← ih (Nat.lt_of_succ_lt_succ hi)]
       ring
 
-def activePulls : List (Interaction F) → List (Interaction F) → List (Interaction F)
-  | [], _ => []
-  | _, [] => []
-  | pull :: pulls, _push :: pushes =>
-      if pull.mult = 0 then activePulls pulls pushes else pull :: activePulls pulls pushes
+def activePulls (pulls : List (Interaction F)) : List (Interaction F) :=
+  pulls.filter (fun pull => pull.mult ≠ 0)
 
-def activePushes : List (Interaction F) → List (Interaction F) → List (Interaction F)
-  | [], _ => []
-  | _, [] => []
-  | pull :: pulls, push :: pushes =>
-      if pull.mult = 0 then activePushes pulls pushes else push :: activePushes pulls pushes
+def activePushes (pushes : List (Interaction F)) : List (Interaction F) :=
+  pushes.filter (fun push => push.mult ≠ 0)
 
-lemma activePulls_length_eq_activePushes_length (pulls pushes : List (Interaction F)) :
-    (activePulls pulls pushes).length = (activePushes pulls pushes).length := by
-  induction pulls generalizing pushes with
-  | nil => simp [activePulls, activePushes]
-  | cons pull pulls ih =>
-    cases pushes with
-    | nil => simp [activePulls, activePushes]
-    | cons push pushes =>
-      by_cases h : pull.mult = 0
-      · simp [activePulls, activePushes, h, ih]
-      · simp [activePulls, activePushes, h, ih]
-
-lemma activePulls_length_le_left (pulls pushes : List (Interaction F)) :
-    (activePulls pulls pushes).length ≤ pulls.length := by
-  induction pulls generalizing pushes with
-  | nil => simp [activePulls]
-  | cons pull pulls ih =>
-    cases pushes with
-    | nil => simp [activePulls]
-    | cons push pushes =>
-      by_cases h : pull.mult = 0
-      · simp [activePulls, h]
-        exact Nat.le_trans (ih pushes) (Nat.le_succ _)
-      · simp [activePulls, h]
-        exact ih pushes
-
-lemma activePulls_mult {pulls pushes : List (Interaction F)}
-    (h : ∀ pull ∈ pulls, pull.mult = -1 ∨ pull.mult = 0) :
-    ∀ pull ∈ activePulls pulls pushes, pull.mult = -1 := by
-  induction pulls generalizing pushes with
-  | nil => simp [activePulls]
-  | cons pull pulls ih =>
-    cases pushes with
-    | nil => simp [activePulls]
-    | cons push pushes =>
-      have h_tail : ∀ pull ∈ pulls, pull.mult = -1 ∨ pull.mult = 0 := by
-        intro p hp
-        exact h p (by simp [hp])
-      by_cases h_zero : pull.mult = 0
-      · simpa [activePulls, h_zero] using ih h_tail
-      · have h_pull : pull.mult = -1 := by
-          rcases h pull (by simp) with h_pull | h_pull
-          · exact h_pull
-          · contradiction
-        simp [activePulls, h_pull]
-        exact ih h_tail
-
-lemma activePushes_mult {pulls pushes : List (Interaction F)}
-    (h_pushes : ∀ push ∈ pushes, push.mult = 1 ∨ push.mult = 0)
+lemma activePulls_length_eq_activePushes_length {pulls pushes : List (Interaction F)}
+    (h_len : pulls.length = pushes.length)
     (h_pair : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
       pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
-    ∀ push ∈ activePushes pulls pushes, push.mult = 1 := by
+    (activePulls pulls).length = (activePushes pushes).length := by
   induction pulls generalizing pushes with
-  | nil => simp [activePushes]
+  | nil =>
+    cases pushes <;> simp [activePulls, activePushes] at h_len ⊢
   | cons pull pulls ih =>
     cases pushes with
-    | nil => simp [activePushes]
+    | nil => simp at h_len
     | cons push pushes =>
-      have h_pushes_tail : ∀ push ∈ pushes, push.mult = 1 ∨ push.mult = 0 := by
-        intro q hq
-        exact h_pushes q (by simp [hq])
+      simp only [List.length_cons, Nat.succ.injEq] at h_len
       have h_pair_tail : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
           pulls[i].mult = 0 ↔ pushes[i].mult = 0 := by
         intro i hpi hqi
-        exact h_pair (i+1) (by simpa) (by simpa)
-      by_cases h_zero : pull.mult = 0
-      · simpa [activePushes, h_zero] using ih h_pushes_tail h_pair_tail
-      · have h_push_ne_zero : push.mult ≠ 0 := by
-          intro h_push_zero
-          exact h_zero ((h_pair 0 (by simp) (by simp)).mpr h_push_zero)
-        have h_push : push.mult = 1 := by
-          rcases h_pushes push (by simp) with h_push | h_push
-          · exact h_push
-          · contradiction
-        simp [activePushes, h_zero, h_push]
-        exact ih h_pushes_tail h_pair_tail
+        exact h_pair (i + 1) (by simpa) (by simpa)
+      have ih' := ih h_len h_pair_tail
+      by_cases h : pull.mult = 0
+      · have h_push : push.mult = 0 := (h_pair 0 (by simp) (by simp)).mp h
+        simpa [activePulls, activePushes, h, h_push] using ih'
+      · have h_push : push.mult ≠ 0 := by
+          intro h_push
+          exact h ((h_pair 0 (by simp) (by simp)).mpr h_push)
+        simpa [activePulls, activePushes, h, h_push] using congrArg Nat.succ ih'
 
-lemma activePulls_channel {channel : RawChannel F} {pulls pushes : List (Interaction F)}
-    (h : ∀ pull ∈ pulls, pull.channel = channel) :
-    ∀ pull ∈ activePulls pulls pushes, pull.channel = channel := by
-  induction pulls generalizing pushes with
+lemma activePulls_length_le_left (pulls : List (Interaction F)) :
+    (activePulls pulls).length ≤ pulls.length := by
+  induction pulls with
   | nil => simp [activePulls]
   | cons pull pulls ih =>
-    cases pushes with
-    | nil => simp [activePulls]
-    | cons push pushes =>
-      have h_tail : ∀ pull ∈ pulls, pull.channel = channel := by
-        intro p hp
-        exact h p (by simp [hp])
-      by_cases h_zero : pull.mult = 0
-      · simpa [activePulls, h_zero] using ih h_tail
-      · simp [activePulls, h_zero, h pull (by simp)]
-        exact ih h_tail
+    by_cases h : pull.mult = 0
+    · simp [activePulls, h]
+      simpa [activePulls] using ih.trans (Nat.le_succ _)
+    · simp [activePulls, h]
+      simpa [activePulls] using ih
 
-lemma activePushes_channel {channel : RawChannel F} {pulls pushes : List (Interaction F)}
+lemma activePushes_length_le_left (pushes : List (Interaction F)) :
+    (activePushes pushes).length ≤ pushes.length := by
+  induction pushes with
+  | nil => simp [activePushes]
+  | cons push pushes ih =>
+    by_cases h : push.mult = 0
+    · simp [activePushes, h]
+      simpa [activePushes] using ih.trans (Nat.le_succ _)
+    · simp [activePushes, h]
+      simpa [activePushes] using ih
+
+lemma activePulls_mult {pulls : List (Interaction F)}
+    (h : ∀ pull ∈ pulls, pull.mult = -1 ∨ pull.mult = 0) :
+    ∀ pull ∈ activePulls pulls, pull.mult = -1 := by
+  intro pull h_mem
+  simp only [activePulls, List.mem_filter] at h_mem
+  rcases h_mem with ⟨ h_mem, h_ne_zero ⟩
+  have h_ne_zero' : pull.mult ≠ 0 := by simpa using h_ne_zero
+  rcases h pull h_mem with h_mult | h_mult
+  · exact h_mult
+  · contradiction
+
+lemma activePushes_mult {pushes : List (Interaction F)}
+    (h_pushes : ∀ push ∈ pushes, push.mult = 1 ∨ push.mult = 0) :
+    ∀ push ∈ activePushes pushes, push.mult = 1 := by
+  intro push h_mem
+  simp only [activePushes, List.mem_filter] at h_mem
+  rcases h_mem with ⟨ h_mem, h_ne_zero ⟩
+  have h_ne_zero' : push.mult ≠ 0 := by simpa using h_ne_zero
+  rcases h_pushes push h_mem with h_mult | h_mult
+  · exact h_mult
+  · contradiction
+
+lemma activePulls_channel {channel : RawChannel F} {pulls : List (Interaction F)}
+    (h : ∀ pull ∈ pulls, pull.channel = channel) :
+    ∀ pull ∈ activePulls pulls, pull.channel = channel := by
+  intro pull h_mem
+  simp only [activePulls, List.mem_filter] at h_mem
+  exact h pull h_mem.1
+
+lemma activePushes_channel {channel : RawChannel F} {pushes : List (Interaction F)}
     (h : ∀ push ∈ pushes, push.channel = channel) :
-    ∀ push ∈ activePushes pulls pushes, push.channel = channel := by
-  induction pulls generalizing pushes with
-  | nil => simp [activePushes]
-  | cons pull pulls ih =>
-    cases pushes with
-    | nil => simp [activePushes]
-    | cons push pushes =>
-      have h_tail : ∀ push ∈ pushes, push.channel = channel := by
-        intro q hq
-        exact h q (by simp [hq])
-      by_cases h_zero : pull.mult = 0
-      · simpa [activePushes, h_zero] using ih h_tail
-      · simp [activePushes, h_zero, h push (by simp)]
-        exact ih h_tail
+    ∀ push ∈ activePushes pushes, push.channel = channel := by
+  intro push h_mem
+  simp only [activePushes, List.mem_filter] at h_mem
+  exact h push h_mem.1
 
-lemma activePushes_assumeRequirements {pulls pushes : List (Interaction F)}
+lemma activePushes_assumeRequirements {pushes : List (Interaction F)}
     (h : ∀ push ∈ pushes, push.assumeGuarantees = false) :
-    ∀ push ∈ activePushes pulls pushes, push.assumeGuarantees = false := by
-  induction pulls generalizing pushes with
-  | nil => simp [activePushes]
-  | cons pull pulls ih =>
-    cases pushes with
-    | nil => simp [activePushes]
-    | cons push pushes =>
-      have h_tail : ∀ push ∈ pushes, push.assumeGuarantees = false := by
-        intro q hq
-        exact h q (by simp [hq])
-      by_cases h_zero : pull.mult = 0
-      · simpa [activePushes, h_zero] using ih h_tail
-      · simp [activePushes, h_zero, h push (by simp)]
-        exact ih h_tail
+    ∀ push ∈ activePushes pushes, push.assumeGuarantees = false := by
+  intro push h_mem
+  simp only [activePushes, List.mem_filter] at h_mem
+  exact h push h_mem.1
 
 lemma activePair_mem_zip {pulls pushes : List (Interaction F)}
-    (i : ℕ) (hi : i < (activePulls pulls pushes).length) :
-    ((activePulls pulls pushes)[i],
-      (activePushes pulls pushes)[i]'(activePulls_length_eq_activePushes_length pulls pushes ▸ hi))
+    (h_len : pulls.length = pushes.length)
+    (h_pair : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
+      pulls[i].mult = 0 ↔ pushes[i].mult = 0)
+    (i : ℕ) (hi : i < (activePulls pulls).length) :
+    ((activePulls pulls)[i],
+      (activePushes pushes)[i]'(activePulls_length_eq_activePushes_length h_len h_pair ▸ hi))
       ∈ pulls.zip pushes := by
   induction pulls generalizing pushes i with
   | nil => simp [activePulls] at hi
   | cons pull pulls ih =>
     cases pushes with
-    | nil => simp [activePulls] at hi
+    | nil => simp at h_len
     | cons push pushes =>
+      simp only [List.length_cons, Nat.succ.injEq] at h_len
+      have h_pair_tail : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
+          pulls[i].mult = 0 ↔ pushes[i].mult = 0 := by
+        intro i hpi hqi
+        exact h_pair (i + 1) (by simpa) (by simpa)
       by_cases h_zero : pull.mult = 0
-      · simp [activePulls, activePushes, h_zero] at hi ⊢
-        exact Or.inr (ih i hi)
+      · have h_push_zero : push.mult = 0 := (h_pair 0 (by simp) (by simp)).mp h_zero
+        simp [activePulls, activePushes, h_zero, h_push_zero] at hi ⊢
+        have hi' : i < (activePulls pulls).length := by simpa [activePulls] using hi
+        exact Or.inr (by simpa [activePulls, activePushes] using ih h_len h_pair_tail i hi')
       · cases i with
         | zero =>
-          simp [activePulls, activePushes, h_zero]
+          have h_push_ne_zero : push.mult ≠ 0 := by
+            intro h_push_zero
+            exact h_zero ((h_pair 0 (by simp) (by simp)).mpr h_push_zero)
+          simp [activePulls, activePushes, h_zero, h_push_ne_zero]
         | succ i =>
-          simp [activePulls, activePushes, h_zero] at hi ⊢
-          exact Or.inr (ih i hi)
+          have h_push_ne_zero : push.mult ≠ 0 := by
+            intro h_push_zero
+            exact h_zero ((h_pair 0 (by simp) (by simp)).mpr h_push_zero)
+          simp [activePulls, activePushes, h_zero, h_push_ne_zero] at hi ⊢
+          have hi' : i < (activePulls pulls).length := by simpa [activePulls] using hi
+          exact Or.inr (by simpa [activePulls, activePushes] using ih h_len h_pair_tail i hi')
 
 lemma balanceOf_active_append_eq {pulls pushes : List (Interaction F)} {msg : Array F}
     (h_len : pulls.length = pushes.length)
     (h_pair : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
       pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
-    balanceOf (activePulls pulls pushes ++ activePushes pulls pushes) msg =
+    balanceOf (activePulls pulls ++ activePushes pushes) msg =
       balanceOf (pulls ++ pushes) msg := by
   induction pulls generalizing pushes with
   | nil =>
@@ -481,7 +455,7 @@ lemma balanceOf_active_append_eq {pulls pushes : List (Interaction F)} {msg : Ar
       · have h_push_ne_zero : push.mult ≠ 0 := by
           intro h_push_zero
           exact h_zero ((h_pair 0 (by simp) (by simp)).mpr h_push_zero)
-        simp [activePulls, activePushes, h_zero, balanceOf_append,
+        simp [activePulls, activePushes, h_zero, h_push_ne_zero, balanceOf_append,
           balanceOf_cons] at ih' ⊢
         ring_nf at ih' ⊢
         exact congrArg (fun x => x + if push.msg = msg then push.mult else 0) ih'
@@ -491,14 +465,14 @@ lemma balancedInteractions_active_append {pulls pushes : List (Interaction F)}
     (h_len : pulls.length = pushes.length)
     (h_pair : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
       pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
-    BalancedInteractions (activePulls pulls pushes ++ activePushes pulls pushes) := by
+    BalancedInteractions (activePulls pulls ++ activePushes pushes) := by
   constructor
   · rcases balance.1 with h_lt | h_char
     · left
-      have h_len_pulls : (activePulls pulls pushes).length ≤ pulls.length :=
-        activePulls_length_le_left pulls pushes
-      have h_len_pushes : (activePushes pulls pushes).length ≤ pushes.length := by
-        rw [← activePulls_length_eq_activePushes_length pulls pushes, ← h_len]
+      have h_len_pulls : (activePulls pulls).length ≤ pulls.length :=
+        activePulls_length_le_left pulls
+      have h_len_pushes : (activePushes pushes).length ≤ pushes.length := by
+        rw [← activePulls_length_eq_activePushes_length h_len h_pair, ← h_len]
         exact h_len_pulls
       simp only [List.length_append] at h_lt ⊢
       omega
@@ -678,30 +652,31 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees_gated [Fact (ri
   -- a pair is disabled on one side iff it is disabled on the other
   (pair_zero : ∀ i (hi_p : i < pulls.length) (hi_q : i < pushes.length),
     pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
-    (∀ (i : ℕ) (hi : i < (activePulls pulls pushes).length),
-      (activePulls pulls pushes)[i].Guarantees data →
-        ((activePushes pulls pushes)[i]'(activePulls_length_eq_activePushes_length pulls pushes ▸ hi)).Requirements data) →
-    ∀ (i : ℕ) (hi : i < (activePulls pulls pushes).length),
-      ((activePushes pulls pushes)[i]'(activePulls_length_eq_activePushes_length pulls pushes ▸ hi)).Requirements data →
-        (activePulls pulls pushes)[i].Guarantees data := by
+    (∀ (i : ℕ) (hi : i < (activePulls pulls).length),
+      (activePulls pulls)[i].Guarantees data →
+        ((activePushes pushes)[i]'(activePulls_length_eq_activePushes_length len_pulls_pushes pair_zero ▸ hi)).Requirements data) →
+    ∀ (i : ℕ) (hi : i < (activePulls pulls).length),
+      ((activePushes pushes)[i]'(activePulls_length_eq_activePushes_length len_pulls_pushes pair_zero ▸ hi)).Requirements data →
+        (activePulls pulls)[i].Guarantees data := by
   intro constraints
-  let activePulls' := activePulls pulls pushes
-  let activePushes' := activePushes pulls pushes
+  let activePulls' := activePulls pulls
+  let activePushes' := activePushes pushes
   have active_balance : BalancedInteractions (activePulls' ++ activePushes') := by
     simpa [activePulls', activePushes'] using
       balancedInteractions_active_append balance len_pulls_pushes pair_zero
   have active_pulls_channel : ∀ a ∈ activePulls', a.channel = channel := by
-    simpa [activePulls'] using activePulls_channel (pushes:=pushes) pulls_channel
+    simpa [activePulls'] using activePulls_channel pulls_channel
   have active_pushes_channel : ∀ b ∈ activePushes', b.channel = channel := by
-    simpa [activePushes'] using activePushes_channel (pulls:=pulls) pushes_channel
+    simpa [activePushes'] using activePushes_channel pushes_channel
   have active_pulls_mult : ∀ a ∈ activePulls', a.mult = -1 := by
-    simpa [activePulls'] using activePulls_mult (pushes:=pushes) pulls_mult
+    simpa [activePulls'] using activePulls_mult pulls_mult
   have active_pushes_mult : ∀ b ∈ activePushes', b.mult = 1 := by
-    simpa [activePushes'] using activePushes_mult (pulls:=pulls) pushes_mult pair_zero
+    simpa [activePushes'] using activePushes_mult pushes_mult
   have active_pushes_assumeRequirements : ∀ b ∈ activePushes', b.assumeGuarantees = false := by
-    simpa [activePushes'] using activePushes_assumeRequirements (pulls:=pulls) pushes_assumeRequirements
+    simpa [activePushes'] using activePushes_assumeRequirements pushes_assumeRequirements
   have active_len : activePulls'.length = activePushes'.length := by
-    simp [activePulls', activePushes', activePulls_length_eq_activePushes_length]
+    simpa [activePulls', activePushes'] using
+      activePulls_length_eq_activePushes_length len_pulls_pushes pair_zero
   have theorem_active := guarantees_of_requirements_of_requirements_of_guarantees
     channel activePulls' activePushes' active_balance data activePulls'.length rfl active_len.symm
     active_pulls_channel active_pushes_channel active_pulls_mult active_pushes_mult

--- a/Clean/Air/Balance.lean
+++ b/Clean/Air/Balance.lean
@@ -296,20 +296,14 @@ lemma List.countP_eraseIdx {α : Type} {l : List α} {p : α → Bool} {i : ℕ}
 def activeInteractions (interactions : List (Interaction F)) : List (Interaction F) :=
   interactions.filter (fun i => i.mult ≠ 0)
 
-abbrev activePulls : List (Interaction F) → List (Interaction F) :=
-  activeInteractions
-
-abbrev activePushes : List (Interaction F) → List (Interaction F) :=
-  activeInteractions
-
-lemma activePulls_length_eq_activePushes_length {pulls pushes : List (Interaction F)}
+lemma activeInteractions_length_eq {pulls pushes : List (Interaction F)}
     (h_len : pulls.length = pushes.length)
     (h_pair : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
       pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
-    (activePulls pulls).length = (activePushes pushes).length := by
+    (activeInteractions pulls).length = (activeInteractions pushes).length := by
   induction pulls generalizing pushes with
   | nil =>
-    cases pushes <;> simp [activePulls, activePushes, activeInteractions] at h_len ⊢
+    cases pushes <;> simp [activeInteractions] at h_len ⊢
   | cons pull pulls ih =>
     cases pushes with
     | nil => simp at h_len
@@ -322,22 +316,22 @@ lemma activePulls_length_eq_activePushes_length {pulls pushes : List (Interactio
       have ih' := ih h_len h_pair_tail
       by_cases h : pull.mult = 0
       · have h_push : push.mult = 0 := (h_pair 0 (by simp) (by simp)).mp h
-        simpa [activePulls, activePushes, activeInteractions, h, h_push] using ih'
+        simpa [activeInteractions, h, h_push] using ih'
       · have h_push : push.mult ≠ 0 := by
           intro h_push
           exact h ((h_pair 0 (by simp) (by simp)).mpr h_push)
-        simpa [activePulls, activePushes, activeInteractions, h, h_push] using congrArg Nat.succ ih'
+        simpa [activeInteractions, h, h_push] using congrArg Nat.succ ih'
 
 lemma activePair_mem_zip {pulls pushes : List (Interaction F)}
     (h_len : pulls.length = pushes.length)
     (h_pair : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
       pulls[i].mult = 0 ↔ pushes[i].mult = 0)
-    (i : ℕ) (hi : i < (activePulls pulls).length) :
-    ((activePulls pulls)[i],
-      (activePushes pushes)[i]'(activePulls_length_eq_activePushes_length h_len h_pair ▸ hi))
+    (i : ℕ) (hi : i < (activeInteractions pulls).length) :
+    ((activeInteractions pulls)[i],
+      (activeInteractions pushes)[i]'(activeInteractions_length_eq h_len h_pair ▸ hi))
       ∈ pulls.zip pushes := by
   induction pulls generalizing pushes i with
-  | nil => simp [activePulls, activeInteractions] at hi
+  | nil => simp [activeInteractions] at hi
   | cons pull pulls ih =>
     cases pushes with
     | nil => simp at h_len
@@ -349,36 +343,36 @@ lemma activePair_mem_zip {pulls pushes : List (Interaction F)}
         exact h_pair (i + 1) (by simpa) (by simpa)
       by_cases h_zero : pull.mult = 0
       · have h_push_zero : push.mult = 0 := (h_pair 0 (by simp) (by simp)).mp h_zero
-        simp [activePulls, activePushes, activeInteractions, h_zero, h_push_zero] at hi ⊢
-        have hi' : i < (activePulls pulls).length := by
-          simpa [activePulls, activeInteractions] using hi
+        simp [activeInteractions, h_zero, h_push_zero] at hi ⊢
+        have hi' : i < (activeInteractions pulls).length := by
+          simpa [activeInteractions] using hi
         exact Or.inr (by
-          simpa [activePulls, activePushes, activeInteractions] using ih h_len h_pair_tail i hi')
+          simpa [activeInteractions] using ih h_len h_pair_tail i hi')
       · cases i with
         | zero =>
           have h_push_ne_zero : push.mult ≠ 0 := by
             intro h_push_zero
             exact h_zero ((h_pair 0 (by simp) (by simp)).mpr h_push_zero)
-          simp [activePulls, activePushes, activeInteractions, h_zero, h_push_ne_zero]
+          simp [activeInteractions, h_zero, h_push_ne_zero]
         | succ i =>
           have h_push_ne_zero : push.mult ≠ 0 := by
             intro h_push_zero
             exact h_zero ((h_pair 0 (by simp) (by simp)).mpr h_push_zero)
-          simp [activePulls, activePushes, activeInteractions, h_zero, h_push_ne_zero] at hi ⊢
-          have hi' : i < (activePulls pulls).length := by
-            simpa [activePulls, activeInteractions] using hi
+          simp [activeInteractions, h_zero, h_push_ne_zero] at hi ⊢
+          have hi' : i < (activeInteractions pulls).length := by
+            simpa [activeInteractions] using hi
           exact Or.inr (by
-            simpa [activePulls, activePushes, activeInteractions] using ih h_len h_pair_tail i hi')
+            simpa [activeInteractions] using ih h_len h_pair_tail i hi')
 
 lemma balanceOf_active_append_eq {pulls pushes : List (Interaction F)} {msg : Array F}
     (h_len : pulls.length = pushes.length)
     (h_pair : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
       pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
-    balanceOf (activePulls pulls ++ activePushes pushes) msg =
+    balanceOf (activeInteractions pulls ++ activeInteractions pushes) msg =
       balanceOf (pulls ++ pushes) msg := by
   induction pulls generalizing pushes with
   | nil =>
-    cases pushes <;> simp [activePulls, activePushes, activeInteractions, balanceOf] at h_len ⊢
+    cases pushes <;> simp [activeInteractions, balanceOf] at h_len ⊢
   | cons pull pulls ih =>
     cases pushes with
     | nil => simp at h_len
@@ -391,13 +385,13 @@ lemma balanceOf_active_append_eq {pulls pushes : List (Interaction F)} {msg : Ar
       have ih' := ih h_len h_pair_tail
       by_cases h_zero : pull.mult = 0
       · have h_push_zero : push.mult = 0 := (h_pair 0 (by simp) (by simp)).mp h_zero
-        simp [activePulls, activePushes, activeInteractions, h_zero, h_push_zero, balanceOf_append,
+        simp [activeInteractions, h_zero, h_push_zero, balanceOf_append,
           balanceOf_cons] at ih' ⊢
         exact ih'
       · have h_push_ne_zero : push.mult ≠ 0 := by
           intro h_push_zero
           exact h_zero ((h_pair 0 (by simp) (by simp)).mpr h_push_zero)
-        simp [activePulls, activePushes, activeInteractions, h_zero, h_push_ne_zero, balanceOf_append,
+        simp [activeInteractions, h_zero, h_push_ne_zero, balanceOf_append,
           balanceOf_cons] at ih' ⊢
         ring_nf at ih' ⊢
         exact congrArg (fun x => x + if push.msg = msg then push.mult else 0) ih'
@@ -407,16 +401,16 @@ lemma balancedInteractions_active_append {pulls pushes : List (Interaction F)}
     (h_len : pulls.length = pushes.length)
     (h_pair : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
       pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
-    BalancedInteractions (activePulls pulls ++ activePushes pushes) := by
+    BalancedInteractions (activeInteractions pulls ++ activeInteractions pushes) := by
   constructor
   · rcases balance.1 with h_lt | h_char
     · left
-      have h_len_pulls : (activePulls pulls).length ≤ pulls.length := by
-        rw [activePulls, activeInteractions]
+      have h_len_pulls : (activeInteractions pulls).length ≤ pulls.length := by
+        rw [activeInteractions]
         have h := pulls.length_eq_length_filter_add (fun i => i.mult ≠ 0)
         omega
-      have h_len_pushes : (activePushes pushes).length ≤ pushes.length := by
-        rw [← activePulls_length_eq_activePushes_length h_len h_pair, ← h_len]
+      have h_len_pushes : (activeInteractions pushes).length ≤ pushes.length := by
+        rw [← activeInteractions_length_eq h_len h_pair, ← h_len]
         exact h_len_pulls
       simp only [List.length_append] at h_lt ⊢
       omega
@@ -596,52 +590,52 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees_gated [Fact (ri
   -- a pair is disabled on one side iff it is disabled on the other
   (pair_zero : ∀ i (hi_p : i < pulls.length) (hi_q : i < pushes.length),
     pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
-    (∀ (i : ℕ) (hi : i < (activePulls pulls).length),
-      (activePulls pulls)[i].Guarantees data →
-        ((activePushes pushes)[i]'(activePulls_length_eq_activePushes_length len_pulls_pushes pair_zero ▸ hi)).Requirements data) →
-    ∀ (i : ℕ) (hi : i < (activePulls pulls).length),
-      ((activePushes pushes)[i]'(activePulls_length_eq_activePushes_length len_pulls_pushes pair_zero ▸ hi)).Requirements data →
-        (activePulls pulls)[i].Guarantees data := by
+    (∀ (i : ℕ) (hi : i < (activeInteractions pulls).length),
+      (activeInteractions pulls)[i].Guarantees data →
+        ((activeInteractions pushes)[i]'(activeInteractions_length_eq len_pulls_pushes pair_zero ▸ hi)).Requirements data) →
+    ∀ (i : ℕ) (hi : i < (activeInteractions pulls).length),
+      ((activeInteractions pushes)[i]'(activeInteractions_length_eq len_pulls_pushes pair_zero ▸ hi)).Requirements data →
+        (activeInteractions pulls)[i].Guarantees data := by
   intro constraints
-  let activePulls' := activePulls pulls
-  let activePushes' := activePushes pushes
-  have active_balance : BalancedInteractions (activePulls' ++ activePushes') := by
-    simpa [activePulls', activePushes'] using
+  let active_pulls := activeInteractions pulls
+  let active_pushes := activeInteractions pushes
+  have active_balance : BalancedInteractions (active_pulls ++ active_pushes) := by
+    simpa [active_pulls, active_pushes] using
       balancedInteractions_active_append balance len_pulls_pushes pair_zero
-  have active_pulls_channel : ∀ a ∈ activePulls', a.channel = channel := by
+  have active_pulls_channel : ∀ a ∈ active_pulls, a.channel = channel := by
     intro a ha
-    simp only [activePulls', activeInteractions, List.mem_filter] at ha
+    simp only [active_pulls, activeInteractions, List.mem_filter] at ha
     exact pulls_channel a ha.1
-  have active_pushes_channel : ∀ b ∈ activePushes', b.channel = channel := by
+  have active_pushes_channel : ∀ b ∈ active_pushes, b.channel = channel := by
     intro b hb
-    simp only [activePushes', activeInteractions, List.mem_filter] at hb
+    simp only [active_pushes, activeInteractions, List.mem_filter] at hb
     exact pushes_channel b hb.1
-  have active_pulls_mult : ∀ a ∈ activePulls', a.mult = -1 := by
+  have active_pulls_mult : ∀ a ∈ active_pulls, a.mult = -1 := by
     intro a ha
-    simp only [activePulls', activeInteractions, List.mem_filter] at ha
+    simp only [active_pulls, activeInteractions, List.mem_filter] at ha
     have a_mult_ne_zero : a.mult ≠ 0 := by simpa using ha.2
     rcases pulls_mult a ha.1 with h_mult | h_mult
     · exact h_mult
     · contradiction
-  have active_pushes_mult : ∀ b ∈ activePushes', b.mult = 1 := by
+  have active_pushes_mult : ∀ b ∈ active_pushes, b.mult = 1 := by
     intro b hb
-    simp only [activePushes', activeInteractions, List.mem_filter] at hb
+    simp only [active_pushes, activeInteractions, List.mem_filter] at hb
     have b_mult_ne_zero : b.mult ≠ 0 := by simpa using hb.2
     rcases pushes_mult b hb.1 with h_mult | h_mult
     · exact h_mult
     · contradiction
-  have active_pushes_assumeRequirements : ∀ b ∈ activePushes', b.assumeGuarantees = false := by
+  have active_pushes_assumeRequirements : ∀ b ∈ active_pushes, b.assumeGuarantees = false := by
     intro b hb
-    simp only [activePushes', activeInteractions, List.mem_filter] at hb
+    simp only [active_pushes, activeInteractions, List.mem_filter] at hb
     exact pushes_assumeRequirements b hb.1
-  have active_len : activePulls'.length = activePushes'.length := by
-    simpa [activePulls', activePushes'] using
-      activePulls_length_eq_activePushes_length len_pulls_pushes pair_zero
+  have active_len : active_pulls.length = active_pushes.length := by
+    simpa [active_pulls, active_pushes] using
+      activeInteractions_length_eq len_pulls_pushes pair_zero
   have theorem_active := guarantees_of_requirements_of_requirements_of_guarantees
-    channel activePulls' activePushes' active_balance data activePulls'.length rfl active_len.symm
+    channel active_pulls active_pushes active_balance data active_pulls.length rfl active_len.symm
     active_pulls_channel active_pushes_channel active_pulls_mult active_pushes_mult
     active_pushes_assumeRequirements
-  have constraints' : ∀ (i : ℕ) (hi : i < activePulls'.length),
-      activePulls'[i].Guarantees data → (activePushes'[i]'(by rw [← active_len]; exact hi)).Requirements data := by
-    simpa [activePulls', activePushes'] using constraints
+  have constraints' : ∀ (i : ℕ) (hi : i < active_pulls.length),
+      active_pulls[i].Guarantees data → (active_pushes[i]'(by rw [← active_len]; exact hi)).Requirements data := by
+    simpa [active_pulls, active_pushes] using constraints
   exact theorem_active constraints'

--- a/Clean/Air/Balance.lean
+++ b/Clean/Air/Balance.lean
@@ -81,27 +81,70 @@ lemma balanceOf_eq_of_const_mult' {interactions : List (Interaction F)} {msg : A
   fun constant_mult => balanceOf_eq_of_const_mult (fun i hi _ => constant_mult i hi)
 
 /--
-If an interaction list is balanced, then for every pull there must be a corresponding "push",
-where "push" means an interaction with multiplicity ≠ -1.
+If every interaction for `msg` has multiplicity either `-1` or `0`, the balance is the
+negative count of the `-1` interactions. This is the zero-padding variant of
+`balanceOf_eq_of_const_mult`.
+-/
+lemma balanceOf_eq_neg_countP_neg_one_of_neg_one_or_zero
+    {interactions : List (Interaction F)} {msg : Array F} :
+    (∀ i ∈ interactions, i.msg = msg → i.mult = -1 ∨ i.mult = 0) →
+    balanceOf interactions msg =
+      - ↑(interactions.countP fun i => i.msg = msg && i.mult = -1) := by
+  intro h
+  induction interactions with
+  | nil => simp [balanceOf]
+  | cons a interactions ih =>
+    have h_tail : ∀ i ∈ interactions, i.msg = msg → i.mult = -1 ∨ i.mult = 0 := by
+      intro i hi
+      exact h i (by simp [hi])
+    specialize ih h_tail
+    by_cases h_msg : a.msg = msg
+    · specialize h a (by simp) h_msg
+      rcases h with h_mult | h_mult
+      · calc
+          balanceOf (a :: interactions) msg = -1 + balanceOf interactions msg := by
+            simp [balanceOf, h_msg, h_mult]
+          _ = -1 + -↑(interactions.countP fun i => i.msg = msg && i.mult = -1) := by
+            rw [ih]
+          _ = -↑((a :: interactions).countP fun i => i.msg = msg && i.mult = -1) := by
+            simp [h_msg, h_mult, Nat.cast_add]
+      · simpa [balanceOf, h_msg, h_mult] using ih
+    · simpa [balanceOf, h_msg] using ih
 
-TODO: the conclusion should be multiplicity ∉ {-1, 0}, then we could generalize our VM
-results to allow for zeroed-out (padded) VM transitions.
+/--
+If an interaction list is balanced, then for every pull there must be a corresponding "push",
+where "push" means an interaction with multiplicity neither `-1` nor `0`.
 -/
 theorem exists_push_of_pull (interactions : List (Interaction F)) (balance : BalancedInteractions interactions) :
-    ∀ a ∈ interactions, a.mult = -1 → ∃ b ∈ interactions, b.msg = a.msg ∧ b.mult ≠ -1 := by
+    ∀ a ∈ interactions, a.mult = -1 → ∃ b ∈ interactions, b.msg = a.msg ∧ b.mult ≠ -1 ∧ b.mult ≠ 0 := by
   intro a h_mem_a h_pull
   set msg := a.msg
-  set count : ℕ := interactions.countP (·.msg = msg)
-  have count_lt_ringChar : count < ringChar F ∨ ringChar F = 0 :=
-    count_lt_ringChar_of_balancedInteractions balance
+  set count : ℕ := interactions.countP fun i => i.msg = msg && i.mult = -1
+  have count_lt_ringChar : count < ringChar F ∨ ringChar F = 0 := by
+    rcases balance.1 with h_len | h_char
+    · left
+      exact lt_of_le_of_lt List.countP_le_length h_len
+    · right
+      exact h_char
   replace balance := balance.2 msg
-  -- assuming no such push exists => all interactions with the same message have multiplicity -1
+  -- assuming no such push exists => all interactions with the same message have multiplicity -1 or 0
   -- this leads to a contradiction with the 0 balance + no overflow
-  by_contra! const_minus_one
+  by_contra! no_nonzero_push
+  have neg_one_or_zero : ∀ i ∈ interactions, i.msg = msg → i.mult = -1 ∨ i.mult = 0 := by
+    intro i hi h_msg
+    by_cases h_mult : i.mult = -1
+    · exact .inl h_mult
+    · exact .inr (no_nonzero_push i hi h_msg h_mult)
   suffices count = 0 by
-    simp only [count, msg, List.countP_eq_zero, decide_eq_true_eq] at this
-    nomatch this a h_mem_a
-  rw [balanceOf_eq_of_const_mult const_minus_one, neg_mul, one_mul, neg_eq_zero] at balance
+    have h_zero : ∀ x ∈ interactions, (decide (x.msg = msg) && decide (x.mult = -1)) = false := by
+      simpa [count, List.countP_eq_zero] using this
+    have h_false : (decide (a.msg = msg) && decide (a.mult = -1)) = false := by
+      exact h_zero a h_mem_a
+    have h_true : (decide (a.msg = msg) && decide (a.mult = -1)) = true := by
+      simp [msg, h_pull]
+    rw [h_true] at h_false
+    contradiction
+  rw [balanceOf_eq_neg_countP_neg_one_of_neg_one_or_zero neg_one_or_zero, neg_eq_zero] at balance
   change (count : F) = 0 at balance
   rcases count_lt_ringChar with count_lt_ringChar | ringChar_zero
   · simp_all [Lean.Grind.IsCharP.natCast_eq_zero_iff_of_lt _ count_lt_ringChar]
@@ -132,7 +175,7 @@ A "normal" channel is one where
 - only push interactions cause requirements to be added
 -/
 class Normal (channel : RawChannel F) : Prop where
-  grts_of_reqs : ∀ (msg : Vector F channel.arity) (mult : F) data, mult ≠ -1 →
+  grts_of_reqs : ∀ (msg : Vector F channel.arity) (mult : F) data, mult ≠ -1 → mult ≠ 0 →
     channel.Requirements mult msg data → channel.Guarantees (-1) msg data
   grts_of_ne_neg_one : ∀ (msg : Vector F channel.arity) (mult : F) data, mult ≠ -1 →
     channel.Guarantees mult msg data
@@ -141,8 +184,8 @@ class Normal (channel : RawChannel F) : Prop where
 /-- Typed `Channel`s are normal by definition! -/
 instance (channel : Channel F Message) : Normal channel.toRaw where
   grts_of_reqs := by
-    intro msg mult data mult_ne_neg_one reqs
-    simp [Channel.toRaw, mult_ne_neg_one] at reqs ⊢
+    intro msg mult data mult_ne_neg_one mult_ne_zero reqs
+    simp [Channel.toRaw, mult_ne_neg_one, mult_ne_zero] at reqs ⊢
     exact reqs
   grts_of_ne_neg_one := by
     intro msg mult data mult_ne_neg_one
@@ -167,8 +210,9 @@ theorem consistent_of_normal (channel : RawChannel F) [channel.Normal] :
   case neg => exact RawChannel.Normal.grts_of_ne_neg_one ⟨ a.msg, a_msg_size ⟩ a.mult data a_mult
   -- if the multiplicity is -1, we get the corresponding push interaction and apply `grts_of_reqs`
   rw [a_mult]
-  have ⟨ b, b_mem, b_msg_eq, b_mult_ne_neg_one ⟩ := exists_push_of_pull interactions balance a a_mem a_mult
-  apply RawChannel.Normal.grts_of_reqs ⟨ a.msg, a_msg_size ⟩ b.mult data b_mult_ne_neg_one
+  have ⟨ b, b_mem, b_msg_eq, b_mult_ne_neg_one, b_mult_ne_zero ⟩ :=
+    exists_push_of_pull interactions balance a a_mem a_mult
+  apply RawChannel.Normal.grts_of_reqs ⟨ a.msg, a_msg_size ⟩ b.mult data b_mult_ne_neg_one b_mult_ne_zero
   have ⟨ b_channel_eq, b_reqs ⟩ := reqs _ b_mem
   symm at b_channel_eq
   simp only [b_msg_eq] at b_reqs
@@ -244,7 +288,8 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees [Fact (ringChar
     have exists_push_of_pull : ∀ pull ∈ pulls, ∃ push ∈ pushes, push.msg = pull.msg := by
       intro pull pull_mem
       have pull_mem_append : pull ∈ pulls ++ pushes := by simp [pull_mem]
-      have ⟨ push, push_mem, push_msg_eq, push_mult_ne_neg_one ⟩ := exists_push_of_pull (pulls ++ pushes)
+      have ⟨ push, push_mem, push_msg_eq, push_mult_ne_neg_one, _push_mult_ne_zero ⟩ :=
+        exists_push_of_pull (pulls ++ pushes)
         balance pull pull_mem_append (pulls_mult pull pull_mem)
       have push_mem : push ∈ pushes := by simp only [List.mem_append] at push_mem; tauto
       exists push
@@ -266,7 +311,7 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees [Fact (ringChar
       suffices grt' : channel.Guarantees (-1) ⟨ msg, msg_size ⟩ data by
         simp only [Interaction.Guarantees]
         convert fun _ => grt'
-      apply RawChannel.Normal.grts_of_reqs ⟨ msg, msg_size ⟩ 1 data one_ne_neg_one
+      apply RawChannel.Normal.grts_of_reqs ⟨ msg, msg_size ⟩ 1 data one_ne_neg_one one_ne_zero
       simp only [Interaction.Requirements, Interaction.msgVector, push_j_msg] at push_j_req
       convert push_j_req
     -- if i = j, we're done

--- a/Clean/Air/Balance.lean
+++ b/Clean/Air/Balance.lean
@@ -29,6 +29,10 @@ lemma balanceOf_append {as bs : List (Interaction F)} {msg : Array F} :
     balanceOf (as ++ bs) msg = balanceOf as msg + balanceOf bs msg := by
   simp [balanceOf, List.filter_append, List.map_append, List.sum_append]
 
+lemma balanceOf_cons {i : Interaction F} {is : List (Interaction F)} {msg : Array F} :
+    balanceOf (i :: is) msg = (if i.msg = msg then i.mult else 0) + balanceOf is msg := by
+  by_cases h : i.msg = msg <;> simp [balanceOf, h]
+
 lemma balanceOf_perm {as bs : List (Interaction F)} {msg : Array F} :
     List.Perm as bs → balanceOf as msg = balanceOf bs msg := by
   intro perm
@@ -252,6 +256,204 @@ lemma List.countP_eraseIdx {α : Type} {l : List α} {p : α → Bool} {i : ℕ}
       rw [← ih (Nat.lt_of_succ_lt_succ hi)]
       ring
 
+def activePulls : List (Interaction F) → List (Interaction F) → List (Interaction F)
+  | [], _ => []
+  | _, [] => []
+  | pull :: pulls, _push :: pushes =>
+      if pull.mult = 0 then activePulls pulls pushes else pull :: activePulls pulls pushes
+
+def activePushes : List (Interaction F) → List (Interaction F) → List (Interaction F)
+  | [], _ => []
+  | _, [] => []
+  | pull :: pulls, push :: pushes =>
+      if pull.mult = 0 then activePushes pulls pushes else push :: activePushes pulls pushes
+
+lemma activePulls_length_eq_activePushes_length (pulls pushes : List (Interaction F)) :
+    (activePulls pulls pushes).length = (activePushes pulls pushes).length := by
+  induction pulls generalizing pushes with
+  | nil => simp [activePulls, activePushes]
+  | cons pull pulls ih =>
+    cases pushes with
+    | nil => simp [activePulls, activePushes]
+    | cons push pushes =>
+      by_cases h : pull.mult = 0
+      · simp [activePulls, activePushes, h, ih]
+      · simp [activePulls, activePushes, h, ih]
+
+lemma activePulls_length_le_left (pulls pushes : List (Interaction F)) :
+    (activePulls pulls pushes).length ≤ pulls.length := by
+  induction pulls generalizing pushes with
+  | nil => simp [activePulls]
+  | cons pull pulls ih =>
+    cases pushes with
+    | nil => simp [activePulls]
+    | cons push pushes =>
+      by_cases h : pull.mult = 0
+      · simp [activePulls, h]
+        exact Nat.le_trans (ih pushes) (Nat.le_succ _)
+      · simp [activePulls, h]
+        exact ih pushes
+
+lemma activePulls_mult {pulls pushes : List (Interaction F)}
+    (h : ∀ pull ∈ pulls, pull.mult = -1 ∨ pull.mult = 0) :
+    ∀ pull ∈ activePulls pulls pushes, pull.mult = -1 := by
+  induction pulls generalizing pushes with
+  | nil => simp [activePulls]
+  | cons pull pulls ih =>
+    cases pushes with
+    | nil => simp [activePulls]
+    | cons push pushes =>
+      have h_tail : ∀ pull ∈ pulls, pull.mult = -1 ∨ pull.mult = 0 := by
+        intro p hp
+        exact h p (by simp [hp])
+      by_cases h_zero : pull.mult = 0
+      · simpa [activePulls, h_zero] using ih h_tail
+      · have h_pull : pull.mult = -1 := by
+          rcases h pull (by simp) with h_pull | h_pull
+          · exact h_pull
+          · contradiction
+        simp [activePulls, h_pull]
+        exact ih h_tail
+
+lemma activePushes_mult {pulls pushes : List (Interaction F)}
+    (h_pushes : ∀ push ∈ pushes, push.mult = 1 ∨ push.mult = 0)
+    (h_pair : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
+      pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
+    ∀ push ∈ activePushes pulls pushes, push.mult = 1 := by
+  induction pulls generalizing pushes with
+  | nil => simp [activePushes]
+  | cons pull pulls ih =>
+    cases pushes with
+    | nil => simp [activePushes]
+    | cons push pushes =>
+      have h_pushes_tail : ∀ push ∈ pushes, push.mult = 1 ∨ push.mult = 0 := by
+        intro q hq
+        exact h_pushes q (by simp [hq])
+      have h_pair_tail : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
+          pulls[i].mult = 0 ↔ pushes[i].mult = 0 := by
+        intro i hpi hqi
+        exact h_pair (i+1) (by simpa) (by simpa)
+      by_cases h_zero : pull.mult = 0
+      · simpa [activePushes, h_zero] using ih h_pushes_tail h_pair_tail
+      · have h_push_ne_zero : push.mult ≠ 0 := by
+          intro h_push_zero
+          exact h_zero ((h_pair 0 (by simp) (by simp)).mpr h_push_zero)
+        have h_push : push.mult = 1 := by
+          rcases h_pushes push (by simp) with h_push | h_push
+          · exact h_push
+          · contradiction
+        simp [activePushes, h_zero, h_push]
+        exact ih h_pushes_tail h_pair_tail
+
+lemma activePulls_channel {channel : RawChannel F} {pulls pushes : List (Interaction F)}
+    (h : ∀ pull ∈ pulls, pull.channel = channel) :
+    ∀ pull ∈ activePulls pulls pushes, pull.channel = channel := by
+  induction pulls generalizing pushes with
+  | nil => simp [activePulls]
+  | cons pull pulls ih =>
+    cases pushes with
+    | nil => simp [activePulls]
+    | cons push pushes =>
+      have h_tail : ∀ pull ∈ pulls, pull.channel = channel := by
+        intro p hp
+        exact h p (by simp [hp])
+      by_cases h_zero : pull.mult = 0
+      · simpa [activePulls, h_zero] using ih h_tail
+      · simp [activePulls, h_zero, h pull (by simp)]
+        exact ih h_tail
+
+lemma activePushes_channel {channel : RawChannel F} {pulls pushes : List (Interaction F)}
+    (h : ∀ push ∈ pushes, push.channel = channel) :
+    ∀ push ∈ activePushes pulls pushes, push.channel = channel := by
+  induction pulls generalizing pushes with
+  | nil => simp [activePushes]
+  | cons pull pulls ih =>
+    cases pushes with
+    | nil => simp [activePushes]
+    | cons push pushes =>
+      have h_tail : ∀ push ∈ pushes, push.channel = channel := by
+        intro q hq
+        exact h q (by simp [hq])
+      by_cases h_zero : pull.mult = 0
+      · simpa [activePushes, h_zero] using ih h_tail
+      · simp [activePushes, h_zero, h push (by simp)]
+        exact ih h_tail
+
+lemma activePair_mem_zip {pulls pushes : List (Interaction F)}
+    (i : ℕ) (hi : i < (activePulls pulls pushes).length) :
+    ((activePulls pulls pushes)[i],
+      (activePushes pulls pushes)[i]'(activePulls_length_eq_activePushes_length pulls pushes ▸ hi))
+      ∈ pulls.zip pushes := by
+  induction pulls generalizing pushes i with
+  | nil => simp [activePulls] at hi
+  | cons pull pulls ih =>
+    cases pushes with
+    | nil => simp [activePulls] at hi
+    | cons push pushes =>
+      by_cases h_zero : pull.mult = 0
+      · simp [activePulls, activePushes, h_zero] at hi ⊢
+        exact Or.inr (ih i hi)
+      · cases i with
+        | zero =>
+          simp [activePulls, activePushes, h_zero]
+        | succ i =>
+          simp [activePulls, activePushes, h_zero] at hi ⊢
+          exact Or.inr (ih i hi)
+
+lemma balanceOf_active_append_eq {pulls pushes : List (Interaction F)} {msg : Array F}
+    (h_len : pulls.length = pushes.length)
+    (h_pair : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
+      pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
+    balanceOf (activePulls pulls pushes ++ activePushes pulls pushes) msg =
+      balanceOf (pulls ++ pushes) msg := by
+  induction pulls generalizing pushes with
+  | nil =>
+    cases pushes <;> simp [activePulls, activePushes, balanceOf] at h_len ⊢
+  | cons pull pulls ih =>
+    cases pushes with
+    | nil => simp at h_len
+    | cons push pushes =>
+      simp only [List.length_cons, Nat.succ.injEq] at h_len
+      have h_pair_tail : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
+          pulls[i].mult = 0 ↔ pushes[i].mult = 0 := by
+        intro i hpi hqi
+        exact h_pair (i+1) (by simpa) (by simpa)
+      have ih' := ih h_len h_pair_tail
+      by_cases h_zero : pull.mult = 0
+      · have h_push_zero : push.mult = 0 := (h_pair 0 (by simp) (by simp)).mp h_zero
+        simp [activePulls, activePushes, h_zero, h_push_zero, balanceOf_append,
+          balanceOf_cons] at ih' ⊢
+        exact ih'
+      · have h_push_ne_zero : push.mult ≠ 0 := by
+          intro h_push_zero
+          exact h_zero ((h_pair 0 (by simp) (by simp)).mpr h_push_zero)
+        simp [activePulls, activePushes, h_zero, balanceOf_append,
+          balanceOf_cons] at ih' ⊢
+        ring_nf at ih' ⊢
+        exact congrArg (fun x => x + if push.msg = msg then push.mult else 0) ih'
+
+lemma balancedInteractions_active_append {pulls pushes : List (Interaction F)}
+    (balance : BalancedInteractions (pulls ++ pushes))
+    (h_len : pulls.length = pushes.length)
+    (h_pair : ∀ i (hpi : i < pulls.length) (hqi : i < pushes.length),
+      pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
+    BalancedInteractions (activePulls pulls pushes ++ activePushes pulls pushes) := by
+  constructor
+  · rcases balance.1 with h_lt | h_char
+    · left
+      have h_len_pulls : (activePulls pulls pushes).length ≤ pulls.length :=
+        activePulls_length_le_left pulls pushes
+      have h_len_pushes : (activePushes pulls pushes).length ≤ pushes.length := by
+        rw [← activePulls_length_eq_activePushes_length pulls pushes, ← h_len]
+        exact h_len_pulls
+      simp only [List.length_append] at h_lt ⊢
+      omega
+    · right
+      exact h_char
+  · intro msg
+    rw [balanceOf_active_append_eq h_len h_pair]
+    exact balance.2 msg
+
 /--
 Assume you have a list of channel interactions that is made up of pairs (-1, pull_i), (1, push_i),
 where for each i, `Guarantees (-1, pull_i) → Requirements (1, push_i)`.
@@ -394,3 +596,55 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees [Fact (ringChar
     rw [List.countP_eraseIdx (by linarith), ←pull_i_msg]
     rw [List.countP_eraseIdx (by simp_all), List.countP_set (len_pushes ▸ hj), push_j_msg]
     simp [h_ij, count_eq]
+
+/--
+Zero-gated variant of `guarantees_of_requirements_of_requirements_of_guarantees`.
+
+The input lists may contain padded pull/push pairs with multiplicity `0`. The active
+subsequence, where pull multiplicity is `-1` and push multiplicity is `1`, satisfies
+the original VM theorem. Disabled pairs are removed at this abstract layer because
+they do not affect balance.
+-/
+theorem guarantees_of_requirements_of_requirements_of_guarantees_gated [Fact (ringChar F ≠ 2)]
+    (channel : RawChannel F) [channel.Normal]
+    (pulls pushes : List (Interaction F))
+    (balance : BalancedInteractions (pulls ++ pushes)) (data : ProverData F)
+  -- same length before filtering
+  (len_pulls_pushes : pulls.length = pushes.length)
+  -- all interactions are on the input channel
+  (pulls_channel : ∀ a ∈ pulls, a.channel = channel) (pushes_channel : ∀ b ∈ pushes, b.channel = channel)
+  -- pulls are either active `-1` pulls or disabled, pushes are either active `1` pushes or disabled
+  (pulls_mult : ∀ a ∈ pulls, a.mult = -1 ∨ a.mult = 0)
+  (pushes_mult : ∀ b ∈ pushes, b.mult = 1 ∨ b.mult = 0)
+  -- a pair is disabled on one side iff it is disabled on the other
+  (pair_zero : ∀ i (hi_p : i < pulls.length) (hi_q : i < pushes.length),
+    pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
+    (∀ (i : ℕ) (hi : i < (activePulls pulls pushes).length),
+      (activePulls pulls pushes)[i].Guarantees data →
+        ((activePushes pulls pushes)[i]'(activePulls_length_eq_activePushes_length pulls pushes ▸ hi)).Requirements data) →
+    ∀ (i : ℕ) (hi : i < (activePulls pulls pushes).length),
+      ((activePushes pulls pushes)[i]'(activePulls_length_eq_activePushes_length pulls pushes ▸ hi)).Requirements data →
+        (activePulls pulls pushes)[i].Guarantees data := by
+  intro constraints
+  let activePulls' := activePulls pulls pushes
+  let activePushes' := activePushes pulls pushes
+  have active_balance : BalancedInteractions (activePulls' ++ activePushes') := by
+    simpa [activePulls', activePushes'] using
+      balancedInteractions_active_append balance len_pulls_pushes pair_zero
+  have active_pulls_channel : ∀ a ∈ activePulls', a.channel = channel := by
+    simpa [activePulls'] using activePulls_channel (pushes:=pushes) pulls_channel
+  have active_pushes_channel : ∀ b ∈ activePushes', b.channel = channel := by
+    simpa [activePushes'] using activePushes_channel (pulls:=pulls) pushes_channel
+  have active_pulls_mult : ∀ a ∈ activePulls', a.mult = -1 := by
+    simpa [activePulls'] using activePulls_mult (pushes:=pushes) pulls_mult
+  have active_pushes_mult : ∀ b ∈ activePushes', b.mult = 1 := by
+    simpa [activePushes'] using activePushes_mult (pulls:=pulls) pushes_mult pair_zero
+  have active_len : activePulls'.length = activePushes'.length := by
+    simp [activePulls', activePushes', activePulls_length_eq_activePushes_length]
+  have theorem_active := guarantees_of_requirements_of_requirements_of_guarantees
+    channel activePulls' activePushes' active_balance data activePulls'.length rfl active_len.symm
+    active_pulls_channel active_pushes_channel active_pulls_mult active_pushes_mult
+  have constraints' : ∀ (i : ℕ) (hi : i < activePulls'.length),
+      activePulls'[i].Guarantees data → (activePushes'[i]'(by rw [← active_len]; exact hi)).Requirements data := by
+    simpa [activePulls', activePushes'] using constraints
+  exact theorem_active constraints'

--- a/Clean/Air/Balance.lean
+++ b/Clean/Air/Balance.lean
@@ -54,6 +54,17 @@ lemma count_lt_ringChar_of_balancedInteractions {ins : List (Interaction F)} {ms
   grw [List.countP_le_length]
   exact lt_ringChar
 
+lemma List.countP_and_left_le {α : Type} (l : List α) (p q : α → Bool) :
+    l.countP (fun x => p x && q x) ≤ l.countP p := by
+  induction l with
+  | nil => simp
+  | cons a l ih =>
+    by_cases hp : p a
+    · by_cases hq : q a
+      · simp [hp, hq, ih]
+      · simp [hp, hq, ih.trans (Nat.le_add_right _ _)]
+    · simp [hp, ih]
+
 /--
 Useful mechanical lemma: if all multiplicities for a given message are the same,
 the balance sum can be written as multiplicity times message count.
@@ -85,34 +96,44 @@ lemma balanceOf_eq_of_const_mult' {interactions : List (Interaction F)} {msg : A
   fun constant_mult => balanceOf_eq_of_const_mult (fun i hi _ => constant_mult i hi)
 
 /--
-If every interaction for `msg` has multiplicity either `-1` or `0`, the balance is the
-negative count of the `-1` interactions. This is the zero-padding variant of
-`balanceOf_eq_of_const_mult`.
+If every interaction for `msg` has multiplicity either nonzero `mult` or `0`, the
+balance is `mult` times the count of the `mult` interactions. This is the zero-padding
+variant of `balanceOf_eq_of_const_mult`.
 -/
-lemma balanceOf_eq_neg_countP_neg_one_of_neg_one_or_zero
-    {interactions : List (Interaction F)} {msg : Array F} :
-    (∀ i ∈ interactions, i.msg = msg → i.mult = -1 ∨ i.mult = 0) →
+lemma balanceOf_eq_mult_countP_of_mult_or_zero
+    {interactions : List (Interaction F)} {msg : Array F} {mult : F} :
+    mult ≠ 0 →
+    (∀ i ∈ interactions, i.msg = msg → i.mult = mult ∨ i.mult = 0) →
     balanceOf interactions msg =
-      - ↑(interactions.countP fun i => i.msg = msg && i.mult = -1) := by
-  intro h
+      mult * ↑(interactions.countP fun i => i.msg = msg && i.mult = mult) := by
+  intro mult_ne_zero h
   induction interactions with
   | nil => simp [balanceOf]
   | cons a interactions ih =>
-    have h_tail : ∀ i ∈ interactions, i.msg = msg → i.mult = -1 ∨ i.mult = 0 := by
+    have h_tail : ∀ i ∈ interactions, i.msg = msg → i.mult = mult ∨ i.mult = 0 := by
       intro i hi
       exact h i (by simp [hi])
     specialize ih h_tail
     by_cases h_msg : a.msg = msg
     · specialize h a (by simp) h_msg
-      rcases h with h_mult | h_mult
+      rcases h with h_mult | h_zero
       · calc
-          balanceOf (a :: interactions) msg = -1 + balanceOf interactions msg := by
+          balanceOf (a :: interactions) msg = mult + balanceOf interactions msg := by
             simp [balanceOf, h_msg, h_mult]
-          _ = -1 + -↑(interactions.countP fun i => i.msg = msg && i.mult = -1) := by
+          _ = mult + mult * ↑(interactions.countP fun i => i.msg = msg && i.mult = mult) := by
             rw [ih]
-          _ = -↑((a :: interactions).countP fun i => i.msg = msg && i.mult = -1) := by
+          _ = mult * ↑((a :: interactions).countP fun i => i.msg = msg && i.mult = mult) := by
             simp [h_msg, h_mult, Nat.cast_add]
-      · simpa [balanceOf, h_msg, h_mult] using ih
+            ring
+      · have h_a_mult_ne : ¬a.mult = mult := by
+          intro h_a_mult
+          exact mult_ne_zero (h_a_mult.symm.trans h_zero)
+        calc
+          balanceOf (a :: interactions) msg = balanceOf interactions msg := by
+            simp [balanceOf_cons, h_msg, h_zero]
+          _ = mult * ↑(interactions.countP fun i => i.msg = msg && i.mult = mult) := ih
+          _ = mult * ↑((a :: interactions).countP fun i => i.msg = msg && i.mult = mult) := by
+            simp [h_msg, h_a_mult_ne]
     · simpa [balanceOf, h_msg] using ih
 
 /--
@@ -123,13 +144,9 @@ theorem exists_push_of_pull (interactions : List (Interaction F)) (balance : Bal
     ∀ a ∈ interactions, a.mult = -1 → ∃ b ∈ interactions, b.msg = a.msg ∧ b.mult ≠ -1 ∧ b.mult ≠ 0 := by
   intro a h_mem_a h_pull
   set msg := a.msg
-  set count : ℕ := interactions.countP fun i => i.msg = msg && i.mult = -1
+  set count : ℕ := interactions.countP (·.msg = msg)
   have count_lt_ringChar : count < ringChar F ∨ ringChar F = 0 := by
-    rcases balance.1 with h_len | h_char
-    · left
-      exact lt_of_le_of_lt List.countP_le_length h_len
-    · right
-      exact h_char
+    exact count_lt_ringChar_of_balancedInteractions balance
   replace balance := balance.2 msg
   -- assuming no such push exists => all interactions with the same message have multiplicity -1 or 0
   -- this leads to a contradiction with the 0 balance + no overflow
@@ -139,31 +156,33 @@ theorem exists_push_of_pull (interactions : List (Interaction F)) (balance : Bal
     by_cases h_mult : i.mult = -1
     · exact .inl h_mult
     · exact .inr (no_nonzero_push i hi h_msg h_mult)
-  suffices count = 0 by
+  suffices interactions.countP (fun i => i.msg = msg && i.mult = -1) = 0 by
     have h_zero : ∀ x ∈ interactions, (decide (x.msg = msg) && decide (x.mult = -1)) = false := by
-      simpa [count, List.countP_eq_zero] using this
-    have h_false : (decide (a.msg = msg) && decide (a.mult = -1)) = false := by
-      exact h_zero a h_mem_a
-    have h_true : (decide (a.msg = msg) && decide (a.mult = -1)) = true := by
-      simp [msg, h_pull]
-    rw [h_true] at h_false
-    contradiction
-  rw [balanceOf_eq_neg_countP_neg_one_of_neg_one_or_zero neg_one_or_zero, neg_eq_zero] at balance
-  change (count : F) = 0 at balance
+      simpa [List.countP_eq_zero] using this
+    have h_false := h_zero a h_mem_a
+    simp [msg, h_pull] at h_false
+  rw [balanceOf_eq_mult_countP_of_mult_or_zero (by simp) neg_one_or_zero] at balance
+  simp only [neg_mul, one_mul, neg_eq_zero] at balance
+  change (↑(interactions.countP fun i => i.msg = msg && i.mult = -1) : F) = 0 at balance
   rcases count_lt_ringChar with count_lt_ringChar | ringChar_zero
-  · simp_all [Lean.Grind.IsCharP.natCast_eq_zero_iff_of_lt _ count_lt_ringChar]
+  · have neg_one_count_lt_ringChar :
+        interactions.countP (fun i => i.msg = msg && i.mult = -1) < ringChar F := by
+      apply lt_of_le_of_lt _ count_lt_ringChar
+      unfold count
+      exact List.countP_and_left_le interactions (fun i => i.msg = msg) (fun i => i.mult = -1)
+    simp_all [Lean.Grind.IsCharP.natCast_eq_zero_iff_of_lt _ neg_one_count_lt_ringChar]
   · simp_all [CharP.ringChar_zero_iff_CharZero]
 
 /- ## Conditions on channels that strengthen the implications of interaction balance. -/
 
 namespace RawChannel
 
-def InteractionsWellFormed (channel : RawChannel F) (interactions : List (Interaction F)) : Prop :=
-  ∀ i ∈ interactions, i.channel = channel → i.assumeGuarantees = true → i.mult = -1 ∨ i.mult = 0
+def InteractionsWellFormed (interactions : List (Interaction F)) : Prop :=
+  ∀ i ∈ interactions, i.assumeGuarantees = true → i.mult = -1 ∨ i.mult = 0
 
 omit [DecidableEq F] in
-theorem InteractionsWellFormed.of_perm {channel : RawChannel F} {as bs : List (Interaction F)} :
-    channel.InteractionsWellFormed as → as.Perm bs → channel.InteractionsWellFormed bs := by
+theorem InteractionsWellFormed.of_perm {as bs : List (Interaction F)} :
+    InteractionsWellFormed as → as.Perm bs → InteractionsWellFormed bs := by
   intro h perm i hi
   exact h i (perm.mem_iff.mpr hi)
 
@@ -179,7 +198,7 @@ For `Channel` it holds by definition, see `NormalChannel` below.
 class Consistent (channel : RawChannel F) : Prop where
   consistent : ∀ (interactions : List (Interaction F)) (data : ProverData F),
     BalancedInteractions interactions →
-    channel.InteractionsWellFormed interactions →
+    InteractionsWellFormed interactions →
     (∀ i ∈ interactions, i.channel = channel ∧ i.Requirements data) →
     (∀ i ∈ interactions, i.Guarantees data)
 
@@ -233,7 +252,7 @@ theorem consistent_of_normal (channel : RawChannel F) [channel.Normal] :
   have b_assume_false : b.assumeGuarantees = false := by
     cases h : b.assumeGuarantees
     · rfl
-    · have b_mult := wellformed b b_mem b_channel_eq.symm h
+    · have b_mult := wellformed b b_mem h
       cases b_mult with
       | inl h_mult => contradiction
       | inr h_mult => contradiction

--- a/Clean/Air/Balance.lean
+++ b/Clean/Air/Balance.lean
@@ -157,6 +157,16 @@ theorem exists_push_of_pull (interactions : List (Interaction F)) (balance : Bal
 /- ## Conditions on channels that strengthen the implications of interaction balance. -/
 
 namespace RawChannel
+
+def InteractionsWellFormed (channel : RawChannel F) (interactions : List (Interaction F)) : Prop :=
+  ∀ i ∈ interactions, i.channel = channel → i.assumeGuarantees = true → i.mult = -1 ∨ i.mult = 0
+
+omit [DecidableEq F] in
+theorem InteractionsWellFormed.of_perm {channel : RawChannel F} {as bs : List (Interaction F)} :
+    channel.InteractionsWellFormed as → as.Perm bs → channel.InteractionsWellFormed bs := by
+  intro h perm i hi
+  exact h i (perm.mem_iff.mpr hi)
+
 /--
 We call a channel "consistent" if balancedness + requirements on all interacions
 imply guarantees on all interactions.
@@ -169,6 +179,7 @@ For `Channel` it holds by definition, see `NormalChannel` below.
 class Consistent (channel : RawChannel F) : Prop where
   consistent : ∀ (interactions : List (Interaction F)) (data : ProverData F),
     BalancedInteractions interactions →
+    channel.InteractionsWellFormed interactions →
     (∀ i ∈ interactions, i.channel = channel ∧ i.Requirements data) →
     (∀ i ∈ interactions, i.Guarantees data)
 
@@ -202,7 +213,7 @@ instance (channel : Channel F Message) : Normal channel.toRaw where
 theorem consistent_of_normal (channel : RawChannel F) [channel.Normal] :
     channel.Consistent := by
   constructor
-  intro interactions data balance reqs a a_mem
+  intro interactions data balance wellformed reqs a a_mem
   simp only [Interaction.Guarantees, Interaction.Requirements, Interaction.msgVector] at reqs ⊢
   intro _
   have a_channel_eq := reqs a a_mem |>.left
@@ -219,8 +230,15 @@ theorem consistent_of_normal (channel : RawChannel F) [channel.Normal] :
   apply RawChannel.Normal.grts_of_reqs ⟨ a.msg, a_msg_size ⟩ b.mult data b_mult_ne_neg_one b_mult_ne_zero
   have ⟨ b_channel_eq, b_reqs ⟩ := reqs _ b_mem
   symm at b_channel_eq
+  have b_assume_false : b.assumeGuarantees = false := by
+    cases h : b.assumeGuarantees
+    · rfl
+    · have b_mult := wellformed b b_mem b_channel_eq.symm h
+      cases b_mult with
+      | inl h_mult => contradiction
+      | inr h_mult => contradiction
   simp only [b_msg_eq] at b_reqs
-  convert b_reqs
+  convert b_reqs b_assume_false
 
 instance (channel : RawChannel F) [channel.Normal] : channel.Consistent :=
   consistent_of_normal channel
@@ -379,6 +397,23 @@ lemma activePushes_channel {channel : RawChannel F} {pulls pushes : List (Intera
       · simp [activePushes, h_zero, h push (by simp)]
         exact ih h_tail
 
+lemma activePushes_assumeRequirements {pulls pushes : List (Interaction F)}
+    (h : ∀ push ∈ pushes, push.assumeGuarantees = false) :
+    ∀ push ∈ activePushes pulls pushes, push.assumeGuarantees = false := by
+  induction pulls generalizing pushes with
+  | nil => simp [activePushes]
+  | cons pull pulls ih =>
+    cases pushes with
+    | nil => simp [activePushes]
+    | cons push pushes =>
+      have h_tail : ∀ push ∈ pushes, push.assumeGuarantees = false := by
+        intro q hq
+        exact h q (by simp [hq])
+      by_cases h_zero : pull.mult = 0
+      · simpa [activePushes, h_zero] using ih h_tail
+      · simp [activePushes, h_zero, h push (by simp)]
+        exact ih h_tail
+
 lemma activePair_mem_zip {pulls pushes : List (Interaction F)}
     (i : ℕ) (hi : i < (activePulls pulls pushes).length) :
     ((activePulls pulls pushes)[i],
@@ -479,7 +514,8 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees [Fact (ringChar
   -- all interactions are on the input channel
   (pulls_channel : ∀ a ∈ pulls, a.channel = channel) (pushes_channel : ∀ b ∈ pushes, b.channel = channel)
   -- the multiplicities are -1 for pulls and 1 for pushes
-  (pulls_mult : ∀ a ∈ pulls, a.mult = -1) (pushes_mult : ∀ b ∈ pushes, b.mult = 1) :
+  (pulls_mult : ∀ a ∈ pulls, a.mult = -1) (pushes_mult : ∀ b ∈ pushes, b.mult = 1)
+  (pushes_assumeRequirements : ∀ b ∈ pushes, b.assumeGuarantees = false) :
     (∀ (i : ℕ) (hi : i < n), pulls[i].Guarantees data → pushes[i].Requirements data) →
     ∀ (i : ℕ) (hi: i < n), pushes[i].Requirements data → pulls[i].Guarantees data := by
   intro constraints
@@ -515,7 +551,7 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees [Fact (ringChar
         convert fun _ => grt'
       apply RawChannel.Normal.grts_of_reqs ⟨ msg, msg_size ⟩ 1 data one_ne_neg_one one_ne_zero
       simp only [Interaction.Requirements, Interaction.msgVector, push_j_msg] at push_j_req
-      convert push_j_req
+      convert push_j_req (pushes_assumeRequirements pushes[j] (List.getElem_mem ..))
     -- if i = j, we're done
     by_cases h_ij : j = i
     · subst h_ij; exact push_j_imp_pull_i push_i_req
@@ -548,7 +584,10 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees [Fact (ringChar
     have pushes'_mult : ∀ b ∈ pushes', b.mult = 1 := by
       simp only [pushes', List.forall_mem_iff_getElem, List.getElem_eraseIdx, List.getElem_set]
       intros; split_ifs <;> simp [*]
-    apply ih pulls' pushes' ?balance' pulls'_len pushes'_len ?pulls'_channel ?pushes'_channel pulls'_mult pushes'_mult ?constraints' j' hj'
+    have pushes'_assumeRequirements : ∀ b ∈ pushes', b.assumeGuarantees = false := by
+      simp only [pushes', List.forall_mem_iff_getElem, List.getElem_eraseIdx, List.getElem_set]
+      intros; split_ifs <;> simp [*]
+    apply ih pulls' pushes' ?balance' pulls'_len pushes'_len ?pulls'_channel ?pushes'_channel pulls'_mult pushes'_mult pushes'_assumeRequirements ?constraints' j' hj'
     <;> clear ih
     case pulls'_channel | pushes'_channel =>
       simp only [pulls', pushes', List.forall_mem_iff_getElem, List.getElem_set, List.getElem_eraseIdx]
@@ -616,6 +655,7 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees_gated [Fact (ri
   -- pulls are either active `-1` pulls or disabled, pushes are either active `1` pushes or disabled
   (pulls_mult : ∀ a ∈ pulls, a.mult = -1 ∨ a.mult = 0)
   (pushes_mult : ∀ b ∈ pushes, b.mult = 1 ∨ b.mult = 0)
+  (pushes_assumeRequirements : ∀ b ∈ pushes, b.assumeGuarantees = false)
   -- a pair is disabled on one side iff it is disabled on the other
   (pair_zero : ∀ i (hi_p : i < pulls.length) (hi_q : i < pushes.length),
     pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
@@ -639,11 +679,14 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees_gated [Fact (ri
     simpa [activePulls'] using activePulls_mult (pushes:=pushes) pulls_mult
   have active_pushes_mult : ∀ b ∈ activePushes', b.mult = 1 := by
     simpa [activePushes'] using activePushes_mult (pulls:=pulls) pushes_mult pair_zero
+  have active_pushes_assumeRequirements : ∀ b ∈ activePushes', b.assumeGuarantees = false := by
+    simpa [activePushes'] using activePushes_assumeRequirements (pulls:=pulls) pushes_assumeRequirements
   have active_len : activePulls'.length = activePushes'.length := by
     simp [activePulls', activePushes', activePulls_length_eq_activePushes_length]
   have theorem_active := guarantees_of_requirements_of_requirements_of_guarantees
     channel activePulls' activePushes' active_balance data activePulls'.length rfl active_len.symm
     active_pulls_channel active_pushes_channel active_pulls_mult active_pushes_mult
+    active_pushes_assumeRequirements
   have constraints' : ∀ (i : ℕ) (hi : i < activePulls'.length),
       activePulls'[i].Guarantees data → (activePushes'[i]'(by rw [← active_len]; exact hi)).Requirements data := by
     simpa [activePulls', activePushes'] using constraints

--- a/Clean/Air/Balance.lean
+++ b/Clean/Air/Balance.lean
@@ -556,8 +556,8 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees_of_mult_zero_if
   -- all interactions are on the input channel
   (pulls_channel : ∀ a ∈ pulls, a.channel = channel) (pushes_channel : ∀ b ∈ pushes, b.channel = channel)
   -- pulls are either active `-1` pulls or disabled, pushes are either active `1` pushes or disabled
-  (pulls_mult : ∀ a ∈ pulls, a.mult = -1 ∨ a.mult = 0)
-  (pushes_mult : ∀ b ∈ pushes, b.mult = 1 ∨ b.mult = 0)
+  (pulls_mult : ∀ a ∈ pulls, a.mult = 0 ∨ a.mult = -1)
+  (pushes_mult : ∀ b ∈ pushes, b.mult = 0 ∨ b.mult = 1)
   -- a pair is disabled on one side iff it is disabled on the other
   (pair_zero : ∀ i (hi_p : i < pulls.length) (hi_q : i < pushes.length),
     pulls[i].mult = 0 ↔ pushes[i].mult = 0) :
@@ -586,15 +586,15 @@ theorem guarantees_of_requirements_of_requirements_of_guarantees_of_mult_zero_if
     simp only [active_pulls, activeInteractions, List.mem_filter] at ha
     have a_mult_ne_zero : a.mult ≠ 0 := by simpa using ha.2
     rcases pulls_mult a ha.1 with h_mult | h_mult
-    · exact h_mult
     · contradiction
+    · exact h_mult
   have active_pushes_mult : ∀ b ∈ active_pushes, b.mult = 1 := by
     intro b hb
     simp only [active_pushes, activeInteractions, List.mem_filter] at hb
     have b_mult_ne_zero : b.mult ≠ 0 := by simpa using hb.2
     rcases pushes_mult b hb.1 with h_mult | h_mult
-    · exact h_mult
     · contradiction
+    · exact h_mult
   have active_len : active_pulls.length = active_pushes.length := by
     simpa [active_pulls, active_pushes] using
       activeInteractions_length_eq len_pulls_pushes pair_zero

--- a/Clean/Air/Circuit.lean
+++ b/Clean/Air/Circuit.lean
@@ -54,6 +54,10 @@ def instantiateConst_toFormal (circuit : GeneralFormalCircuit F Input unit) (inp
   Assumptions _ := circuit.Assumptions input
   ProverAssumptions _ := circuit.ProverAssumptions input
   Spec _ _ := circuit.Spec input ()
+  channelsWithRequirements := circuit.channelsWithRequirements
+  requirementsChannelsLawful := by
+    intro input_var offset
+    simp [circuit_norm, instantiateConst]
   soundness := by circuit_proof_all
   completeness := by circuit_proof_all
 

--- a/Clean/Air/Circuit.lean
+++ b/Clean/Air/Circuit.lean
@@ -55,9 +55,6 @@ def instantiateConst_toFormal (circuit : GeneralFormalCircuit F Input unit) (inp
   ProverAssumptions _ := circuit.ProverAssumptions input
   Spec _ _ := circuit.Spec input ()
   channelsWithRequirements := circuit.channelsWithRequirements
-  requirementsChannelsLawful := by
-    intro input_var offset
-    simp [circuit_norm, instantiateConst]
   soundness := by circuit_proof_all
   completeness := by circuit_proof_all
 

--- a/Clean/Air/FlatComponent.lean
+++ b/Clean/Air/FlatComponent.lean
@@ -105,14 +105,13 @@ lemma channelRequirements_iff (env : Environment F) (channel : RawChannel F) :
     component.operations.ChannelRequirements channel env ↔ component.rowOperations.ChannelRequirements channel env := by
   simp only [circuit_norm, interactions_eq]
 
-lemma inChannelsOrRequirements (env : Environment F)
-    (h_constraints : component.operations.ConstraintsHold env) :
+lemma inChannelsOrRequirements_of_constraints (env : Environment F) :
+    component.operations.ConstraintsHold env →
     component.operations.InChannelsOrRequirementsFull component.circuit.channelsWithRequirements env := by
-  have h_row_constraints : component.rowOperations.ConstraintsHold env :=
-    (component.constraintsHold_iff env).mp h_constraints
-  have h := component.circuit.in_channels_or_requirements_full component.rowInputVar
-    component.rowOffset env h_row_constraints
-  simpa only [circuit_norm, interactions_eq] using h
+  rw [constraintsHold_iff]
+  intro h_constraints
+  simp only [circuit_norm, interactions_eq]
+  exact component.circuit.in_channels_or_requirements_full_of_constraints h_constraints
 
 lemma inChannelsOrGuarantees (env : Environment F) :
     component.operations.InChannelsOrGuaranteesFull component.circuit.channelsWithGuarantees env := by
@@ -296,7 +295,7 @@ lemma guarantees_iff_channelGuarantees (table : Table F) :
     ∀ channel ∈ table.channelsWithGuarantees, table.ChannelGuarantees channel := by
   simp only [Table.Guarantees, Table.ChannelGuarantees, channelsWithGuarantees]
   simp only [Component.guarantees_iff, Component.channelGuarantees_iff, Component.rowOperations]
-  simp only [GeneralFormalCircuit.guarantees_iff']
+  simp only [GeneralFormalCircuit.guarantees_iff]
   constructor <;> simp_all
 
 lemma channelGuarantees_of_requirements (table : Table F) {channel : RawChannel F} :
@@ -315,46 +314,42 @@ lemma channelRequirements_iff_forall (table : Table F) (channel : RawChannel F) 
   simp only [Table.ChannelRequirements, circuit_norm, forall_interactionsWith_iff]
   rfl
 
-lemma requirements_iff_channelRequirements (table : Table F)
-    (h_constraints : table.Constraints) :
-    table.Requirements ↔
-    ∀ channel ∈ table.channelsWithRequirements, table.ChannelRequirements channel := by
+lemma requirements_iff_channelRequirements_of_constraints (table : Table F) :
+    table.Constraints →
+    (table.Requirements ↔
+    ∀ channel ∈ table.channelsWithRequirements, table.ChannelRequirements channel) := by
+  intro h_constraints
   simp only [Table.Requirements, Table.ChannelRequirements, channelsWithRequirements]
   simp only [Component.requirements_iff, Component.channelRequirements_iff, Component.rowOperations]
+  simp_rw [Table.Constraints, table.component.constraintsHold_iff] at h_constraints
   constructor
   · intro h_reqs channel h_channel row h_row
-    have h_row_constraints :
-        ((table.component.circuit.main table.component.rowInputVar).operations table.component.rowOffset)
-          |>.ConstraintsHold (table.environment row) :=
-      (table.component.constraintsHold_iff (table.environment row)).mp (h_constraints row h_row)
-    exact (GeneralFormalCircuit.requirements_iff' table.component.circuit table.component.rowInputVar
-      table.component.rowOffset (table.environment row) h_row_constraints).mp (h_reqs row h_row)
-      channel h_channel
+    specialize h_reqs row h_row
+    rw [table.component.circuit.requirements_iff_of_constraints (h_constraints row h_row)] at h_reqs
+    exact h_reqs channel h_channel
   · intro h_reqs row h_row
-    have h_row_constraints :
-        ((table.component.circuit.main table.component.rowInputVar).operations table.component.rowOffset)
-          |>.ConstraintsHold (table.environment row) :=
-      (table.component.constraintsHold_iff (table.environment row)).mp (h_constraints row h_row)
-    exact (GeneralFormalCircuit.requirements_iff' table.component.circuit table.component.rowInputVar
-      table.component.rowOffset (table.environment row) h_row_constraints).mpr
-      (fun channel h_channel => h_reqs channel h_channel row h_row)
+    rw [table.component.circuit.requirements_iff_of_constraints (h_constraints row h_row)]
+    intro channel h_channel
+    exact h_reqs channel h_channel row h_row
 
 lemma channelRequirements_of_requirements (table : Table F) {channel : RawChannel F} :
     table.Requirements → table.ChannelRequirements channel := by
   simp_all [Table.Requirements, Table.ChannelRequirements, circuit_norm]
 
-lemma inChannelsOrRequirements (table : Table F)
-    (h_constraints : table.Constraints) :
+lemma inChannelsOrRequirements_of_constraints (table : Table F) :
+    table.Constraints →
     table.InChannelsOrRequirements table.channelsWithRequirements := by
+  intro h_constraints
   simp only [InChannelsOrRequirements, channelsWithRequirements]
   intro row h_row
-  exact table.component.inChannelsOrRequirements (table.environment row) (h_constraints row h_row)
+  exact table.component.inChannelsOrRequirements_of_constraints
+    (table.environment row) (h_constraints row h_row)
 
-lemma requirements_of_not_mem (table : Table F) {channel : RawChannel F}
-    (h_constraints : table.Constraints) :
+lemma requirements_of_not_mem_of_constraints (table : Table F) {channel : RawChannel F} :
+    table.Constraints →
     channel ∉ table.channelsWithRequirements → table.ChannelRequirements channel := by
-  intro h_not_mem
-  have h_in_or_req := table.inChannelsOrRequirements h_constraints
+  intro h_constraints h_not_mem
+  have h_in_or_req := table.inChannelsOrRequirements_of_constraints h_constraints
   simp only [ChannelRequirements, InChannelsOrRequirements] at *
   intro row h_row
   specialize h_in_or_req row h_row
@@ -409,7 +404,7 @@ lemma requirements_of_partial_guarantees_of_constraints {table : Table F}
   suffices table.component.operations.FullGuarantees env from
     table.component.weakSoundness (assumptions row h_row) (constraints row h_row) this |>.right
   simp only [Component.guarantees_iff, Component.rowOperations]
-  rw [GeneralFormalCircuit.guarantees_iff']
+  rw [GeneralFormalCircuit.guarantees_iff]
   intro channel channel_mem
   show table.component.rowOperations.ChannelGuarantees channel env
   rw [← Component.channelGuarantees_iff]

--- a/Clean/Air/FlatComponent.lean
+++ b/Clean/Air/FlatComponent.lean
@@ -105,11 +105,14 @@ lemma channelRequirements_iff (env : Environment F) (channel : RawChannel F) :
     component.operations.ChannelRequirements channel env ↔ component.rowOperations.ChannelRequirements channel env := by
   simp only [circuit_norm, interactions_eq]
 
-lemma inChannelsOrRequirements (env : Environment F) :
+lemma inChannelsOrRequirements (env : Environment F)
+    (h_constraints : component.operations.ConstraintsHold env) :
     component.operations.InChannelsOrRequirementsFull component.circuit.channelsWithRequirements env := by
-  have h := component.circuit.in_channels_or_requirements_full
-  simp only [circuit_norm, interactions_eq] at *
-  convert h _ _ env
+  have h_row_constraints : component.rowOperations.ConstraintsHold env :=
+    (component.constraintsHold_iff env).mp h_constraints
+  have h := component.circuit.in_channels_or_requirements_full component.rowInputVar
+    component.rowOffset env h_row_constraints
+  simpa only [circuit_norm, interactions_eq] using h
 
 lemma inChannelsOrGuarantees (env : Environment F) :
     component.operations.InChannelsOrGuaranteesFull component.circuit.channelsWithGuarantees env := by
@@ -270,7 +273,9 @@ lemma interactionsWith_nil_of_channel_not_mem :
   intro component table_mem i i_mem channel_eq
   symm at channel_eq; subst channel_eq
   simp only [Component.interactions_eq] at i_mem
-  apply table.component.circuit.channels_subset
+  have h_subset := table.component.circuit.channels_subset table.component.rowInputVar
+    table.component.rowOffset
+  apply h_subset
   simp only [Operations.channels, List.mem_map]
   exists i
 
@@ -310,26 +315,46 @@ lemma channelRequirements_iff_forall (table : Table F) (channel : RawChannel F) 
   simp only [Table.ChannelRequirements, circuit_norm, forall_interactionsWith_iff]
   rfl
 
-lemma requirements_iff_channelRequirements (table : Table F) :
+lemma requirements_iff_channelRequirements (table : Table F)
+    (h_constraints : table.Constraints) :
     table.Requirements ↔
     ∀ channel ∈ table.channelsWithRequirements, table.ChannelRequirements channel := by
   simp only [Table.Requirements, Table.ChannelRequirements, channelsWithRequirements]
   simp only [Component.requirements_iff, Component.channelRequirements_iff, Component.rowOperations]
-  simp only [GeneralFormalCircuit.requirements_iff']
-  constructor <;> simp_all
+  constructor
+  · intro h_reqs channel h_channel row h_row
+    have h_row_constraints :
+        ((table.component.circuit.main table.component.rowInputVar).operations table.component.rowOffset)
+          |>.ConstraintsHold (table.environment row) :=
+      (table.component.constraintsHold_iff (table.environment row)).mp (h_constraints row h_row)
+    exact (GeneralFormalCircuit.requirements_iff' table.component.circuit table.component.rowInputVar
+      table.component.rowOffset (table.environment row) h_row_constraints).mp (h_reqs row h_row)
+      channel h_channel
+  · intro h_reqs row h_row
+    have h_row_constraints :
+        ((table.component.circuit.main table.component.rowInputVar).operations table.component.rowOffset)
+          |>.ConstraintsHold (table.environment row) :=
+      (table.component.constraintsHold_iff (table.environment row)).mp (h_constraints row h_row)
+    exact (GeneralFormalCircuit.requirements_iff' table.component.circuit table.component.rowInputVar
+      table.component.rowOffset (table.environment row) h_row_constraints).mpr
+      (fun channel h_channel => h_reqs channel h_channel row h_row)
 
 lemma channelRequirements_of_requirements (table : Table F) {channel : RawChannel F} :
     table.Requirements → table.ChannelRequirements channel := by
   simp_all [Table.Requirements, Table.ChannelRequirements, circuit_norm]
 
-lemma inChannelsOrRequirements (table : Table F) :
+lemma inChannelsOrRequirements (table : Table F)
+    (h_constraints : table.Constraints) :
     table.InChannelsOrRequirements table.channelsWithRequirements := by
-  simp [InChannelsOrRequirements, channelsWithRequirements, Component.inChannelsOrRequirements]
+  simp only [InChannelsOrRequirements, channelsWithRequirements]
+  intro row h_row
+  exact table.component.inChannelsOrRequirements (table.environment row) (h_constraints row h_row)
 
-lemma requirements_of_not_mem (table : Table F) {channel : RawChannel F} :
+lemma requirements_of_not_mem (table : Table F) {channel : RawChannel F}
+    (h_constraints : table.Constraints) :
     channel ∉ table.channelsWithRequirements → table.ChannelRequirements channel := by
   intro h_not_mem
-  have h_in_or_req := table.inChannelsOrRequirements
+  have h_in_or_req := table.inChannelsOrRequirements h_constraints
   simp only [ChannelRequirements, InChannelsOrRequirements] at *
   intro row h_row
   specialize h_in_or_req row h_row

--- a/Clean/Air/FlatComponent.lean
+++ b/Clean/Air/FlatComponent.lean
@@ -23,11 +23,18 @@ def operations (component : Component F) : Operations F :=
 
 def width (component : Component F) : ℕ := component.circuit.size
 
-@[circuit_norm]
-abbrev rowOffset (component : Component F) : ℕ := size component.Input
-@[circuit_norm]
-abbrev rowInputVar (component : Component F): Var component.Input F :=
+def rowOffset (component : Component F) : ℕ := size component.Input
+
+def rowInputVar (component : Component F): Var component.Input F :=
   varFromOffset component.Input 0
+
+@[circuit_norm]
+lemma rowOffset_mk (circuit : GeneralFormalCircuit F Input Output) :
+  (⟨ circuit ⟩ : Component F).rowOffset = size Input := rfl
+
+@[circuit_norm]
+lemma rowInputVar_mk (circuit : GeneralFormalCircuit F Input Output) :
+  (⟨ circuit ⟩ : Component F).rowInputVar = varFromOffset Input 0 := rfl
 
 /-- first `size Input` elements of the environment are the input -/
 @[circuit_norm]
@@ -40,9 +47,13 @@ def rowOutput (component : Component F) (row : Environment F) : component.Output
   let outputVar := (component.circuit component.rowInputVar).output component.rowOffset
   eval row outputVar
 
-@[circuit_norm]
 def rowOperations (component : Component F) : Operations F :=
   component.circuit.main (varFromOffset component.Input 0) |>.operations (size component.Input)
+
+@[circuit_norm]
+lemma rowOperations_mk (circuit : GeneralFormalCircuit F Input Output) :
+  (⟨ circuit ⟩ : Component F).rowOperations =
+    (circuit.main (varFromOffset Input 0)).operations (size Input) := rfl
 
 def Spec (component : Component F) (row : Environment F) : Prop :=
   component.circuit.Spec (component.rowInput row) (component.rowOutput row) row.data
@@ -50,23 +61,23 @@ def Spec (component : Component F) (row : Environment F) : Prop :=
 def Assumptions (component : Component F) (row : Environment F) : Prop :=
   component.circuit.Assumptions (component.rowInput row) row.data
 
-abbrev exposedChannels (component : Component F) : List (ExposedChannel F) :=
+def exposedChannels (component : Component F) : List (ExposedChannel F) :=
   component.circuit.exposedChannels component.rowInputVar component.rowOffset
 
 variable {component : Component F} {env : Environment F}
 
 lemma constraints_eq : component.operations.constraints = component.rowOperations.constraints := by
-  simp only [circuit_norm, witnessAny, GeneralFormalCircuit.instantiate, Component.operations,
+  simp only [circuit_norm, rowOperations, witnessAny, GeneralFormalCircuit.instantiate, Component.operations,
     GeneralFormalCircuit.toSubcircuit, GeneralFormalCircuit.toWithHint,
     GeneralFormalCircuit.WithHint.toSubcircuit, Operations.toNested_toFlat]
 
 lemma lookups_eq : component.operations.lookups = component.rowOperations.lookups := by
-  simp only [circuit_norm, witnessAny, GeneralFormalCircuit.instantiate, Component.operations,
+  simp only [circuit_norm, rowOperations, witnessAny, GeneralFormalCircuit.instantiate, Component.operations,
     GeneralFormalCircuit.toSubcircuit, GeneralFormalCircuit.toWithHint,
     GeneralFormalCircuit.WithHint.toSubcircuit, Operations.toNested_toFlat]
 
 lemma interactions_eq : component.operations.interactions = component.rowOperations.interactions := by
-  simp only [circuit_norm, witnessAny, GeneralFormalCircuit.instantiate, Component.operations,
+  simp only [circuit_norm, rowOperations, witnessAny, GeneralFormalCircuit.instantiate, Component.operations,
     GeneralFormalCircuit.toSubcircuit, GeneralFormalCircuit.toWithHint,
     GeneralFormalCircuit.WithHint.toSubcircuit, Operations.toNested_toFlat]
 

--- a/Clean/Air/FlatEnsemble.lean
+++ b/Clean/Air/FlatEnsemble.lean
@@ -102,23 +102,23 @@ def VerifierSpec (ens : Ensemble F PublicIO) (publicInput : PublicIO F) (data : 
 lemma verifierTable_constraints :
   ens.verifierTable.operations.constraints = ens.verifierOperations.constraints := by
   rw [Component.constraints_eq]
-  simp only [circuit_norm]
+  simp only [circuit_norm, Component.rowOperations]
 
 lemma verifierTable_lookups :
   ens.verifierTable.operations.lookups = ens.verifierOperations.lookups := by
   rw [Component.lookups_eq]
-  simp only [circuit_norm]
+  simp only [circuit_norm, Component.rowOperations]
 
 lemma verifierTable_interactions :
   ens.verifierTable.operations.interactions = ens.verifierOperations.interactions := by
   rw [Component.interactions_eq]
-  simp only [circuit_norm]
+  simp only [circuit_norm, Component.rowOperations]
 
 lemma verifierTable_interactionsWith {channel : RawChannel F} :
   ens.verifierTable.operations.interactionsWith channel =
     ens.verifierOperations.interactionsWith channel := by
   rw [Component.interactionsWith_eq]
-  simp only [circuit_norm]
+  simp only [circuit_norm, Component.rowOperations]
 
 def channelsWithGuarantees (ens : Ensemble F PublicIO) : List (RawChannel F) :=
   ens.allTables.flatMap (·.circuit.channelsWithGuarantees)

--- a/Clean/Air/FlatEnsemble.lean
+++ b/Clean/Air/FlatEnsemble.lean
@@ -74,6 +74,8 @@ lemma size_verifier {ens : Ensemble F PublicIO} :
 
 @[circuit_norm] lemma mem_allTables_verifierTable:
   ens.verifierTable ∈ ens.allTables := by simp [allTables]
+lemma mem_allTables_of_mem_tables {table : Component F} :
+    table ∈ ens.tables → table ∈ ens.allTables := by simp_all [allTables]
 
 lemma verifierTable_ext {ens1 ens2 : Ensemble F PublicIO} {witness1 : EnsembleWitness ens1} {witness2 : EnsembleWitness ens2} :
     ens1.verifier = ens2.verifier →

--- a/Clean/Air/FlatEnsemble.lean
+++ b/Clean/Air/FlatEnsemble.lean
@@ -329,8 +329,7 @@ lemma verifierTable_assumptions_of_verifier_empty {ens : Ensemble F PublicIO} {w
 @[circuit_norm]
 abbrev BalancedChannel [DecidableEq F] {ens : Ensemble F PublicIO} (witness : EnsembleWitness ens)
     (channel : RawChannel F) : Prop :=
-  BalancedInteractions (witness.allTablesWitness.interactionsWith channel) ∧
-  InteractionsWellFormed (witness.allTablesWitness.interactionsWith channel)
+  BalancedInteractions (witness.allTablesWitness.interactionsWith channel)
 
 /-- All ensemble interactions with all ensemble channels are balanced. -/
 @[circuit_norm]

--- a/Clean/Air/FlatEnsemble.lean
+++ b/Clean/Air/FlatEnsemble.lean
@@ -330,7 +330,7 @@ lemma verifierTable_assumptions_of_verifier_empty {ens : Ensemble F PublicIO} {w
 abbrev BalancedChannel [DecidableEq F] {ens : Ensemble F PublicIO} (witness : EnsembleWitness ens)
     (channel : RawChannel F) : Prop :=
   BalancedInteractions (witness.allTablesWitness.interactionsWith channel) ∧
-  RawChannel.InteractionsWellFormed (witness.allTablesWitness.interactionsWith channel)
+  InteractionsWellFormed (witness.allTablesWitness.interactionsWith channel)
 
 /-- All ensemble interactions with all ensemble channels are balanced. -/
 @[circuit_norm]

--- a/Clean/Air/FlatEnsemble.lean
+++ b/Clean/Air/FlatEnsemble.lean
@@ -330,7 +330,7 @@ lemma verifierTable_assumptions_of_verifier_empty {ens : Ensemble F PublicIO} {w
 abbrev BalancedChannel [DecidableEq F] {ens : Ensemble F PublicIO} (witness : EnsembleWitness ens)
     (channel : RawChannel F) : Prop :=
   BalancedInteractions (witness.allTablesWitness.interactionsWith channel) ∧
-  channel.InteractionsWellFormed (witness.allTablesWitness.interactionsWith channel)
+  RawChannel.InteractionsWellFormed (witness.allTablesWitness.interactionsWith channel)
 
 /-- All ensemble interactions with all ensemble channels are balanced. -/
 @[circuit_norm]

--- a/Clean/Air/FlatEnsemble.lean
+++ b/Clean/Air/FlatEnsemble.lean
@@ -329,7 +329,8 @@ lemma verifierTable_assumptions_of_verifier_empty {ens : Ensemble F PublicIO} {w
 @[circuit_norm]
 abbrev BalancedChannel [DecidableEq F] {ens : Ensemble F PublicIO} (witness : EnsembleWitness ens)
     (channel : RawChannel F) : Prop :=
-  BalancedInteractions (witness.allTablesWitness.interactionsWith channel)
+  BalancedInteractions (witness.allTablesWitness.interactionsWith channel) ∧
+  channel.InteractionsWellFormed (witness.allTablesWitness.interactionsWith channel)
 
 /-- All ensemble interactions with all ensemble channels are balanced. -/
 @[circuit_norm]

--- a/Clean/Air/OrderedChannel.lean
+++ b/Clean/Air/OrderedChannel.lean
@@ -191,11 +191,13 @@ designed to be used for proving soundness by adding one table after another.
 -/
 def PartialBalancedChannel [DecidableEq F] (tables : Tables F) (channel : RawChannel F) : Prop :=
   -- `extraInteractions` represents the unknown interactions from tables added later
-  ∃ extraInteractions : List (Interaction F),
-    -- the total of known + unknown interactions is balanced
-    BalancedInteractions (tables.interactionsWith channel ++ extraInteractions) ∧
-    -- the extra interactions are with the same channel.
-    (∀ i ∈ extraInteractions, i.channel = channel) ∧
+    ∃ extraInteractions : List (Interaction F),
+      -- the total of known + unknown interactions is balanced
+      BalancedInteractions (tables.interactionsWith channel ++ extraInteractions) ∧
+      -- guarantee-side interactions are either active pulls or disabled padding
+      channel.InteractionsWellFormed (tables.interactionsWith channel ++ extraInteractions) ∧
+      -- the extra interactions are with the same channel.
+      (∀ i ∈ extraInteractions, i.channel = channel) ∧
     -- additionally, we _assume_ that either the requirements on future interactions hold unconditionally,
     -- or that known interactions do not assume guarantees on the same channel.
     -- this restricts the order in which tables can be added. essentially, it requires that the `extraTables`
@@ -205,10 +207,12 @@ def PartialBalancedChannel [DecidableEq F] (tables : Tables F) (channel : RawCha
 
 /-- Partial balance is trivially weaker than balance -/
 lemma partialBalancedChannel_of_balancedInteractions [DecidableEq F] {tables : Tables F} {channel : RawChannel F} :
-    BalancedInteractions (tables.interactionsWith channel) → PartialBalancedChannel tables channel := by
-  intro balanced
+    BalancedInteractions (tables.interactionsWith channel) →
+    channel.InteractionsWellFormed (tables.interactionsWith channel) →
+    PartialBalancedChannel tables channel := by
+  intro balanced wellformed
   use []
-  simp [balanced]
+  simp [balanced, wellformed]
 
 /--
 For ordered channels, we can always instantiate partial balance at an initial sublist.
@@ -219,12 +223,15 @@ theorem partialBalancedChannel_of_cons_of_orderedChannelLt [DecidableEq F]
   PartialBalancedChannel (.cons table tables same_data) channel →
   OrderedChannelLt channel tables.components [table.component] →
     PartialBalancedChannel tables channel := by
-  rintro ⟨ extraInteractions, balanced, same_channel, extra_reqs_or_no_grts ⟩ not_in_reqs_or
+  rintro ⟨ extraInteractions, balanced, wellformed, same_channel, extra_reqs_or_no_grts ⟩ not_in_reqs_or
   use table.interactionsWith channel ++ extraInteractions
   simp only [circuit_norm] at *
   simp [or_imp] at ⊢ not_in_reqs_or extra_reqs_or_no_grts
   constructor
   · apply balancedInteractions_of_perm balanced
+    grw [List.perm_append_comm_assoc]
+  constructor
+  · apply wellformed.of_perm
     grw [List.perm_append_comm_assoc]
   constructor
   · intro a
@@ -279,7 +286,7 @@ lemma guarantees_of_requirements_cons [DecidableEq F]
   · exact table.guarantees_of_not_mem grts
   replace reqs := table.requirements_of_not_mem reqs
   -- there's a special case to discard where the guarantees are trivially satisfied
-  rcases partial_balance with ⟨ extraInteractions, balanced, same_channel, grts | extra_reqs ⟩
+  rcases partial_balance with ⟨ extraInteractions, balanced, wellformed, same_channel, grts | extra_reqs ⟩
   · simp only [circuit_norm] at grts
     exact table.guarantees_of_not_mem grts.left
   -- now, to prove this table's channel guarantees, we show guarantees on _all_ channel interactions (that we know are balanced)
@@ -309,7 +316,7 @@ lemma guarantees_of_requirements_cons [DecidableEq F]
     · exact ⟨ same_channel i h_mem_extra, extra_reqs i h_mem_extra ⟩
   -- consistent channels goes from requirements to guarantees
   -- uses `consistent_channels` and `partial_balance`
-  apply ‹channel.Consistent›.consistent channelInteractions tables.data balanced all_reqs
+  apply ‹channel.Consistent›.consistent channelInteractions tables.data balanced wellformed all_reqs
 
 /--
 Partial balance can be specialized to a sublist (= part of a permutation),
@@ -320,13 +327,15 @@ lemma partialBalancedChannel_of_sublist [DecidableEq F] {subtables tables : Tabl
   (∃ otherTables, tables.tables.Perm (subtables.tables ++ otherTables) ∧
     ∀ table ∈ otherTables, channel ∉ table.channelsWithRequirements) →
     PartialBalancedChannel subtables channel := by
-  rintro ⟨ extraInteractions, balanced, same_channel, no_grts_or_extra_reqs ⟩ subset_tables
+  rintro ⟨ extraInteractions, balanced, wellformed, same_channel, no_grts_or_extra_reqs ⟩ subset_tables
   obtain ⟨ otherTables, perm, otherReqs ⟩ := subset_tables
   by_cases subtables_empty : subtables.tables = []
   · simp [subtables_empty, circuit_norm, PartialBalancedChannel, Tables.interactionsWith]
     use []
-    simp [BalancedInteractions, balanceOf]
-    omega
+    simp [BalancedInteractions, balanceOf, RawChannel.InteractionsWellFormed]
+    by_cases h : ringChar F = 0
+    · exact Or.inr h
+    · exact Or.inl (Nat.pos_of_ne_zero h)
   have subtables_subset : subtables.tables ⊆ tables.tables := by
     have p := perm.symm.subset
     simp_all
@@ -341,6 +350,11 @@ lemma partialBalancedChannel_of_sublist [DecidableEq F] {subtables tables : Tabl
   constructor; swap
   -- TODO this half is surprisingly long/annoying, maybe missing helper lemmas
   · simp [circuit_norm, or_imp]
+    constructor
+    · apply wellformed.of_perm
+      simp only [Tables.interactionsWith]
+      grw [← List.append_assoc, List.perm_append_right_iff, ← List.flatMap_append, perm.flatMap]
+      exact fun _ _ => List.Perm.refl _
     constructor
     · intro i
       use fun _ _ => Table.channel_eq_of_mem_interactionsWith

--- a/Clean/Air/OrderedChannel.lean
+++ b/Clean/Air/OrderedChannel.lean
@@ -195,7 +195,7 @@ def PartialBalancedChannel [DecidableEq F] (tables : Tables F) (channel : RawCha
       -- the total of known + unknown interactions is balanced
       BalancedInteractions (tables.interactionsWith channel ++ extraInteractions) ∧
       -- guarantee-side interactions are either active pulls or disabled padding
-      channel.InteractionsWellFormed (tables.interactionsWith channel ++ extraInteractions) ∧
+      RawChannel.InteractionsWellFormed (tables.interactionsWith channel ++ extraInteractions) ∧
       -- the extra interactions are with the same channel.
       (∀ i ∈ extraInteractions, i.channel = channel) ∧
     -- additionally, we _assume_ that either the requirements on future interactions hold unconditionally,
@@ -208,7 +208,7 @@ def PartialBalancedChannel [DecidableEq F] (tables : Tables F) (channel : RawCha
 /-- Partial balance is trivially weaker than balance -/
 lemma partialBalancedChannel_of_balancedInteractions [DecidableEq F] {tables : Tables F} {channel : RawChannel F} :
     BalancedInteractions (tables.interactionsWith channel) →
-    channel.InteractionsWellFormed (tables.interactionsWith channel) →
+    RawChannel.InteractionsWellFormed (tables.interactionsWith channel) →
     PartialBalancedChannel tables channel := by
   intro balanced wellformed
   use []

--- a/Clean/Air/OrderedChannel.lean
+++ b/Clean/Air/OrderedChannel.lean
@@ -195,7 +195,7 @@ def PartialBalancedChannel [DecidableEq F] (tables : Tables F) (channel : RawCha
       -- the total of known + unknown interactions is balanced
       BalancedInteractions (tables.interactionsWith channel ++ extraInteractions) ∧
       -- guarantee-side interactions are either active pulls or disabled padding
-      RawChannel.InteractionsWellFormed (tables.interactionsWith channel ++ extraInteractions) ∧
+      InteractionsWellFormed (tables.interactionsWith channel ++ extraInteractions) ∧
       -- the extra interactions are with the same channel.
       (∀ i ∈ extraInteractions, i.channel = channel) ∧
     -- additionally, we _assume_ that either the requirements on future interactions hold unconditionally,
@@ -208,7 +208,7 @@ def PartialBalancedChannel [DecidableEq F] (tables : Tables F) (channel : RawCha
 /-- Partial balance is trivially weaker than balance -/
 lemma partialBalancedChannel_of_balancedInteractions [DecidableEq F] {tables : Tables F} {channel : RawChannel F} :
     BalancedInteractions (tables.interactionsWith channel) →
-    RawChannel.InteractionsWellFormed (tables.interactionsWith channel) →
+    InteractionsWellFormed (tables.interactionsWith channel) →
     PartialBalancedChannel tables channel := by
   intro balanced wellformed
   use []
@@ -332,7 +332,7 @@ lemma partialBalancedChannel_of_sublist [DecidableEq F] {subtables tables : Tabl
   by_cases subtables_empty : subtables.tables = []
   · simp [subtables_empty, circuit_norm, PartialBalancedChannel, Tables.interactionsWith]
     use []
-    simp [BalancedInteractions, balanceOf, RawChannel.InteractionsWellFormed]
+    simp [BalancedInteractions, balanceOf, InteractionsWellFormed]
     by_cases h : ringChar F = 0
     · exact Or.inr h
     · exact Or.inl (Nat.pos_of_ne_zero h)

--- a/Clean/Air/OrderedChannel.lean
+++ b/Clean/Air/OrderedChannel.lean
@@ -220,10 +220,11 @@ For ordered channels, we can always instantiate partial balance at an initial su
 theorem partialBalancedChannel_of_cons_of_orderedChannelLt [DecidableEq F]
   {table : Table F} {tables : Tables F} (same_data : table.data = tables.data)
   {channel : RawChannel F} :
+  table.Constraints →
   PartialBalancedChannel (.cons table tables same_data) channel →
   OrderedChannelLt channel tables.components [table.component] →
     PartialBalancedChannel tables channel := by
-  rintro ⟨ extraInteractions, balanced, wellformed, same_channel, extra_reqs_or_no_grts ⟩ not_in_reqs_or
+  rintro table_constraints ⟨ extraInteractions, balanced, wellformed, same_channel, extra_reqs_or_no_grts ⟩ not_in_reqs_or
   use table.interactionsWith channel ++ extraInteractions
   simp only [circuit_norm] at *
   simp [or_imp] at ⊢ not_in_reqs_or extra_reqs_or_no_grts
@@ -243,7 +244,7 @@ theorem partialBalancedChannel_of_cons_of_orderedChannelLt [DecidableEq F]
   rcases extra_reqs_or_no_grts with no_grts | extra_reqs
   · simp_all
   · right
-    have channel_reqs := table.requirements_of_not_mem channel_not_in_reqs
+    have channel_reqs := table.requirements_of_not_mem table_constraints channel_not_in_reqs
     rw [Table.channelRequirements_iff_forall, same_data] at channel_reqs
     exact ⟨ channel_reqs, extra_reqs ⟩
 
@@ -253,11 +254,12 @@ For ordered channels, we can always instantiate partial balance at an initial su
 lemma partialBalancedChannel_of_cons_of_orderedChannel [DecidableEq F]
   {table : Table F} {tables : Tables F} (same_data : table.data = tables.data)
   {channel : RawChannel F} :
+  table.Constraints →
   PartialBalancedChannel (tables.cons table same_data) channel →
   OrderedChannel channel (table.component :: tables.components) →
     PartialBalancedChannel tables channel := by
-  intro partial_balance ordered_channel
-  apply partialBalancedChannel_of_cons_of_orderedChannelLt same_data partial_balance
+  intro table_constraints partial_balance ordered_channel
+  apply partialBalancedChannel_of_cons_of_orderedChannelLt same_data table_constraints partial_balance
   simp_all [circuit_norm]
 
 /--
@@ -269,12 +271,13 @@ lemma guarantees_of_requirements_cons [DecidableEq F]
   {table : Table F} {tables : Tables F} (same_data : table.data = tables.data)
   -- and a channel that is consistent, ordered on the new table, and partially balanced on the combined tables
   {channel : RawChannel F} [channel.Consistent] :
+  table.Constraints →
   OrderedChannelRefl channel table.component →
   PartialBalancedChannel (tables.cons table same_data) channel →
   -- the channel requirements on the old tables imply guarantees on the new table
   (∀ table ∈ tables.tables, table.ChannelRequirements channel) →
     table.ChannelGuarantees channel := by
-  rintro ordered_channel partial_balance ih
+  rintro table_constraints ordered_channel partial_balance ih
   /-
   thanks to ordered channel, we know that channel cannot add _both_ grts and reqs for the new table.
   1) if the channel does not add grts, we're done as the grts are trivially satisifed.
@@ -284,7 +287,7 @@ lemma guarantees_of_requirements_cons [DecidableEq F]
   simp only [circuit_norm] at ordered_channel
   rcases ordered_channel with grts | reqs
   · exact table.guarantees_of_not_mem grts
-  replace reqs := table.requirements_of_not_mem reqs
+  replace reqs := table.requirements_of_not_mem table_constraints reqs
   -- there's a special case to discard where the guarantees are trivially satisfied
   rcases partial_balance with ⟨ extraInteractions, balanced, wellformed, same_channel, grts | extra_reqs ⟩
   · simp only [circuit_norm] at grts
@@ -325,10 +328,11 @@ as long as none of the extra tables add requirements.
 lemma partialBalancedChannel_of_sublist [DecidableEq F] {subtables tables : Tables F} {channel : RawChannel F} :
   PartialBalancedChannel tables channel →
   (∃ otherTables, tables.tables.Perm (subtables.tables ++ otherTables) ∧
+    (∀ table ∈ otherTables, table.Constraints) ∧
     ∀ table ∈ otherTables, channel ∉ table.channelsWithRequirements) →
     PartialBalancedChannel subtables channel := by
   rintro ⟨ extraInteractions, balanced, wellformed, same_channel, no_grts_or_extra_reqs ⟩ subset_tables
-  obtain ⟨ otherTables, perm, otherReqs ⟩ := subset_tables
+  obtain ⟨ otherTables, perm, otherConstraints, otherReqs ⟩ := subset_tables
   by_cases subtables_empty : subtables.tables = []
   · simp [subtables_empty, circuit_norm, PartialBalancedChannel, Tables.interactionsWith]
     use []
@@ -375,6 +379,7 @@ lemma partialBalancedChannel_of_sublist [DecidableEq F] {subtables tables : Tabl
       simp [ht]
     rw [← tables.same_data _ ht', ← Table.channelRequirements_iff_forall]
     apply Table.requirements_of_not_mem
+    exact otherConstraints _ ht
     exact otherReqs _ ht
   -- balance
   apply balancedInteractions_of_perm balanced
@@ -395,29 +400,33 @@ lemma guarantees_of_requirements_append [DecidableEq F]
   -- and a channel that is consistent, _doesn't add requirements_ on the new tables,
   -- and is partially balanced on the combined tables
   {channel : RawChannel F} [channel.Consistent] :
+  (∀ table ∈ ts.tables, table.Constraints) →
   (∀ table ∈ ts.tables, channel ∉ table.component.circuit.channelsWithRequirements) →
   PartialBalancedChannel (ts.append ss same_data) channel →
   -- the channel requirements on the old tables imply guarantees on the new tables
   (∀ table ∈ ss.tables, table.ChannelRequirements channel) →
     ∀ table ∈ ts.tables, table.ChannelGuarantees channel := by
   -- we show that for each (t, ss) pair, the assumptions of `*_cons` hold
-  rintro reqs partial_balance ih table h_table
+  rintro constraints reqs partial_balance ih table h_table
   have same_data' : table.data = ss.data := by
     rw [ts.same_data _ h_table, same_data]
-  apply guarantees_of_requirements_cons (tables := ss) same_data' ?_ ?_ ih
+  apply guarantees_of_requirements_cons (tables := ss) same_data' (constraints _ h_table) ?_ ?_ ih
   · right; exact reqs _ h_table
   -- get partial balance by sublist/permutation argument
   apply partialBalancedChannel_of_sublist partial_balance
   obtain ⟨ i, hi, h' ⟩ := List.getElem_of_mem h_table
   symm at h'; subst h'
   use ts.tables.eraseIdx i
-  constructor; swap
+  constructor
+  · simp [circuit_norm]
+    grw [List.perm_append_comm, List.perm_cons_append_cons _ List.perm_rfl,
+      List.perm_append_left_iff, List.perm_comm]
+    apply List.getElem_cons_eraseIdx_perm
+  constructor
+  · intro t' ht'
+    exact constraints _ (List.mem_of_mem_eraseIdx ht')
   · intro t' ht'
     apply reqs _ (List.mem_of_mem_eraseIdx ht')
-  simp [circuit_norm]
-  grw [List.perm_append_comm, List.perm_cons_append_cons _ List.perm_rfl,
-    List.perm_append_left_iff, List.perm_comm]
-  apply List.getElem_cons_eraseIdx_perm
 
 /-- Helper lemma that uses circuit soundness, to strengthen guarantees to include requirements -/
 lemma iff_guarantees_of_constraints {table : Table F} {finished : List (RawChannel F)} :
@@ -480,11 +489,22 @@ theorem spec_and_guarantees_of_soundChannels [DecidableEq F] {witness : Tables F
   · intro _ h_table; nomatch h_table
   -- induction step
   rename_i table tables same_data ih
-  -- first, we use the IH
-  have partial_balance' c hc := partialBalancedChannel_of_cons_of_orderedChannel
-    same_data (partial_balance c hc) (ordered_channels c hc)
   simp only [Tables.Assumptions, Tables.Constraints, circuit_norm] at *
   simp only [forall_exists_index, and_imp, forall_apply_eq_imp_iff₂] at *
+  -- first, we use the IH
+  have partial_balance' c hc := by
+    apply partialBalancedChannel_of_cons_of_orderedChannelLt same_data constraints.left
+      (partial_balance c hc)
+    rw [OrderedChannelLt]
+    simp only [Tables.components, List.flatMap_singleton]
+    rcases (ordered_channels c hc).2.2 with no_grts | no_reqs
+    · left
+      intro h_component
+      rcases List.mem_flatMap.mp h_component with ⟨component, h_component, h_channel⟩
+      rcases List.mem_map.mp h_component with ⟨table, h_table, rfl⟩
+      exact no_grts table h_table h_channel
+    · right
+      simpa using no_reqs
   specialize ih subset_finished.right (fun c hc => (ordered_channels c hc).right.left)
     assumptions.right constraints.right partial_balance'
   constructor; swap
@@ -497,7 +517,7 @@ theorem spec_and_guarantees_of_soundChannels [DecidableEq F] {witness : Tables F
   have orderedChannelRefl : OrderedChannelRefl channel table.component := by
     simp only [circuit_norm, ordered_channels channel h_channel]
   apply guarantees_of_requirements_cons same_data
-    orderedChannelRefl (partial_balance channel h_channel)
+    constraints.left orderedChannelRefl (partial_balance channel h_channel)
   intro t ht
   exact (ih t ht).right _ h_channel |>.right
 

--- a/Clean/Air/OrderedChannel.lean
+++ b/Clean/Air/OrderedChannel.lean
@@ -191,11 +191,11 @@ designed to be used for proving soundness by adding one table after another.
 -/
 def PartialBalancedChannel [DecidableEq F] (tables : Tables F) (channel : RawChannel F) : Prop :=
   -- `extraInteractions` represents the unknown interactions from tables added later
-    ∃ extraInteractions : List (Interaction F),
-      -- the total of known + unknown interactions is balanced
-      BalancedInteractions (tables.interactionsWith channel ++ extraInteractions) ∧
-      -- the extra interactions are with the same channel.
-      (∀ i ∈ extraInteractions, i.channel = channel) ∧
+  ∃ extraInteractions : List (Interaction F),
+    -- the total of known + unknown interactions is balanced
+    BalancedInteractions (tables.interactionsWith channel ++ extraInteractions) ∧
+    -- the extra interactions are with the same channel.
+    (∀ i ∈ extraInteractions, i.channel = channel) ∧
     -- additionally, we _assume_ that either the requirements on future interactions hold unconditionally,
     -- or that known interactions do not assume guarantees on the same channel.
     -- this restricts the order in which tables can be added. essentially, it requires that the `extraTables`
@@ -205,8 +205,7 @@ def PartialBalancedChannel [DecidableEq F] (tables : Tables F) (channel : RawCha
 
 /-- Partial balance is trivially weaker than balance -/
 lemma partialBalancedChannel_of_balancedInteractions [DecidableEq F] {tables : Tables F} {channel : RawChannel F} :
-    BalancedInteractions (tables.interactionsWith channel) →
-    PartialBalancedChannel tables channel := by
+    BalancedInteractions (tables.interactionsWith channel) → PartialBalancedChannel tables channel := by
   intro balanced
   use []
   simp [balanced]
@@ -221,7 +220,8 @@ theorem partialBalancedChannel_of_cons_of_orderedChannelLt [DecidableEq F]
   PartialBalancedChannel (.cons table tables same_data) channel →
   OrderedChannelLt channel tables.components [table.component] →
     PartialBalancedChannel tables channel := by
-  rintro table_constraints ⟨ extraInteractions, balanced, same_channel, extra_reqs_or_no_grts ⟩ not_in_reqs_or
+  rintro table_constraints ⟨ extraInteractions, balanced, same_channel, extra_reqs_or_no_grts ⟩
+    not_in_reqs_or
   use table.interactionsWith channel ++ extraInteractions
   simp only [circuit_norm] at *
   simp [or_imp] at ⊢ not_in_reqs_or extra_reqs_or_no_grts
@@ -238,7 +238,7 @@ theorem partialBalancedChannel_of_cons_of_orderedChannelLt [DecidableEq F]
   rcases extra_reqs_or_no_grts with no_grts | extra_reqs
   · simp_all
   · right
-    have channel_reqs := table.requirements_of_not_mem table_constraints channel_not_in_reqs
+    have channel_reqs := table.requirements_of_not_mem_of_constraints table_constraints channel_not_in_reqs
     rw [Table.channelRequirements_iff_forall, same_data] at channel_reqs
     exact ⟨ channel_reqs, extra_reqs ⟩
 
@@ -281,7 +281,7 @@ lemma guarantees_of_requirements_cons [DecidableEq F]
   simp only [circuit_norm] at ordered_channel
   rcases ordered_channel with grts | reqs
   · exact table.guarantees_of_not_mem grts
-  replace reqs := table.requirements_of_not_mem table_constraints reqs
+  replace reqs := table.requirements_of_not_mem_of_constraints table_constraints reqs
   -- there's a special case to discard where the guarantees are trivially satisfied
   rcases partial_balance with ⟨ extraInteractions, balanced, same_channel, grts | extra_reqs ⟩
   · simp only [circuit_norm] at grts
@@ -367,7 +367,7 @@ lemma partialBalancedChannel_of_sublist [DecidableEq F] {subtables tables : Tabl
       apply perm.symm.subset
       simp [ht]
     rw [← tables.same_data _ ht', ← Table.channelRequirements_iff_forall]
-    apply Table.requirements_of_not_mem
+    apply Table.requirements_of_not_mem_of_constraints
     exact otherConstraints _ ht
     exact otherReqs _ ht
   -- balance

--- a/Clean/Air/OrderedChannel.lean
+++ b/Clean/Air/OrderedChannel.lean
@@ -194,8 +194,6 @@ def PartialBalancedChannel [DecidableEq F] (tables : Tables F) (channel : RawCha
     ∃ extraInteractions : List (Interaction F),
       -- the total of known + unknown interactions is balanced
       BalancedInteractions (tables.interactionsWith channel ++ extraInteractions) ∧
-      -- guarantee-side interactions are either active pulls or disabled padding
-      InteractionsWellFormed (tables.interactionsWith channel ++ extraInteractions) ∧
       -- the extra interactions are with the same channel.
       (∀ i ∈ extraInteractions, i.channel = channel) ∧
     -- additionally, we _assume_ that either the requirements on future interactions hold unconditionally,
@@ -208,11 +206,10 @@ def PartialBalancedChannel [DecidableEq F] (tables : Tables F) (channel : RawCha
 /-- Partial balance is trivially weaker than balance -/
 lemma partialBalancedChannel_of_balancedInteractions [DecidableEq F] {tables : Tables F} {channel : RawChannel F} :
     BalancedInteractions (tables.interactionsWith channel) →
-    InteractionsWellFormed (tables.interactionsWith channel) →
     PartialBalancedChannel tables channel := by
-  intro balanced wellformed
+  intro balanced
   use []
-  simp [balanced, wellformed]
+  simp [balanced]
 
 /--
 For ordered channels, we can always instantiate partial balance at an initial sublist.
@@ -224,15 +221,12 @@ theorem partialBalancedChannel_of_cons_of_orderedChannelLt [DecidableEq F]
   PartialBalancedChannel (.cons table tables same_data) channel →
   OrderedChannelLt channel tables.components [table.component] →
     PartialBalancedChannel tables channel := by
-  rintro table_constraints ⟨ extraInteractions, balanced, wellformed, same_channel, extra_reqs_or_no_grts ⟩ not_in_reqs_or
+  rintro table_constraints ⟨ extraInteractions, balanced, same_channel, extra_reqs_or_no_grts ⟩ not_in_reqs_or
   use table.interactionsWith channel ++ extraInteractions
   simp only [circuit_norm] at *
   simp [or_imp] at ⊢ not_in_reqs_or extra_reqs_or_no_grts
   constructor
   · apply balancedInteractions_of_perm balanced
-    grw [List.perm_append_comm_assoc]
-  constructor
-  · apply wellformed.of_perm
     grw [List.perm_append_comm_assoc]
   constructor
   · intro a
@@ -289,7 +283,7 @@ lemma guarantees_of_requirements_cons [DecidableEq F]
   · exact table.guarantees_of_not_mem grts
   replace reqs := table.requirements_of_not_mem table_constraints reqs
   -- there's a special case to discard where the guarantees are trivially satisfied
-  rcases partial_balance with ⟨ extraInteractions, balanced, wellformed, same_channel, grts | extra_reqs ⟩
+  rcases partial_balance with ⟨ extraInteractions, balanced, same_channel, grts | extra_reqs ⟩
   · simp only [circuit_norm] at grts
     exact table.guarantees_of_not_mem grts.left
   -- now, to prove this table's channel guarantees, we show guarantees on _all_ channel interactions (that we know are balanced)
@@ -319,7 +313,7 @@ lemma guarantees_of_requirements_cons [DecidableEq F]
     · exact ⟨ same_channel i h_mem_extra, extra_reqs i h_mem_extra ⟩
   -- consistent channels goes from requirements to guarantees
   -- uses `consistent_channels` and `partial_balance`
-  apply ‹channel.Consistent›.consistent channelInteractions tables.data balanced wellformed all_reqs
+  apply ‹channel.Consistent›.consistent channelInteractions tables.data balanced all_reqs
 
 /--
 Partial balance can be specialized to a sublist (= part of a permutation),
@@ -331,12 +325,12 @@ lemma partialBalancedChannel_of_sublist [DecidableEq F] {subtables tables : Tabl
     (∀ table ∈ otherTables, table.Constraints) ∧
     ∀ table ∈ otherTables, channel ∉ table.channelsWithRequirements) →
     PartialBalancedChannel subtables channel := by
-  rintro ⟨ extraInteractions, balanced, wellformed, same_channel, no_grts_or_extra_reqs ⟩ subset_tables
+  rintro ⟨ extraInteractions, balanced, same_channel, no_grts_or_extra_reqs ⟩ subset_tables
   obtain ⟨ otherTables, perm, otherConstraints, otherReqs ⟩ := subset_tables
   by_cases subtables_empty : subtables.tables = []
   · simp [subtables_empty, circuit_norm, PartialBalancedChannel, Tables.interactionsWith]
     use []
-    simp [BalancedInteractions, balanceOf, InteractionsWellFormed]
+    simp [BalancedInteractions, balanceOf]
     by_cases h : ringChar F = 0
     · exact Or.inr h
     · exact Or.inl (Nat.pos_of_ne_zero h)
@@ -354,11 +348,6 @@ lemma partialBalancedChannel_of_sublist [DecidableEq F] {subtables tables : Tabl
   constructor; swap
   -- TODO this half is surprisingly long/annoying, maybe missing helper lemmas
   · simp [circuit_norm, or_imp]
-    constructor
-    · apply wellformed.of_perm
-      simp only [Tables.interactionsWith]
-      grw [← List.append_assoc, List.perm_append_right_iff, ← List.flatMap_append, perm.flatMap]
-      exact fun _ _ => List.Perm.refl _
     constructor
     · intro i
       use fun _ _ => Table.channel_eq_of_mem_interactionsWith

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -53,32 +53,19 @@ structure VmTables (F : Type) [Field F] [DecidableEq F] (PublicIO : TypeMap) [Pr
   verifier_length_zero : ∀ pi, (verifier pi).localLength 0 = 0 := by
     simp only [circuit_norm]
 
-  step : Component F → VmStep Message F
-  verifierStep : VmStep Message F
-
   tables_channel : ∀ table ∈ tables,
-    let step := step table
-    ⟨ channel,
-      [(pullIf (channel:=channel) step.enabled step.pull).toRaw,
-        (pushIf (channel:=channel) step.enabled step.push).toRaw] ⟩ ∈ table.exposedChannels
+    ∃ step : VmStep Message F,
+      ⟨ channel,
+        [(pullIf (channel:=channel) step.enabled step.pull).toRaw,
+          (pushIf (channel:=channel) step.enabled step.push).toRaw] ⟩ ∈ table.exposedChannels ∧
+      ∀ env,
+        table.Assumptions env →
+        Operations.ConstraintsHold env table.operations →
+          env step.enabled = 0 ∨ env step.enabled = 1
 
   -- the verifier pulls and pushes to the channel, and doesn't push anything else
-  verifier_channel :
-    ⟨ channel,
-      [(pullIf (channel:=channel) verifierStep.enabled verifierStep.pull).toRaw,
-        (pushIf (channel:=channel) verifierStep.enabled verifierStep.push).toRaw] ⟩ ∈
+  verifier_channel : ∃ m1 m2, ⟨ channel, [(channel.pulled m1).toRaw, (channel.pushed m2).toRaw] ⟩ ∈
     verifier.exposedChannels (varFromOffset PublicIO 0) (size PublicIO)
-
-  -- VM gates must be boolean. This is what lets the abstract balance theorem
-  -- view a row as either an active pull/push pair or disabled padding.
-  tables_enabled_boolean : ∀ table ∈ tables, ∀ env,
-    table.Assumptions env →
-    Operations.ConstraintsHold env table.operations →
-      env (step table).enabled = 0 ∨ env (step table).enabled = 1
-
-  verifier_enabled_one : ∀ env,
-    Operations.ConstraintsHold env (verifier.main (varFromOffset PublicIO 0) |>.operations (size PublicIO)) →
-      env verifierStep.enabled = 1
 
   -- verifier requirements follow _unconditionally_ from constraints (without relying on guarantees)
   -- essentially a modified soundness theorem for the verifier
@@ -252,10 +239,50 @@ variable {vm : VmTables F PublicIO}
 @[circuit_norm] abbrev allTables (vm : VmTables F PublicIO) : List (Component F) :=
   vm.toEnsemble.allTables
 
+noncomputable def step (vm : VmTables F PublicIO) (table : Component F)
+    (table_mem : table ∈ vm.tables) : VmStep vm.Message F :=
+  (vm.tables_channel table table_mem).choose
+
+theorem tables_channel' (vm : VmTables F PublicIO) {table} (table_mem : table ∈ vm.tables) :
+  let step := vm.step table table_mem
+  ⟨ vm.channel,
+    [(pullIf (channel:=vm.channel) step.enabled step.pull).toRaw,
+      (pushIf (channel:=vm.channel) step.enabled step.push).toRaw] ⟩ ∈ table.exposedChannels :=
+  (vm.tables_channel table table_mem).choose_spec.1
+
+theorem tables_enabled_boolean (vm : VmTables F PublicIO) {table} (table_mem : table ∈ vm.tables) :
+    ∀ env,
+      table.Assumptions env →
+      Operations.ConstraintsHold env table.operations →
+        env (vm.step table table_mem).enabled = 0 ∨ env (vm.step table table_mem).enabled = 1 :=
+  (vm.tables_channel table table_mem).choose_spec.2
+
+noncomputable def verifierPull (vm : VmTables F PublicIO) : Var vm.Message F :=
+  vm.verifier_channel.choose
+
+noncomputable def verifierPush (vm : VmTables F PublicIO) : Var vm.Message F :=
+  vm.verifier_channel.choose_spec.choose
+
+theorem verifier_channel' (vm : VmTables F PublicIO) :
+  ⟨ vm.channel,
+    [(vm.channel.pulled vm.verifierPull).toRaw,
+      (vm.channel.pushed vm.verifierPush).toRaw] ⟩ ∈
+    vm.verifier.exposedChannels (varFromOffset PublicIO 0) (size PublicIO) :=
+  vm.verifier_channel.choose_spec.choose_spec
+
+noncomputable def verifierStep (vm : VmTables F PublicIO) : VmStep vm.Message F where
+  enabled := 1
+  pull := vm.verifierPull
+  push := vm.verifierPush
+
 noncomputable def stepOfAllTables (vm : VmTables F PublicIO) (table : Component F)
     (_ : table ∈ vm.allTables) : VmStep vm.Message F := by
   classical
-  exact if table = vm.toEnsemble.verifierTable then vm.verifierStep else vm.step table
+  exact if h : table = vm.toEnsemble.verifierTable then vm.verifierStep else
+    vm.step table (by
+      have h_mem := ‹table ∈ vm.allTables›
+      simp only [allTables, toEnsemble, Ensemble.allTables, List.mem_cons] at h_mem
+      exact h_mem.resolve_left h)
 
 theorem allTables_channel (vm : VmTables F PublicIO) : ∀ (table) (table_mem : table ∈ vm.allTables),
   let step := vm.stepOfAllTables table table_mem
@@ -267,13 +294,13 @@ theorem allTables_channel (vm : VmTables F PublicIO) : ∀ (table) (table_mem : 
   simp only [circuit_norm, Ensemble.allTables] at table_mem ⊢
   rcases table_mem with rfl | table_mem
   · simp only [circuit_norm, stepOfAllTables]
-    exact vm.verifier_channel
+    exact vm.verifier_channel'
   · by_cases h : table = vm.toEnsemble.verifierTable
     · subst table
       simp only [circuit_norm, stepOfAllTables]
-      exact vm.verifier_channel
+      exact vm.verifier_channel'
     · simp only [circuit_norm, stepOfAllTables, h]
-      exact vm.tables_channel table table_mem
+      exact vm.tables_channel' table_mem
 
 /-- Concrete version of VmTables.allTables_channel -/
 lemma allTables_channel' (vm : VmTables F PublicIO) {table} (_ : table ∈ vm.allTables) :
@@ -317,13 +344,13 @@ noncomputable def rowPush (witness : VmWitness vm) {table} (_ : table ∈ witnes
   eval (table.environment row)
     (vm.stepOfAllTables table.component (witness.mem_allTables_component_of_mem_allTables ‹_›)).push
 
-def verifierEnabled (witness : VmWitness vm) : F :=
+noncomputable def verifierEnabled (witness : VmWitness vm) : F :=
   (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.enabled
 
-def verifierPull (witness : VmWitness vm) : vm.Message F :=
+noncomputable def verifierPull (witness : VmWitness vm) : vm.Message F :=
   eval (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.pull
 
-def verifierPush (witness : VmWitness vm) : vm.Message F :=
+noncomputable def verifierPush (witness : VmWitness vm) : vm.Message F :=
   eval (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.push
 
 lemma interactionValuesWith_eq (witness : VmWitness vm)
@@ -520,11 +547,10 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
     table.component.operations.ChannelRequirements vm.channel.toRaw (table.environment row)) →
   (∀ (table) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
     witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1) →
-  witness.verifierEnabled = 1 →
   -- vm channel verifier requirements imply vm channel verifier guarantees
   witness.verifierTable.ChannelRequirements vm.channel.toRaw →
     witness.verifierTable.ChannelGuarantees vm.channel.toRaw := by
-  intro balance constraints row_enabled_boolean verifier_enabled_one
+  intro balance constraints row_enabled_boolean
   -- prove balance of pulls + pushes
   replace balance : BalancedInteractions (witness.pulls ++ witness.pushes) := by
     rw [witness.interactions_eq_pulls_pushes] at balance
@@ -562,7 +588,8 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
   -- to get the conclusion about the verifier, we specialize to index 0
   have verifier_enabled_one' :
       Expression.eval (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.enabled = 1 := by
-    simpa [verifierEnabled] using verifier_enabled_one
+    change Expression.eval (Environment.fromInput witness.publicInput witness.data) (Expression.const (1 : F)) = 1
+    rfl
   have active_length_pos : 0 < (activePulls witness.pulls witness.pushes).length := by
     simp [activePulls, pulls, pushes, interactionPairs, allTables, circuit_norm,
       rowEnabled, VmTables.stepOfAllTables, verifier_enabled_one']
@@ -817,36 +844,19 @@ theorem addVm_soundVmChannel_of_soundChannels [Fact (ringChar F ≠ 2)] (ens : E
     classical
     by_cases h_verifier : table.component = vm.toEnsemble.verifierTable
     · right
-      have h_constraints : Operations.ConstraintsHold (table.environment row)
-          (vm.verifier.main (varFromOffset PublicIO 0) |>.operations (size PublicIO)) := by
-        have hc := (Component.constraintsHold_iff (component:=table.component)
-          (env:=table.environment row)).mp (vm_constraints table table_mem row row_mem)
-        rw [h_verifier] at hc
-        simpa [Component.rowOperations, VmTables.toEnsemble, Ensemble.verifierTable] using hc
-      have h_enabled := vm.verifier_enabled_one (table.environment row) h_constraints
-      simpa [VmWitness.rowEnabled, VmTables.stepOfAllTables, h_verifier] using h_enabled
+      simp [VmWitness.rowEnabled, VmTables.stepOfAllTables, h_verifier, VmTables.verifierStep,
+        Expression.eval]
     · have h_component_mem : table.component ∈ vm.tables := by
         have := vmWitness.mem_allTables_component_of_mem_allTables table_mem
         simp only [VmTables.toEnsemble, Ensemble.allTables, List.mem_cons] at this
         rcases this with h | h
         · contradiction
         · exact h
-      have h_enabled := vm.tables_enabled_boolean table.component h_component_mem
+      have h_enabled := vm.tables_enabled_boolean h_component_mem
         (table.environment row) (vm_assumptions table table_mem row row_mem)
         (vm_constraints table table_mem row row_mem)
       simpa [VmWitness.rowEnabled, VmTables.stepOfAllTables, h_verifier] using h_enabled
-  have verifier_enabled_one : vmWitness.verifierEnabled = 1 := by
-    apply vm.verifier_enabled_one
-    have hc_table : Operations.ConstraintsHold
-        (vmWitness.verifierTable.environment (toElements vmWitness.publicInput).toArray)
-        vmWitness.verifierTable.component.operations :=
-      vm_constraints _ vmWitness.mem_allTables_verifierTable _
-        (by simp [EnsembleWitness.verifierTable])
-    have hc := (Component.constraintsHold_iff (component:=vmWitness.verifierTable.component)
-      (env:=vmWitness.verifierTable.environment (toElements vmWitness.publicInput).toArray)).mp hc_table
-    simpa [Component.rowOperations, VmTables.toEnsemble, Ensemble.verifierTable,
-      EnsembleWitness.verifierTable_environment] using hc
-  specialize verifier_guarantees row_enabled_boolean verifier_enabled_one
+  specialize verifier_guarantees row_enabled_boolean
   -- massage the conclusion so it matches that of `verifier_guarantees`.
   -- mainly, we need to use (again) that all guarantees apart from the VM channel are satisfied
   rw [EnsembleWitness.verifierGuarantees_iff_verifierTable_guarantees, ← verifierTable_eq,

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -508,7 +508,7 @@ lemma mem_zip_pulls_pushes_iff (witness : VmWitness vm) (pull push : Interaction
   simp [← interactionss_eq_pulls_pushes, Table.interactionssWith]
 
 lemma rowEnabled_boolean_of_wellformed {witness : VmWitness vm}
-    (wellformed : RawChannel.InteractionsWellFormed (witness.interactionsWith vm.channel.toRaw)) :
+    (wellformed : InteractionsWellFormed (witness.interactionsWith vm.channel.toRaw)) :
     ∀ (table : Table F) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
       witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1 := by
   intro table table_mem row row_mem
@@ -522,7 +522,7 @@ lemma rowEnabled_boolean_of_wellformed {witness : VmWitness vm}
     exact List.mem_map.mpr ⟨ (pull, push), pair_mem, rfl ⟩
   have pull_mem_interactions : pull ∈ witness.interactionsWith vm.channel.toRaw := by
     rw [witness.interactions_eq_pulls_pushes]
-    apply (List.zip_flattenPairs_perm (witness.pushes_length ▸ witness.pulls_length.symm)).mem_iff.mpr
+    apply (List.zip_flattenPairs_perm ((witness.pushes_length).trans witness.pulls_length.symm)).mem_iff.mpr
     exact List.mem_append_left witness.pushes pull_mem_pulls
   have h_mult := wellformed pull pull_mem_interactions (by rfl)
   rcases h_mult with h_neg_one | h_zero
@@ -578,7 +578,7 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
   [Fact (ringChar F ≠ 2)] (witness : VmWitness vm) :
   -- if the vm interactions with the vm channel are balanced
   BalancedInteractions (witness.interactionsWith vm.channel.toRaw) →
-  RawChannel.InteractionsWellFormed (witness.interactionsWith vm.channel.toRaw) →
+  InteractionsWellFormed (witness.interactionsWith vm.channel.toRaw) →
   -- and for every row, vm channel guarantees imply vm channel requirements
   -- (this will come from constraints + soundness of the existing ensemble)
   (∀ table ∈ witness.allTables, ∀ row ∈ table.table,
@@ -603,12 +603,15 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
     witness.pushes_assumeRequirements
     witness.pair_zero
   -- it remains to prove the (grts → reqs) assumption. this is a reformulation of our `constraints`
-  have reqs_of_grts : (∀ i (hi : i < (activePulls witness.pulls witness.pushes).length),
-      (activePulls witness.pulls witness.pushes)[i].Guarantees witness.data →
-        ((activePushes witness.pulls witness.pushes)[i]'(activePulls_length_eq_activePushes_length witness.pulls witness.pushes ▸ hi)).Requirements witness.data) := by
+  have reqs_of_grts : (∀ i (hi : i < (activePulls witness.pulls).length),
+      (activePulls witness.pulls)[i].Guarantees witness.data →
+        ((activePushes witness.pushes)[i]'(
+          activePulls_length_eq_activePushes_length
+            ((witness.pulls_length).trans witness.pushes_length.symm) witness.pair_zero ▸ hi)).Requirements witness.data) := by
     suffices ∀ pair ∈ (witness.pulls.zip witness.pushes), pair.1.Guarantees witness.data → pair.2.Requirements witness.data by
       intro i hi
-      exact this _ (activePair_mem_zip i hi)
+      exact this _ (activePair_mem_zip
+        ((witness.pulls_length).trans witness.pushes_length.symm) witness.pair_zero i hi)
     intro (pull, push) pair_mem
     simp only
     have ⟨ mem_pull, mem_push ⟩ := List.of_mem_zip pair_mem
@@ -628,15 +631,16 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
       Expression.eval (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.enabled = 1 := by
     change Expression.eval (Environment.fromInput witness.publicInput witness.data) (Expression.const (1 : F)) = 1
     rfl
-  have active_length_pos : 0 < (activePulls witness.pulls witness.pushes).length := by
-    simp [activePulls, pulls, pushes, interactionPairs, allTables, circuit_norm,
+  have active_length_pos : 0 < (activePulls witness.pulls).length := by
+    simp [activePulls, pulls, interactionPairs, allTables, circuit_norm,
       rowEnabled, VmTables.stepOfAllTables, verifier_enabled_one']
   specialize grts_of_reqs reqs_of_grts 0 active_length_pos
   simp [activePulls, activePushes, pulls, pushes, interactionPairs, allTables, circuit_norm,
     rowEnabled, VmTables.stepOfAllTables,
     verifier_enabled_one'] at grts_of_reqs
-  have active_push_length_pos : 0 < (activePushes witness.pulls witness.pushes).length := by
-    rwa [← activePulls_length_eq_activePushes_length witness.pulls witness.pushes]
+  have active_push_length_pos : 0 < (activePushes witness.pushes).length := by
+    rwa [← activePulls_length_eq_activePushes_length
+      ((witness.pulls_length).trans witness.pushes_length.symm) witness.pair_zero]
   simp only [Table.ChannelGuarantees, Table.ChannelRequirements, circuit_norm]
   simp only [← Operations.forall_interactionsWith_iff, vm.verifierInteractionsWith_eq]
   intro hreqs

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -508,7 +508,7 @@ lemma mem_zip_pulls_pushes_iff (witness : VmWitness vm) (pull push : Interaction
   simp [← interactionss_eq_pulls_pushes, Table.interactionssWith]
 
 lemma rowEnabled_boolean_of_wellformed {witness : VmWitness vm}
-    (wellformed : vm.channel.toRaw.InteractionsWellFormed (witness.interactionsWith vm.channel.toRaw)) :
+    (wellformed : RawChannel.InteractionsWellFormed (witness.interactionsWith vm.channel.toRaw)) :
     ∀ (table : Table F) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
       witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1 := by
   intro table table_mem row row_mem
@@ -524,7 +524,7 @@ lemma rowEnabled_boolean_of_wellformed {witness : VmWitness vm}
     rw [witness.interactions_eq_pulls_pushes]
     apply (List.zip_flattenPairs_perm (witness.pushes_length ▸ witness.pulls_length.symm)).mem_iff.mpr
     exact List.mem_append_left witness.pushes pull_mem_pulls
-  have h_mult := wellformed pull pull_mem_interactions (by rfl) (by rfl)
+  have h_mult := wellformed pull pull_mem_interactions (by rfl)
   rcases h_mult with h_neg_one | h_zero
   · right
     have h := congrArg Neg.neg h_neg_one
@@ -578,7 +578,7 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
   [Fact (ringChar F ≠ 2)] (witness : VmWitness vm) :
   -- if the vm interactions with the vm channel are balanced
   BalancedInteractions (witness.interactionsWith vm.channel.toRaw) →
-  vm.channel.toRaw.InteractionsWellFormed (witness.interactionsWith vm.channel.toRaw) →
+  RawChannel.InteractionsWellFormed (witness.interactionsWith vm.channel.toRaw) →
   -- and for every row, vm channel guarantees imply vm channel requirements
   -- (this will come from constraints + soundness of the existing ensemble)
   (∀ table ∈ witness.allTables, ∀ row ∈ table.table,

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -603,10 +603,10 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
     witness.pushes_assumeRequirements
     witness.pair_zero
   -- it remains to prove the (grts → reqs) assumption. this is a reformulation of our `constraints`
-  have reqs_of_grts : (∀ i (hi : i < (activePulls witness.pulls).length),
-      (activePulls witness.pulls)[i].Guarantees witness.data →
-        ((activePushes witness.pushes)[i]'(
-          activePulls_length_eq_activePushes_length
+  have reqs_of_grts : (∀ i (hi : i < (activeInteractions witness.pulls).length),
+      (activeInteractions witness.pulls)[i].Guarantees witness.data →
+        ((activeInteractions witness.pushes)[i]'(
+          activeInteractions_length_eq
             ((witness.pulls_length).trans witness.pushes_length.symm) witness.pair_zero ▸ hi)).Requirements witness.data) := by
     suffices ∀ pair ∈ (witness.pulls.zip witness.pushes), pair.1.Guarantees witness.data → pair.2.Requirements witness.data by
       intro i hi
@@ -631,15 +631,15 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
       Expression.eval (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.enabled = 1 := by
     change Expression.eval (Environment.fromInput witness.publicInput witness.data) (Expression.const (1 : F)) = 1
     rfl
-  have active_length_pos : 0 < (activePulls witness.pulls).length := by
-    simp [activePulls, activeInteractions, pulls, interactionPairs, allTables, circuit_norm,
+  have active_length_pos : 0 < (activeInteractions witness.pulls).length := by
+    simp [activeInteractions, pulls, interactionPairs, allTables, circuit_norm,
       rowEnabled, VmTables.stepOfAllTables, verifier_enabled_one']
   specialize grts_of_reqs reqs_of_grts 0 active_length_pos
-  simp [activePulls, activePushes, activeInteractions, pulls, pushes, interactionPairs, allTables, circuit_norm,
+  simp [activeInteractions, pulls, pushes, interactionPairs, allTables, circuit_norm,
     rowEnabled, VmTables.stepOfAllTables,
     verifier_enabled_one'] at grts_of_reqs
-  have active_push_length_pos : 0 < (activePushes witness.pushes).length := by
-    rwa [← activePulls_length_eq_activePushes_length
+  have active_push_length_pos : 0 < (activeInteractions witness.pushes).length := by
+    rwa [← activeInteractions_length_eq
       ((witness.pulls_length).trans witness.pushes_length.symm) witness.pair_zero]
   simp only [Table.ChannelGuarantees, Table.ChannelRequirements, circuit_norm]
   simp only [← Operations.forall_interactionsWith_iff, vm.verifierInteractionsWith_eq]
@@ -653,12 +653,12 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
           (i:=(pushIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.push).toRaw)
           (env:=env)).mpr hreqs.2.1
     have hpull_grt := grts_of_reqs (by
-      simpa [activePushes, activeInteractions, pulls, pushes, interactionPairs, allTables, circuit_norm,
+      simpa [activeInteractions, pulls, pushes, interactionPairs, allTables, circuit_norm,
         rowEnabled, rowPush, VmTables.stepOfAllTables, verifier_enabled_one', env,
         Channel.eval_pushIf] using hpush_eval)
     have hpull_eval :
         ((pullIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.pull).toRaw.eval env).Guarantees env.data := by
-      simpa [activePulls, activeInteractions, pulls, pushes, interactionPairs, allTables, circuit_norm,
+      simpa [activeInteractions, pulls, pushes, interactionPairs, allTables, circuit_norm,
         rowEnabled, rowPull, VmTables.stepOfAllTables, verifier_enabled_one', env,
         Channel.eval_pullIf] using hpull_grt
     exact AbstractInteraction.eval_guarantees.mp hpull_eval

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -233,16 +233,13 @@ variable {vm : VmTables F PublicIO}
 @[circuit_norm] lemma toEnsemble_verifier (vm : VmTables F PublicIO) :
   vm.toEnsemble.verifier = vm.verifier := rfl
 
-@[circuit_norm] abbrev allTables (vm : VmTables F PublicIO) : List (Component F) :=
-  vm.toEnsemble.allTables
-
 theorem tables_channel_of_mem (vm : VmTables F PublicIO) {table} (table_mem : table ∈ vm.tables) :
-    ∃ enabled : Expression F, ∃ pull push : Var vm.Message F,
-      ⟨ vm.channel,
-        [(pullIf (channel:=vm.channel) enabled pull).toRaw,
-          (pushIf (channel:=vm.channel) enabled push).toRaw] ⟩ ∈ table.exposedChannels ∧
-      ∀ env, table.operations.ConstraintsHold env →
-        Expression.eval env enabled = 0 ∨ Expression.eval env enabled = 1 := by
+  ∃ enabled : Expression F, ∃ pull push : Var vm.Message F,
+    ⟨ vm.channel,
+      [(vm.channel.pulledIf enabled pull).toRaw,
+        (vm.channel.pushedIf enabled push).toRaw] ⟩ ∈ table.exposedChannels ∧
+    ∀ env, table.operations.ConstraintsHold env →
+      Expression.eval env enabled = 0 ∨ Expression.eval env enabled = 1 := by
   have h := vm.tables_channel
   simp_rw [List.forall_iff_forall_mem] at h
   simp_rw [table.constraintsHold_iff]
@@ -254,23 +251,26 @@ theorem tables_channel_of_mem (vm : VmTables F PublicIO) {table} (table_mem : ta
   rw [Circuit.constraintsHold_toFlat_iff]
   exact h_constraints
 
-noncomputable def step (vm : VmTables F PublicIO) (table : Component F)
+@[circuit_norm] abbrev allTables (vm : VmTables F PublicIO) : List (Component F) :=
+  vm.toEnsemble.allTables
+
+noncomputable def tableStep (vm : VmTables F PublicIO) {table : Component F}
     (table_mem : table ∈ vm.tables) : VmStep vm.Message F where
   enabled := (vm.tables_channel_of_mem table_mem).choose
   pull := (vm.tables_channel_of_mem table_mem).choose_spec.choose
   push := (vm.tables_channel_of_mem table_mem).choose_spec.choose_spec.choose
 
+/-- Concrete version of VmTables.tables_channel -/
 theorem tables_channel' (vm : VmTables F PublicIO) {table} (table_mem : table ∈ vm.tables) :
-  let step := vm.step table table_mem
+  let step := vm.tableStep table_mem
   ⟨ vm.channel,
-    [(pullIf (channel:=vm.channel) step.enabled step.pull).toRaw,
-      (pushIf (channel:=vm.channel) step.enabled step.push).toRaw] ⟩ ∈ table.exposedChannels :=
+    [(vm.channel.pulledIf step.enabled step.pull).toRaw,
+      (vm.channel.pushedIf step.enabled step.push).toRaw] ⟩ ∈ table.exposedChannels :=
   (vm.tables_channel_of_mem table_mem).choose_spec.choose_spec.choose_spec.left
 
-theorem tables_enabled_boolean (vm : VmTables F PublicIO) {table} (table_mem : table ∈ vm.tables) :
+theorem tableStep_enabled_isBool (vm : VmTables F PublicIO) {table} (table_mem : table ∈ vm.tables) :
     ∀ env, table.operations.ConstraintsHold env →
-      Expression.eval env (vm.step table table_mem).enabled = 0 ∨
-        Expression.eval env (vm.step table table_mem).enabled = 1 :=
+      IsBool (Expression.eval env (vm.tableStep table_mem).enabled) :=
   (vm.tables_channel_of_mem table_mem).choose_spec.choose_spec.choose_spec.right
 
 noncomputable def verifierPull (vm : VmTables F PublicIO) : Var vm.Message F :=
@@ -279,6 +279,7 @@ noncomputable def verifierPull (vm : VmTables F PublicIO) : Var vm.Message F :=
 noncomputable def verifierPush (vm : VmTables F PublicIO) : Var vm.Message F :=
   vm.verifier_channel.choose_spec.choose
 
+/-- Concrete version of VmTables.verifier_channel -/
 theorem verifier_channel' (vm : VmTables F PublicIO) :
   ⟨ vm.channel,
     [(vm.channel.pulled vm.verifierPull).toRaw,
@@ -291,57 +292,39 @@ noncomputable def verifierStep (vm : VmTables F PublicIO) : VmStep vm.Message F 
   pull := vm.verifierPull
   push := vm.verifierPush
 
-noncomputable def stepOfAllTables (vm : VmTables F PublicIO) (table : Component F)
-    (_ : table ∈ vm.allTables) : VmStep vm.Message F := by
-  classical
-  exact if h : table = vm.toEnsemble.verifierTable then vm.verifierStep else
-    vm.step table (by
-      have h_mem := ‹table ∈ vm.allTables›
-      simp only [allTables, toEnsemble, Ensemble.allTables, List.mem_cons] at h_mem
-      exact h_mem.resolve_left h)
+open Classical in noncomputable
+def step (vm : VmTables F PublicIO) {table : Component F}
+    (h_mem : table ∈ vm.allTables) : VmStep vm.Message F :=
+  if h : table = vm.toEnsemble.verifierTable
+  then vm.verifierStep
+  else vm.tableStep (List.mem_of_ne_of_mem h h_mem)
 
 theorem allTables_channel (vm : VmTables F PublicIO) : ∀ (table) (table_mem : table ∈ vm.allTables),
-  let step := vm.stepOfAllTables table table_mem
+  let step := vm.step table_mem
   ⟨ vm.channel,
-    [(pullIf (channel:=vm.channel) step.enabled step.pull).toRaw,
-      (pushIf (channel:=vm.channel) step.enabled step.push).toRaw] ⟩ ∈ table.exposedChannels := by
+    [(vm.channel.pulledIf step.enabled step.pull).toRaw,
+      (vm.channel.pushedIf step.enabled step.push).toRaw] ⟩ ∈ table.exposedChannels := by
   intro table table_mem
-  classical
   simp only [circuit_norm, Ensemble.allTables] at table_mem ⊢
-  rcases table_mem with rfl | table_mem
-  · simp only [circuit_norm, stepOfAllTables]
+  by_cases h : table = vm.toEnsemble.verifierTable
+  · subst table
+    simp only [circuit_norm, step, reduceDIte]
     exact vm.verifier_channel'
-  · by_cases h : table = vm.toEnsemble.verifierTable
-    · subst table
-      simp only [circuit_norm, stepOfAllTables]
-      exact vm.verifier_channel'
-    · simp only [circuit_norm, stepOfAllTables, h]
-      exact vm.tables_channel' table_mem
-
-/-- Concrete version of VmTables.allTables_channel -/
-lemma allTables_channel' (vm : VmTables F PublicIO) {table} (_ : table ∈ vm.allTables) :
-  let step := vm.stepOfAllTables table ‹_›
-  ⟨ vm.channel.toRaw,
-    [(pullIf (channel:=vm.channel) step.enabled step.pull).toRaw,
-      (pushIf (channel:=vm.channel) step.enabled step.push).toRaw]
-  ⟩ ∈ table.exposedChannels := by
-  exact vm.allTables_channel table ‹_›
+  · simp only [circuit_norm, step, h, reduceDIte] at ⊢ table_mem
+    exact vm.tables_channel' table_mem
 
 lemma interactionsWith_eq {vm : VmTables F PublicIO} {table} (_ : table ∈ vm.allTables) :
-  let step := vm.stepOfAllTables table ‹_›
   table.operations.interactionsWith vm.channel.toRaw = [
-    (pullIf (channel:=vm.channel) step.enabled step.pull).toRaw,
-    (pushIf (channel:=vm.channel) step.enabled step.push).toRaw ] := by
+    (vm.channel.pulledIf (vm.step ‹_›).enabled (vm.step ‹_›).pull).toRaw,
+    (vm.channel.pushedIf (vm.step ‹_›).enabled (vm.step ‹_›).push).toRaw ] := by
   apply Component.interactionsWith_of_exposedChannels
-  apply vm.allTables_channel'
+  apply vm.allTables_channel
 
 lemma verifierInteractionsWith_eq {vm : VmTables F PublicIO} :
   vm.toEnsemble.verifierTable.operations.interactionsWith vm.channel.toRaw = [
-    (pullIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.pull).toRaw,
-    (pushIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.push).toRaw ] := by
-  simpa [stepOfAllTables] using
-    interactionsWith_eq (vm:=vm) (table:=vm.toEnsemble.verifierTable)
-      Ensemble.mem_allTables_verifierTable
+    (vm.channel.pulledIf vm.verifierStep.enabled vm.verifierStep.pull).toRaw,
+    (vm.channel.pushedIf vm.verifierStep.enabled vm.verifierStep.push).toRaw ] := by
+  simpa only [step] using interactionsWith_eq Ensemble.mem_allTables_verifierTable
 end VmTables
 
 namespace VmWitness
@@ -350,18 +333,21 @@ open EnsembleWitness
 
 noncomputable def rowEnabled (witness : VmWitness vm) {table} (_ : table ∈ witness.allTables) (row : Array F) : F :=
   (table.environment row)
-    (vm.stepOfAllTables table.component (witness.mem_allTables_component_of_mem_allTables ‹_›)).enabled
+    (vm.step (witness.mem_allTables_component_of_mem_allTables ‹_›)).enabled
 
 noncomputable def rowPull (witness : VmWitness vm) {table} (_ : table ∈ witness.allTables) (row : Array F) : vm.Message F :=
   eval (table.environment row)
-    (vm.stepOfAllTables table.component (witness.mem_allTables_component_of_mem_allTables ‹_›)).pull
+    (vm.step (witness.mem_allTables_component_of_mem_allTables ‹_›)).pull
 
 noncomputable def rowPush (witness : VmWitness vm) {table} (_ : table ∈ witness.allTables) (row : Array F) : vm.Message F :=
   eval (table.environment row)
-    (vm.stepOfAllTables table.component (witness.mem_allTables_component_of_mem_allTables ‹_›)).push
+    (vm.step (witness.mem_allTables_component_of_mem_allTables ‹_›)).push
 
 noncomputable def verifierEnabled (witness : VmWitness vm) : F :=
-  (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.enabled
+  eval (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.enabled
+
+lemma verifierEnabled_eq_one (witness : VmWitness vm) : witness.verifierEnabled = 1 := by
+  simp only [verifierEnabled, VmTables.verifierStep, circuit_norm]
 
 noncomputable def verifierPull (witness : VmWitness vm) : vm.Message F :=
   eval (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.pull
@@ -372,8 +358,8 @@ noncomputable def verifierPush (witness : VmWitness vm) : vm.Message F :=
 lemma interactionValuesWith_eq (witness : VmWitness vm)
     {table} (_ : table ∈ witness.allTables) (row : Array F) :
   table.component.operations.interactionValuesWith vm.channel.toRaw (table.environment row) = [
-    vm.channel.pullIfValue (witness.rowEnabled ‹_› row) (witness.rowPull ‹_› row),
-    vm.channel.pushIfValue (witness.rowEnabled ‹_› row) (witness.rowPush ‹_› row) ] := by
+    vm.channel.pulledIfValue (witness.rowEnabled ‹_› row) (witness.rowPull ‹_› row),
+    vm.channel.pushedIfValue (witness.rowEnabled ‹_› row) (witness.rowPush ‹_› row) ] := by
   simp only [circuit_norm, vm.interactionsWith_eq (witness.mem_allTables_component_of_mem_allTables ‹_›),
     rowEnabled, rowPull, rowPush, AbstractInteraction.eval, ProvableType.toElements_eval]
 
@@ -385,14 +371,40 @@ lemma interactionValuesWith_length (witness : VmWitness vm)
 noncomputable def interactionPairs (witness : VmWitness vm) : List (Interaction F × Interaction F) :=
   witness.allTables.attach.flatMap fun ⟨ table, _ ⟩ =>
     table.table.map fun row =>
-      (vm.channel.pullIfValue (witness.rowEnabled ‹_› row) (witness.rowPull ‹_› row),
-        vm.channel.pushIfValue (witness.rowEnabled ‹_› row) (witness.rowPush ‹_› row))
+      (vm.channel.pulledIfValue (witness.rowEnabled ‹_› row) (witness.rowPull ‹_› row),
+        vm.channel.pushedIfValue (witness.rowEnabled ‹_› row) (witness.rowPush ‹_› row))
+
+lemma mem_interactionPairs_iff {witness : VmWitness vm} {pair : Interaction F × Interaction F} :
+  pair ∈ witness.interactionPairs ↔
+    ∃ (table : Table F) (_ : table ∈ witness.allTables), ∃ row ∈ table.table,
+    pair = (vm.channel.pulledIfValue (witness.rowEnabled ‹_› row) (witness.rowPull ‹_› row),
+      vm.channel.pushedIfValue (witness.rowEnabled ‹_› row) (witness.rowPush ‹_› row)) := by
+  simp [interactionPairs]
+  tauto
 
 noncomputable def pulls (witness : VmWitness vm) : List (Interaction F) :=
   witness.interactionPairs.map Prod.fst
 
 noncomputable def pushes (witness : VmWitness vm) : List (Interaction F) :=
   witness.interactionPairs.map Prod.snd
+
+lemma zip_pulls_pushes_eq_interactionPairs {witness : VmWitness vm} :
+    List.zip witness.pulls witness.pushes = witness.interactionPairs := by
+  simp only [pulls, pushes, List.zip_map_fst_snd]
+
+lemma mem_pulls_iff {witness : VmWitness vm} {pull : Interaction F} :
+  pull ∈ witness.pulls ↔
+    ∃ (table : Table F) (_ : table ∈ witness.allTables), ∃ row ∈ table.table,
+    pull = vm.channel.pulledIfValue (witness.rowEnabled ‹_› row) (witness.rowPull ‹_› row) := by
+  simp [pulls, interactionPairs]
+  tauto
+
+lemma mem_pushes_iff {witness : VmWitness vm} {push : Interaction F} :
+  push ∈ witness.pushes ↔
+    ∃ (table : Table F) (_ : table ∈ witness.allTables), ∃ row ∈ table.table,
+    push = vm.channel.pushedIfValue (witness.rowEnabled ‹_› row) (witness.rowPush ‹_› row) := by
+  simp [pushes, interactionPairs]
+  tauto
 
 def steps (witness : VmWitness vm) : ℕ := witness.tables.map (·.length) |>.sum
 
@@ -404,74 +416,64 @@ lemma pulls_length {witness : VmWitness vm} : witness.pulls.length = witness.ste
 lemma pushes_length {witness : VmWitness vm} : witness.pushes.length = witness.steps + 1 := by
   simp [steps, pushes, interactionPairs, allTables, circuit_norm]
 
-lemma pulls_mult {witness : VmWitness vm}
-    (row_enabled_boolean : ∀ (table) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
-      witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1) :
-    ∀ pull ∈ witness.pulls, pull.mult = -1 ∨ pull.mult = 0 := by
-  simp only [pulls, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
-    forall_exists_index, and_imp]
-  rintro pull pair table table_mem row row_mem hpair hpull
-  subst pair
-  subst pull
-  rcases row_enabled_boolean table table_mem row row_mem with h0 | h1
-  · right
-    change -witness.rowEnabled table_mem row = 0
-    rw [h0]
-    simp
-  · left
-    change -witness.rowEnabled table_mem row = -1
-    rw [h1]
+lemma rowEnabled_isBool_of_constraints {witness : VmWitness vm} :
+    witness.Constraints →
+    ∀ table (_ : table ∈ witness.allTables), ∀ row ∈ table.table,
+      IsBool (witness.rowEnabled ‹_› row) := by
+  intro constraints table table_mem row row_mem
+  simp only [circuit_norm, rowEnabled, VmTables.step, VmTables.verifierStep]
+  by_cases h_verifier : table.component = vm.toEnsemble.verifierTable
+  · simp [circuit_norm, h_verifier]
+  have component_mem : table.component ∈ vm.tables := by
+    have h_mem := witness.mem_allTables_component_of_mem_allTables table_mem
+    simp only [circuit_norm, Ensemble.allTables, List.mem_cons] at h_mem
+    exact h_mem.resolve_left h_verifier
+  have h_constraints := constraints table table_mem row row_mem
+  simp only [h_verifier, reduceDIte]
+  exact vm.tableStep_enabled_isBool component_mem _ h_constraints
 
-lemma pushes_mult {witness : VmWitness vm}
-    (row_enabled_boolean : ∀ (table) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
-      witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1) :
-    ∀ push ∈ witness.pushes, push.mult = 1 ∨ push.mult = 0 := by
-  simp only [pushes, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
-    forall_exists_index, and_imp]
-  rintro push pair table table_mem row row_mem hpair hpush
-  subst pair
-  subst push
-  rcases row_enabled_boolean table table_mem row row_mem with h0 | h1
-  · right
-    change witness.rowEnabled table_mem row = 0
-    exact h0
-  · left
-    change witness.rowEnabled table_mem row = 1
-    exact h1
+lemma pulls_mult {witness : VmWitness vm} :
+  witness.Constraints →
+    ∀ pull ∈ witness.pulls, pull.mult = 0 ∨ pull.mult = -1 := by
+  simp_rw [witness.mem_pulls_iff]
+  rintro constraints pull ⟨ table, table_mem, row, row_mem, rfl ⟩
+  simp only [circuit_norm, neg_inj]
+  apply witness.rowEnabled_isBool_of_constraints constraints _ ‹_› _ ‹_›
 
-lemma pair_zero {witness : VmWitness vm} :
-    ∀ i (hi_p : i < witness.pulls.length) (hi_q : i < witness.pushes.length),
+lemma pushes_mult {witness : VmWitness vm} :
+  witness.Constraints →
+    ∀ push ∈ witness.pushes, push.mult = 0 ∨ push.mult = 1 := by
+  simp_rw [witness.mem_pushes_iff]
+  rintro constraints push ⟨ table, table_mem, row, row_mem, rfl ⟩
+  simp only [circuit_norm]
+  apply witness.rowEnabled_isBool_of_constraints constraints _ ‹_› _ ‹_›
+
+lemma pulls_zero_iff_pushes_zero {witness : VmWitness vm} :
+    ∀ i (hi : i < witness.pulls.length) (hi' : i < witness.pushes.length),
       witness.pulls[i].mult = 0 ↔ witness.pushes[i].mult = 0 := by
   intro i hi_p hi_q
-  have pair_mem : witness.interactionPairs[i]'(by simpa [pulls] using hi_p) ∈ witness.interactionPairs :=
-    List.getElem_mem _
   simp only [pulls, pushes, List.getElem_map]
-  revert pair_mem
-  simp only [interactionPairs, List.mem_flatMap, List.mem_attach, List.mem_map, true_and, Subtype.exists,
-    forall_exists_index, and_imp]
-  rintro table table_mem row row_mem hpair
-  rw [← hpair]
-  simp [circuit_norm]
+  have hi : i < witness.interactionPairs.length := by
+    simpa [pulls, interactionPairs] using hi_p
+  have pair_mem : witness.interactionPairs[i]'hi ∈ witness.interactionPairs := List.getElem_mem _
+  rw [mem_interactionPairs_iff] at pair_mem
+  rcases pair_mem with ⟨ pair, pair_mem, table, table_mem, hpair ⟩
+  rw [hpair]
+  simp only [circuit_norm]
 
 @[circuit_norm]
 lemma pulls_channel {witness : VmWitness vm} : ∀ pull ∈ witness.pulls, pull.channel = vm.channel.toRaw := by
-  simp only [pulls, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
-    forall_exists_index, and_imp]
-  rintro pull pair table table_mem row row_mem hpair hpull
-  subst pair
-  subst pull
+  simp_rw [mem_pulls_iff]
+  rintro pull ⟨ table, table_mem, row, row_mem, rfl ⟩
   simp only [circuit_norm]
 
 @[circuit_norm]
 lemma pushes_channel {witness : VmWitness vm} : ∀ push ∈ witness.pushes, push.channel = vm.channel.toRaw := by
-  simp only [pushes, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
-    forall_exists_index, and_imp]
-  rintro push pair table table_mem row row_mem hpair hpush
-  subst pair
-  subst push
+  simp_rw [mem_pushes_iff]
+  rintro push ⟨ table, table_mem, row, row_mem, rfl ⟩
   simp only [circuit_norm]
 
-lemma interactionss_eq_pairs (witness : VmWitness vm) :
+lemma interactionss_eq_interactionPairs (witness : VmWitness vm) :
   witness.allTables.flatMap (·.interactionssWith vm.channel.toRaw) =
     witness.interactionPairs.map (fun ⟨pull, push⟩ => [pull, push]) := by
   simp only [interactionPairs, List.flatMap_def, List.map_flatten]
@@ -485,7 +487,7 @@ lemma interactionss_eq_pairs (witness : VmWitness vm) :
 lemma interactionss_eq_pulls_pushes (witness : VmWitness vm) :
   witness.allTables.flatMap (·.interactionssWith vm.channel.toRaw) =
     (List.zip witness.pulls witness.pushes).map (fun ⟨pull, push⟩ => [pull, push]) := by
-  rw [interactionss_eq_pairs]
+  rw [interactionss_eq_interactionPairs]
   simp [pulls, pushes, List.zip_map_fst_snd]
 
 lemma interactions_eq_pulls_pushes (witness : VmWitness vm) :
@@ -502,44 +504,20 @@ lemma mem_zip_pulls_pushes_iff (witness : VmWitness vm) (pull push : Interaction
   · simp
   simp [← interactionss_eq_pulls_pushes, Table.interactionssWith]
 
-lemma rowEnabled_boolean_of_constraints {witness : VmWitness vm}
-    (constraints : witness.Constraints) :
-    ∀ (table : Table F) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
-      witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1 := by
-  intro table table_mem row row_mem
-  classical
-  by_cases h_verifier : table.component = vm.toEnsemble.verifierTable
-  · right
-    simp [rowEnabled, VmTables.stepOfAllTables, h_verifier, VmTables.verifierStep]
-    rfl
-  · have table_mem_components : table.component ∈ vm.tables := by
-      have h_mem := witness.mem_allTables_component_of_mem_allTables table_mem
-      simp only [VmTables.toEnsemble, Ensemble.allTables, List.mem_cons] at h_mem
-      exact h_mem.resolve_left h_verifier
-    have h_constraints := constraints table table_mem row row_mem
-    simpa [rowEnabled, VmTables.stepOfAllTables, h_verifier] using
-      vm.tables_enabled_boolean table_mem_components (table.environment row) h_constraints
-
-lemma pull_requirements (witness : VmWitness vm)
-    (row_enabled_boolean : ∀ (table) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
-      witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1) :
+lemma pull_requirements_of_constraints {witness : VmWitness vm} :
+  witness.Constraints →
     ∀ pull ∈ witness.pulls, pull.Requirements witness.data := by
-  simp only [pulls, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
-    forall_exists_index, and_imp]
-  rintro pull pair table table_mem row row_mem hpair hpull
-  subst pair
-  subst pull
-  rcases row_enabled_boolean table table_mem row row_mem with h0 | h1
-  · simp [circuit_norm, Interaction.Requirements, Channel.toRaw, h0]
-  · simp [circuit_norm, Interaction.Requirements, Channel.toRaw, h1]
+  intro constraints
+  simp_rw [witness.mem_pulls_iff]
+  rintro pull ⟨ table, table_mem, row, row_mem, rfl ⟩
+  apply Channel.pulledIfValue_requirements_of_isBool_enabled
+  apply witness.rowEnabled_isBool_of_constraints constraints _ ‹_› _ ‹_›
 
-lemma push_guarantees (witness : VmWitness vm) : ∀ push ∈ witness.pushes, push.Guarantees witness.data := by
-  simp only [pushes, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
-    forall_exists_index, and_imp]
-  rintro push pair table table_mem row row_mem hpair hpush
-  subst pair
-  subst push
-  simp only [circuit_norm, Interaction.Guarantees]
+lemma push_guarantees {witness : VmWitness vm} :
+  ∀ push ∈ witness.pushes, push.Guarantees witness.data := by
+  simp_rw [witness.mem_pushes_iff]
+  rintro push ⟨ table, table_mem, row, row_mem, rfl ⟩
+  apply Channel.pushedIfValue_guarantees
 
 lemma pulls_length_pos {witness : VmWitness vm} : witness.pulls.length > 0 := by
   simp [pulls_length]
@@ -548,17 +526,41 @@ lemma pushes_length_pos {witness : VmWitness vm} : witness.pushes.length > 0 := 
 
 lemma pulls_getElem_zero_eq (witness : VmWitness vm) :
     witness.pulls[0]'pulls_length_pos =
-      vm.channel.pullIfValue witness.verifierEnabled witness.verifierPull := by
-  classical
+      vm.channel.pulledIfValue witness.verifierEnabled witness.verifierPull := by
   simp [pulls, interactionPairs, allTables, circuit_norm, rowEnabled, rowPull,
-    verifierEnabled, verifierPull, VmTables.stepOfAllTables]
+    verifierPull, verifierEnabled, VmTables.step, VmTables.verifierStep]
 
 lemma pushes_getElem_zero_eq (witness : VmWitness vm) :
     witness.pushes[0]'pushes_length_pos =
-      vm.channel.pushIfValue witness.verifierEnabled witness.verifierPush := by
-  classical
+      vm.channel.pushedIfValue witness.verifierEnabled witness.verifierPush := by
   simp [pushes, interactionPairs, allTables, circuit_norm, rowEnabled, rowPush,
-    verifierEnabled, verifierPush, VmTables.stepOfAllTables]
+    verifierPush, verifierEnabled, VmTables.step, VmTables.verifierStep]
+
+lemma activeInteractions_pulls_length_pos {witness : VmWitness vm} :
+    (activeInteractions witness.pulls).length > 0 := by
+  simp_rw [activeInteractions, ←List.countP_eq_length_filter, List.countP_pos_iff]
+  use witness.pulls[0]'pulls_length_pos, List.getElem_mem pulls_length_pos
+  rw [witness.pulls_getElem_zero_eq]
+  simp [circuit_norm, verifierEnabled_eq_one]
+
+lemma activeInteractions_pushes_length_pos {witness : VmWitness vm} :
+    (activeInteractions witness.pushes).length > 0 := by
+  simp_rw [activeInteractions, ←List.countP_eq_length_filter, List.countP_pos_iff]
+  use witness.pushes[0]'pushes_length_pos, List.getElem_mem pushes_length_pos
+  rw [witness.pushes_getElem_zero_eq]
+  simp [circuit_norm, verifierEnabled_eq_one]
+
+lemma activeInteractions_pulls_getElem_zero_eq {witness : VmWitness vm} :
+    (activeInteractions witness.pulls)[0]'activeInteractions_pulls_length_pos =
+      vm.channel.pulledIfValue witness.verifierEnabled witness.verifierPull := by
+  simp [activeInteractions, pulls, interactionPairs, allTables, circuit_norm, rowEnabled, rowPull,
+    verifierPull, verifierEnabled, VmTables.step, VmTables.verifierStep]
+
+lemma activeInteractions_pushes_getElem_zero_eq {witness : VmWitness vm} :
+    (activeInteractions witness.pushes)[0]'activeInteractions_pushes_length_pos =
+      vm.channel.pushedIfValue witness.verifierEnabled witness.verifierPush := by
+  simp [activeInteractions, pushes, interactionPairs, allTables, circuit_norm, rowEnabled, rowPush,
+    verifierPush, verifierEnabled, VmTables.step, VmTables.verifierStep]
 
 /-- Translation of the VM soundness theorem to VmTables -/
 theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
@@ -575,34 +577,35 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
   witness.verifierTable.ChannelRequirements vm.channel.toRaw →
     witness.verifierTable.ChannelGuarantees vm.channel.toRaw := by
   intro balance witness_constraints constraints
-  have row_enabled_boolean := witness.rowEnabled_boolean_of_constraints witness_constraints
+  have row_enabled_boolean := witness.rowEnabled_isBool_of_constraints witness_constraints
   -- prove balance of pulls + pushes
   replace balance : BalancedInteractions (witness.pulls ++ witness.pushes) := by
     rw [witness.interactions_eq_pulls_pushes] at balance
     apply balancedInteractions_of_perm balance
     apply List.zip_flattenPairs_perm <| witness.pushes_length ▸ witness.pulls_length.symm
   -- we fill in the conditions on pulls and pushes in `guarantees_of_requirements_of_requirements_of_guarantees`
+  let n := (activeInteractions witness.pulls).length
+  have same_length : witness.pulls.length = witness.pushes.length := by
+    simp [pulls_length, pushes_length]
+  have : (activeInteractions witness.pushes).length = n := by
+    simp only [n, activeInteractions_length_eq same_length witness.pulls_zero_iff_pushes_zero]
   have grts_of_reqs := guarantees_of_requirements_of_requirements_of_guarantees_of_mult_zero_iff
-    vm.channel.toRaw witness.pulls witness.pushes balance witness.data
-    (by simp [witness.pulls_length, witness.pushes_length])
+    vm.channel.toRaw witness.pulls witness.pushes balance witness.data same_length
     witness.pulls_channel witness.pushes_channel
-    (witness.pulls_mult row_enabled_boolean) (witness.pushes_mult row_enabled_boolean)
-    witness.pair_zero
+    (witness.pulls_mult witness_constraints) (witness.pushes_mult witness_constraints)
+    witness.pulls_zero_iff_pushes_zero
   -- it remains to prove the (grts → reqs) assumption. this is a reformulation of our `constraints`
-  have reqs_of_grts : (∀ i (hi : i < (activeInteractions witness.pulls).length),
+  have reqs_of_grts : (∀ i (hi : i < n),
       (activeInteractions witness.pulls)[i].Guarantees witness.data →
-        ((activeInteractions witness.pushes)[i]'(
-          activeInteractions_length_eq
-            ((witness.pulls_length).trans witness.pushes_length.symm) witness.pair_zero ▸ hi)).Requirements witness.data) := by
+      (activeInteractions witness.pushes)[i].Requirements witness.data) := by
     suffices ∀ pair ∈ (witness.pulls.zip witness.pushes), pair.1.Guarantees witness.data → pair.2.Requirements witness.data by
       intro i hi
-      exact this _ (activePair_mem_zip
-        ((witness.pulls_length).trans witness.pushes_length.symm) witness.pair_zero i hi)
+      exact this _ (activePair_mem_zip same_length witness.pulls_zero_iff_pushes_zero _ hi)
     intro (pull, push) pair_mem
     simp only
     have ⟨ mem_pull, mem_push ⟩ := List.of_mem_zip pair_mem
     have push_grts := witness.push_guarantees push mem_push
-    have pull_reqs := witness.pull_requirements row_enabled_boolean pull mem_pull
+    have pull_reqs := witness.pull_requirements_of_constraints witness_constraints pull mem_pull
     rw [witness.mem_zip_pulls_pushes_iff] at pair_mem
     obtain ⟨ table, table_mem, row, row_mem, interactions_eq ⟩ := pair_mem
     suffices (∀ i ∈ [pull, push], i.Guarantees witness.data) → (∀ i ∈ [pull, push], i.Requirements witness.data) by
@@ -613,45 +616,16 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
       Operations.forall_interactionsWith_iff]
     convert constraints table table_mem row row_mem
   -- to get the conclusion about the verifier, we specialize to index 0
-  have verifier_enabled_one' :
-      Expression.eval (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.enabled = 1 := by
-    change Expression.eval (Environment.fromInput witness.publicInput witness.data) (Expression.const (1 : F)) = 1
-    rfl
-  have active_length_pos : 0 < (activeInteractions witness.pulls).length := by
-    simp [activeInteractions, pulls, interactionPairs, allTables, circuit_norm,
-      rowEnabled, VmTables.stepOfAllTables, verifier_enabled_one']
-  specialize grts_of_reqs reqs_of_grts 0 active_length_pos
-  simp [activeInteractions, pulls, pushes, interactionPairs, allTables, circuit_norm,
-    rowEnabled, VmTables.stepOfAllTables,
-    verifier_enabled_one'] at grts_of_reqs
-  have active_push_length_pos : 0 < (activeInteractions witness.pushes).length := by
-    rwa [← activeInteractions_length_eq
-      ((witness.pulls_length).trans witness.pushes_length.symm) witness.pair_zero]
+  specialize grts_of_reqs reqs_of_grts 0 activeInteractions_pulls_length_pos
+  rw [witness.activeInteractions_pulls_getElem_zero_eq,
+    witness.activeInteractions_pushes_getElem_zero_eq] at grts_of_reqs
+  simp only [VmWitness.verifierPush, VmWitness.verifierPull, VmWitness.verifierEnabled] at grts_of_reqs
+  rw [← Channel.eval_pulledIf, AbstractInteraction.eval_guarantees] at grts_of_reqs
+  rw [← Channel.eval_pushedIf, AbstractInteraction.eval_requirements] at grts_of_reqs
   simp only [Table.ChannelGuarantees, Table.ChannelRequirements, circuit_norm]
   simp only [← Operations.forall_interactionsWith_iff, vm.verifierInteractionsWith_eq]
-  intro hreqs
-  simp only [List.mem_cons, List.not_mem_nil, forall_eq_or_imp] at hreqs ⊢
-  refine ⟨?_, ?_, ?_⟩
-  · let env := Environment.fromInput witness.publicInput witness.data
-    have hpush_eval :
-        ((pushIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.push).toRaw.eval env).Requirements env.data :=
-        (AbstractInteraction.eval_requirements
-          (i:=(pushIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.push).toRaw)
-          (env:=env)).mpr hreqs.2.1
-    have hpull_grt := grts_of_reqs (by
-      simpa [activeInteractions, pulls, pushes, interactionPairs, allTables, circuit_norm,
-        rowEnabled, rowPush, VmTables.stepOfAllTables, verifier_enabled_one', env,
-        Channel.eval_pushIf] using hpush_eval)
-    have hpull_eval :
-        ((pullIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.pull).toRaw.eval env).Guarantees env.data := by
-      simpa [activeInteractions, pulls, pushes, interactionPairs, allTables, circuit_norm,
-        rowEnabled, rowPull, VmTables.stepOfAllTables, verifier_enabled_one', env,
-        Channel.eval_pullIf] using hpull_grt
-    exact AbstractInteraction.eval_guarantees.mp hpull_eval
-  · intro h
-    cases h
-  · intro a h
-    cases h
+  simp_all only [List.mem_cons, List.not_mem_nil, forall_eq_or_imp]
+  tauto
 end VmWitness
 
 namespace Ensemble

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -57,7 +57,9 @@ structure VmTables (F : Type) [Field F] [DecidableEq F] (PublicIO : TypeMap) [Pr
     ∃ enabled : Expression F, ∃ pull push : Var Message F,
       ⟨ channel,
         [(pullIf (channel:=channel) enabled pull).toRaw,
-          (pushIf (channel:=channel) enabled push).toRaw] ⟩ ∈ table.exposedChannels
+          (pushIf (channel:=channel) enabled push).toRaw] ⟩ ∈ table.exposedChannels ∧
+      ∀ env, table.operations.ConstraintsHold env →
+        Expression.eval env enabled = 0 ∨ Expression.eval env enabled = 1
 
   -- the verifier pulls and pushes to the channel, and doesn't push anything else
   verifier_channel : ∃ m1 m2, ⟨ channel, [(channel.pulled m1).toRaw, (channel.pushed m2).toRaw] ⟩ ∈
@@ -253,7 +255,9 @@ theorem tables_channel_of_mem (vm : VmTables F PublicIO) {table} (table_mem : ta
     ∃ enabled : Expression F, ∃ pull push : Var vm.Message F,
       ⟨ vm.channel,
         [(pullIf (channel:=vm.channel) enabled pull).toRaw,
-          (pushIf (channel:=vm.channel) enabled push).toRaw] ⟩ ∈ table.exposedChannels := by
+          (pushIf (channel:=vm.channel) enabled push).toRaw] ⟩ ∈ table.exposedChannels ∧
+      ∀ env, table.operations.ConstraintsHold env →
+        Expression.eval env enabled = 0 ∨ Expression.eval env enabled = 1 := by
   exact list_forall_mem vm.tables_channel table_mem
 
 noncomputable def step (vm : VmTables F PublicIO) (table : Component F)
@@ -267,7 +271,13 @@ theorem tables_channel' (vm : VmTables F PublicIO) {table} (table_mem : table �
   ⟨ vm.channel,
     [(pullIf (channel:=vm.channel) step.enabled step.pull).toRaw,
       (pushIf (channel:=vm.channel) step.enabled step.push).toRaw] ⟩ ∈ table.exposedChannels :=
-  (vm.tables_channel_of_mem table_mem).choose_spec.choose_spec.choose_spec
+  (vm.tables_channel_of_mem table_mem).choose_spec.choose_spec.choose_spec.left
+
+theorem tables_enabled_boolean (vm : VmTables F PublicIO) {table} (table_mem : table ∈ vm.tables) :
+    ∀ env, table.operations.ConstraintsHold env →
+      Expression.eval env (vm.step table table_mem).enabled = 0 ∨
+        Expression.eval env (vm.step table table_mem).enabled = 1 :=
+  (vm.tables_channel_of_mem table_mem).choose_spec.choose_spec.choose_spec.right
 
 noncomputable def verifierPull (vm : VmTables F PublicIO) : Var vm.Message F :=
   vm.verifier_channel.choose
@@ -507,31 +517,23 @@ lemma mem_zip_pulls_pushes_iff (witness : VmWitness vm) (pull push : Interaction
   · simp
   simp [← interactionss_eq_pulls_pushes, Table.interactionssWith]
 
-lemma rowEnabled_boolean_of_wellformed {witness : VmWitness vm}
-    (wellformed : InteractionsWellFormed (witness.interactionsWith vm.channel.toRaw)) :
+lemma rowEnabled_boolean_of_constraints {witness : VmWitness vm}
+    (constraints : witness.Constraints) :
     ∀ (table : Table F) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
       witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1 := by
   intro table table_mem row row_mem
-  let pull := vm.channel.pullIfValue (witness.rowEnabled table_mem row) (witness.rowPull table_mem row)
-  let push := vm.channel.pushIfValue (witness.rowEnabled table_mem row) (witness.rowPush table_mem row)
-  have pair_mem : (pull, push) ∈ witness.interactionPairs := by
-    simp only [interactionPairs, List.mem_flatMap, List.mem_attach, true_and, List.mem_map]
-    refine ⟨ ⟨ table, table_mem ⟩, row, row_mem, ?_ ⟩
-    simp [pull, push]
-  have pull_mem_pulls : pull ∈ witness.pulls := by
-    exact List.mem_map.mpr ⟨ (pull, push), pair_mem, rfl ⟩
-  have pull_mem_interactions : pull ∈ witness.interactionsWith vm.channel.toRaw := by
-    rw [witness.interactions_eq_pulls_pushes]
-    apply (List.zip_flattenPairs_perm ((witness.pushes_length).trans witness.pulls_length.symm)).mem_iff.mpr
-    exact List.mem_append_left witness.pushes pull_mem_pulls
-  have h_mult := wellformed pull pull_mem_interactions (by rfl)
-  rcases h_mult with h_neg_one | h_zero
+  classical
+  by_cases h_verifier : table.component = vm.toEnsemble.verifierTable
   · right
-    have h := congrArg Neg.neg h_neg_one
-    simpa [pull, Channel.pullIfValue] using h
-  · left
-    have h := congrArg Neg.neg h_zero
-    simpa [pull, Channel.pullIfValue] using h
+    simp [rowEnabled, VmTables.stepOfAllTables, h_verifier, VmTables.verifierStep]
+    rfl
+  · have table_mem_components : table.component ∈ vm.tables := by
+      have h_mem := witness.mem_allTables_component_of_mem_allTables table_mem
+      simp only [VmTables.toEnsemble, Ensemble.allTables, List.mem_cons] at h_mem
+      exact h_mem.resolve_left h_verifier
+    have h_constraints := constraints table table_mem row row_mem
+    simpa [rowEnabled, VmTables.stepOfAllTables, h_verifier] using
+      vm.tables_enabled_boolean table_mem_components (table.environment row) h_constraints
 
 lemma pull_requirements (witness : VmWitness vm)
     (row_enabled_boolean : ∀ (table) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
@@ -578,7 +580,7 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
   [Fact (ringChar F ≠ 2)] (witness : VmWitness vm) :
   -- if the vm interactions with the vm channel are balanced
   BalancedInteractions (witness.interactionsWith vm.channel.toRaw) →
-  InteractionsWellFormed (witness.interactionsWith vm.channel.toRaw) →
+  witness.Constraints →
   -- and for every row, vm channel guarantees imply vm channel requirements
   -- (this will come from constraints + soundness of the existing ensemble)
   (∀ table ∈ witness.allTables, ∀ row ∈ table.table,
@@ -587,8 +589,8 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
   -- vm channel verifier requirements imply vm channel verifier guarantees
   witness.verifierTable.ChannelRequirements vm.channel.toRaw →
     witness.verifierTable.ChannelGuarantees vm.channel.toRaw := by
-  intro balance wellformed constraints
-  have row_enabled_boolean := witness.rowEnabled_boolean_of_wellformed wellformed
+  intro balance witness_constraints constraints
+  have row_enabled_boolean := witness.rowEnabled_boolean_of_constraints witness_constraints
   -- prove balance of pulls + pushes
   replace balance : BalancedInteractions (witness.pulls ++ witness.pushes) := by
     rw [witness.interactions_eq_pulls_pushes] at balance
@@ -793,8 +795,6 @@ theorem addVm_soundVmChannel_of_soundChannels [Fact (ringChar F ≠ 2)] (ens : E
   -- this already lets us supply the balance condition
   have vm_balance := balance vmChannel (by simp [vmChannel, Ensemble.addVm])
   simp only [circuit_norm, vmInteractions_eq] at vm_balance
-  have verifier_guarantees := vmWitness
-    |>.verifier_guarantees_of_requirements_of_requirements_of_guarantees vm_balance.1 vm_balance.2
   -- next, we work on instantiating `requirements_of_partial_guarantees_of_constraints`
   -- which will give us exactly the second hypothesis of `verifier_guarantees`
   -- first, unify channel subset assumptions to all tables
@@ -824,6 +824,8 @@ theorem addVm_soundVmChannel_of_soundChannels [Fact (ringChar F ≠ 2)] (ens : E
     simp only [EnsembleWitness.Constraints, allTables_split, List.mem_append] at constraints ⊢
     intro table table_mem
     exact constraints table (.inl table_mem)
+  have verifier_guarantees := vmWitness
+    |>.verifier_guarantees_of_requirements_of_requirements_of_guarantees vm_balance.1 vm_constraints
   have assumptions' : witness'.Assumptions := by
     simp only [EnsembleWitness.Assumptions, allTables_split, List.mem_append] at assumptions ⊢
     simp only [EnsembleWitness.forall_mem_allTables_iff]

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -855,7 +855,7 @@ theorem addVm_soundVmChannel_of_soundChannels [Fact (ringChar F ≠ 2)] (ens : E
     apply partialBalancedChannel_of_sublist (partial_balance _ channel_mem')
     use vmWitness.allTables
     simp only [circuit_norm, List.perm_append_comm]
-    exact reqs_disjoint _ channel_mem'
+    exact ⟨vm_constraints, reqs_disjoint _ channel_mem'⟩
   -- invoke old tables soundness to get reqs for finished channels from constraints
   -- uses `soundChannels`, `constraints'`, `partial_balance'`
   have finished_reqs : ∀ channel ∈ finished, ∀ table ∈ witness'.allTables,
@@ -872,7 +872,7 @@ theorem addVm_soundVmChannel_of_soundChannels [Fact (ringChar F ≠ 2)] (ens : E
     intro table table_mem channel channel_mem
     have : channel.Consistent := consistent channel channel_mem
     apply guarantees_of_requirements_append (ts := vmWitness.allTablesWitness)
-      (ss := witness'.allTablesWitness) data_eq (reqs_disjoint _ channel_mem)
+      (ss := witness'.allTablesWitness) data_eq vm_constraints (reqs_disjoint _ channel_mem)
       (partial_balance _ channel_mem) (finished_reqs _ channel_mem) _ table_mem
   -- invoke `requirements_of_partial_guarantees_of_constraints` to get per-row grts → reqs for the vm channel,
   -- and use it in `verifier_guarantees`

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -53,7 +53,7 @@ structure VmTables (F : Type) [Field F] [DecidableEq F] (PublicIO : TypeMap) [Pr
   verifier_length_zero : ∀ pi, (verifier pi).localLength 0 = 0 := by
     simp only [circuit_norm]
 
-  tables_channel : ∀ table ∈ tables,
+  tables_channel : tables.Forall fun table =>
     ∃ enabled : Expression F, ∃ pull push : Var Message F,
       ⟨ channel,
         [(pullIf (channel:=channel) enabled pull).toRaw,
@@ -235,18 +235,39 @@ variable {vm : VmTables F PublicIO}
 @[circuit_norm] abbrev allTables (vm : VmTables F PublicIO) : List (Component F) :=
   vm.toEnsemble.allTables
 
+private theorem list_forall_mem {α : Type*} {P : α → Prop} :
+    ∀ {xs : List α}, xs.Forall P → ∀ {x}, x ∈ xs → P x
+  | [], _, _, h => by cases h
+  | head :: [], h_forall, _, h_mem => by
+      simp only [List.mem_singleton] at h_mem
+      subst h_mem
+      simpa [List.Forall] using h_forall
+  | head :: next :: tail, h_forall, _, h_mem => by
+      change P head ∧ (next :: tail).Forall P at h_forall
+      simp only [List.mem_cons] at h_mem
+      rcases h_mem with rfl | h_mem
+      · exact h_forall.1
+      · exact list_forall_mem h_forall.2 (by simpa [List.mem_cons] using h_mem)
+
+theorem tables_channel_of_mem (vm : VmTables F PublicIO) {table} (table_mem : table ∈ vm.tables) :
+    ∃ enabled : Expression F, ∃ pull push : Var vm.Message F,
+      ⟨ vm.channel,
+        [(pullIf (channel:=vm.channel) enabled pull).toRaw,
+          (pushIf (channel:=vm.channel) enabled push).toRaw] ⟩ ∈ table.exposedChannels := by
+  exact list_forall_mem vm.tables_channel table_mem
+
 noncomputable def step (vm : VmTables F PublicIO) (table : Component F)
     (table_mem : table ∈ vm.tables) : VmStep vm.Message F where
-  enabled := (vm.tables_channel table table_mem).choose
-  pull := (vm.tables_channel table table_mem).choose_spec.choose
-  push := (vm.tables_channel table table_mem).choose_spec.choose_spec.choose
+  enabled := (vm.tables_channel_of_mem table_mem).choose
+  pull := (vm.tables_channel_of_mem table_mem).choose_spec.choose
+  push := (vm.tables_channel_of_mem table_mem).choose_spec.choose_spec.choose
 
 theorem tables_channel' (vm : VmTables F PublicIO) {table} (table_mem : table ∈ vm.tables) :
   let step := vm.step table table_mem
   ⟨ vm.channel,
     [(pullIf (channel:=vm.channel) step.enabled step.pull).toRaw,
       (pushIf (channel:=vm.channel) step.enabled step.push).toRaw] ⟩ ∈ table.exposedChannels :=
-  (vm.tables_channel table table_mem).choose_spec.choose_spec.choose_spec
+  (vm.tables_channel_of_mem table_mem).choose_spec.choose_spec.choose_spec
 
 noncomputable def verifierPull (vm : VmTables F PublicIO) : Var vm.Message F :=
   vm.verifier_channel.choose

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -54,14 +54,10 @@ structure VmTables (F : Type) [Field F] [DecidableEq F] (PublicIO : TypeMap) [Pr
     simp only [circuit_norm]
 
   tables_channel : ∀ table ∈ tables,
-    ∃ step : VmStep Message F,
+    ∃ enabled : Expression F, ∃ pull push : Var Message F,
       ⟨ channel,
-        [(pullIf (channel:=channel) step.enabled step.pull).toRaw,
-          (pushIf (channel:=channel) step.enabled step.push).toRaw] ⟩ ∈ table.exposedChannels ∧
-      ∀ env,
-        table.Assumptions env →
-        Operations.ConstraintsHold env table.operations →
-          env step.enabled = 0 ∨ env step.enabled = 1
+        [(pullIf (channel:=channel) enabled pull).toRaw,
+          (pushIf (channel:=channel) enabled push).toRaw] ⟩ ∈ table.exposedChannels
 
   -- the verifier pulls and pushes to the channel, and doesn't push anything else
   verifier_channel : ∃ m1 m2, ⟨ channel, [(channel.pulled m1).toRaw, (channel.pushed m2).toRaw] ⟩ ∈
@@ -240,22 +236,17 @@ variable {vm : VmTables F PublicIO}
   vm.toEnsemble.allTables
 
 noncomputable def step (vm : VmTables F PublicIO) (table : Component F)
-    (table_mem : table ∈ vm.tables) : VmStep vm.Message F :=
-  (vm.tables_channel table table_mem).choose
+    (table_mem : table ∈ vm.tables) : VmStep vm.Message F where
+  enabled := (vm.tables_channel table table_mem).choose
+  pull := (vm.tables_channel table table_mem).choose_spec.choose
+  push := (vm.tables_channel table table_mem).choose_spec.choose_spec.choose
 
 theorem tables_channel' (vm : VmTables F PublicIO) {table} (table_mem : table ∈ vm.tables) :
   let step := vm.step table table_mem
   ⟨ vm.channel,
     [(pullIf (channel:=vm.channel) step.enabled step.pull).toRaw,
       (pushIf (channel:=vm.channel) step.enabled step.push).toRaw] ⟩ ∈ table.exposedChannels :=
-  (vm.tables_channel table table_mem).choose_spec.1
-
-theorem tables_enabled_boolean (vm : VmTables F PublicIO) {table} (table_mem : table ∈ vm.tables) :
-    ∀ env,
-      table.Assumptions env →
-      Operations.ConstraintsHold env table.operations →
-        env (vm.step table table_mem).enabled = 0 ∨ env (vm.step table table_mem).enabled = 1 :=
-  (vm.tables_channel table table_mem).choose_spec.2
+  (vm.tables_channel table table_mem).choose_spec.choose_spec.choose_spec
 
 noncomputable def verifierPull (vm : VmTables F PublicIO) : Var vm.Message F :=
   vm.verifier_channel.choose
@@ -495,6 +486,32 @@ lemma mem_zip_pulls_pushes_iff (witness : VmWitness vm) (pull push : Interaction
   · simp
   simp [← interactionss_eq_pulls_pushes, Table.interactionssWith]
 
+lemma rowEnabled_boolean_of_wellformed {witness : VmWitness vm}
+    (wellformed : vm.channel.toRaw.InteractionsWellFormed (witness.interactionsWith vm.channel.toRaw)) :
+    ∀ (table : Table F) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
+      witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1 := by
+  intro table table_mem row row_mem
+  let pull := vm.channel.pullIfValue (witness.rowEnabled table_mem row) (witness.rowPull table_mem row)
+  let push := vm.channel.pushIfValue (witness.rowEnabled table_mem row) (witness.rowPush table_mem row)
+  have pair_mem : (pull, push) ∈ witness.interactionPairs := by
+    simp only [interactionPairs, List.mem_flatMap, List.mem_attach, true_and, List.mem_map]
+    refine ⟨ ⟨ table, table_mem ⟩, row, row_mem, ?_ ⟩
+    simp [pull, push]
+  have pull_mem_pulls : pull ∈ witness.pulls := by
+    exact List.mem_map.mpr ⟨ (pull, push), pair_mem, rfl ⟩
+  have pull_mem_interactions : pull ∈ witness.interactionsWith vm.channel.toRaw := by
+    rw [witness.interactions_eq_pulls_pushes]
+    apply (List.zip_flattenPairs_perm (witness.pushes_length ▸ witness.pulls_length.symm)).mem_iff.mpr
+    exact List.mem_append_left witness.pushes pull_mem_pulls
+  have h_mult := wellformed pull pull_mem_interactions (by rfl) (by rfl)
+  rcases h_mult with h_neg_one | h_zero
+  · right
+    have h := congrArg Neg.neg h_neg_one
+    simpa [pull, Channel.pullIfValue] using h
+  · left
+    have h := congrArg Neg.neg h_zero
+    simpa [pull, Channel.pullIfValue] using h
+
 lemma pull_requirements (witness : VmWitness vm)
     (row_enabled_boolean : ∀ (table) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
       witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1) :
@@ -540,17 +557,17 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
   [Fact (ringChar F ≠ 2)] (witness : VmWitness vm) :
   -- if the vm interactions with the vm channel are balanced
   BalancedInteractions (witness.interactionsWith vm.channel.toRaw) →
+  vm.channel.toRaw.InteractionsWellFormed (witness.interactionsWith vm.channel.toRaw) →
   -- and for every row, vm channel guarantees imply vm channel requirements
   -- (this will come from constraints + soundness of the existing ensemble)
   (∀ table ∈ witness.allTables, ∀ row ∈ table.table,
     table.component.operations.ChannelGuarantees vm.channel.toRaw (table.environment row) →
     table.component.operations.ChannelRequirements vm.channel.toRaw (table.environment row)) →
-  (∀ (table) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
-    witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1) →
   -- vm channel verifier requirements imply vm channel verifier guarantees
   witness.verifierTable.ChannelRequirements vm.channel.toRaw →
     witness.verifierTable.ChannelGuarantees vm.channel.toRaw := by
-  intro balance constraints row_enabled_boolean
+  intro balance wellformed constraints
+  have row_enabled_boolean := witness.rowEnabled_boolean_of_wellformed wellformed
   -- prove balance of pulls + pushes
   replace balance : BalancedInteractions (witness.pulls ++ witness.pushes) := by
     rw [witness.interactions_eq_pulls_pushes] at balance
@@ -752,7 +769,7 @@ theorem addVm_soundVmChannel_of_soundChannels [Fact (ringChar F ≠ 2)] (ens : E
   have vm_balance := balance vmChannel (by simp [vmChannel, Ensemble.addVm])
   simp only [circuit_norm, vmInteractions_eq] at vm_balance
   have verifier_guarantees := vmWitness
-    |>.verifier_guarantees_of_requirements_of_requirements_of_guarantees vm_balance.1
+    |>.verifier_guarantees_of_requirements_of_requirements_of_guarantees vm_balance.1 vm_balance.2
   -- next, we work on instantiating `requirements_of_partial_guarantees_of_constraints`
   -- which will give us exactly the second hypothesis of `verifier_guarantees`
   -- first, unify channel subset assumptions to all tables
@@ -837,26 +854,6 @@ theorem addVm_soundVmChannel_of_soundChannels [Fact (ringChar F ≠ 2)] (ens : E
     (vm_assumptions table h_table) (vm_constraints table h_table)
     (grts_subset_all table h_table) (finished_grts table h_table)
   specialize verifier_guarantees reqs_of_grts
-  have row_enabled_boolean :
-      ∀ (table : Table F) (table_mem : table ∈ vmWitness.allTables), ∀ row ∈ table.table,
-        vmWitness.rowEnabled table_mem row = 0 ∨ vmWitness.rowEnabled table_mem row = 1 := by
-    intro table table_mem row row_mem
-    classical
-    by_cases h_verifier : table.component = vm.toEnsemble.verifierTable
-    · right
-      simp [VmWitness.rowEnabled, VmTables.stepOfAllTables, h_verifier, VmTables.verifierStep,
-        Expression.eval]
-    · have h_component_mem : table.component ∈ vm.tables := by
-        have := vmWitness.mem_allTables_component_of_mem_allTables table_mem
-        simp only [VmTables.toEnsemble, Ensemble.allTables, List.mem_cons] at this
-        rcases this with h | h
-        · contradiction
-        · exact h
-      have h_enabled := vm.tables_enabled_boolean h_component_mem
-        (table.environment row) (vm_assumptions table table_mem row row_mem)
-        (vm_constraints table table_mem row row_mem)
-      simpa [VmWitness.rowEnabled, VmTables.stepOfAllTables, h_verifier] using h_enabled
-  specialize verifier_guarantees row_enabled_boolean
   -- massage the conclusion so it matches that of `verifier_guarantees`.
   -- mainly, we need to use (again) that all guarantees apart from the VM channel are satisfied
   rw [EnsembleWitness.verifierGuarantees_iff_verifierTable_guarantees, ← verifierTable_eq,

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -632,10 +632,10 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
     change Expression.eval (Environment.fromInput witness.publicInput witness.data) (Expression.const (1 : F)) = 1
     rfl
   have active_length_pos : 0 < (activePulls witness.pulls).length := by
-    simp [activePulls, pulls, interactionPairs, allTables, circuit_norm,
+    simp [activePulls, activeInteractions, pulls, interactionPairs, allTables, circuit_norm,
       rowEnabled, VmTables.stepOfAllTables, verifier_enabled_one']
   specialize grts_of_reqs reqs_of_grts 0 active_length_pos
-  simp [activePulls, activePushes, pulls, pushes, interactionPairs, allTables, circuit_norm,
+  simp [activePulls, activePushes, activeInteractions, pulls, pushes, interactionPairs, allTables, circuit_norm,
     rowEnabled, VmTables.stepOfAllTables,
     verifier_enabled_one'] at grts_of_reqs
   have active_push_length_pos : 0 < (activePushes witness.pushes).length := by
@@ -653,12 +653,12 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
           (i:=(pushIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.push).toRaw)
           (env:=env)).mpr hreqs.2.1
     have hpull_grt := grts_of_reqs (by
-      simpa [activePushes, pulls, pushes, interactionPairs, allTables, circuit_norm,
+      simpa [activePushes, activeInteractions, pulls, pushes, interactionPairs, allTables, circuit_norm,
         rowEnabled, rowPush, VmTables.stepOfAllTables, verifier_enabled_one', env,
         Channel.eval_pushIf] using hpush_eval)
     have hpull_eval :
         ((pullIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.pull).toRaw.eval env).Guarantees env.data := by
-      simpa [activePulls, pulls, pushes, interactionPairs, allTables, circuit_norm,
+      simpa [activePulls, activeInteractions, pulls, pushes, interactionPairs, allTables, circuit_norm,
         rowEnabled, rowPull, VmTables.stepOfAllTables, verifier_enabled_one', env,
         Channel.eval_pullIf] using hpull_grt
     exact AbstractInteraction.eval_guarantees.mp hpull_eval

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -57,7 +57,7 @@ structure VmTables (F : Type) [Field F] [DecidableEq F] (PublicIO : TypeMap) [Pr
     ∃ enabled : Expression F, ∃ pull push : Var Message F,
       ⟨ channel, [(channel.pulledIf enabled pull).toRaw, (channel.pushedIf enabled push).toRaw] ⟩ ∈
         table.circuit.exposedChannels table.rowInputVar table.rowOffset ∧
-      ∀ env, table.rowOperations.ConstraintsHold env →
+      ∀ env, ConstraintsHold.Shallow env table.rowOperations →
         Expression.eval env enabled = 0 ∨ Expression.eval env enabled = 1
 
   -- the verifier pulls and pushes to the channel, and doesn't push anything else
@@ -246,7 +246,13 @@ theorem tables_channel_of_mem (vm : VmTables F PublicIO) {table} (table_mem : ta
   have h := vm.tables_channel
   simp_rw [List.forall_iff_forall_mem] at h
   simp_rw [table.constraintsHold_iff]
-  exact h _ table_mem
+  obtain ⟨ enabled, pull, push, h_exposed, h_enabled ⟩ := h _ table_mem
+  use enabled, pull, push, h_exposed
+  intro env h_constraints
+  apply h_enabled
+  apply FlatOperation.shallowConstraints_of_constraintsHoldFlat
+  rw [Circuit.constraintsHold_toFlat_iff]
+  exact h_constraints
 
 noncomputable def step (vm : VmTables F PublicIO) (table : Component F)
     (table_mem : table ∈ vm.tables) : VmStep vm.Message F where

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -39,6 +39,11 @@ Here, we introduce the `VmTables` structure (capturing basic assumptions we put 
 
 namespace Air.Flat
 
+structure VmStep (Message : TypeMap) [ProvableType Message] (F : Type) where
+  enabled : Expression F
+  pull : Var Message F
+  push : Var Message F
+
 structure VmTables (F : Type) [Field F] [DecidableEq F] (PublicIO : TypeMap) [ProvableType PublicIO] where
   {Message : TypeMap} [provableMessage : ProvableType Message]
   channel : Channel F Message
@@ -48,13 +53,32 @@ structure VmTables (F : Type) [Field F] [DecidableEq F] (PublicIO : TypeMap) [Pr
   verifier_length_zero : ∀ pi, (verifier pi).localLength 0 = 0 := by
     simp only [circuit_norm]
 
+  step : Component F → VmStep Message F
+  verifierStep : VmStep Message F
+
   tables_channel : ∀ table ∈ tables,
-    ∃ m1 m2, ⟨ channel, [(channel.pulled m1).toRaw, (channel.pushed m2).toRaw] ⟩ ∈
-      table.circuit.exposedChannels table.rowInputVar table.rowOffset
+    let step := step table
+    ⟨ channel,
+      [(pullIf (channel:=channel) step.enabled step.pull).toRaw,
+        (pushIf (channel:=channel) step.enabled step.push).toRaw] ⟩ ∈ table.exposedChannels
 
   -- the verifier pulls and pushes to the channel, and doesn't push anything else
-  verifier_channel : ∃ m1 m2, ⟨ channel, [(channel.pulled m1).toRaw, (channel.pushed m2).toRaw] ⟩ ∈
+  verifier_channel :
+    ⟨ channel,
+      [(pullIf (channel:=channel) verifierStep.enabled verifierStep.pull).toRaw,
+        (pushIf (channel:=channel) verifierStep.enabled verifierStep.push).toRaw] ⟩ ∈
     verifier.exposedChannels (varFromOffset PublicIO 0) (size PublicIO)
+
+  -- VM gates must be boolean. This is what lets the abstract balance theorem
+  -- view a row as either an active pull/push pair or disabled padding.
+  tables_enabled_boolean : ∀ table ∈ tables, ∀ env,
+    table.Assumptions env →
+    Operations.ConstraintsHold env table.operations →
+      env (step table).enabled = 0 ∨ env (step table).enabled = 1
+
+  verifier_enabled_one : ∀ env,
+    Operations.ConstraintsHold env (verifier.main (varFromOffset PublicIO 0) |>.operations (size PublicIO)) →
+      env verifierStep.enabled = 1
 
   -- verifier requirements follow _unconditionally_ from constraints (without relying on guarantees)
   -- essentially a modified soundness theorem for the verifier
@@ -200,6 +224,13 @@ lemma List.zip_flatten_flatten {α : Type} (as bs : List (List (α)))
     specialize ih as bs alen blen same_length_succ
     rw [ih]
 
+lemma List.zip_map_fst_snd {α β : Type} (pairs : List (α × β)) :
+    List.zip (pairs.map Prod.fst) (pairs.map Prod.snd) = pairs := by
+  induction pairs with
+  | nil => rfl
+  | cons pair pairs ih =>
+    simp [ih]
+
 namespace Air.Flat
 omit [DecidableEq F] in
 /-- Ensemble interactions preserving the per-row structure until the final flatten. -/
@@ -221,136 +252,207 @@ variable {vm : VmTables F PublicIO}
 @[circuit_norm] abbrev allTables (vm : VmTables F PublicIO) : List (Component F) :=
   vm.toEnsemble.allTables
 
-theorem allTables_channel (vm : VmTables F PublicIO) : ∀ table ∈ vm.allTables,
-  ∃ m1 m2, ⟨ vm.channel, [(vm.channel.pulled m1).toRaw, (vm.channel.pushed m2).toRaw] ⟩ ∈
-    table.circuit.exposedChannels table.rowInputVar table.rowOffset := by
+noncomputable def stepOfAllTables (vm : VmTables F PublicIO) (table : Component F)
+    (_ : table ∈ vm.allTables) : VmStep vm.Message F := by
+  classical
+  exact if table = vm.toEnsemble.verifierTable then vm.verifierStep else vm.step table
+
+theorem allTables_channel (vm : VmTables F PublicIO) : ∀ (table) (table_mem : table ∈ vm.allTables),
+  let step := vm.stepOfAllTables table table_mem
+  ⟨ vm.channel,
+    [(pullIf (channel:=vm.channel) step.enabled step.pull).toRaw,
+      (pushIf (channel:=vm.channel) step.enabled step.push).toRaw] ⟩ ∈ table.exposedChannels := by
   intro table table_mem
-  simp only [circuit_norm, Ensemble.allTables] at table_mem
+  classical
+  simp only [circuit_norm, Ensemble.allTables] at table_mem ⊢
   rcases table_mem with rfl | table_mem
-  · simp only [circuit_norm]
+  · simp only [circuit_norm, stepOfAllTables]
     exact vm.verifier_channel
-  · simp only [circuit_norm]
-    exact vm.tables_channel table table_mem
-
-noncomputable def interactionPair (vm : VmTables F PublicIO) (table : Component F)
-  (table_mem : table ∈ vm.allTables) :
-    Var vm.Message F × Var vm.Message F :=
-  let h := vm.allTables_channel table table_mem
-  ⟨ h.choose, h.choose_spec.choose ⟩
-
-noncomputable def pull (vm : VmTables F PublicIO)
-  {table : Component F} (table_mem : table ∈ vm.allTables) := vm.interactionPair table table_mem |>.fst
-
-noncomputable def push (vm : VmTables F PublicIO)
-  {table : Component F} (table_mem : table ∈ vm.allTables) := vm.interactionPair table table_mem |>.snd
+  · by_cases h : table = vm.toEnsemble.verifierTable
+    · subst table
+      simp only [circuit_norm, stepOfAllTables]
+      exact vm.verifier_channel
+    · simp only [circuit_norm, stepOfAllTables, h]
+      exact vm.tables_channel table table_mem
 
 /-- Concrete version of VmTables.allTables_channel -/
 lemma allTables_channel' (vm : VmTables F PublicIO) {table} (_ : table ∈ vm.allTables) :
+  let step := vm.stepOfAllTables table ‹_›
   ⟨ vm.channel.toRaw,
-    [(vm.channel.pulled (vm.pull ‹_›)).toRaw, (vm.channel.pushed (vm.push ‹_›)).toRaw]
-  ⟩ ∈ table.exposedChannels :=
-  vm.allTables_channel table ‹_› |>.choose_spec.choose_spec
+    [(pullIf (channel:=vm.channel) step.enabled step.pull).toRaw,
+      (pushIf (channel:=vm.channel) step.enabled step.push).toRaw]
+  ⟩ ∈ table.exposedChannels := by
+  exact vm.allTables_channel table ‹_›
 
 lemma interactionsWith_eq {vm : VmTables F PublicIO} {table} (_ : table ∈ vm.allTables) :
+  let step := vm.stepOfAllTables table ‹_›
   table.operations.interactionsWith vm.channel.toRaw = [
-    vm.channel.pulled (vm.pull ‹_›) |>.toRaw,
-    vm.channel.pushed (vm.push ‹_›) |>.toRaw ] := by
+    (pullIf (channel:=vm.channel) step.enabled step.pull).toRaw,
+    (pushIf (channel:=vm.channel) step.enabled step.push).toRaw ] := by
   apply Component.interactionsWith_of_exposedChannels
   apply vm.allTables_channel'
 
 lemma verifierInteractionsWith_eq {vm : VmTables F PublicIO} :
   vm.toEnsemble.verifierTable.operations.interactionsWith vm.channel.toRaw = [
-    vm.channel.pulled (vm.pull Ensemble.mem_allTables_verifierTable) |>.toRaw,
-    vm.channel.pushed (vm.push Ensemble.mem_allTables_verifierTable) |>.toRaw ] := by
-  apply interactionsWith_eq
+    (pullIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.pull).toRaw,
+    (pushIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.push).toRaw ] := by
+  simpa [stepOfAllTables] using
+    interactionsWith_eq (vm:=vm) (table:=vm.toEnsemble.verifierTable)
+      Ensemble.mem_allTables_verifierTable
 end VmTables
 
 namespace VmWitness
 variable {vm : VmTables F PublicIO}
 open EnsembleWitness
 
+noncomputable def rowEnabled (witness : VmWitness vm) {table} (_ : table ∈ witness.allTables) (row : Array F) : F :=
+  (table.environment row)
+    (vm.stepOfAllTables table.component (witness.mem_allTables_component_of_mem_allTables ‹_›)).enabled
+
 noncomputable def rowPull (witness : VmWitness vm) {table} (_ : table ∈ witness.allTables) (row : Array F) : vm.Message F :=
-  eval (table.environment row) (vm.pull (witness.mem_allTables_component_of_mem_allTables ‹_›))
+  eval (table.environment row)
+    (vm.stepOfAllTables table.component (witness.mem_allTables_component_of_mem_allTables ‹_›)).pull
 
 noncomputable def rowPush (witness : VmWitness vm) {table} (_ : table ∈ witness.allTables) (row : Array F) : vm.Message F :=
-  eval (table.environment row) (vm.push (witness.mem_allTables_component_of_mem_allTables ‹_›))
+  eval (table.environment row)
+    (vm.stepOfAllTables table.component (witness.mem_allTables_component_of_mem_allTables ‹_›)).push
 
-noncomputable def verifierPull (witness : VmWitness vm) : vm.Message F :=
-  eval (Environment.fromInput witness.publicInput witness.data) (vm.pull Ensemble.mem_allTables_verifierTable)
+def verifierEnabled (witness : VmWitness vm) : F :=
+  (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.enabled
 
-noncomputable def verifierPush (witness : VmWitness vm) : vm.Message F :=
-  eval (Environment.fromInput witness.publicInput witness.data) (vm.push Ensemble.mem_allTables_verifierTable)
+def verifierPull (witness : VmWitness vm) : vm.Message F :=
+  eval (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.pull
+
+def verifierPush (witness : VmWitness vm) : vm.Message F :=
+  eval (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.push
 
 lemma interactionValuesWith_eq (witness : VmWitness vm)
     {table} (_ : table ∈ witness.allTables) (row : Array F) :
   table.component.operations.interactionValuesWith vm.channel.toRaw (table.environment row) = [
-    vm.channel.pulledValue (witness.rowPull ‹_› row),
-    vm.channel.pushedValue (witness.rowPush ‹_› row) ] := by
+    vm.channel.pullIfValue (witness.rowEnabled ‹_› row) (witness.rowPull ‹_› row),
+    vm.channel.pushIfValue (witness.rowEnabled ‹_› row) (witness.rowPush ‹_› row) ] := by
   simp only [circuit_norm, vm.interactionsWith_eq (witness.mem_allTables_component_of_mem_allTables ‹_›),
-    rowPull, rowPush, AbstractInteraction.eval, ProvableType.toElements_eval]
+    rowEnabled, rowPull, rowPush, AbstractInteraction.eval, ProvableType.toElements_eval]
 
 lemma interactionValuesWith_length (witness : VmWitness vm)
     {table} (_ : table ∈ witness.allTables) (row : Array F) :
   (table.component.operations.interactionValuesWith vm.channel.toRaw (table.environment row)).length = 2 := by
   simp [witness.interactionValuesWith_eq ‹_› row]
 
-noncomputable def pulls (witness : VmWitness vm) : List (Interaction F) :=
+noncomputable def interactionPairs (witness : VmWitness vm) : List (Interaction F × Interaction F) :=
   witness.allTables.attach.flatMap fun ⟨ table, _ ⟩ =>
-    table.table.map fun row => vm.channel.pulledValue (witness.rowPull ‹_› row)
+    table.table.map fun row =>
+      (vm.channel.pullIfValue (witness.rowEnabled ‹_› row) (witness.rowPull ‹_› row),
+        vm.channel.pushIfValue (witness.rowEnabled ‹_› row) (witness.rowPush ‹_› row))
+
+noncomputable def pulls (witness : VmWitness vm) : List (Interaction F) :=
+  witness.interactionPairs.map Prod.fst
 
 noncomputable def pushes (witness : VmWitness vm) : List (Interaction F) :=
-  witness.allTables.attach.flatMap fun ⟨ table, _ ⟩ =>
-    table.table.map fun row => vm.channel.pushedValue (witness.rowPush ‹_› row)
+  witness.interactionPairs.map Prod.snd
 
 def steps (witness : VmWitness vm) : ℕ := witness.tables.map (·.length) |>.sum
 
 @[circuit_norm]
 lemma pulls_length {witness : VmWitness vm} : witness.pulls.length = witness.steps + 1 := by
-  simp [steps, pulls, allTables, circuit_norm]
+  simp [steps, pulls, interactionPairs, allTables, circuit_norm]
 
 @[circuit_norm]
 lemma pushes_length {witness : VmWitness vm} : witness.pushes.length = witness.steps + 1 := by
-  simp [steps, pushes, allTables, circuit_norm]
+  simp [steps, pushes, interactionPairs, allTables, circuit_norm]
 
-@[circuit_norm]
-lemma pulls_mult {witness : VmWitness vm} : ∀ pull ∈ witness.pulls, pull.mult = -1 := by
-  simp only [pulls, List.mem_flatMap, List.mem_attach, List.mem_map, true_and, Subtype.exists,
+lemma pulls_mult {witness : VmWitness vm}
+    (row_enabled_boolean : ∀ (table) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
+      witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1) :
+    ∀ pull ∈ witness.pulls, pull.mult = -1 ∨ pull.mult = 0 := by
+  simp only [pulls, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
     forall_exists_index, and_imp]
-  rintro pull _ _ _ _ rfl
+  rintro pull pair table table_mem row row_mem hpair hpull
+  subst pair
+  subst pull
+  rcases row_enabled_boolean table table_mem row row_mem with h0 | h1
+  · right
+    change -witness.rowEnabled table_mem row = 0
+    rw [h0]
+    simp
+  · left
+    change -witness.rowEnabled table_mem row = -1
+    rw [h1]
+
+lemma pushes_mult {witness : VmWitness vm}
+    (row_enabled_boolean : ∀ (table) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
+      witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1) :
+    ∀ push ∈ witness.pushes, push.mult = 1 ∨ push.mult = 0 := by
+  simp only [pushes, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
+    forall_exists_index, and_imp]
+  rintro push pair table table_mem row row_mem hpair hpush
+  subst pair
+  subst push
+  rcases row_enabled_boolean table table_mem row row_mem with h0 | h1
+  · right
+    change witness.rowEnabled table_mem row = 0
+    exact h0
+  · left
+    change witness.rowEnabled table_mem row = 1
+    exact h1
+
+lemma pushes_assumeRequirements {witness : VmWitness vm} :
+    ∀ push ∈ witness.pushes, push.assumeGuarantees = false := by
+  simp only [pushes, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
+    forall_exists_index, and_imp]
+  rintro push pair table table_mem row row_mem hpair hpush
+  subst pair
+  subst push
   simp only [circuit_norm]
 
-@[circuit_norm]
-lemma pushes_mult {witness : VmWitness vm} : ∀ push ∈ witness.pushes, push.mult = 1 := by
-  simp only [pushes, List.mem_flatMap, List.mem_attach, List.mem_map, true_and, Subtype.exists,
+lemma pair_zero {witness : VmWitness vm} :
+    ∀ i (hi_p : i < witness.pulls.length) (hi_q : i < witness.pushes.length),
+      witness.pulls[i].mult = 0 ↔ witness.pushes[i].mult = 0 := by
+  intro i hi_p hi_q
+  have pair_mem : witness.interactionPairs[i]'(by simpa [pulls] using hi_p) ∈ witness.interactionPairs :=
+    List.getElem_mem _
+  simp only [pulls, pushes, List.getElem_map]
+  revert pair_mem
+  simp only [interactionPairs, List.mem_flatMap, List.mem_attach, List.mem_map, true_and, Subtype.exists,
     forall_exists_index, and_imp]
-  rintro push _ _ _ _ rfl
-  simp only [circuit_norm]
+  rintro table table_mem row row_mem hpair
+  rw [← hpair]
+  simp [circuit_norm]
 
 @[circuit_norm]
 lemma pulls_channel {witness : VmWitness vm} : ∀ pull ∈ witness.pulls, pull.channel = vm.channel.toRaw := by
-  simp only [pulls, List.mem_flatMap, List.mem_attach, List.mem_map, true_and, Subtype.exists,
+  simp only [pulls, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
     forall_exists_index, and_imp]
-  rintro pull _ _ _ _ rfl
+  rintro pull pair table table_mem row row_mem hpair hpull
+  subst pair
+  subst pull
   simp only [circuit_norm]
 
 @[circuit_norm]
 lemma pushes_channel {witness : VmWitness vm} : ∀ push ∈ witness.pushes, push.channel = vm.channel.toRaw := by
-  simp only [pushes, List.mem_flatMap, List.mem_attach, List.mem_map, true_and, Subtype.exists,
+  simp only [pushes, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
     forall_exists_index, and_imp]
-  rintro push _ _ _ _ rfl
+  rintro push pair table table_mem row row_mem hpair hpush
+  subst pair
+  subst push
   simp only [circuit_norm]
+
+lemma interactionss_eq_pairs (witness : VmWitness vm) :
+  witness.allTables.flatMap (·.interactionssWith vm.channel.toRaw) =
+    witness.interactionPairs.map (fun ⟨pull, push⟩ => [pull, push]) := by
+  simp only [interactionPairs, List.flatMap_def, List.map_flatten]
+  rw [← List.pmap_eq_map (fun _ _ => trivial), List.pmap_eq_map_attach]
+  rw [List.map_map]
+  apply congrArg List.flatten
+  apply List.map_congr_left
+  intro ⟨ table, table_mem ⟩ _
+  simp [Table.interactionssWith, witness.interactionValuesWith_eq table_mem]
 
 lemma interactionss_eq_pulls_pushes (witness : VmWitness vm) :
   witness.allTables.flatMap (·.interactionssWith vm.channel.toRaw) =
     (List.zip witness.pulls witness.pushes).map (fun ⟨pull, push⟩ => [pull, push]) := by
-  simp only [pulls, pushes, List.flatMap_def]
-  rw [List.zip_flatten_flatten _ _ (by simp), List.map_flatten]
-  simp only [List.zip_map', List.map_map]
-  rw [← List.pmap_eq_map (fun _ _ => trivial), List.pmap_eq_map_attach]
-  congr
-  funext ⟨ table, table_mem ⟩
-  simp [Table.interactionssWith, List.zip_map',
-    witness.interactionValuesWith_eq table_mem]
+  rw [interactionss_eq_pairs]
+  simp [pulls, pushes, List.zip_map_fst_snd]
 
 lemma interactions_eq_pulls_pushes (witness : VmWitness vm) :
   witness.interactionsWith vm.channel.toRaw =
@@ -366,16 +468,25 @@ lemma mem_zip_pulls_pushes_iff (witness : VmWitness vm) (pull push : Interaction
   · simp
   simp [← interactionss_eq_pulls_pushes, Table.interactionssWith]
 
-lemma pull_requirements (witness : VmWitness vm) : ∀ pull ∈ witness.pulls, pull.Requirements witness.data := by
-  simp only [pulls, List.mem_flatMap, List.mem_attach, List.mem_map, true_and, Subtype.exists,
+lemma pull_requirements (witness : VmWitness vm)
+    (row_enabled_boolean : ∀ (table) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
+      witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1) :
+    ∀ pull ∈ witness.pulls, pull.Requirements witness.data := by
+  simp only [pulls, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
     forall_exists_index, and_imp]
-  rintro pull _ _ _ _ rfl
-  simp [circuit_norm, Interaction.Requirements, Channel.toRaw]
+  rintro pull pair table table_mem row row_mem hpair hpull
+  subst pair
+  subst pull
+  rcases row_enabled_boolean table table_mem row row_mem with h0 | h1
+  · simp [circuit_norm, Interaction.Requirements, Channel.toRaw, h0]
+  · simp [circuit_norm, Interaction.Requirements, Channel.toRaw, h1]
 
 lemma push_guarantees (witness : VmWitness vm) : ∀ push ∈ witness.pushes, push.Guarantees witness.data := by
-  simp only [pushes, List.mem_flatMap, List.mem_attach, List.mem_map, true_and, Subtype.exists,
+  simp only [pushes, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
     forall_exists_index, and_imp]
-  rintro push _ _ _ _ rfl
+  rintro push pair table table_mem row row_mem hpair hpush
+  subst pair
+  subst push
   simp only [circuit_norm, Interaction.Guarantees]
 
 lemma pulls_length_pos {witness : VmWitness vm} : witness.pulls.length > 0 := by
@@ -384,12 +495,18 @@ lemma pushes_length_pos {witness : VmWitness vm} : witness.pushes.length > 0 := 
   simp [pushes_length]
 
 lemma pulls_getElem_zero_eq (witness : VmWitness vm) :
-    witness.pulls[0]'pulls_length_pos = vm.channel.pulledValue witness.verifierPull := by
-  simp [pulls, allTables, circuit_norm, rowPull, verifierPull]
+    witness.pulls[0]'pulls_length_pos =
+      vm.channel.pullIfValue witness.verifierEnabled witness.verifierPull := by
+  classical
+  simp [pulls, interactionPairs, allTables, circuit_norm, rowEnabled, rowPull,
+    verifierEnabled, verifierPull, VmTables.stepOfAllTables]
 
 lemma pushes_getElem_zero_eq (witness : VmWitness vm) :
-    witness.pushes[0]'pushes_length_pos = vm.channel.pushedValue witness.verifierPush := by
-  simp [pushes, allTables, circuit_norm, rowPush, verifierPush]
+    witness.pushes[0]'pushes_length_pos =
+      vm.channel.pushIfValue witness.verifierEnabled witness.verifierPush := by
+  classical
+  simp [pushes, interactionPairs, allTables, circuit_norm, rowEnabled, rowPush,
+    verifierEnabled, verifierPush, VmTables.stepOfAllTables]
 
 /-- Translation of the VM soundness theorem to VmTables -/
 theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
@@ -401,35 +518,38 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
   (∀ table ∈ witness.allTables, ∀ row ∈ table.table,
     table.component.operations.ChannelGuarantees vm.channel.toRaw (table.environment row) →
     table.component.operations.ChannelRequirements vm.channel.toRaw (table.environment row)) →
+  (∀ (table) (table_mem : table ∈ witness.allTables), ∀ row ∈ table.table,
+    witness.rowEnabled table_mem row = 0 ∨ witness.rowEnabled table_mem row = 1) →
+  witness.verifierEnabled = 1 →
   -- vm channel verifier requirements imply vm channel verifier guarantees
   witness.verifierTable.ChannelRequirements vm.channel.toRaw →
     witness.verifierTable.ChannelGuarantees vm.channel.toRaw := by
-  intro balance constraints
+  intro balance constraints row_enabled_boolean verifier_enabled_one
   -- prove balance of pulls + pushes
   replace balance : BalancedInteractions (witness.pulls ++ witness.pushes) := by
     rw [witness.interactions_eq_pulls_pushes] at balance
     apply balancedInteractions_of_perm balance
     apply List.zip_flattenPairs_perm <| witness.pushes_length ▸ witness.pulls_length.symm
   -- we fill in the conditions on pulls and pushes in `guarantees_of_requirements_of_requirements_of_guarantees`
-  let n := witness.steps + 1
-  have : witness.pulls.length = n := by simp [witness.pulls_length, n]
-  have : witness.pushes.length = n := by simp [witness.pushes_length, n]
-  have grts_of_reqs := guarantees_of_requirements_of_requirements_of_guarantees
-    vm.channel.toRaw witness.pulls witness.pushes balance witness.data n
-    witness.pulls_length witness.pushes_length witness.pulls_channel witness.pushes_channel
-    witness.pulls_mult witness.pushes_mult
+  have grts_of_reqs := guarantees_of_requirements_of_requirements_of_guarantees_gated
+    vm.channel.toRaw witness.pulls witness.pushes balance witness.data
+    (by simp [witness.pulls_length, witness.pushes_length])
+    witness.pulls_channel witness.pushes_channel
+    (witness.pulls_mult row_enabled_boolean) (witness.pushes_mult row_enabled_boolean)
+    witness.pushes_assumeRequirements
+    witness.pair_zero
   -- it remains to prove the (grts → reqs) assumption. this is a reformulation of our `constraints`
-  have reqs_of_grts : (∀ i (hi : i < n),
-      witness.pulls[i].Guarantees witness.data → witness.pushes[i].Requirements witness.data) := by
+  have reqs_of_grts : (∀ i (hi : i < (activePulls witness.pulls witness.pushes).length),
+      (activePulls witness.pulls witness.pushes)[i].Guarantees witness.data →
+        ((activePushes witness.pulls witness.pushes)[i]'(activePulls_length_eq_activePushes_length witness.pulls witness.pushes ▸ hi)).Requirements witness.data) := by
     suffices ∀ pair ∈ (witness.pulls.zip witness.pushes), pair.1.Guarantees witness.data → pair.2.Requirements witness.data by
-      simp only [List.forall_mem_iff_getElem, List.getElem_zip] at this
       intro i hi
-      exact this i (by simp [*])
+      exact this _ (activePair_mem_zip i hi)
     intro (pull, push) pair_mem
     simp only
     have ⟨ mem_pull, mem_push ⟩ := List.of_mem_zip pair_mem
     have push_grts := witness.push_guarantees push mem_push
-    have pull_reqs := witness.pull_requirements pull mem_pull
+    have pull_reqs := witness.pull_requirements row_enabled_boolean pull mem_pull
     rw [witness.mem_zip_pulls_pushes_iff] at pair_mem
     obtain ⟨ table, table_mem, row, row_mem, interactions_eq ⟩ := pair_mem
     suffices (∀ i ∈ [pull, push], i.Guarantees witness.data) → (∀ i ∈ [pull, push], i.Requirements witness.data) by
@@ -440,15 +560,43 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
       Operations.forall_interactionsWith_iff]
     convert constraints table table_mem row row_mem
   -- to get the conclusion about the verifier, we specialize to index 0
-  specialize grts_of_reqs reqs_of_grts 0 (by simp [n])
-  rw [witness.pulls_getElem_zero_eq, witness.pushes_getElem_zero_eq] at grts_of_reqs
-  simp only [VmWitness.verifierPush, VmWitness.verifierPull] at grts_of_reqs
-  rw [← Channel.eval_pushed, AbstractInteraction.eval_requirements] at grts_of_reqs
-  rw [← Channel.eval_pulled, AbstractInteraction.eval_guarantees] at grts_of_reqs
+  have verifier_enabled_one' :
+      Expression.eval (Environment.fromInput witness.publicInput witness.data) vm.verifierStep.enabled = 1 := by
+    simpa [verifierEnabled] using verifier_enabled_one
+  have active_length_pos : 0 < (activePulls witness.pulls witness.pushes).length := by
+    simp [activePulls, pulls, pushes, interactionPairs, allTables, circuit_norm,
+      rowEnabled, VmTables.stepOfAllTables, verifier_enabled_one']
+  specialize grts_of_reqs reqs_of_grts 0 active_length_pos
+  simp [activePulls, activePushes, pulls, pushes, interactionPairs, allTables, circuit_norm,
+    rowEnabled, VmTables.stepOfAllTables,
+    verifier_enabled_one'] at grts_of_reqs
+  have active_push_length_pos : 0 < (activePushes witness.pulls witness.pushes).length := by
+    rwa [← activePulls_length_eq_activePushes_length witness.pulls witness.pushes]
   simp only [Table.ChannelGuarantees, Table.ChannelRequirements, circuit_norm]
   simp only [← Operations.forall_interactionsWith_iff, vm.verifierInteractionsWith_eq]
-  simp_all only [List.mem_cons, List.not_mem_nil, forall_eq_or_imp]
-  tauto
+  intro hreqs
+  simp only [List.mem_cons, List.not_mem_nil, forall_eq_or_imp] at hreqs ⊢
+  refine ⟨?_, ?_, ?_⟩
+  · let env := Environment.fromInput witness.publicInput witness.data
+    have hpush_eval :
+        ((pushIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.push).toRaw.eval env).Requirements env.data :=
+        (AbstractInteraction.eval_requirements
+          (i:=(pushIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.push).toRaw)
+          (env:=env)).mpr hreqs.2.1
+    have hpull_grt := grts_of_reqs (by
+      simpa [activePushes, pulls, pushes, interactionPairs, allTables, circuit_norm,
+        rowEnabled, rowPush, VmTables.stepOfAllTables, verifier_enabled_one', env,
+        Channel.eval_pushIf] using hpush_eval)
+    have hpull_eval :
+        ((pullIf (channel:=vm.channel) vm.verifierStep.enabled vm.verifierStep.pull).toRaw.eval env).Guarantees env.data := by
+      simpa [activePulls, pulls, pushes, interactionPairs, allTables, circuit_norm,
+        rowEnabled, rowPull, VmTables.stepOfAllTables, verifier_enabled_one', env,
+        Channel.eval_pullIf] using hpull_grt
+    exact AbstractInteraction.eval_guarantees.mp hpull_eval
+  · intro h
+    cases h
+  · intro a h
+    cases h
 end VmWitness
 
 namespace Ensemble
@@ -577,7 +725,7 @@ theorem addVm_soundVmChannel_of_soundChannels [Fact (ringChar F ≠ 2)] (ens : E
   have vm_balance := balance vmChannel (by simp [vmChannel, Ensemble.addVm])
   simp only [circuit_norm, vmInteractions_eq] at vm_balance
   have verifier_guarantees := vmWitness
-    |>.verifier_guarantees_of_requirements_of_requirements_of_guarantees vm_balance
+    |>.verifier_guarantees_of_requirements_of_requirements_of_guarantees vm_balance.1
   -- next, we work on instantiating `requirements_of_partial_guarantees_of_constraints`
   -- which will give us exactly the second hypothesis of `verifier_guarantees`
   -- first, unify channel subset assumptions to all tables
@@ -622,10 +770,14 @@ theorem addVm_soundVmChannel_of_soundChannels [Fact (ringChar F ≠ 2)] (ens : E
       PartialBalancedChannel (.append vmWitness witness' data_eq) channel := by
     intro channel channel_mem
     apply partialBalancedChannel_of_balancedInteractions
-    convert balance channel ?_ using 1 <;> simp only [circuit_norm]
-    · rw [EnsembleWitness.interactionsWith_of_verifier_empty verifier_empty]
+    · convert (balance channel (by simp [Ensemble.addVm, finished_subset channel_mem])).1 using 1
+      simp only [circuit_norm]
+      rw [EnsembleWitness.interactionsWith_of_verifier_empty verifier_empty]
       simp only [EnsembleWitness.interactionsWith, allTables_split, circuit_norm]
-    exact .inr (finished_subset channel_mem)
+    · convert (balance channel (by simp [Ensemble.addVm, finished_subset channel_mem])).2 using 1
+      simp only [circuit_norm]
+      rw [EnsembleWitness.interactionsWith_of_verifier_empty verifier_empty]
+      simp only [EnsembleWitness.interactionsWith, allTables_split, circuit_norm]
   have partial_balance' : ∀ channel ∈ finished,
       PartialBalancedChannel witness' channel := by
     intro channel' channel_mem'
@@ -658,6 +810,43 @@ theorem addVm_soundVmChannel_of_soundChannels [Fact (ringChar F ≠ 2)] (ens : E
     (vm_assumptions table h_table) (vm_constraints table h_table)
     (grts_subset_all table h_table) (finished_grts table h_table)
   specialize verifier_guarantees reqs_of_grts
+  have row_enabled_boolean :
+      ∀ (table : Table F) (table_mem : table ∈ vmWitness.allTables), ∀ row ∈ table.table,
+        vmWitness.rowEnabled table_mem row = 0 ∨ vmWitness.rowEnabled table_mem row = 1 := by
+    intro table table_mem row row_mem
+    classical
+    by_cases h_verifier : table.component = vm.toEnsemble.verifierTable
+    · right
+      have h_constraints : Operations.ConstraintsHold (table.environment row)
+          (vm.verifier.main (varFromOffset PublicIO 0) |>.operations (size PublicIO)) := by
+        have hc := (Component.constraintsHold_iff (component:=table.component)
+          (env:=table.environment row)).mp (vm_constraints table table_mem row row_mem)
+        rw [h_verifier] at hc
+        simpa [Component.rowOperations, VmTables.toEnsemble, Ensemble.verifierTable] using hc
+      have h_enabled := vm.verifier_enabled_one (table.environment row) h_constraints
+      simpa [VmWitness.rowEnabled, VmTables.stepOfAllTables, h_verifier] using h_enabled
+    · have h_component_mem : table.component ∈ vm.tables := by
+        have := vmWitness.mem_allTables_component_of_mem_allTables table_mem
+        simp only [VmTables.toEnsemble, Ensemble.allTables, List.mem_cons] at this
+        rcases this with h | h
+        · contradiction
+        · exact h
+      have h_enabled := vm.tables_enabled_boolean table.component h_component_mem
+        (table.environment row) (vm_assumptions table table_mem row row_mem)
+        (vm_constraints table table_mem row row_mem)
+      simpa [VmWitness.rowEnabled, VmTables.stepOfAllTables, h_verifier] using h_enabled
+  have verifier_enabled_one : vmWitness.verifierEnabled = 1 := by
+    apply vm.verifier_enabled_one
+    have hc_table : Operations.ConstraintsHold
+        (vmWitness.verifierTable.environment (toElements vmWitness.publicInput).toArray)
+        vmWitness.verifierTable.component.operations :=
+      vm_constraints _ vmWitness.mem_allTables_verifierTable _
+        (by simp [EnsembleWitness.verifierTable])
+    have hc := (Component.constraintsHold_iff (component:=vmWitness.verifierTable.component)
+      (env:=vmWitness.verifierTable.environment (toElements vmWitness.publicInput).toArray)).mp hc_table
+    simpa [Component.rowOperations, VmTables.toEnsemble, Ensemble.verifierTable,
+      EnsembleWitness.verifierTable_environment] using hc
+  specialize verifier_guarantees row_enabled_boolean verifier_enabled_one
   -- massage the conclusion so it matches that of `verifier_guarantees`.
   -- mainly, we need to use (again) that all guarantees apart from the VM channel are satisfied
   rw [EnsembleWitness.verifierGuarantees_iff_verifierTable_guarantees, ← verifierTable_eq,

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -445,15 +445,6 @@ lemma pushes_mult {witness : VmWitness vm}
     change witness.rowEnabled table_mem row = 1
     exact h1
 
-lemma pushes_assumeRequirements {witness : VmWitness vm} :
-    ∀ push ∈ witness.pushes, push.assumeGuarantees = false := by
-  simp only [pushes, interactionPairs, List.mem_map, List.mem_flatMap, List.mem_attach, true_and, Subtype.exists,
-    forall_exists_index, and_imp]
-  rintro push pair table table_mem row row_mem hpair hpush
-  subst pair
-  subst push
-  simp only [circuit_norm]
-
 lemma pair_zero {witness : VmWitness vm} :
     ∀ i (hi_p : i < witness.pulls.length) (hi_q : i < witness.pushes.length),
       witness.pulls[i].mult = 0 ↔ witness.pushes[i].mult = 0 := by
@@ -602,7 +593,6 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
     (by simp [witness.pulls_length, witness.pushes_length])
     witness.pulls_channel witness.pushes_channel
     (witness.pulls_mult row_enabled_boolean) (witness.pushes_mult row_enabled_boolean)
-    witness.pushes_assumeRequirements
     witness.pair_zero
   -- it remains to prove the (grts → reqs) assumption. this is a reformulation of our `constraints`
   have reqs_of_grts : (∀ i (hi : i < (activeInteractions witness.pulls).length),
@@ -825,7 +815,7 @@ theorem addVm_soundVmChannel_of_soundChannels [Fact (ringChar F ≠ 2)] (ens : E
     intro table table_mem
     exact constraints table (.inl table_mem)
   have verifier_guarantees := vmWitness
-    |>.verifier_guarantees_of_requirements_of_requirements_of_guarantees vm_balance.1 vm_constraints
+    |>.verifier_guarantees_of_requirements_of_requirements_of_guarantees vm_balance vm_constraints
   have assumptions' : witness'.Assumptions := by
     simp only [EnsembleWitness.Assumptions, allTables_split, List.mem_append] at assumptions ⊢
     simp only [EnsembleWitness.forall_mem_allTables_iff]
@@ -841,11 +831,7 @@ theorem addVm_soundVmChannel_of_soundChannels [Fact (ringChar F ≠ 2)] (ens : E
       PartialBalancedChannel (.append vmWitness witness' data_eq) channel := by
     intro channel channel_mem
     apply partialBalancedChannel_of_balancedInteractions
-    · convert (balance channel (by simp [Ensemble.addVm, finished_subset channel_mem])).1 using 1
-      simp only [circuit_norm]
-      rw [EnsembleWitness.interactionsWith_of_verifier_empty verifier_empty]
-      simp only [EnsembleWitness.interactionsWith, allTables_split, circuit_norm]
-    · convert (balance channel (by simp [Ensemble.addVm, finished_subset channel_mem])).2 using 1
+    · convert balance channel (by simp [Ensemble.addVm, finished_subset channel_mem]) using 1
       simp only [circuit_norm]
       rw [EnsembleWitness.interactionsWith_of_verifier_empty verifier_empty]
       simp only [EnsembleWitness.interactionsWith, allTables_split, circuit_norm]

--- a/Clean/Air/Vm.lean
+++ b/Clean/Air/Vm.lean
@@ -55,10 +55,9 @@ structure VmTables (F : Type) [Field F] [DecidableEq F] (PublicIO : TypeMap) [Pr
 
   tables_channel : tables.Forall fun table =>
     ∃ enabled : Expression F, ∃ pull push : Var Message F,
-      ⟨ channel,
-        [(pullIf (channel:=channel) enabled pull).toRaw,
-          (pushIf (channel:=channel) enabled push).toRaw] ⟩ ∈ table.exposedChannels ∧
-      ∀ env, table.operations.ConstraintsHold env →
+      ⟨ channel, [(channel.pulledIf enabled pull).toRaw, (channel.pushedIf enabled push).toRaw] ⟩ ∈
+        table.circuit.exposedChannels table.rowInputVar table.rowOffset ∧
+      ∀ env, table.rowOperations.ConstraintsHold env →
         Expression.eval env enabled = 0 ∨ Expression.eval env enabled = 1
 
   -- the verifier pulls and pushes to the channel, and doesn't push anything else
@@ -237,20 +236,6 @@ variable {vm : VmTables F PublicIO}
 @[circuit_norm] abbrev allTables (vm : VmTables F PublicIO) : List (Component F) :=
   vm.toEnsemble.allTables
 
-private theorem list_forall_mem {α : Type*} {P : α → Prop} :
-    ∀ {xs : List α}, xs.Forall P → ∀ {x}, x ∈ xs → P x
-  | [], _, _, h => by cases h
-  | head :: [], h_forall, _, h_mem => by
-      simp only [List.mem_singleton] at h_mem
-      subst h_mem
-      simpa [List.Forall] using h_forall
-  | head :: next :: tail, h_forall, _, h_mem => by
-      change P head ∧ (next :: tail).Forall P at h_forall
-      simp only [List.mem_cons] at h_mem
-      rcases h_mem with rfl | h_mem
-      · exact h_forall.1
-      · exact list_forall_mem h_forall.2 (by simpa [List.mem_cons] using h_mem)
-
 theorem tables_channel_of_mem (vm : VmTables F PublicIO) {table} (table_mem : table ∈ vm.tables) :
     ∃ enabled : Expression F, ∃ pull push : Var vm.Message F,
       ⟨ vm.channel,
@@ -258,7 +243,10 @@ theorem tables_channel_of_mem (vm : VmTables F PublicIO) {table} (table_mem : ta
           (pushIf (channel:=vm.channel) enabled push).toRaw] ⟩ ∈ table.exposedChannels ∧
       ∀ env, table.operations.ConstraintsHold env →
         Expression.eval env enabled = 0 ∨ Expression.eval env enabled = 1 := by
-  exact list_forall_mem vm.tables_channel table_mem
+  have h := vm.tables_channel
+  simp_rw [List.forall_iff_forall_mem] at h
+  simp_rw [table.constraintsHold_iff]
+  exact h _ table_mem
 
 noncomputable def step (vm : VmTables F PublicIO) (table : Component F)
     (table_mem : table ∈ vm.tables) : VmStep vm.Message F where
@@ -588,7 +576,7 @@ theorem verifier_guarantees_of_requirements_of_requirements_of_guarantees
     apply balancedInteractions_of_perm balance
     apply List.zip_flattenPairs_perm <| witness.pushes_length ▸ witness.pulls_length.symm
   -- we fill in the conditions on pulls and pushes in `guarantees_of_requirements_of_requirements_of_guarantees`
-  have grts_of_reqs := guarantees_of_requirements_of_requirements_of_guarantees_gated
+  have grts_of_reqs := guarantees_of_requirements_of_requirements_of_guarantees_of_mult_zero_iff
     vm.channel.toRaw witness.pulls witness.pushes balance witness.data
     (by simp [witness.pulls_length, witness.pushes_length])
     witness.pulls_channel witness.pushes_channel

--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -442,15 +442,6 @@ theorem mem_nil_or_mem_nil_of_mem_shallowChannels (n : ℕ) (input : Var (fields
       · apply IH ((m + 3) / 2) (by omega)
       · apply IH ((m + 3) - ((m + 3) / 2)) (by omega)
 
-theorem requirementsChannelsLawful (n : ℕ) (input : Var (fields n) (F p)) (offset : ℕ) :
-    ((main input).operations offset).RequirementsChannelsLawful [] [] := by
-  constructor
-  · exact (subcircuitChannelsWithRequirements_subset_nil_and_inChannelsOrRequirements_nil n input offset).1
-  constructor
-  · exact mem_nil_or_mem_nil_of_mem_shallowChannels n input offset
-  · intro env _
-    exact (subcircuitChannelsWithRequirements_subset_nil_and_inChannelsOrRequirements_nil n input offset).2 env
-
 -- Extract Assumptions and Spec outside the circuit
 def Assumptions (n : ℕ) (input : fields n (F p)) : Prop :=
   ∀ (i : ℕ) (h : i < n), IsBool input[i]
@@ -916,7 +907,13 @@ def circuit (n : ℕ) : FormalCircuit (F p) (fields n) field where
       · exact (subcircuitChannelsWithGuarantees_subset_nil_and_inChannelsOrGuarantees_nil n input_var offset).2
       · exact subcircuitChannelsLawful n input_var offset
   }
-  requirementsChannelsLawful := requirementsChannelsLawful n
+  requirementsChannelsLawful input offset := by
+    constructor
+    · exact (subcircuitChannelsWithRequirements_subset_nil_and_inChannelsOrRequirements_nil n input offset).1
+    constructor
+    · exact mem_nil_or_mem_nil_of_mem_shallowChannels n input offset
+    · intro env _
+      exact (subcircuitChannelsWithRequirements_subset_nil_and_inChannelsOrRequirements_nil n input offset).2 env
 
   Assumptions := Assumptions n
   Spec := Spec n

--- a/Clean/Circomlib/Gates.lean
+++ b/Clean/Circomlib/Gates.lean
@@ -442,6 +442,15 @@ theorem mem_nil_or_mem_nil_of_mem_shallowChannels (n : ℕ) (input : Var (fields
       · apply IH ((m + 3) / 2) (by omega)
       · apply IH ((m + 3) - ((m + 3) / 2)) (by omega)
 
+theorem requirementsChannelsLawful (n : ℕ) (input : Var (fields n) (F p)) (offset : ℕ) :
+    ((main input).operations offset).RequirementsChannelsLawful [] [] := by
+  constructor
+  · exact (subcircuitChannelsWithRequirements_subset_nil_and_inChannelsOrRequirements_nil n input offset).1
+  constructor
+  · exact mem_nil_or_mem_nil_of_mem_shallowChannels n input offset
+  · intro env _
+    exact (subcircuitChannelsWithRequirements_subset_nil_and_inChannelsOrRequirements_nil n input offset).2 env
+
 -- Extract Assumptions and Spec outside the circuit
 def Assumptions (n : ℕ) (input : fields n (F p)) : Prop :=
   ∀ (i : ℕ) (h : i < n), IsBool input[i]
@@ -905,11 +914,9 @@ def circuit (n : ℕ) : FormalCircuit (F p) (fields n) field where
       and_intros
       · exact (subcircuitChannelsWithGuarantees_subset_nil_and_inChannelsOrGuarantees_nil n input_var offset).1
       · exact (subcircuitChannelsWithGuarantees_subset_nil_and_inChannelsOrGuarantees_nil n input_var offset).2
-      · exact (subcircuitChannelsWithRequirements_subset_nil_and_inChannelsOrRequirements_nil n input_var offset).1
-      · exact (subcircuitChannelsWithRequirements_subset_nil_and_inChannelsOrRequirements_nil n input_var offset).2
-      · exact mem_nil_or_mem_nil_of_mem_shallowChannels n input_var offset
       · exact subcircuitChannelsLawful n input_var offset
   }
+  requirementsChannelsLawful := requirementsChannelsLawful n
 
   Assumptions := Assumptions n
   Spec := Spec n

--- a/Clean/Circomlib/Mux1.lean
+++ b/Clean/Circomlib/Mux1.lean
@@ -104,7 +104,7 @@ def circuit (n : ℕ) : FormalCircuit (F p) (Inputs n) (fields n) where
       | inr h1 =>
         -- When s = 1
         rw [h1]
-        simp only [mul_one, if_neg (by norm_num : (1 : F p) ≠ 0), circuit_norm]
+        simp only [mul_one, circuit_norm]
         norm_num
 
   completeness := by

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -1,4 +1,5 @@
 import Clean.Circuit.Operations
+import Clean.Utils.Field
 import Mathlib.Control.Monad.Writer
 
 variable {F : Type} [Field F] {α β : Type} {n : ℕ}
@@ -472,12 +473,6 @@ attribute [circuit_norm] Fin.coe_ofNat_eq_mod
 
 -- simplify `vector[i]` (which occurs in ProvableType definitions) and similar
 attribute [circuit_norm] Fin.val_eq_zero Fin.cast_eq_self Fin.coe_cast Fin.isValue
-
-@[circuit_norm]
-lemma zero_ne_neg_one {F : Type} [Field F] : (0 : F) ≠ -1 := by
-  intro h
-  apply zero_ne_one (α:=F)
-  rw [← neg_zero, h, neg_neg]
 
 -- simplify constraint expressions and +0 indices
 attribute [circuit_norm] neg_mul one_mul add_zero zero_add neg_zero neg_eq_zero one_ne_zero zero_ne_one

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -141,8 +141,8 @@ def Channel.pull {Message : TypeMap} [ProvableType Message] (channel : Channel F
 
 @[circuit_norm]
 def Channel.pullIf {Message : TypeMap} [ProvableType Message] (channel : Channel F Message)
-    (gate : Expression F) (msg : Message (Expression F)) : Circuit F Unit := fun _ =>
-  let interaction : ChannelInteraction channel := ⟨ -gate, msg, true ⟩
+    (enabled : Expression F) (msg : Message (Expression F)) : Circuit F Unit := fun _ =>
+  let interaction : ChannelInteraction channel := ⟨ -enabled, msg, true ⟩
   ((), [.interact interaction.toRaw])
 
 @[circuit_norm]
@@ -153,8 +153,8 @@ def Channel.push {Message : TypeMap} [ProvableType Message] (channel : Channel F
 
 @[circuit_norm]
 def Channel.pushIf {Message : TypeMap} [ProvableType Message] (channel : Channel F Message)
-    (gate : Expression F) (msg : Message (Expression F)) : Circuit F Unit := fun _ =>
-  let interaction : ChannelInteraction channel := ⟨ gate, msg, false ⟩
+    (enabled : Expression F) (msg : Message (Expression F)) : Circuit F Unit := fun _ =>
+  let interaction : ChannelInteraction channel := ⟨ enabled, msg, false ⟩
   ((), [.interact interaction.toRaw])
 
 /-- Create a new variable of an arbitrary "provable type". -/

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -1,5 +1,4 @@
 import Clean.Circuit.Operations
-import Clean.Utils.Field
 import Mathlib.Control.Monad.Writer
 
 variable {F : Type} [Field F] {α β : Type} {n : ℕ}

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -140,9 +140,21 @@ def Channel.pull {Message : TypeMap} [ProvableType Message] (channel : Channel F
   ((), [.interact interaction.toRaw])
 
 @[circuit_norm]
+def Channel.pullIf {Message : TypeMap} [ProvableType Message] (channel : Channel F Message)
+    (gate : Expression F) (msg : Message (Expression F)) : Circuit F Unit := fun _ =>
+  let interaction : ChannelInteraction channel := ⟨ -gate, msg, true ⟩
+  ((), [.interact interaction.toRaw])
+
+@[circuit_norm]
 def Channel.push {Message : TypeMap} [ProvableType Message] (channel : Channel F Message)
     (msg : Message (Expression F)) : Circuit F Unit := fun _ =>
   let interaction : ChannelInteraction channel := ⟨ 1, msg, false ⟩
+  ((), [.interact interaction.toRaw])
+
+@[circuit_norm]
+def Channel.pushIf {Message : TypeMap} [ProvableType Message] (channel : Channel F Message)
+    (gate : Expression F) (msg : Message (Expression F)) : Circuit F Unit := fun _ =>
+  let interaction : ChannelInteraction channel := ⟨ gate, msg, false ⟩
   ((), [.interact interaction.toRaw])
 
 /-- Create a new variable of an arbitrary "provable type". -/
@@ -461,8 +473,15 @@ attribute [circuit_norm] Fin.coe_ofNat_eq_mod
 -- simplify `vector[i]` (which occurs in ProvableType definitions) and similar
 attribute [circuit_norm] Fin.val_eq_zero Fin.cast_eq_self Fin.coe_cast Fin.isValue
 
+@[circuit_norm]
+lemma zero_ne_neg_one {F : Type} [Field F] : (0 : F) ≠ -1 := by
+  intro h
+  apply zero_ne_one (α:=F)
+  rw [← neg_zero, h, neg_neg]
+
 -- simplify constraint expressions and +0 indices
-attribute [circuit_norm] neg_mul one_mul add_zero zero_add Nat.reduceAdd
+attribute [circuit_norm] neg_mul one_mul add_zero zero_add neg_zero neg_eq_zero one_ne_zero zero_ne_one
+  Nat.reduceAdd
 
 attribute [circuit_norm] List.append_nil
 

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -209,10 +209,10 @@ declared channel interface.
 @[circuit_norm]
 def ElaboratedCircuit.ChannelsLawful [CircuitType Input] [CircuitType Output]
     (main : Var Input F → Circuit F (Var Output F))
-    (channelsWithGuarantees channelsWithRequirements : List (RawChannel F)) : Prop :=
+    (channelsWithGuarantees : List (RawChannel F)) : Prop :=
   ∀ input_var offset,
     ((main input_var).operations offset).ChannelsLawful
-      channelsWithGuarantees channelsWithRequirements
+      channelsWithGuarantees
 
 /-
 Common base type for circuits that are to be used in formal proofs.
@@ -243,12 +243,11 @@ class ElaboratedCircuit (F : Type) (Input Output : TypeMap) [Field F] [CircuitTy
       try first | ac_rfl | trivial
     )
 
-  /-- expose the channel guarantees and requirements, for end-to-end proofs -/
+  /-- expose the channel guarantees for end-to-end proofs -/
   channelsWithGuarantees : List (RawChannel F) := []
-  channelsWithRequirements : List (RawChannel F) := []
 
   channelsLawful : ElaboratedCircuit.ChannelsLawful main
-      channelsWithGuarantees channelsWithRequirements := by
+      channelsWithGuarantees := by
     -- TODO this tactic would be more effective if it would unfold all channel declarations/uses.
     dsimp only [ElaboratedCircuit.ChannelsLawful]
     try dsimp only [main]
@@ -256,7 +255,7 @@ class ElaboratedCircuit (F : Type) (Input Output : TypeMap) [Field F] [CircuitTy
     try first | ac_rfl | trivial | tauto
 
 attribute [circuit_norm] ElaboratedCircuit.localLength ElaboratedCircuit.output
-  ElaboratedCircuit.channelsWithGuarantees ElaboratedCircuit.channelsWithRequirements
+  ElaboratedCircuit.channelsWithGuarantees
 
 end
 

--- a/Clean/Circuit/Channel.lean
+++ b/Clean/Circuit/Channel.lean
@@ -214,7 +214,7 @@ def Guarantees (i : ChannelInteraction channel) (env : Environment F) : Prop :=
 
 @[circuit_norm]
 def Requirements (i : ChannelInteraction channel) (env : Environment F) : Prop :=
-  i.assumeGuarantees = false → Expression.eval env i.mult ≠ -1 → Expression.eval env i.mult ≠ 0 →
+  Expression.eval env i.mult ≠ -1 → Expression.eval env i.mult ≠ 0 →
       channel.Guarantees (eval env i.msg) env.data
 end ChannelInteraction
 
@@ -223,7 +223,7 @@ def Guarantees (i : AbstractInteraction F) (env : Environment F) : Prop :=
   i.assumeGuarantees → i.channel.Guarantees (env i.mult) (i.msg.map env) env.data
 
 def Requirements (i : AbstractInteraction F) (env : Environment F) : Prop :=
-  i.assumeGuarantees = false → i.channel.Requirements (env i.mult) (i.msg.map env) env.data
+  i.channel.Requirements (env i.mult) (i.msg.map env) env.data
 end AbstractInteraction
 
 namespace ChannelInteraction
@@ -269,7 +269,7 @@ def Guarantees (i : Interaction F) (data : ProverData F) : Prop :=
   i.assumeGuarantees → i.channel.Guarantees i.mult i.msgVector data
 
 def Requirements (i : Interaction F) (data : ProverData F) : Prop :=
-  i.assumeGuarantees = false → i.channel.Requirements i.mult i.msgVector data
+  i.channel.Requirements i.mult i.msgVector data
 end Interaction
 
 namespace AbstractInteraction

--- a/Clean/Circuit/Channel.lean
+++ b/Clean/Circuit/Channel.lean
@@ -37,6 +37,7 @@ def toRaw (channel : Channel F Message) : RawChannel F where
     mult = -1 → channel.Guarantees (fromElements message) data
   Requirements mult message data :=
     mult ≠ -1 →
+    mult ≠ 0 →
     channel.Guarantees (fromElements message) data
 
 instance : CoeOut (Channel F Message) (RawChannel F) where
@@ -62,8 +63,8 @@ lemma toRaw_ext_iff {Message2 : TypeMap} [ProvableType Message2]
     size Message = size Message2 ∧
     ((fun mult message data ↦ mult = (-1 : F) → channel1.Guarantees (fromElements message) data) ≍
       fun mult message data ↦ mult = (-1 : F) → channel2.Guarantees (fromElements message) data) ∧
-    (fun mult message data ↦ mult ≠ (-1 : F) → channel1.Guarantees (fromElements message) data) ≍
-      fun mult message data ↦ mult ≠ (-1 : F) → channel2.Guarantees (fromElements message) data := by
+    (fun mult message data ↦ mult ≠ (-1 : F) → mult ≠ 0 → channel1.Guarantees (fromElements message) data) ≍
+      fun mult message data ↦ mult ≠ (-1 : F) → mult ≠ 0 → channel2.Guarantees (fromElements message) data := by
   simp only [toRaw, RawChannel.mk.injEq]
 end Channel
 
@@ -129,6 +130,11 @@ lemma emitted_assumeGuarantees (mult : Expression F) (msg : Message (Expression 
 def pulled {channel : Channel F Message} (msg : Message (Expression F)) : ChannelInteraction channel :=
   { mult := -1, msg, assumeGuarantees := true }
 
+/-- Conditional pull. When `gate = 1`, this is a pull; when `gate = 0`, it is disabled. -/
+def pullIf {channel : Channel F Message} (gate : Expression F) (msg : Message (Expression F)) :
+    ChannelInteraction channel :=
+  { mult := -gate, msg, assumeGuarantees := true }
+
 @[circuit_norm] lemma pulled_def (msg : Message (Expression F)) :
   ({ mult := -1, msg, assumeGuarantees := true } : ChannelInteraction channel) = pulled msg := rfl
 @[circuit_norm] lemma pulled_mult (msg : Message (Expression F)) :
@@ -138,9 +144,25 @@ def pulled {channel : Channel F Message} (msg : Message (Expression F)) : Channe
 @[circuit_norm] lemma pulled_assumeGuarantees (msg : Message (Expression F)) :
   (pulled msg : ChannelInteraction channel).assumeGuarantees = true := rfl
 
+@[circuit_norm] lemma pullIf_def (gate : Expression F) (msg : Message (Expression F)) :
+  ({ mult := -gate, msg, assumeGuarantees := true } : ChannelInteraction channel) = pullIf gate msg := rfl
+@[circuit_norm] lemma pulled_eq_pullIf_one (msg : Message (Expression F)) :
+  (pulled msg : ChannelInteraction channel) = pullIf 1 msg := rfl
+@[circuit_norm] lemma pullIf_mult (gate : Expression F) (msg : Message (Expression F)) :
+  (pullIf gate msg : ChannelInteraction channel).mult = -gate := rfl
+@[circuit_norm] lemma pullIf_msg (gate : Expression F) (msg : Message (Expression F)) :
+  (pullIf gate msg : ChannelInteraction channel).msg = msg := rfl
+@[circuit_norm] lemma pullIf_assumeGuarantees (gate : Expression F) (msg : Message (Expression F)) :
+  (pullIf gate msg : ChannelInteraction channel).assumeGuarantees = true := rfl
+
 /-- Convenience alias for interaction with multiplicity `1`. -/
 def pushed {channel : Channel F Message} (msg : Message (Expression F)) : ChannelInteraction channel :=
   { mult := 1, msg, assumeGuarantees := false }
+
+/-- Conditional push. When `gate = 1`, this is a push; when `gate = 0`, it is disabled. -/
+def pushIf {channel : Channel F Message} (gate : Expression F) (msg : Message (Expression F)) :
+    ChannelInteraction channel :=
+  { mult := gate, msg, assumeGuarantees := false }
 
 @[circuit_norm] lemma pushed_def (msg : Message (Expression F)) :
   ({ mult := 1, msg, assumeGuarantees := false } : ChannelInteraction channel) = pushed msg := rfl
@@ -152,6 +174,17 @@ def pushed {channel : Channel F Message} (msg : Message (Expression F)) : Channe
   (pushed msg : ChannelInteraction channel).msg = msg := rfl
 @[circuit_norm] lemma pushed_assumeGuarantees (msg : Message (Expression F)) :
   (pushed msg : ChannelInteraction channel).assumeGuarantees = false := rfl
+
+omit [Field F] in @[circuit_norm] lemma pushIf_def (gate : Expression F) (msg : Message (Expression F)) :
+  ({ mult := gate, msg, assumeGuarantees := false } : ChannelInteraction channel) = pushIf gate msg := rfl
+@[circuit_norm] lemma pushed_eq_pushIf_one (msg : Message (Expression F)) :
+  (pushed msg : ChannelInteraction channel) = pushIf 1 msg := rfl
+omit [Field F] in @[circuit_norm] lemma pushIf_mult (gate : Expression F) (msg : Message (Expression F)) :
+  (pushIf gate msg : ChannelInteraction channel).mult = gate := rfl
+omit [Field F] in @[circuit_norm] lemma pushIf_msg (gate : Expression F) (msg : Message (Expression F)) :
+  (pushIf gate msg : ChannelInteraction channel).msg = msg := rfl
+omit [Field F] in @[circuit_norm] lemma pushIf_assumeGuarantees (gate : Expression F) (msg : Message (Expression F)) :
+  (pushIf gate msg : ChannelInteraction channel).assumeGuarantees = false := rfl
 
 @[circuit_norm] def Channel.emitted (channel : Channel F Message) mult msg :=
   _root_.emitted (channel := channel) mult msg
@@ -179,7 +212,8 @@ def Guarantees (i : ChannelInteraction channel) (env : Environment F) : Prop :=
 
 @[circuit_norm]
 def Requirements (i : ChannelInteraction channel) (env : Environment F) : Prop :=
-  Expression.eval env i.mult ≠ -1 → channel.Guarantees (eval env i.msg) env.data
+  Expression.eval env i.mult ≠ -1 → Expression.eval env i.mult ≠ 0 →
+    channel.Guarantees (eval env i.msg) env.data
 end ChannelInteraction
 
 namespace AbstractInteraction
@@ -278,6 +312,22 @@ def pushedValue (channel : Channel F Message) (msg : Message F) : Interaction F 
   same_size := by simp [Channel.toRaw]
   assumeGuarantees := false
 
+@[circuit_norm]
+def pullIfValue (channel : Channel F Message) (gate : F) (msg : Message F) : Interaction F where
+  channel := channel.toRaw
+  mult := -gate
+  msg := (toElements msg).toArray
+  same_size := by simp [Channel.toRaw]
+  assumeGuarantees := true
+
+@[circuit_norm]
+def pushIfValue (channel : Channel F Message) (gate : F) (msg : Message F) : Interaction F where
+  channel := channel.toRaw
+  mult := gate
+  msg := (toElements msg).toArray
+  same_size := by simp [Channel.toRaw]
+  assumeGuarantees := false
+
 lemma eval_pulled {channel : Channel F Message} {msg : Message (Expression F)} {env : Environment F} :
      (channel.pulled msg).toRaw.eval env = channel.pulledValue (eval env msg) := by
   simp only [circuit_norm, AbstractInteraction.eval, Interaction.mk.injEq]
@@ -288,6 +338,26 @@ lemma eval_pulled {channel : Channel F Message} {msg : Message (Expression F)} {
 
 lemma eval_pushed {channel : Channel F Message} {msg : Message (Expression F)} {env : Environment F} :
      (channel.pushed msg).toRaw.eval env = channel.pushedValue (eval env msg) := by
+  simp only [circuit_norm, AbstractInteraction.eval, Interaction.mk.injEq]
+  simp only [and_true, true_and]
+  congr
+  rw [←ProvableType.fromElements_eq_iff, CircuitType.eval_var]
+  rfl
+
+lemma eval_pullIf {channel : Channel F Message} {gate : Expression F}
+    {msg : Message (Expression F)} {env : Environment F} :
+     (pullIf (channel:=channel) gate msg).toRaw.eval env = channel.pullIfValue (env gate) (eval env msg) := by
+  simp only [circuit_norm, AbstractInteraction.eval, Interaction.mk.injEq]
+  simp only [and_true, true_and]
+  constructor
+  · exact (neg_eq_neg_one_mul (env gate)).symm
+  · apply congrArg Vector.toArray
+    rw [←ProvableType.fromElements_eq_iff, CircuitType.eval_var]
+    rfl
+
+lemma eval_pushIf {channel : Channel F Message} {gate : Expression F}
+    {msg : Message (Expression F)} {env : Environment F} :
+     (pushIf (channel:=channel) gate msg).toRaw.eval env = channel.pushIfValue (env gate) (eval env msg) := by
   simp only [circuit_norm, AbstractInteraction.eval, Interaction.mk.injEq]
   simp only [and_true, true_and]
   congr

--- a/Clean/Circuit/Channel.lean
+++ b/Clean/Circuit/Channel.lean
@@ -177,6 +177,8 @@ def pushIf {channel : Channel F Message} (gate : Expression F) (msg : Message (E
 
 omit [Field F] in @[circuit_norm] lemma pushIf_def (gate : Expression F) (msg : Message (Expression F)) :
   ({ mult := gate, msg, assumeGuarantees := false } : ChannelInteraction channel) = pushIf gate msg := rfl
+omit [Field F] in @[circuit_norm] lemma emitted_eq_pushIf (gate : Expression F) (msg : Message (Expression F)) :
+  (emitted gate msg : ChannelInteraction channel) = pushIf gate msg := rfl
 @[circuit_norm] lemma pushed_eq_pushIf_one (msg : Message (Expression F)) :
   (pushed msg : ChannelInteraction channel) = pushIf 1 msg := rfl
 omit [Field F] in @[circuit_norm] lemma pushIf_mult (gate : Expression F) (msg : Message (Expression F)) :
@@ -212,8 +214,8 @@ def Guarantees (i : ChannelInteraction channel) (env : Environment F) : Prop :=
 
 @[circuit_norm]
 def Requirements (i : ChannelInteraction channel) (env : Environment F) : Prop :=
-  Expression.eval env i.mult ≠ -1 → Expression.eval env i.mult ≠ 0 →
-    channel.Guarantees (eval env i.msg) env.data
+  i.assumeGuarantees = false → Expression.eval env i.mult ≠ -1 → Expression.eval env i.mult ≠ 0 →
+      channel.Guarantees (eval env i.msg) env.data
 end ChannelInteraction
 
 namespace AbstractInteraction
@@ -221,7 +223,7 @@ def Guarantees (i : AbstractInteraction F) (env : Environment F) : Prop :=
   i.assumeGuarantees → i.channel.Guarantees (env i.mult) (i.msg.map env) env.data
 
 def Requirements (i : AbstractInteraction F) (env : Environment F) : Prop :=
-  i.channel.Requirements (env i.mult) (i.msg.map env) env.data
+  i.assumeGuarantees = false → i.channel.Requirements (env i.mult) (i.msg.map env) env.data
 end AbstractInteraction
 
 namespace ChannelInteraction
@@ -267,7 +269,7 @@ def Guarantees (i : Interaction F) (data : ProverData F) : Prop :=
   i.assumeGuarantees → i.channel.Guarantees i.mult i.msgVector data
 
 def Requirements (i : Interaction F) (data : ProverData F) : Prop :=
-  i.channel.Requirements i.mult i.msgVector data
+  i.assumeGuarantees = false → i.channel.Requirements i.mult i.msgVector data
 end Interaction
 
 namespace AbstractInteraction
@@ -293,6 +295,7 @@ lemma eval_requirements {i : AbstractInteraction F} {env : Environment F} :
     (i.eval env).Requirements env.data ↔ i.Requirements env := by
   simp only [Interaction.Requirements, AbstractInteraction.eval, AbstractInteraction.Requirements]
   rfl
+
 end AbstractInteraction
 
 namespace Channel

--- a/Clean/Circuit/Channel.lean
+++ b/Clean/Circuit/Channel.lean
@@ -152,6 +152,9 @@ def pulledIf {channel : Channel F Message} (enabled : Expression F) (msg : Messa
   (pulledIf enabled msg : ChannelInteraction channel).msg = msg := rfl
 @[circuit_norm] lemma pulledIf_assumeGuarantees (enabled : Expression F) (msg : Message (Expression F)) :
   (pulledIf enabled msg : ChannelInteraction channel).assumeGuarantees = true := rfl
+@[circuit_norm] lemma pulledIf_one_eq_pulled (msg : Message (Expression F)) :
+  (pulledIf 1 msg : ChannelInteraction channel) = pulled msg := by
+  simp [pulledIf, pulled]
 
 /-- Convenience alias for interaction with multiplicity `1`. -/
 def pushed {channel : Channel F Message} (msg : Message (Expression F)) : ChannelInteraction channel :=
@@ -172,6 +175,9 @@ def pushedIf {channel : Channel F Message} (enabled : Expression F) (msg : Messa
   (pushed msg : ChannelInteraction channel).msg = msg := rfl
 @[circuit_norm] lemma pushed_assumeGuarantees (msg : Message (Expression F)) :
   (pushed msg : ChannelInteraction channel).assumeGuarantees = false := rfl
+@[circuit_norm] lemma pushedIf_one_eq_pushed (msg : Message (Expression F)) :
+  (pushedIf 1 msg : ChannelInteraction channel) = pushed msg := by
+  simp [pushedIf, pushed]
 
 omit [Field F] in @[circuit_norm] lemma pushedIf_def (enabled : Expression F) (msg : Message (Expression F)) :
   ({ mult := enabled, msg, assumeGuarantees := false } : ChannelInteraction channel) = pushedIf enabled msg := rfl
@@ -244,10 +250,48 @@ structure ExposedChannel (F : Type) [Field F] where
   channel : RawChannel F
   interactions : List (AbstractInteraction F)
 
-@[circuit_norm]
 def expose {Message : TypeMap} [ProvableType Message] (channel : Channel F Message)
     (interactions : List (ChannelInteraction channel)) : List (ExposedChannel F) :=
   [{ channel, interactions := interactions.map (·.toRaw) }]
+
+lemma channelInteraction_toRaw_inj {i j : ChannelInteraction channel} :
+    i.toRaw = j.toRaw ↔ i = j := by
+  constructor; swap
+  · rintro rfl; rfl
+  intro h
+  rcases i with ⟨ mult, msg, assumeGuarantees ⟩
+  rcases j with ⟨ mult', msg', assumeGuarantees' ⟩
+  simp only [ChannelInteraction.toRaw, AbstractInteraction.mk.injEq,
+    ChannelInteraction.mk.injEq, true_and] at h ⊢
+  rcases h with ⟨ h_mult, h_msg, h_assume ⟩
+  refine ⟨ h_mult, ?_, h_assume ⟩
+  have h_msg_eq : toElements msg = toElements msg' := eq_of_heq h_msg
+  rw [← ProvableType.fromElements_toElements msg,
+    ← ProvableType.fromElements_toElements msg', h_msg_eq]
+
+@[circuit_norm]
+lemma mem_expose_pullIf_pushIf (enabled enabled' : Expression F)
+    (pull pull' push push' : Message (Expression F)) :
+    ⟨ channel.toRaw, [(pulledIf (channel := channel) enabled pull).toRaw,
+      (pushedIf (channel := channel) enabled push).toRaw] ⟩ ∈
+      expose channel [pulledIf enabled' pull', pushedIf enabled' push'] ↔
+    enabled = enabled' ∧ pull = pull' ∧ push = push' := by
+  simp only [expose, List.mem_singleton, List.map_cons, List.map_nil,
+    ExposedChannel.mk.injEq, true_and, List.cons.injEq, and_true,
+    channelInteraction_toRaw_inj, pulledIf, pushedIf]
+  simp
+  tauto
+
+@[circuit_norm]
+lemma mem_expose_pulled_pushed (pull pull' push push' : Message (Expression F)) :
+    ⟨ channel.toRaw, [(pulled (channel := channel) pull).toRaw,
+      (pushed (channel := channel) push).toRaw] ⟩ ∈
+      expose channel [pulled pull', pushed push'] ↔
+    pull = pull' ∧ push = push' := by
+  simp only [expose, List.mem_singleton, List.map_cons, List.map_nil,
+    ExposedChannel.mk.injEq, true_and, List.cons.injEq, and_true,
+    channelInteraction_toRaw_inj, pulled, pushed]
+  simp
 
 /--
 Concrete interaction values are heterogeneous: after evaluation, we collect interactions for

--- a/Clean/Circuit/Channel.lean
+++ b/Clean/Circuit/Channel.lean
@@ -130,10 +130,10 @@ lemma emitted_assumeGuarantees (mult : Expression F) (msg : Message (Expression 
 def pulled {channel : Channel F Message} (msg : Message (Expression F)) : ChannelInteraction channel :=
   { mult := -1, msg, assumeGuarantees := true }
 
-/-- Conditional pull. When `gate = 1`, this is a pull; when `gate = 0`, it is disabled. -/
-def pullIf {channel : Channel F Message} (gate : Expression F) (msg : Message (Expression F)) :
+/-- Conditional pull. When `enabled = 1`, this is a pull; when `enabled = 0`, it is disabled. -/
+def pullIf {channel : Channel F Message} (enabled : Expression F) (msg : Message (Expression F)) :
     ChannelInteraction channel :=
-  { mult := -gate, msg, assumeGuarantees := true }
+  { mult := -enabled, msg, assumeGuarantees := true }
 
 @[circuit_norm] lemma pulled_def (msg : Message (Expression F)) :
   ({ mult := -1, msg, assumeGuarantees := true } : ChannelInteraction channel) = pulled msg := rfl
@@ -144,25 +144,23 @@ def pullIf {channel : Channel F Message} (gate : Expression F) (msg : Message (E
 @[circuit_norm] lemma pulled_assumeGuarantees (msg : Message (Expression F)) :
   (pulled msg : ChannelInteraction channel).assumeGuarantees = true := rfl
 
-@[circuit_norm] lemma pullIf_def (gate : Expression F) (msg : Message (Expression F)) :
-  ({ mult := -gate, msg, assumeGuarantees := true } : ChannelInteraction channel) = pullIf gate msg := rfl
-@[circuit_norm] lemma pulled_eq_pullIf_one (msg : Message (Expression F)) :
-  (pulled msg : ChannelInteraction channel) = pullIf 1 msg := rfl
-@[circuit_norm] lemma pullIf_mult (gate : Expression F) (msg : Message (Expression F)) :
-  (pullIf gate msg : ChannelInteraction channel).mult = -gate := rfl
-@[circuit_norm] lemma pullIf_msg (gate : Expression F) (msg : Message (Expression F)) :
-  (pullIf gate msg : ChannelInteraction channel).msg = msg := rfl
-@[circuit_norm] lemma pullIf_assumeGuarantees (gate : Expression F) (msg : Message (Expression F)) :
-  (pullIf gate msg : ChannelInteraction channel).assumeGuarantees = true := rfl
+@[circuit_norm] lemma pullIf_def (enabled : Expression F) (msg : Message (Expression F)) :
+  ({ mult := -enabled, msg, assumeGuarantees := true } : ChannelInteraction channel) = pullIf enabled msg := rfl
+@[circuit_norm] lemma pullIf_mult (enabled : Expression F) (msg : Message (Expression F)) :
+  (pullIf enabled msg : ChannelInteraction channel).mult = -enabled := rfl
+@[circuit_norm] lemma pullIf_msg (enabled : Expression F) (msg : Message (Expression F)) :
+  (pullIf enabled msg : ChannelInteraction channel).msg = msg := rfl
+@[circuit_norm] lemma pullIf_assumeGuarantees (enabled : Expression F) (msg : Message (Expression F)) :
+  (pullIf enabled msg : ChannelInteraction channel).assumeGuarantees = true := rfl
 
 /-- Convenience alias for interaction with multiplicity `1`. -/
 def pushed {channel : Channel F Message} (msg : Message (Expression F)) : ChannelInteraction channel :=
   { mult := 1, msg, assumeGuarantees := false }
 
-/-- Conditional push. When `gate = 1`, this is a push; when `gate = 0`, it is disabled. -/
-def pushIf {channel : Channel F Message} (gate : Expression F) (msg : Message (Expression F)) :
+/-- Conditional push. When `enabled = 1`, this is a push; when `enabled = 0`, it is disabled. -/
+def pushIf {channel : Channel F Message} (enabled : Expression F) (msg : Message (Expression F)) :
     ChannelInteraction channel :=
-  { mult := gate, msg, assumeGuarantees := false }
+  { mult := enabled, msg, assumeGuarantees := false }
 
 @[circuit_norm] lemma pushed_def (msg : Message (Expression F)) :
   ({ mult := 1, msg, assumeGuarantees := false } : ChannelInteraction channel) = pushed msg := rfl
@@ -175,18 +173,16 @@ def pushIf {channel : Channel F Message} (gate : Expression F) (msg : Message (E
 @[circuit_norm] lemma pushed_assumeGuarantees (msg : Message (Expression F)) :
   (pushed msg : ChannelInteraction channel).assumeGuarantees = false := rfl
 
-omit [Field F] in @[circuit_norm] lemma pushIf_def (gate : Expression F) (msg : Message (Expression F)) :
-  ({ mult := gate, msg, assumeGuarantees := false } : ChannelInteraction channel) = pushIf gate msg := rfl
-omit [Field F] in @[circuit_norm] lemma emitted_eq_pushIf (gate : Expression F) (msg : Message (Expression F)) :
-  (emitted gate msg : ChannelInteraction channel) = pushIf gate msg := rfl
-@[circuit_norm] lemma pushed_eq_pushIf_one (msg : Message (Expression F)) :
-  (pushed msg : ChannelInteraction channel) = pushIf 1 msg := rfl
-omit [Field F] in @[circuit_norm] lemma pushIf_mult (gate : Expression F) (msg : Message (Expression F)) :
-  (pushIf gate msg : ChannelInteraction channel).mult = gate := rfl
-omit [Field F] in @[circuit_norm] lemma pushIf_msg (gate : Expression F) (msg : Message (Expression F)) :
-  (pushIf gate msg : ChannelInteraction channel).msg = msg := rfl
-omit [Field F] in @[circuit_norm] lemma pushIf_assumeGuarantees (gate : Expression F) (msg : Message (Expression F)) :
-  (pushIf gate msg : ChannelInteraction channel).assumeGuarantees = false := rfl
+omit [Field F] in @[circuit_norm] lemma pushIf_def (enabled : Expression F) (msg : Message (Expression F)) :
+  ({ mult := enabled, msg, assumeGuarantees := false } : ChannelInteraction channel) = pushIf enabled msg := rfl
+omit [Field F] in @[circuit_norm] lemma emitted_eq_pushIf (enabled : Expression F) (msg : Message (Expression F)) :
+  (emitted enabled msg : ChannelInteraction channel) = pushIf enabled msg := rfl
+omit [Field F] in @[circuit_norm] lemma pushIf_mult (enabled : Expression F) (msg : Message (Expression F)) :
+  (pushIf enabled msg : ChannelInteraction channel).mult = enabled := rfl
+omit [Field F] in @[circuit_norm] lemma pushIf_msg (enabled : Expression F) (msg : Message (Expression F)) :
+  (pushIf enabled msg : ChannelInteraction channel).msg = msg := rfl
+omit [Field F] in @[circuit_norm] lemma pushIf_assumeGuarantees (enabled : Expression F) (msg : Message (Expression F)) :
+  (pushIf enabled msg : ChannelInteraction channel).assumeGuarantees = false := rfl
 
 @[circuit_norm] def Channel.emitted (channel : Channel F Message) mult msg :=
   _root_.emitted (channel := channel) mult msg
@@ -194,6 +190,10 @@ omit [Field F] in @[circuit_norm] lemma pushIf_assumeGuarantees (gate : Expressi
   _root_.pulled (channel := channel) msg
 @[circuit_norm] def Channel.pushed (channel : Channel F Message) msg :=
   _root_.pushed (channel := channel) msg
+@[circuit_norm] def Channel.pulledIf (channel : Channel F Message) enabled msg :=
+  _root_.pullIf (channel := channel) enabled msg
+@[circuit_norm] def Channel.pushedIf (channel : Channel F Message) enabled msg :=
+  _root_.pushIf (channel := channel) enabled msg
 
 namespace ChannelInteraction
 def toRaw (i : ChannelInteraction channel) : AbstractInteraction F :=
@@ -215,7 +215,7 @@ def Guarantees (i : ChannelInteraction channel) (env : Environment F) : Prop :=
 @[circuit_norm]
 def Requirements (i : ChannelInteraction channel) (env : Environment F) : Prop :=
   Expression.eval env i.mult ≠ -1 → Expression.eval env i.mult ≠ 0 →
-      channel.Guarantees (eval env i.msg) env.data
+    channel.Guarantees (eval env i.msg) env.data
 end ChannelInteraction
 
 namespace AbstractInteraction
@@ -295,7 +295,6 @@ lemma eval_requirements {i : AbstractInteraction F} {env : Environment F} :
     (i.eval env).Requirements env.data ↔ i.Requirements env := by
   simp only [Interaction.Requirements, AbstractInteraction.eval, AbstractInteraction.Requirements]
   rfl
-
 end AbstractInteraction
 
 namespace Channel

--- a/Clean/Circuit/Channel.lean
+++ b/Clean/Circuit/Channel.lean
@@ -131,7 +131,7 @@ def pulled {channel : Channel F Message} (msg : Message (Expression F)) : Channe
   { mult := -1, msg, assumeGuarantees := true }
 
 /-- Conditional pull. When `enabled = 1`, this is a pull; when `enabled = 0`, it is disabled. -/
-def pullIf {channel : Channel F Message} (enabled : Expression F) (msg : Message (Expression F)) :
+def pulledIf {channel : Channel F Message} (enabled : Expression F) (msg : Message (Expression F)) :
     ChannelInteraction channel :=
   { mult := -enabled, msg, assumeGuarantees := true }
 
@@ -144,21 +144,21 @@ def pullIf {channel : Channel F Message} (enabled : Expression F) (msg : Message
 @[circuit_norm] lemma pulled_assumeGuarantees (msg : Message (Expression F)) :
   (pulled msg : ChannelInteraction channel).assumeGuarantees = true := rfl
 
-@[circuit_norm] lemma pullIf_def (enabled : Expression F) (msg : Message (Expression F)) :
-  ({ mult := -enabled, msg, assumeGuarantees := true } : ChannelInteraction channel) = pullIf enabled msg := rfl
-@[circuit_norm] lemma pullIf_mult (enabled : Expression F) (msg : Message (Expression F)) :
-  (pullIf enabled msg : ChannelInteraction channel).mult = -enabled := rfl
-@[circuit_norm] lemma pullIf_msg (enabled : Expression F) (msg : Message (Expression F)) :
-  (pullIf enabled msg : ChannelInteraction channel).msg = msg := rfl
-@[circuit_norm] lemma pullIf_assumeGuarantees (enabled : Expression F) (msg : Message (Expression F)) :
-  (pullIf enabled msg : ChannelInteraction channel).assumeGuarantees = true := rfl
+@[circuit_norm] lemma pulledIf_def (enabled : Expression F) (msg : Message (Expression F)) :
+  ({ mult := -enabled, msg, assumeGuarantees := true } : ChannelInteraction channel) = pulledIf enabled msg := rfl
+@[circuit_norm] lemma pulledIf_mult (enabled : Expression F) (msg : Message (Expression F)) :
+  (pulledIf enabled msg : ChannelInteraction channel).mult = -enabled := rfl
+@[circuit_norm] lemma pulledIf_msg (enabled : Expression F) (msg : Message (Expression F)) :
+  (pulledIf enabled msg : ChannelInteraction channel).msg = msg := rfl
+@[circuit_norm] lemma pulledIf_assumeGuarantees (enabled : Expression F) (msg : Message (Expression F)) :
+  (pulledIf enabled msg : ChannelInteraction channel).assumeGuarantees = true := rfl
 
 /-- Convenience alias for interaction with multiplicity `1`. -/
 def pushed {channel : Channel F Message} (msg : Message (Expression F)) : ChannelInteraction channel :=
   { mult := 1, msg, assumeGuarantees := false }
 
 /-- Conditional push. When `enabled = 1`, this is a push; when `enabled = 0`, it is disabled. -/
-def pushIf {channel : Channel F Message} (enabled : Expression F) (msg : Message (Expression F)) :
+def pushedIf {channel : Channel F Message} (enabled : Expression F) (msg : Message (Expression F)) :
     ChannelInteraction channel :=
   { mult := enabled, msg, assumeGuarantees := false }
 
@@ -173,16 +173,16 @@ def pushIf {channel : Channel F Message} (enabled : Expression F) (msg : Message
 @[circuit_norm] lemma pushed_assumeGuarantees (msg : Message (Expression F)) :
   (pushed msg : ChannelInteraction channel).assumeGuarantees = false := rfl
 
-omit [Field F] in @[circuit_norm] lemma pushIf_def (enabled : Expression F) (msg : Message (Expression F)) :
-  ({ mult := enabled, msg, assumeGuarantees := false } : ChannelInteraction channel) = pushIf enabled msg := rfl
-omit [Field F] in @[circuit_norm] lemma emitted_eq_pushIf (enabled : Expression F) (msg : Message (Expression F)) :
-  (emitted enabled msg : ChannelInteraction channel) = pushIf enabled msg := rfl
-omit [Field F] in @[circuit_norm] lemma pushIf_mult (enabled : Expression F) (msg : Message (Expression F)) :
-  (pushIf enabled msg : ChannelInteraction channel).mult = enabled := rfl
-omit [Field F] in @[circuit_norm] lemma pushIf_msg (enabled : Expression F) (msg : Message (Expression F)) :
-  (pushIf enabled msg : ChannelInteraction channel).msg = msg := rfl
-omit [Field F] in @[circuit_norm] lemma pushIf_assumeGuarantees (enabled : Expression F) (msg : Message (Expression F)) :
-  (pushIf enabled msg : ChannelInteraction channel).assumeGuarantees = false := rfl
+omit [Field F] in @[circuit_norm] lemma pushedIf_def (enabled : Expression F) (msg : Message (Expression F)) :
+  ({ mult := enabled, msg, assumeGuarantees := false } : ChannelInteraction channel) = pushedIf enabled msg := rfl
+omit [Field F] in @[circuit_norm] lemma emitted_eq_pushedIf (enabled : Expression F) (msg : Message (Expression F)) :
+  (emitted enabled msg : ChannelInteraction channel) = pushedIf enabled msg := rfl
+omit [Field F] in @[circuit_norm] lemma pushedIf_mult (enabled : Expression F) (msg : Message (Expression F)) :
+  (pushedIf enabled msg : ChannelInteraction channel).mult = enabled := rfl
+omit [Field F] in @[circuit_norm] lemma pushedIf_msg (enabled : Expression F) (msg : Message (Expression F)) :
+  (pushedIf enabled msg : ChannelInteraction channel).msg = msg := rfl
+omit [Field F] in @[circuit_norm] lemma pushedIf_assumeGuarantees (enabled : Expression F) (msg : Message (Expression F)) :
+  (pushedIf enabled msg : ChannelInteraction channel).assumeGuarantees = false := rfl
 
 @[circuit_norm] def Channel.emitted (channel : Channel F Message) mult msg :=
   _root_.emitted (channel := channel) mult msg
@@ -191,9 +191,9 @@ omit [Field F] in @[circuit_norm] lemma pushIf_assumeGuarantees (enabled : Expre
 @[circuit_norm] def Channel.pushed (channel : Channel F Message) msg :=
   _root_.pushed (channel := channel) msg
 @[circuit_norm] def Channel.pulledIf (channel : Channel F Message) enabled msg :=
-  _root_.pullIf (channel := channel) enabled msg
+  _root_.pulledIf (channel := channel) enabled msg
 @[circuit_norm] def Channel.pushedIf (channel : Channel F Message) enabled msg :=
-  _root_.pushIf (channel := channel) enabled msg
+  _root_.pushedIf (channel := channel) enabled msg
 
 namespace ChannelInteraction
 def toRaw (i : ChannelInteraction channel) : AbstractInteraction F :=
@@ -315,20 +315,32 @@ def pushedValue (channel : Channel F Message) (msg : Message F) : Interaction F 
   assumeGuarantees := false
 
 @[circuit_norm]
-def pullIfValue (channel : Channel F Message) (gate : F) (msg : Message F) : Interaction F where
+def pulledIfValue (channel : Channel F Message) (enabled : F) (msg : Message F) : Interaction F where
   channel := channel.toRaw
-  mult := -gate
+  mult := -enabled
   msg := (toElements msg).toArray
   same_size := by simp [Channel.toRaw]
   assumeGuarantees := true
 
 @[circuit_norm]
-def pushIfValue (channel : Channel F Message) (gate : F) (msg : Message F) : Interaction F where
+def pushedIfValue (channel : Channel F Message) (enabled : F) (msg : Message F) : Interaction F where
   channel := channel.toRaw
-  mult := gate
+  mult := enabled
   msg := (toElements msg).toArray
   same_size := by simp [Channel.toRaw]
   assumeGuarantees := false
+
+lemma pulledIfValue_requirements_of_isBool_enabled {channel : Channel F Message}
+  {enabled : F} {msg : Message F} {data : ProverData F} :
+    enabled = 0 ∨ enabled = 1 →
+    (channel.pulledIfValue enabled msg).Requirements data := by
+  simp only [Interaction.Requirements, Channel.pulledIfValue, Channel.toRaw]
+  grind
+
+lemma pushedIfValue_guarantees {channel : Channel F Message}
+  {enabled : F} {msg : Message F} {data : ProverData F} :
+    (channel.pushedIfValue enabled msg).Guarantees data := by
+  simp [Interaction.Guarantees, Channel.pushedIfValue]
 
 lemma eval_pulled {channel : Channel F Message} {msg : Message (Expression F)} {env : Environment F} :
      (channel.pulled msg).toRaw.eval env = channel.pulledValue (eval env msg) := by
@@ -346,20 +358,20 @@ lemma eval_pushed {channel : Channel F Message} {msg : Message (Expression F)} {
   rw [←ProvableType.fromElements_eq_iff, CircuitType.eval_var]
   rfl
 
-lemma eval_pullIf {channel : Channel F Message} {gate : Expression F}
+lemma eval_pulledIf {channel : Channel F Message} {enabled : Expression F}
     {msg : Message (Expression F)} {env : Environment F} :
-     (pullIf (channel:=channel) gate msg).toRaw.eval env = channel.pullIfValue (env gate) (eval env msg) := by
+     (channel.pulledIf enabled msg).toRaw.eval env = channel.pulledIfValue (eval env enabled) (eval env msg) := by
   simp only [circuit_norm, AbstractInteraction.eval, Interaction.mk.injEq]
   simp only [and_true, true_and]
   constructor
-  · exact (neg_eq_neg_one_mul (env gate)).symm
+  · exact (neg_eq_neg_one_mul (env enabled)).symm
   · apply congrArg Vector.toArray
     rw [←ProvableType.fromElements_eq_iff, CircuitType.eval_var]
     rfl
 
-lemma eval_pushIf {channel : Channel F Message} {gate : Expression F}
+lemma eval_pushedIf {channel : Channel F Message} {enabled : Expression F}
     {msg : Message (Expression F)} {env : Environment F} :
-     (pushIf (channel:=channel) gate msg).toRaw.eval env = channel.pushIfValue (env gate) (eval env msg) := by
+     (channel.pushedIf enabled msg).toRaw.eval env = channel.pushedIfValue (eval env enabled) (eval env msg) := by
   simp only [circuit_norm, AbstractInteraction.eval, Interaction.mk.injEq]
   simp only [and_true, true_and]
   congr

--- a/Clean/Circuit/Explicit.lean
+++ b/Clean/Circuit/Explicit.lean
@@ -486,7 +486,7 @@ instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message
   localLength _ _ := 0
   operations msg _ := [.interact (pullIf (channel:=channel) gate msg).toRaw]
   channelsWithGuarantees _ _ := [channel.toRaw]
-  channelsWithRequirements _ _ := [channel.toRaw]
+  channelsWithRequirements _ _ := []
 
 instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message} :
     ExplicitCircuits (F:=F) (channel.push) where

--- a/Clean/Circuit/Explicit.lean
+++ b/Clean/Circuit/Explicit.lean
@@ -479,6 +479,15 @@ instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message
   channelsWithGuarantees _ _ := [channel.toRaw]
   channelsWithRequirements _ _ := []
 
+instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message}
+    {gate : Expression F} :
+    ExplicitCircuits (F:=F) (channel.pullIf gate) where
+  output _ _ := ()
+  localLength _ _ := 0
+  operations msg _ := [.interact (pullIf (channel:=channel) gate msg).toRaw]
+  channelsWithGuarantees _ _ := [channel.toRaw]
+  channelsWithRequirements _ _ := [channel.toRaw]
+
 instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message} :
     ExplicitCircuits (F:=F) (channel.push) where
   output _ _ := ()
@@ -487,10 +496,20 @@ instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message
   channelsWithGuarantees _ _ := []
   channelsWithRequirements _ _ := [channel.toRaw]
 
+instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message}
+    {gate : Expression F} :
+    ExplicitCircuits (F:=F) (channel.pushIf gate) where
+  output _ _ := ()
+  localLength _ _ := 0
+  operations msg _ := [.interact (pushIf (channel:=channel) gate msg).toRaw]
+  channelsWithGuarantees _ _ := []
+  channelsWithRequirements _ _ := [channel.toRaw]
+
 attribute [explicit_circuit_unfold_type] Circuit
 
 attribute [explicit_circuit_no_unfold] Circuit.bind witnessVar witnessVars witnessVector ProvableType.witness
-  witness assertZero lookup Channel.emit Channel.pull Channel.push Pure.pure Bind.bind Functor.map
+  witness assertZero lookup Channel.emit Channel.pull Channel.push Channel.pullIf Channel.pushIf
+  Pure.pure Bind.bind Functor.map
 
 attribute [explicit_circuit_norm, circuit_norm] ExplicitCircuit.localLength ExplicitCircuit.operations ExplicitCircuit.output
   ExplicitCircuit.channelsWithGuarantees ExplicitCircuit.channelsWithRequirements

--- a/Clean/Circuit/Explicit.lean
+++ b/Clean/Circuit/Explicit.lean
@@ -421,7 +421,7 @@ instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message
     ExplicitCircuits (F:=F) (channel.pullIf gate) where
   output _ _ := ()
   localLength _ _ := 0
-  operations msg _ := [.interact (pullIf (channel:=channel) gate msg).toRaw]
+  operations msg _ := [.interact (pulledIf (channel:=channel) gate msg).toRaw]
   channelsWithGuarantees _ _ := [channel.toRaw]
 
 instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message} :
@@ -436,7 +436,7 @@ instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message
     ExplicitCircuits (F:=F) (channel.pushIf gate) where
   output _ _ := ()
   localLength _ _ := 0
-  operations msg _ := [.interact (pushIf (channel:=channel) gate msg).toRaw]
+  operations msg _ := [.interact (pushedIf (channel:=channel) gate msg).toRaw]
   channelsWithGuarantees _ _ := []
 
 attribute [explicit_circuit_unfold_type] Circuit

--- a/Clean/Circuit/Explicit.lean
+++ b/Clean/Circuit/Explicit.lean
@@ -138,8 +138,7 @@ def ElaboratedCircuit.withData {Input Output : TypeMap} [CircuitType Input] [Cir
       and_intros
       · intro a; ac_rfl
       · intro a n; rfl
-      · try simp only [circuit_norm]; try grind; done)
-    :
+      · try simp only [circuit_norm]; try grind; done) :
     ElaboratedCircuit F Input Output circuit where
   localLength := data.localLength
   output := data.output

--- a/Clean/Circuit/Explicit.lean
+++ b/Clean/Circuit/Explicit.lean
@@ -417,11 +417,11 @@ instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message
   channelsWithGuarantees _ _ := [channel.toRaw]
 
 instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message}
-    {gate : Expression F} :
-    ExplicitCircuits (F:=F) (channel.pullIf gate) where
+    {enabled : Expression F} :
+    ExplicitCircuits (F:=F) (channel.pullIf enabled) where
   output _ _ := ()
   localLength _ _ := 0
-  operations msg _ := [.interact (pulledIf (channel:=channel) gate msg).toRaw]
+  operations msg _ := [.interact (pulledIf (channel:=channel) enabled msg).toRaw]
   channelsWithGuarantees _ _ := [channel.toRaw]
 
 instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message} :
@@ -432,11 +432,11 @@ instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message
   channelsWithGuarantees _ _ := []
 
 instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message}
-    {gate : Expression F} :
-    ExplicitCircuits (F:=F) (channel.pushIf gate) where
+    {enabled : Expression F} :
+    ExplicitCircuits (F:=F) (channel.pushIf enabled) where
   output _ _ := ()
   localLength _ _ := 0
-  operations msg _ := [.interact (pushedIf (channel:=channel) gate msg).toRaw]
+  operations msg _ := [.interact (pushedIf (channel:=channel) enabled msg).toRaw]
   channelsWithGuarantees _ _ := []
 
 attribute [explicit_circuit_unfold_type] Circuit

--- a/Clean/Circuit/Explicit.lean
+++ b/Clean/Circuit/Explicit.lean
@@ -35,12 +35,11 @@ class ExplicitCircuit (circuit : Circuit F α) where
     intro _; and_intros <;> try first | ac_rfl | trivial
   /-- channel metadata explicitly collected from the circuit structure -/
   channelsWithGuarantees : ℕ → List (RawChannel F)
-  channelsWithRequirements : ℕ → List (RawChannel F)
   channelsLawful : ∀ n : ℕ, (circuit.operations n).ChannelsLawful
-      (channelsWithGuarantees n) (channelsWithRequirements n) := by
+      (channelsWithGuarantees n) := by
     intro n
     try rw [operations_eq n]
-    try dsimp only [channelsWithGuarantees, channelsWithRequirements, operations]
+    try dsimp only [channelsWithGuarantees, operations]
     simp [circuit_norm]
     all_goals try first | ac_rfl | trivial | tauto
 
@@ -56,12 +55,11 @@ class ExplicitCircuits (circuit : α → Circuit F β) where
     intro _ _; and_intros <;> try first | ac_rfl | trivial
   /-- channel metadata explicitly collected from the circuit structure -/
   channelsWithGuarantees : α → ℕ → List (RawChannel F)
-  channelsWithRequirements : α → ℕ → List (RawChannel F)
   channelsLawful : ∀ (a : α) (n : ℕ), ((circuit a).operations n).ChannelsLawful
-      (channelsWithGuarantees a n) (channelsWithRequirements a n) := by
+      (channelsWithGuarantees a n) := by
     intro a n
     try rw [operations_eq a n]
-    try dsimp only [channelsWithGuarantees, channelsWithRequirements, operations]
+    try dsimp only [channelsWithGuarantees, operations]
     simp [Operations.ChannelsLawful, circuit_norm]
     all_goals try first | ac_rfl | trivial | tauto
 
@@ -71,8 +69,6 @@ class ExplicitCircuits.IsElaborated (circuit : α → Circuit F β) (explicit : 
     explicit.localLength a n = explicit.localLength a m := by intros; rfl
   channelsWithGuarantees_eq : ∀ (a a' : α) (n m : ℕ),
     explicit.channelsWithGuarantees a n = explicit.channelsWithGuarantees a' m := by intros; rfl
-  channelsWithRequirements_eq : ∀ (a a' : α) (n m : ℕ),
-    explicit.channelsWithRequirements a n = explicit.channelsWithRequirements a' m := by intros; rfl
 
 @[circuit_norm, explicit_circuit_norm]
 def ExplicitCircuits.toElaborated {Input Output : TypeMap}
@@ -88,11 +84,9 @@ def ExplicitCircuits.toElaborated {Input Output : TypeMap}
   output_eq a n := explicit.output_eq a n
   subcircuitsConsistent a n := explicit.subcircuitsConsistent a n
   channelsWithGuarantees := explicit.channelsWithGuarantees default 0
-  channelsWithRequirements := explicit.channelsWithRequirements default 0
   channelsLawful a n := by
     convert explicit.channelsLawful a n using 1
     rw [explicit_elaborated.channelsWithGuarantees_eq]
-    rw [explicit_elaborated.channelsWithRequirements_eq]
 
 @[circuit_norm, explicit_circuit_norm]
 def ElaboratedCircuit.fromExplicit {Input Output : TypeMap}
@@ -126,20 +120,11 @@ theorem ExplicitCircuits.toElaborated_channelsWithGuarantees {Input Output : Typ
     (ExplicitCircuits.toElaborated circuit explicit explicit_elaborated).channelsWithGuarantees =
       explicit.channelsWithGuarantees default 0 := rfl
 
-theorem ExplicitCircuits.toElaborated_channelsWithRequirements {Input Output : TypeMap}
-    [CircuitType Input] [CircuitType Output] [Inhabited (Var Input F)]
-    {circuit : Var Input F → Circuit F (Var Output F)}
-    (explicit : ExplicitCircuits circuit)
-    (explicit_elaborated : ExplicitCircuits.IsElaborated circuit explicit) :
-    (ExplicitCircuits.toElaborated circuit explicit explicit_elaborated).channelsWithRequirements =
-      explicit.channelsWithRequirements default 0 := rfl
-
 structure ElaboratedCircuit.Data {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
     {circuit : Var Input F → Circuit F (Var Output F)} (elaborated : ElaboratedCircuit F Input Output circuit) where
   localLength : Var Input F → ℕ := elaborated.localLength
   output : Var Input F → ℕ → Var Output F := elaborated.output
   channelsWithGuarantees : List (RawChannel F) := elaborated.channelsWithGuarantees
-  channelsWithRequirements : List (RawChannel F) := elaborated.channelsWithRequirements
 
 @[circuit_norm, explicit_circuit_norm]
 def ElaboratedCircuit.withData {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
@@ -149,13 +134,12 @@ def ElaboratedCircuit.withData {Input Output : TypeMap} [CircuitType Input] [Cir
   (data_eq :
     (∀ a, derived.localLength a = data.localLength a) ∧
     (∀ a n, derived.output a n = data.output a n) ∧
-    (derived.channelsWithGuarantees ⊆ data.channelsWithGuarantees) ∧
-    (derived.channelsWithRequirements ⊆ data.channelsWithRequirements) := by
+    (derived.channelsWithGuarantees ⊆ data.channelsWithGuarantees) := by
       and_intros
       · intro a; ac_rfl
       · intro a n; rfl
-      · try simp only [circuit_norm]; try grind; done
-      · try simp only [circuit_norm]; try grind; done) :
+      · try simp only [circuit_norm]; try grind; done)
+    :
     ElaboratedCircuit F Input Output circuit where
   localLength := data.localLength
   output := data.output
@@ -165,24 +149,15 @@ def ElaboratedCircuit.withData {Input Output : TypeMap} [CircuitType Input] [Cir
     rw [derived.output_eq, data_eq.2.1]
   subcircuitsConsistent := derived.subcircuitsConsistent
   channelsWithGuarantees := data.channelsWithGuarantees
-  channelsWithRequirements := data.channelsWithRequirements
   channelsLawful a n := by
     have h_lawful := derived.channelsLawful a n
-    have channelsWithGuarantees_subset := data_eq.2.2.1
-    have channelsWithRequirements_subset := data_eq.2.2.2
+    have channelsWithGuarantees_subset := data_eq.2.2
     dsimp only [Operations.ChannelsLawful] at h_lawful ⊢
-    obtain ⟨h_g_sub, h_g, h_r_sub, h_r, h_shallow, h_sub⟩ := h_lawful
+    obtain ⟨h_g_sub, h_g, h_sub⟩ := h_lawful
     and_intros
     · exact List.Subset.trans h_g_sub channelsWithGuarantees_subset
     · intro env
       exact (h_g env).mono channelsWithGuarantees_subset
-    · exact List.Subset.trans h_r_sub channelsWithRequirements_subset
-    · intro env
-      exact (h_r env).mono channelsWithRequirements_subset
-    · intro channel h_mem
-      rcases h_shallow channel h_mem with h_channel | h_channel
-      · exact Or.inl (channelsWithGuarantees_subset h_channel)
-      · exact Or.inr (channelsWithRequirements_subset h_channel)
     · exact h_sub
 
 theorem ElaboratedCircuit.withData_localLength {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
@@ -204,13 +179,6 @@ theorem ElaboratedCircuit.withData_channelsWithGuarantees {Input Output : TypeMa
     (data : ElaboratedCircuit.Data derived) (data_eq) :
     (ElaboratedCircuit.withData derived data data_eq).channelsWithGuarantees = data.channelsWithGuarantees := rfl
 
-theorem ElaboratedCircuit.withData_channelsWithRequirements {Input Output : TypeMap}
-    [CircuitType Input] [CircuitType Output]
-    {circuit : Var Input F → Circuit F (Var Output F)}
-    (derived : ElaboratedCircuit F Input Output circuit)
-    (data : ElaboratedCircuit.Data derived) (data_eq) :
-    (ElaboratedCircuit.withData derived data data_eq).channelsWithRequirements = data.channelsWithRequirements := rfl
-
 -- move between family and single explicit circuit
 
 def ExplicitCircuits.fromSingle {circuit : α → Circuit F β}
@@ -223,7 +191,6 @@ def ExplicitCircuits.fromSingle {circuit : α → Circuit F β}
   operations_eq a n := (explicit a).operations_eq n
   subcircuitsConsistent a n := (explicit a).subcircuitsConsistent n
   channelsWithGuarantees a n := (explicit a).channelsWithGuarantees n
-  channelsWithRequirements a n := (explicit a).channelsWithRequirements n
   channelsLawful a n := (explicit a).channelsLawful n
 
 instance ExplicitCircuits.toSingle (circuit : α → Circuit F β) (a : α)
@@ -236,7 +203,6 @@ instance ExplicitCircuits.toSingle (circuit : α → Circuit F β) (a : α)
   operations_eq n := operations_eq a n
   subcircuitsConsistent n := subcircuitsConsistent a n
   channelsWithGuarantees n := channelsWithGuarantees circuit a n
-  channelsWithRequirements n := channelsWithRequirements circuit a n
   channelsLawful n := channelsLawful a n
 
 instance ExplicitCircuits.fromProvableInputOutput {α β : TypeMap} [ProvableType α] [ProvableType β]
@@ -250,14 +216,12 @@ instance ExplicitCircuit.from_pure {a : α} : ExplicitCircuit (pure a : Circuit 
   localLength _ := 0
   operations _ := []
   channelsWithGuarantees _ := []
-  channelsWithRequirements _ := []
 
 instance ExplicitCircuits.from_pure {f : α → β} : ExplicitCircuits (fun a => pure (f a) : α → Circuit F β) where
   output a _ := f a
   localLength _ _ := 0
   operations _ _ := []
   channelsWithGuarantees _ _ := []
-  channelsWithRequirements _ _ := []
 
 -- `bind` of two explicit circuits yields an explicit circuit
 @[explicit_circuit_constructor]
@@ -278,10 +242,6 @@ instance ExplicitCircuit.from_bind {f : Circuit F α} {g : α → Circuit F β}
   channelsWithGuarantees n :=
     let a := output f n
     channelsWithGuarantees f n ++ channelsWithGuarantees (g a) (n + localLength f n)
-
-  channelsWithRequirements n :=
-    let a := output f n
-    channelsWithRequirements f n ++ channelsWithRequirements (g a) (n + localLength f n)
 
   output_eq n := by rw [Circuit.bind_output_eq, output_eq, output_eq, localLength_eq]
   localLength_eq n := by rw [Circuit.bind_localLength_eq, localLength_eq, output_eq, localLength_eq]
@@ -327,13 +287,6 @@ theorem ExplicitCircuit.from_bind_channelsWithGuarantees {f : Circuit F α} {g :
       ExplicitCircuit.channelsWithGuarantees f n ++
         ExplicitCircuit.channelsWithGuarantees (g (ExplicitCircuit.output f n)) (n + ExplicitCircuit.localLength f n) := rfl
 
-@[circuit_norm, explicit_circuit_norm]
-theorem ExplicitCircuit.from_bind_channelsWithRequirements {f : Circuit F α} {g : α → Circuit F β}
-    (f_explicit : ExplicitCircuit f) (g_explicit : ∀ a : α, ExplicitCircuit (g a)) (n : ℕ) :
-    @ExplicitCircuit.channelsWithRequirements F _ β (f >>= g) (ExplicitCircuit.from_bind f_explicit g_explicit) n =
-      ExplicitCircuit.channelsWithRequirements f n ++
-        ExplicitCircuit.channelsWithRequirements (g (ExplicitCircuit.output f n)) (n + ExplicitCircuit.localLength f n) := rfl
-
 -- `map` of an explicit circuit yields an explicit circuit
 @[explicit_circuit_constructor]
 instance ExplicitCircuit.from_map {f : α → β} {g : Circuit F α}
@@ -342,7 +295,6 @@ instance ExplicitCircuit.from_map {f : α → β} {g : Circuit F α}
   localLength n := localLength g n
   operations n := operations g n
   channelsWithGuarantees n := channelsWithGuarantees g n
-  channelsWithRequirements n := channelsWithRequirements g n
 
   output_eq n := by rw [Circuit.map_output_eq, output_eq]
   localLength_eq n := by rw [Circuit.map_localLength_eq, localLength_eq]
@@ -370,10 +322,6 @@ theorem ExplicitCircuit.from_map_operations {f : α → β} {g : Circuit F α} (
 theorem ExplicitCircuit.from_map_channelsWithGuarantees {f : α → β} {g : Circuit F α} (g_explicit : ExplicitCircuit g) (n : ℕ) :
     @ExplicitCircuit.channelsWithGuarantees F _ β (f <$> g) (ExplicitCircuit.from_map g_explicit) n = ExplicitCircuit.channelsWithGuarantees g n := rfl
 
-@[circuit_norm, explicit_circuit_norm]
-theorem ExplicitCircuit.from_map_channelsWithRequirements {f : α → β} {g : Circuit F α} (g_explicit : ExplicitCircuit g) (n : ℕ) :
-    @ExplicitCircuit.channelsWithRequirements F _ β (f <$> g) (ExplicitCircuit.from_map g_explicit) n = ExplicitCircuit.channelsWithRequirements g n := rfl
-
 -- basic operations are explicit circuits
 
 instance : ExplicitCircuits (F:=F) witnessVar where
@@ -381,28 +329,24 @@ instance : ExplicitCircuits (F:=F) witnessVar where
   localLength _ _ := 1
   operations c n := [.witness 1 fun env => #v[c env]]
   channelsWithGuarantees _ _ := []
-  channelsWithRequirements _ _ := []
 
 instance {k : ℕ} {c : ProverEnvironment F → Vector F k} : ExplicitCircuit (witnessVars k c) where
   output n := .mapRange k fun i => ⟨n + i⟩
   localLength _ := k
   operations n := [.witness k c]
   channelsWithGuarantees _ := []
-  channelsWithRequirements _ := []
 
 instance {k : ℕ} {c : ProverEnvironment F → Vector F k} : ExplicitCircuit (witnessVector k c) where
   output n := varFromOffset (fields k) n
   localLength _ := k
   operations n := [.witness k c]
   channelsWithGuarantees _ := []
-  channelsWithRequirements _ := []
 
 instance {M : TypeMap} [ProvableType M] : ExplicitCircuits (ProvableType.witness (α:=M) (F:=F)) where
   localLength _ _ := size M
   output _ n := varFromOffset M n
   operations c n := [.witness (size M) (toElements ∘ c)]
   channelsWithGuarantees _ _ := []
-  channelsWithRequirements _ _ := []
 
 instance {M : TypeMap} [ProvableType M] (c : Var (UnconstrainedDep M) F) :
     ExplicitCircuit (witness c (self := inferInstanceAs (Witnessable F M (Var M)))) where
@@ -410,7 +354,6 @@ instance {M : TypeMap} [ProvableType M] (c : Var (UnconstrainedDep M) F) :
   output offset := varFromOffset M offset
   operations _ := [.witness (size M) (toElements ∘ c)]
   channelsWithGuarantees _ := []
-  channelsWithRequirements _ := []
 
 instance {value var : TypeMap} [ProvableType value] [inst : Witnessable F value var] :
     ExplicitCircuits (witness (F:=F) (value:=value) (var:=var)) where
@@ -434,7 +377,6 @@ instance {value var : TypeMap} [ProvableType value] [inst : Witnessable F value 
     rfl
 
   channelsWithGuarantees _ _ := []
-  channelsWithRequirements _ _ := []
 
   subcircuitsConsistent c n := by
     simp only [circuit_norm]
@@ -453,14 +395,12 @@ instance : ExplicitCircuits (F:=F) assertZero where
   localLength _ _ := 0
   operations e n := [.assert e]
   channelsWithGuarantees _ _ := []
-  channelsWithRequirements _ _ := []
 
 instance {α : TypeMap} [ProvableType α] {table : Table F α} : ExplicitCircuits (F:=F) (lookup table) where
   output _ _ := ()
   localLength _ _ := 0
   operations entry n := [.lookup { table := table.toRaw, entry := toElements entry }]
   channelsWithGuarantees _ _ := []
-  channelsWithRequirements _ _ := []
 
 instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message}
     {mult : Expression F} :
@@ -469,7 +409,6 @@ instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message
   localLength _ _ := 0
   operations msg _ := [.interact (channel.emitted mult msg).toRaw]
   channelsWithGuarantees _ _ := []
-  channelsWithRequirements _ _ := [channel.toRaw]
 
 instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message} :
     ExplicitCircuits (F:=F) (channel.pull) where
@@ -477,7 +416,6 @@ instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message
   localLength _ _ := 0
   operations msg _ := [.interact (channel.pulled msg).toRaw]
   channelsWithGuarantees _ _ := [channel.toRaw]
-  channelsWithRequirements _ _ := []
 
 instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message}
     {gate : Expression F} :
@@ -486,7 +424,6 @@ instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message
   localLength _ _ := 0
   operations msg _ := [.interact (pullIf (channel:=channel) gate msg).toRaw]
   channelsWithGuarantees _ _ := [channel.toRaw]
-  channelsWithRequirements _ _ := []
 
 instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message} :
     ExplicitCircuits (F:=F) (channel.push) where
@@ -494,7 +431,6 @@ instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message
   localLength _ _ := 0
   operations msg _ := [.interact (channel.pushed msg).toRaw]
   channelsWithGuarantees _ _ := []
-  channelsWithRequirements _ _ := [channel.toRaw]
 
 instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message}
     {gate : Expression F} :
@@ -503,7 +439,6 @@ instance {Message : TypeMap} [ProvableType Message] {channel : Channel F Message
   localLength _ _ := 0
   operations msg _ := [.interact (pushIf (channel:=channel) gate msg).toRaw]
   channelsWithGuarantees _ _ := []
-  channelsWithRequirements _ _ := [channel.toRaw]
 
 attribute [explicit_circuit_unfold_type] Circuit
 
@@ -512,12 +447,12 @@ attribute [explicit_circuit_no_unfold] Circuit.bind witnessVar witnessVars witne
   Pure.pure Bind.bind Functor.map
 
 attribute [explicit_circuit_norm, circuit_norm] ExplicitCircuit.localLength ExplicitCircuit.operations ExplicitCircuit.output
-  ExplicitCircuit.channelsWithGuarantees ExplicitCircuit.channelsWithRequirements
+  ExplicitCircuit.channelsWithGuarantees
 attribute [explicit_circuit_norm, circuit_norm] ExplicitCircuits.localLength ExplicitCircuits.operations ExplicitCircuits.output
-  ExplicitCircuits.channelsWithGuarantees ExplicitCircuits.channelsWithRequirements
+  ExplicitCircuits.channelsWithGuarantees
 attribute [explicit_circuit_norm, circuit_norm] ExplicitCircuits.toSingle ExplicitCircuits.fromSingle
 attribute [explicit_circuit_norm] ElaboratedCircuit.localLength ElaboratedCircuit.output
-  ElaboratedCircuit.channelsWithGuarantees ElaboratedCircuit.channelsWithRequirements
+  ElaboratedCircuit.channelsWithGuarantees
 
 -- simplification of terms coming from `bind` aggregation e.g. 8 + 0 + 1 + ...
 attribute [explicit_circuit_norm] size Nat.add_zero Nat.zero_add Nat.mul_zero Nat.zero_mul
@@ -561,6 +496,32 @@ def isUnfoldableCircuitDecl (declName : Name)
   | some (.defnInfo info) => return ok info.type
   | some (.opaqueInfo info) => return ok info.type
   | _ => return false
+
+/-- Collect constants in an expression that are unfoldable circuit wrappers according to
+`isUnfoldableCircuitDecl`. Pass already-read label sets to avoid re-reading attributes per node. -/
+partial def collectUnfoldableCircuitDecls
+    (e : Expr) (decls : Array Name := #[])
+    (noUnfold? : Option (Array Name) := none) (unfoldType? : Option (Array Name) := none) :
+    MetaM (Array Name) := do
+  let noUnfold ← match noUnfold? with
+    | some s => pure s | none => labelled `explicit_circuit_no_unfold
+  let unfoldType ← match unfoldType? with
+    | some s => pure s | none => labelled `explicit_circuit_unfold_type
+  let rec go (e : Expr) (decls : Array Name) : MetaM (Array Name) := do
+    match e with
+    | .const declName _ =>
+        if decls.contains declName ||
+            !(← isUnfoldableCircuitDecl declName (some noUnfold) (some unfoldType)) then
+          return decls
+        else
+          return decls.push declName
+    | .app f a => go a (← go f decls)
+    | .lam _ t b _ | .forallE _ t b _ => go b (← go t decls)
+    | .letE _ t v b _ => go b (← go v (← go t decls))
+    | .mdata _ b => go b decls
+    | .proj _ _ b => go b decls
+    | _ => return decls
+  go e decls
 
 /-- The `@[explicit_circuit_constructor]` lemma whose conclusion `ExplicitCircuit <c>` keys on
 `head` (the head constant of `<c>`), if any. -/
@@ -755,24 +716,6 @@ elab "elaborate_circuit" : tactic => withMainContext do
   let unfoldTypeHeads ← labelled `explicit_circuit_unfold_type
   let noUnfoldHeads ← labelled `explicit_circuit_no_unfold
 
-  -- Collect the user circuit definitions that occur in an expression.  The list is
-  -- fed to one `dsimp only` call; repeatedly simplifying already-expanded metadata
-  -- is expensive for large loops.
-  let rec collectUnfoldable (e : Expr) (decls : Array Name) : MetaM (Array Name) := do
-    match e with
-    | .const declName _ =>
-        if decls.contains declName ||
-            !(← isUnfoldableCircuitDecl declName (some noUnfoldHeads) (some unfoldTypeHeads)) then
-          return decls
-        else
-          return decls.push declName
-    | .app f a => collectUnfoldable a (← collectUnfoldable f decls)
-    | .lam _ t b _ | .forallE _ t b _ => collectUnfoldable b (← collectUnfoldable t decls)
-    | .letE _ t v b _ => collectUnfoldable b (← collectUnfoldable v (← collectUnfoldable t decls))
-    | .mdata _ b => collectUnfoldable b decls
-    | .proj _ _ b => collectUnfoldable b decls
-    | _ => return decls
-
   -- Build a `dsimp` context from `[explicit_circuit_norm]` plus the user
   -- declarations found in the inferred explicit proof and the target circuit.
   let mkDsimpCtx (decls : Array Name) : MetaM Simp.Context := do
@@ -785,7 +728,9 @@ elab "elaborate_circuit" : tactic => withMainContext do
   -- Normalize the inferred explicit metadata once with the common unfold set.  The
   -- field projections below read from this pre-normalized term, avoiding four
   -- repeated reductions of the same explicit proof.
-  let commonDecls ← collectUnfoldable explicit (← collectUnfoldable main #[])
+  let commonDecls ← collectUnfoldableCircuitDecls explicit
+    (← collectUnfoldableCircuitDecls main #[] (some noUnfoldHeads) (some unfoldTypeHeads))
+    (some noUnfoldHeads) (some unfoldTypeHeads)
   let commonDsimpCtx ← mkDsimpCtx commonDecls
   let explicitMetadata := (← dsimp explicit commonDsimpCtx).1
 
@@ -901,31 +846,19 @@ elab "elaborate_circuit" : tactic => withMainContext do
       let channelsWithGuaranteesNormProof ← mkLambdaFVars #[input, offset] proof
       return (channelsWithGuaranteesFun, channelsWithGuaranteesNormProof)
   let channelsWithGuarantees := mkApp2 channelsWithGuaranteesFun defaultInput zero
-  let (channelsWithRequirementsFun, channelsWithRequirementsNormProof) ←
-      withLocalDeclD `input varInputType fun input => do
-    withLocalDeclD `offset natType fun offset => do
-      let ch ← mkAppOptM ``ExplicitCircuits.channelsWithRequirements
-        #[none, none, none, none, main, explicitMetadata, input, offset]
-      let (ch, proof) ← normalizeExplicitSimp "channelsWithRequirements" ch
-      let channelsWithRequirementsFun ← mkLambdaFVars #[input, offset] ch
-      let channelsWithRequirementsNormProof ← mkLambdaFVars #[input, offset] proof
-      return (channelsWithRequirementsFun, channelsWithRequirementsNormProof)
-  let channelsWithRequirements := mkApp2 channelsWithRequirementsFun defaultInput zero
-
   -- Channel lawfulness is delegated to the inferred explicit circuit proof.  If the
   -- stored channel metadata was simplified propositionally, transport the delegated
-  -- proof across the corresponding channel-list equalities.
+  -- proof across the corresponding channel-list equality.
   let channelsLawful ← withLocalDeclD `input varInputType fun input => do
     withLocalDeclD `offset natType fun offset => do
       let p := mkAppN (mkConst ``ExplicitCircuits.channelsLawful)
         #[F, fieldInst, varInputType, varOutputType, main, explicitProof, input, offset]
       let pType ← inferType p
       let pArgs := pType.getAppArgs
-      if !pType.getAppFn.isConstOf ``Operations.ChannelsLawful || pArgs.size < 5 then
+      if !pType.getAppFn.isConstOf ``Operations.ChannelsLawful || pArgs.size < 4 then
         throwError "unexpected channelsLawful type: {pType}"
       let ops := pArgs[2]!
       let actualGuarantees := pArgs[3]!
-      let actualRequirements := pArgs[4]!
       let rawChannelType := mkApp (mkConst ``RawChannel) F
       let rawChannelListType := mkApp (mkConst ``List [levelZero]) rawChannelType
       let guaranteesProof := mkApp2 channelsWithGuaranteesNormProof input offset
@@ -938,23 +871,9 @@ elab "elaborate_circuit" : tactic => withMainContext do
         #[none, actualGuarantees, currentGuarantees, channelsWithGuarantees, guaranteesProof, guaranteesStoredProof]
       let p ← withLocalDeclD `channelsWithGuarantees rawChannelListType fun normalizedGuarantees => do
         let prop := mkAppN (mkConst ``Operations.ChannelsLawful)
-          #[F, fieldInst, ops, normalizedGuarantees, actualRequirements]
+          #[F, fieldInst, ops, normalizedGuarantees]
         let motive ← mkLambdaFVars #[normalizedGuarantees] prop
         let propEq ← mkAppM ``congrArg #[motive, guaranteesProof]
-        mkEqMP propEq p
-      let requirementsProof := mkApp2 channelsWithRequirementsNormProof input offset
-      let currentRequirements := mkApp2 channelsWithRequirementsFun input offset
-      let requirementsProofType ← mkEq actualRequirements currentRequirements
-      let requirementsProof ← mkExpectedTypeHint requirementsProof requirementsProofType
-      let requirementsStoredType ← mkEq currentRequirements channelsWithRequirements
-      let requirementsStoredProof ← mkExpectedTypeHint (← mkEqRefl channelsWithRequirements) requirementsStoredType
-      let requirementsProof ← mkAppOptM ``Eq.trans
-        #[none, actualRequirements, currentRequirements, channelsWithRequirements, requirementsProof, requirementsStoredProof]
-      let p ← withLocalDeclD `channelsWithRequirements rawChannelListType fun normalizedRequirements => do
-        let prop := mkAppN (mkConst ``Operations.ChannelsLawful)
-          #[F, fieldInst, ops, channelsWithGuarantees, normalizedRequirements]
-        let motive ← mkLambdaFVars #[normalizedRequirements] prop
-        let propEq ← mkAppM ``congrArg #[motive, requirementsProof]
         mkEqMP propEq p
       mkLambdaFVars #[input, offset] p
 
@@ -962,7 +881,7 @@ elab "elaborate_circuit" : tactic => withMainContext do
   -- the delegated proofs, then close the user's goal.
   let val ← mkAppOptM ``ElaboratedCircuit.mk #[F, Input, Output, none, none, none, main,
     localLengthFun, localLengthEq, outputFun, outputEq, subProof, channelsWithGuarantees,
-    channelsWithRequirements, channelsLawful]
+    channelsLawful]
   goal.assign val
   replaceMainGoal []
 
@@ -1024,20 +943,13 @@ private def elaborateCircuitWith (dataStx : TSyntax `term) (dataEqStx? : Option 
       let rhs ← mkAppOptM ``ElaboratedCircuit.Data.channelsWithGuarantees
         #[F, fieldInst, Input, Output, inputCircuitTypeInst, outputCircuitTypeInst, main, derived, data]
       mkAppM ``HasSubset.Subset #[lhs, rhs]
-    let requirementsSubset ← do
-      let lhs ← mkAppOptM ``ElaboratedCircuit.channelsWithRequirements
-        #[F, Input, Output, fieldInst, inputCircuitTypeInst, outputCircuitTypeInst, main, derived]
-      let rhs ← mkAppOptM ``ElaboratedCircuit.Data.channelsWithRequirements
-        #[F, fieldInst, Input, Output, inputCircuitTypeInst, outputCircuitTypeInst, main, derived, data]
-      mkAppM ``HasSubset.Subset #[lhs, rhs]
-    pure (mkAnd localLengthEq (mkAnd outputEq (mkAnd guaranteesSubset requirementsSubset)))
+    pure (mkAnd localLengthEq (mkAnd outputEq guaranteesSubset))
 
   let defaultDataEqStx : TacticM (TSyntax `term) :=
     `(by
       and_intros
       · intro a; ac_rfl
       · intro a n; rfl
-      · try simp only [circuit_norm]; try grind; done
       · try simp only [circuit_norm]; try grind; done)
 
   let elabDataEq (derived data : Expr) : TacticM (Expr × Expr) := do

--- a/Clean/Circuit/Formal.lean
+++ b/Clean/Circuit/Formal.lean
@@ -1,9 +1,23 @@
 import Clean.Circuit.Explicit
 
+open Lean Meta Elab Tactic
+
 variable {F : Type} [Field F] {α β : Type} {n : ℕ}
 
 section
 variable {Input Output : TypeMap}
+
+elab "unfold_formal_circuit_consts" : tactic => do
+  withMainContext do
+    let noUnfold ← labelled `explicit_circuit_no_unfold
+    let unfoldTypes ← labelled `explicit_circuit_unfold_type
+    let names ← collectUnfoldableCircuitDecls (← getMainTarget) #[]
+      (some noUnfold) (some unfoldTypes)
+    for name in names do
+      try
+        evalTactic (← `(tactic| unfold $(mkIdent name)))
+      catch _ =>
+        pure ()
 
 @[explicit_circuit_unfold_type]
 structure FormalCircuitBase (F : Type) (Input Output : TypeMap)
@@ -22,7 +36,27 @@ structure FormalCircuitBase (F : Type) (Input Output : TypeMap)
     simp only [circuit_norm, seval]
     try first | ac_rfl | trivial | tauto
 
+  /-- The channels for which this circuit may add requirements. Defaults to none. -/
+  channelsWithRequirements : List (RawChannel F) := []
+
+  /--
+  Requirement channel metadata:
+  - `channelsWithRequirements` cover subcircuit interactions that add requirements.
+  - guarantee and requirement channel lists cover all shallow interactions.
+  - under local constraints, `channelsWithRequirements` cover active shallow requirements.
+  -/
+  requirementsChannelsLawful : ∀ input offset,
+    ((main input).operations offset).RequirementsChannelsLawful
+      elaborated.channelsWithGuarantees channelsWithRequirements := by
+    try dsimp only [main]
+    simp only [circuit_norm, seval]
+    try (unfold_formal_circuit_consts; simp only [circuit_norm, seval])
+    try (unfold_formal_circuit_consts; simp only [circuit_norm, seval])
+    try first | ac_rfl | trivial | tauto
+
 attribute [circuit_norm] FormalCircuitBase.elaborated FormalCircuitBase.exposedChannels
+  FormalCircuitBase.channelsWithRequirements
+  FormalCircuitBase.requirementsChannelsLawful
 
 namespace FormalCircuitBase
 variable [CircuitType Input] [CircuitType Output]
@@ -31,14 +65,19 @@ variable {name : String} {main : Var Input F → Circuit F (Var Output F)}
   {exposedChannels : Var Input F → ℕ → List (ExposedChannel F)}
   {exposedChannels_eq : ∀ input offset,
     ((main input).operations offset).ExposedChannelsLawful (exposedChannels input offset)}
+  {channelsWithRequirements : List (RawChannel F)}
+  {requirementsChannelsLawful : ∀ input offset,
+    ((main input).operations offset).RequirementsChannelsLawful
+      elaborated.channelsWithGuarantees channelsWithRequirements}
 
 @[explicit_circuit_norm]
 def output (self : FormalCircuitBase F Input Output) (input : Var Input F) (offset : ℕ) : Var Output F :=
   self.elaborated.output input offset
 
 @[circuit_norm]
-lemma output_def (input : Var Input F) (offset : ℕ) :
-  ({name, main, elaborated, exposedChannels, exposedChannels_eq} : FormalCircuitBase F Input Output).output input offset =
+  lemma output_def (input : Var Input F) (offset : ℕ) :
+    (FormalCircuitBase.mk name main elaborated exposedChannels exposedChannels_eq
+      channelsWithRequirements requirementsChannelsLawful).output input offset =
     elaborated.output input offset := rfl
 
 @[explicit_circuit_norm]
@@ -46,8 +85,9 @@ def localLength (self : FormalCircuitBase F Input Output) (input : Var Input F) 
   self.elaborated.localLength input
 
 @[circuit_norm]
-lemma localLength_def (input : Var Input F) :
-  ({name, main, elaborated, exposedChannels, exposedChannels_eq} : FormalCircuitBase F Input Output).localLength input =
+  lemma localLength_def (input : Var Input F) :
+    (FormalCircuitBase.mk name main elaborated exposedChannels exposedChannels_eq
+      channelsWithRequirements requirementsChannelsLawful).localLength input =
     elaborated.localLength input := rfl
 
 @[explicit_circuit_norm]
@@ -55,25 +95,23 @@ def channelsWithGuarantees (self : FormalCircuitBase F Input Output) : List (Raw
   self.elaborated.channelsWithGuarantees
 
 @[circuit_norm]
-lemma channelsWithGuarantees_def :
-  ({name, main, elaborated, exposedChannels, exposedChannels_eq} : FormalCircuitBase F Input Output).channelsWithGuarantees =
+  lemma channelsWithGuarantees_def :
+    (FormalCircuitBase.mk name main elaborated exposedChannels exposedChannels_eq
+      channelsWithRequirements requirementsChannelsLawful).channelsWithGuarantees =
     elaborated.channelsWithGuarantees := rfl
 
-@[explicit_circuit_norm]
-def channelsWithRequirements (self : FormalCircuitBase F Input Output) : List (RawChannel F) :=
-  self.elaborated.channelsWithRequirements
-
 @[circuit_norm]
-lemma channelsWithRequirements_def :
-  ({name, main, elaborated, exposedChannels, exposedChannels_eq} : FormalCircuitBase F Input Output).channelsWithRequirements =
-    elaborated.channelsWithRequirements := rfl
+  lemma channelsWithRequirements_def :
+    (FormalCircuitBase.mk name main elaborated exposedChannels exposedChannels_eq
+      channelsWithRequirements requirementsChannelsLawful).channelsWithRequirements =
+    channelsWithRequirements := rfl
 
 theorem localLength_eq (self : FormalCircuitBase F Input Output) (input : Var Input F) (offset : ℕ) :
   (self.main input).localLength offset = self.localLength input :=
   self.elaborated.localLength_eq input offset
 
 theorem channelsLawful (self : FormalCircuitBase F Input Output) : ElaboratedCircuit.ChannelsLawful self.main
-    self.channelsWithGuarantees self.channelsWithRequirements :=
+    self.channelsWithGuarantees :=
   self.elaborated.channelsLawful
 
 theorem subcircuitsConsistent (self : FormalCircuitBase F Input Output) (input : Var Input F) (offset : ℕ) :
@@ -370,23 +408,26 @@ theorem subcircuitChannelsWithRequirements_subset_channelsWithRequirements
       ((circuit.main input_var).operations offset).subcircuitChannelsWithRequirements ⊆
         circuit.channelsWithRequirements := by
   intro input_var offset
-  exact (circuit.channelsLawful input_var offset).2.2.1
+  exact (circuit.requirementsChannelsLawful input_var offset).1
 
 theorem inChannelsOrRequirements_channelsWithRequirements
   (circuit : FormalCircuitBase F Input Output) :
   ∀ input_var offset env,
+    ConstraintsHold.Shallow env ((circuit.main input_var).operations offset) →
     ((circuit.main input_var).operations offset).InChannelsOrRequirements
-      circuit.channelsWithRequirements env := by
-  intro input_var offset env
-  exact (circuit.channelsLawful input_var offset).2.2.2.1 env
+      circuit.channelsWithRequirements env :=
+  fun input_var offset env => (circuit.requirementsChannelsLawful input_var offset).2.2 env
 
 theorem mem_channelsWithGuarantees_or_mem_channelsWithRequirements_of_mem_shallowChannels
   (circuit : FormalCircuitBase F Input Output) :
   ∀ input_var offset,
-    let ops := (circuit.main input_var).operations offset
-    ∀ channel ∈ ops.shallowChannels,
-      channel ∈ circuit.channelsWithGuarantees ∨ channel ∈ circuit.channelsWithRequirements :=
-  fun input_var offset => (circuit.channelsLawful input_var offset).2.2.2.2.1
+      let ops := (circuit.main input_var).operations offset
+      ∀ channel ∈ ops.shallowChannels,
+      channel ∈ circuit.channelsWithGuarantees ∨ channel ∈ circuit.channelsWithRequirements := by
+  intro input_var offset
+  dsimp only
+  intro channel h_mem
+  exact (circuit.requirementsChannelsLawful input_var offset).2.1 channel h_mem
 
 theorem interactionsWith_eq_of_mem_exposedChannels (circuit : FormalCircuitBase F Input Output) :
   ∀ input_var offset,
@@ -397,7 +438,7 @@ theorem interactionsWith_eq_of_mem_exposedChannels (circuit : FormalCircuitBase 
 
 theorem subcircuitChannelsLawful (circuit : FormalCircuitBase F Input Output) :
     ∀ input offset, ((circuit.main input).operations offset).SubcircuitChannelsLawful :=
-  fun input offset => (circuit.channelsLawful input offset).2.2.2.2.2
+  fun input offset => (circuit.channelsLawful input offset).2.2
 
 @[circuit_norm]
 def channels (circuit : FormalCircuitBase F Input Output) :=

--- a/Clean/Circuit/Formal.lean
+++ b/Clean/Circuit/Formal.lean
@@ -1,12 +1,11 @@
 import Clean.Circuit.Explicit
 
-open Lean Meta Elab Tactic
-
 variable {F : Type} [Field F] {α β : Type} {n : ℕ}
 
 section
 variable {Input Output : TypeMap}
 
+open Lean Meta Elab Tactic in
 elab "unfold_formal_circuit_consts" : tactic => do
   withMainContext do
     let noUnfold ← labelled `explicit_circuit_no_unfold
@@ -415,14 +414,15 @@ theorem inChannelsOrRequirements_channelsWithRequirements
   ∀ input_var offset env,
     ConstraintsHold.Shallow env ((circuit.main input_var).operations offset) →
     ((circuit.main input_var).operations offset).InChannelsOrRequirements
-      circuit.channelsWithRequirements env :=
-  fun input_var offset env => (circuit.requirementsChannelsLawful input_var offset).2.2 env
+      circuit.channelsWithRequirements env := by
+  intro input_var offset env
+  exact (circuit.requirementsChannelsLawful input_var offset).2.2 env
 
 theorem mem_channelsWithGuarantees_or_mem_channelsWithRequirements_of_mem_shallowChannels
   (circuit : FormalCircuitBase F Input Output) :
   ∀ input_var offset,
-      let ops := (circuit.main input_var).operations offset
-      ∀ channel ∈ ops.shallowChannels,
+    let ops := (circuit.main input_var).operations offset
+    ∀ channel ∈ ops.shallowChannels,
       channel ∈ circuit.channelsWithGuarantees ∨ channel ∈ circuit.channelsWithRequirements := by
   intro input_var offset
   dsimp only

--- a/Clean/Circuit/Formal.lean
+++ b/Clean/Circuit/Formal.lean
@@ -30,7 +30,6 @@ structure FormalCircuitBase (F : Type) (Input Output : TypeMap)
   exposedChannels : Var Input F → ℕ → List (ExposedChannel F) := fun _ _ => []
   exposedChannels_eq : ∀ input offset,
     ((main input).operations offset).ExposedChannelsLawful (exposedChannels input offset) := by
-    dsimp only [Operations.ExposedChannelsLawful]
     try dsimp only [main]
     simp only [circuit_norm, seval]
     try first | ac_rfl | trivial | tauto

--- a/Clean/Circuit/Loops.lean
+++ b/Clean/Circuit/Loops.lean
@@ -971,17 +971,16 @@ end Circuit
 
 theorem Operations.channelsLawful_flatten_of_forall {m : ℕ}
     {ops : Fin m → Operations F}
-    {channelsWithGuarantees channelsWithRequirements : Fin m → List (RawChannel F)} :
-    (∀ i, (ops i).ChannelsLawful (channelsWithGuarantees i) (channelsWithRequirements i)) →
+    {channelsWithGuarantees : Fin m → List (RawChannel F)} :
+    (∀ i, (ops i).ChannelsLawful (channelsWithGuarantees i)) →
     Operations.ChannelsLawful (List.ofFn ops).flatten
-      (List.ofFn channelsWithGuarantees).flatten
-      (List.ofFn channelsWithRequirements).flatten := by
+      (List.ofFn channelsWithGuarantees).flatten := by
   intro h
   induction m with
   | zero => simp [Operations.channelsLawful_nil]
   | succ m ih =>
-    rw [List.ofFn_succ, List.ofFn_succ, List.ofFn_succ]
-    rw [List.flatten_cons, List.flatten_cons, List.flatten_cons]
+    rw [List.ofFn_succ, List.ofFn_succ]
+    rw [List.flatten_cons, List.flatten_cons]
     apply Operations.channelsLawful_append_of_channelsLawful
     · exact h 0
     · apply ih
@@ -1001,8 +1000,6 @@ instance from_forEach {m : ℕ} [Inhabited α] {xs : Vector α m}
     (explicit xs[i.val]).operations (n + i * ((explicit default).localLength 0))).flatten
   channelsWithGuarantees n := (List.ofFn fun (i : Fin m) =>
     (explicit xs[i.val]).channelsWithGuarantees (n + i * ((explicit default).localLength 0))).flatten
-  channelsWithRequirements n := (List.ofFn fun (i : Fin m) =>
-    (explicit xs[i.val]).channelsWithRequirements (n + i * ((explicit default).localLength 0))).flatten
   output_eq n := Circuit.forEach.output_eq
   localLength_eq n := by
     rw [forEach.localLength_eq, localLength_eq]
@@ -1050,13 +1047,6 @@ theorem from_forEach_channelsWithGuarantees {m : ℕ} [Inhabited α] {xs : Vecto
     (from_forEach explicit (xs:=xs) (constant:=constant)).channelsWithGuarantees n =
       (List.ofFn fun (i : Fin m) => (explicit xs[i.val]).channelsWithGuarantees (n + i * ((explicit default).localLength 0))).flatten := rfl
 
-@[circuit_norm, explicit_circuit_norm]
-theorem from_forEach_channelsWithRequirements {m : ℕ} [Inhabited α] {xs : Vector α m}
-    {body : α → Circuit F Unit} [explicit : ∀ a, ExplicitCircuit (body a)]
-    {constant : ConstantLength body} (n : ℕ) :
-    (from_forEach explicit (xs:=xs) (constant:=constant)).channelsWithRequirements n =
-      (List.ofFn fun (i : Fin m) => (explicit xs[i.val]).channelsWithRequirements (n + i * ((explicit default).localLength 0))).flatten := rfl
-
 @[explicit_circuit_constructor]
 instance from_map_loop {m : ℕ} [Inhabited α] {xs : Vector α m}
     {body : α → Circuit F β} (explicit : ∀ a, ExplicitCircuit (body a))
@@ -1067,8 +1057,6 @@ instance from_map_loop {m : ℕ} [Inhabited α] {xs : Vector α m}
     (explicit xs[i.val]).operations (n + i * ((explicit default).localLength 0))).flatten
   channelsWithGuarantees n := (List.ofFn fun (i : Fin m) =>
     (explicit xs[i.val]).channelsWithGuarantees (n + i * ((explicit default).localLength 0))).flatten
-  channelsWithRequirements n := (List.ofFn fun (i : Fin m) =>
-    (explicit xs[i.val]).channelsWithRequirements (n + i * ((explicit default).localLength 0))).flatten
   output_eq n := by
     simp only [map.output_eq, localLength_eq, output_eq]
   localLength_eq n := by
@@ -1118,13 +1106,6 @@ theorem from_map_loop_channelsWithGuarantees {m : ℕ} [Inhabited α] {xs : Vect
     (from_map_loop explicit (xs:=xs) (constant:=constant)).channelsWithGuarantees n =
       (List.ofFn fun (i : Fin m) => (explicit xs[i.val]).channelsWithGuarantees (n + i * ((explicit default).localLength 0))).flatten := rfl
 
-@[circuit_norm, explicit_circuit_norm]
-theorem from_map_loop_channelsWithRequirements {m : ℕ} [Inhabited α] {xs : Vector α m}
-    {body : α → Circuit F β} [explicit : ∀ a, ExplicitCircuit (body a)]
-    {constant : ConstantLength body} (n : ℕ) :
-    (from_map_loop explicit (xs:=xs) (constant:=constant)).channelsWithRequirements n =
-      (List.ofFn fun (i : Fin m) => (explicit xs[i.val]).channelsWithRequirements (n + i * ((explicit default).localLength 0))).flatten := rfl
-
 @[explicit_circuit_constructor]
 instance from_mapFinRange {m : ℕ} [NeZero m]
     {body : Fin m → Circuit F β} (explicit : ∀ i, ExplicitCircuit (body i))
@@ -1135,8 +1116,6 @@ instance from_mapFinRange {m : ℕ} [NeZero m]
     (explicit i).operations (n + i * ((explicit 0).localLength 0))).flatten
   channelsWithGuarantees n := (List.ofFn fun (i : Fin m) =>
     (explicit i).channelsWithGuarantees (n + i * ((explicit 0).localLength 0))).flatten
-  channelsWithRequirements n := (List.ofFn fun (i : Fin m) =>
-    (explicit i).channelsWithRequirements (n + i * ((explicit 0).localLength 0))).flatten
   output_eq n := by
     simp only [mapFinRange.output_eq, localLength_eq, output_eq]
   localLength_eq n := by
@@ -1189,13 +1168,6 @@ theorem from_mapFinRange_channelsWithGuarantees {m : ℕ} [NeZero m]
     (from_mapFinRange explicit (constant:=constant)).channelsWithGuarantees n =
       (List.ofFn fun (i : Fin m) => (explicit i).channelsWithGuarantees (n + i * ((explicit 0).localLength 0))).flatten := rfl
 
-@[circuit_norm, explicit_circuit_norm]
-theorem from_mapFinRange_channelsWithRequirements {m : ℕ} [NeZero m]
-    {body : Fin m → Circuit F β} [explicit : ∀ i, ExplicitCircuit (body i)]
-    {constant : ConstantLength body} (n : ℕ) :
-    (from_mapFinRange explicit (constant:=constant)).channelsWithRequirements n =
-      (List.ofFn fun (i : Fin m) => (explicit i).channelsWithRequirements (n + i * ((explicit 0).localLength 0))).flatten := rfl
-
 @[explicit_circuit_constructor]
 instance from_foldl {m : ℕ} [Inhabited α] [Inhabited β] {xs : Vector α m}
     -- `explicit` is a regular explicit binder (not `[explicit]`) so the `infer_explicit_head`
@@ -1217,9 +1189,6 @@ instance from_foldl {m : ℕ} [Inhabited α] [Inhabited β] {xs : Vector α m}
       (n + i * ((explicit default default).localLength 0))).flatten
   channelsWithGuarantees n := (List.ofFn fun (i : Fin m) =>
     (explicit (Circuit.FoldlM.foldlAcc n xs body init i) xs[i.val]).channelsWithGuarantees
-      (n + i * ((explicit default default).localLength 0))).flatten
-  channelsWithRequirements n := (List.ofFn fun (i : Fin m) =>
-    (explicit (Circuit.FoldlM.foldlAcc n xs body init i) xs[i.val]).channelsWithRequirements
       (n + i * ((explicit default default).localLength 0))).flatten
   output_eq n := by
     by_cases h : m > 0
@@ -1281,9 +1250,6 @@ instance from_foldlRange {m : ℕ} [Inhabited β]
       (n + i * ((explicit default i).localLength 0))).flatten
   channelsWithGuarantees n := (List.ofFn fun i =>
     (explicit (Circuit.FoldlM.foldlAcc n (Vector.finRange m) body init i) i).channelsWithGuarantees
-      (n + i * ((explicit default i).localLength 0))).flatten
-  channelsWithRequirements n := (List.ofFn fun i =>
-    (explicit (Circuit.FoldlM.foldlAcc n (Vector.finRange m) body init i) i).channelsWithRequirements
       (n + i * ((explicit default i).localLength 0))).flatten
   output_eq n := by
     rw [foldlRange.output_eq]
@@ -1399,6 +1365,16 @@ theorem interactions_forEach {m : ℕ} [Inhabited α] (xs : Vector α m) (body :
       (List.ofFn fun (i : Fin m) =>
         ((body xs[i]).operations (offset + i * constant.localLength)).interactions).flatten := by
   rw [forEach, ForM.operations_eq, interactions_flatten_eq_map, List.map_ofFn]
+  rfl
+
+@[circuit_norm ↓]
+theorem channels_forEach {m : ℕ} [Inhabited α] (xs : Vector α m) (body : α → Circuit F Unit)
+    (constant : ConstantLength body) (offset : ℕ) :
+    ((forEach xs body constant).operations offset).channels =
+      (List.ofFn fun (i : Fin m) =>
+        ((body xs[i]).operations (offset + i * constant.localLength)).channels).flatten := by
+  rw [Operations.channels, interactions_forEach, List.map_flatten]
+  rw [List.map_ofFn]
   rfl
 
 @[circuit_norm ↓]

--- a/Clean/Circuit/Operations.lean
+++ b/Clean/Circuit/Operations.lean
@@ -1167,6 +1167,14 @@ def ExposedChannelsLawful (ops : Operations F) (exposedChannels : List (ExposedC
   (∀ exposed ∈ exposedChannels,
     ops.interactionsWith exposed.channel = exposed.interactions)
 
+@[circuit_norm ↓]
+lemma exposedChannelsLawful_expose {Message : TypeMap} [ProvableType Message]
+    (ops : Operations F) (channel : Channel F Message)
+    (interactions : List (ChannelInteraction channel)) :
+    ops.ExposedChannelsLawful (expose channel interactions) ↔
+      ops.interactionsWith channel.toRaw = interactions.map (·.toRaw) := by
+  simp only [ExposedChannelsLawful, expose, List.mem_singleton, forall_eq]
+
 theorem channelsLawful_nil : ChannelsLawful ([] : Operations F) [] := by
   simp [ChannelsLawful, InChannelsOrGuarantees, SubcircuitChannelsLawful,
     subcircuitChannelsWithGuarantees, subcircuits, forAllNoOffset]

--- a/Clean/Circuit/Operations.lean
+++ b/Clean/Circuit/Operations.lean
@@ -297,7 +297,8 @@ structure Subcircuit (F : Type) [Field F] (offset : ℕ) where
 
 def Subcircuit.ChannelsLawful (s : Subcircuit F n) : Prop :=
   (∀ env, FlatOperation.InChannelsOrGuarantees s.channelsWithGuarantees env s.ops.toFlat) ∧
-  (∀ env, FlatOperation.InChannelsOrRequirements s.channelsWithRequirements env s.ops.toFlat) ∧
+  (∀ env, ConstraintsHoldFlat env s.ops.toFlat →
+    FlatOperation.InChannelsOrRequirements s.channelsWithRequirements env s.ops.toFlat) ∧
   FlatOperation.channels s.ops.toFlat ⊆ s.channelsWithGuarantees ++ s.channelsWithRequirements
 
 @[reducible, circuit_norm]
@@ -696,6 +697,16 @@ def ConstraintsHold.Soundness (env : Environment F)
   subcircuit s := s.Assumptions env → s.Spec env
 }
 
+/-- The local constraints used to prove requirement-channel metadata.
+Unlike `ConstraintsHold.Soundness`, this is intentionally shallow: subcircuits prove
+their own metadata lawfulness and are lifted by the library. -/
+@[circuit_norm]
+def ConstraintsHold.Shallow (env : Environment F)
+    (ops : Operations F) : Prop := ops.forAllNoOffset {
+  assert e := env e = 0
+  lookup l := l.Soundness env
+}
+
 /-- Version of `ConstraintsHold` that replaces the statement of subcircuits with their `ProverAssumptions`. -/
 @[circuit_norm]
 def ConstraintsHold.Completeness (env : ProverEnvironment F)
@@ -713,6 +724,12 @@ lemma constraintsHold_soundness_iff_forall_mem {env : Environment F} {ops : Oper
     (∀ i ∈ ops.shallowInteractions, i.Guarantees env) ∧
     (∀ s ∈ ops.subcircuits, s.2.Assumptions env → s.2.Spec env) := by
   simp [ConstraintsHold.Soundness, Operations.forAllNoOffset_iff_forall_mem]
+
+lemma constraintsHold_shallow_iff_forall_mem {env : Environment F} {ops : Operations F} :
+    ConstraintsHold.Shallow env ops ↔
+    (∀ e ∈ ops.shallowConstraints, env e = 0) ∧
+    (∀ l ∈ ops.shallowLookups, l.Soundness env) := by
+  simp [ConstraintsHold.Shallow, Operations.forAllNoOffset_iff_forall_mem]
 
 lemma constraintsHold_completeness_iff_forall_mem {env : ProverEnvironment F} {ops : Operations F} :
     ConstraintsHold.Completeness env ops ↔
@@ -783,6 +800,30 @@ lemma guarantees_iff_forall_mem {env : Environment F} {ops : Operations F} :
 @[circuit_norm]
 def FullGuarantees (env : Environment F) (ops : Operations F) : Prop :=
   ∀ i ∈ ops.interactions, i.Guarantees env
+
+lemma mem_interactions_of_mem_shallowInteractions {i : AbstractInteraction F} {ops : Operations F} :
+    i ∈ ops.shallowInteractions → i ∈ ops.interactions := by
+  induction ops using induct with
+  | empty => simp [shallowInteractions]
+  | witness m c ops ih => simpa [shallowInteractions, interactions] using ih
+  | assert e ops ih => simpa [shallowInteractions, interactions] using ih
+  | lookup l ops ih => simpa [shallowInteractions, interactions] using ih
+  | interact i' ops ih =>
+      simp only [shallowInteractions, interactions, List.mem_cons]
+      intro h
+      rcases h with rfl | h
+      · exact Or.inl rfl
+      · exact Or.inr (ih h)
+  | subcircuit s ops ih =>
+      simp only [shallowInteractions, interactions, List.mem_append]
+      intro h
+      exact Or.inr (ih h)
+
+lemma guarantees_of_fullGuarantees {env : Environment F} {ops : Operations F} :
+    ops.FullGuarantees env → ops.Guarantees env := by
+  rw [guarantees_iff_forall_mem]
+  intro h i hi
+  exact h i (mem_interactions_of_mem_shallowInteractions hi)
 
 -- TODO rename to ShallowRequirements
 @[circuit_norm]
@@ -1062,6 +1103,19 @@ lemma shallowChannels_eq_interactions_map {ops : Operations F} :
     shallowChannels (ops1 ++ ops2) = shallowChannels ops1 ++ shallowChannels ops2 := by
   simp [shallowChannels_eq_interactions_map, shallowInteractions_append]
 
+@[circuit_norm] theorem channels_nil : channels ([] : Operations F) = [] := rfl
+@[circuit_norm] theorem channels_witness (m : ℕ) (c : ProverEnvironment F → Vector F m) (ops : Operations F) :
+  channels (.witness m c :: ops) = channels ops := rfl
+@[circuit_norm] theorem channels_assert (e : Expression F) (ops : Operations F) :
+  channels (.assert e :: ops) = channels ops := rfl
+@[circuit_norm] theorem channels_lookup (l : Lookup F) (ops : Operations F) :
+  channels (.lookup l :: ops) = channels ops := rfl
+@[circuit_norm] theorem channels_interact (i : AbstractInteraction F) (ops : Operations F) :
+  channels (.interact i :: ops) = i.channel :: channels ops := rfl
+@[circuit_norm] theorem channels_subcircuit {n : ℕ} (s : Subcircuit F n) (ops : Operations F) :
+  channels (.subcircuit s :: ops) = FlatOperation.channels s.ops.toFlat ++ channels ops := by
+  simp [channels, interactions, FlatOperation.channels]
+
 def SubcircuitChannelsLawful (ops : Operations F) : Prop :=
   ∀ s ∈ ops.subcircuits, s.2.ChannelsLawful
 
@@ -1086,33 +1140,29 @@ def shallowChannelsWithGuarantees (ops : Operations F) : List (RawChannel F) :=
 def shallowChannelsWithRequirements (ops : Operations F) : List (RawChannel F) :=
   (ops.shallowInteractions.filter fun i => !i.assumeGuarantees).map (·.channel)
 
-/--
-Property we require from a circuit that exposes three channel lists:
-`channelsWithGuarantees`, `channelsWithRequirements`, and `exposedChannels`.
- -/
+/-- Channel metadata used by circuit elaboration: guarantee channels and lawful subcircuit metadata. -/
 @[circuit_norm]
 def ChannelsLawful (ops : Operations F)
-    (channelsWithGuarantees channelsWithRequirements : List (RawChannel F)) : Prop :=
+    (channelsWithGuarantees : List (RawChannel F)) : Prop :=
   -- The `channelsWithGuarantees` cover all interactions that add guarantees.
   ops.subcircuitChannelsWithGuarantees ⊆ channelsWithGuarantees ∧
   (∀ env, ops.InChannelsOrGuarantees channelsWithGuarantees env) ∧
-
-  -- The `channelsWithRequirements` cover all interactions that add requirements.
-  ops.subcircuitChannelsWithRequirements ⊆ channelsWithRequirements ∧
-  (∀ env, ops.InChannelsOrRequirements channelsWithRequirements env) ∧
-
-  -- Together, the two channel lists cover all interactions.
-  -- Even if the conditions so far theoretically allow it, we must not leave out any channels
-  -- we interacted with from the combination of both lists. This is because "did not interact
-  -- with a given channel" is important knowledge during end-to-end proofs, when we need to prove
-  -- that _all_ interactions with a given channel have some property.
-  -- (If this ever becomes too restrictive for real circuits, we can relax by introducing a third
-  -- list of "other channels".)
-  (∀ channel ∈ ops.shallowChannels,
-    channel ∈ channelsWithGuarantees ∨ channel ∈ channelsWithRequirements) ∧
-
   -- Every subcircuit used by this circuit exposes lawful channel metadata itself.
   ops.SubcircuitChannelsLawful
+
+/-- Channel metadata for requirements that depends on circuit constraints. -/
+@[circuit_norm]
+def RequirementsChannelsLawful (ops : Operations F)
+    (channelsWithGuarantees channelsWithRequirements : List (RawChannel F)) : Prop :=
+  -- The `channelsWithRequirements` cover all subcircuit interactions that add requirements.
+  ops.subcircuitChannelsWithRequirements ⊆ channelsWithRequirements ∧
+  -- Guarantee and requirement channel lists cover all shallow interactions.
+  (∀ channel ∈ ops.shallowChannels,
+    channel ∈ channelsWithGuarantees ∨ channel ∈ channelsWithRequirements) ∧
+  -- The `channelsWithRequirements` cover all shallow interactions that add requirements, under
+  -- the local constraints that may decide whether a conditional interaction is active.
+  ∀ env, ConstraintsHold.Shallow env ops →
+    ops.InChannelsOrRequirements channelsWithRequirements env
 
 /-- Exposed channel interactions agree with the actual interactions in the circuit. -/
 @[circuit_norm]
@@ -1120,53 +1170,31 @@ def ExposedChannelsLawful (ops : Operations F) (exposedChannels : List (ExposedC
   (∀ exposed ∈ exposedChannels,
     ops.interactionsWith exposed.channel = exposed.interactions)
 
-theorem channelsLawful_nil : ChannelsLawful ([] : Operations F) [] [] := by
-  simp [ChannelsLawful, InChannelsOrGuarantees, InChannelsOrRequirements, SubcircuitChannelsLawful,
-    subcircuitChannelsWithGuarantees, subcircuitChannelsWithRequirements, shallowChannels, subcircuits,
-    forAllNoOffset]
+theorem channelsLawful_nil : ChannelsLawful ([] : Operations F) [] := by
+  simp [ChannelsLawful, InChannelsOrGuarantees, SubcircuitChannelsLawful,
+    subcircuitChannelsWithGuarantees, subcircuits, forAllNoOffset]
 
 theorem channelsLawful_append_of_channelsLawful {ops ops' : Operations F}
-    {channelsWithGuarantees channelsWithGuarantees' channelsWithRequirements channelsWithRequirements' :
-      List (RawChannel F)} :
-    ops.ChannelsLawful channelsWithGuarantees channelsWithRequirements →
-    ops'.ChannelsLawful channelsWithGuarantees' channelsWithRequirements' →
+    {channelsWithGuarantees channelsWithGuarantees' : List (RawChannel F)} :
+    ops.ChannelsLawful channelsWithGuarantees →
+    ops'.ChannelsLawful channelsWithGuarantees' →
     (ops ++ ops').ChannelsLawful
-      (channelsWithGuarantees ++ channelsWithGuarantees')
-      (channelsWithRequirements ++ channelsWithRequirements') := by
+      (channelsWithGuarantees ++ channelsWithGuarantees') := by
   intro h h'
   dsimp only [ChannelsLawful] at h h' ⊢
-  obtain ⟨h_g_subset, h_g, h_r_subset, h_r, h_shallow, h_sub⟩ := h
-  obtain ⟨h_g_subset', h_g', h_r_subset', h_r', h_shallow', h_sub'⟩ := h'
-  have append_subset_append {as bs cs ds : List (RawChannel F)}
-      (h_as : as ⊆ cs) (h_bs : bs ⊆ ds) : as ++ bs ⊆ cs ++ ds := by
+  obtain ⟨h_g_subset, h_g, h_sub⟩ := h
+  obtain ⟨h_g_subset', h_g', h_sub'⟩ := h'
+  and_intros
+  · rw [subcircuitChannelsWithGuarantees_append]
     intro channel h_channel
     rw [List.mem_append] at h_channel ⊢
     rcases h_channel with h_channel | h_channel
-    · exact Or.inl (h_as h_channel)
-    · exact Or.inr (h_bs h_channel)
-  and_intros
-  · rw [subcircuitChannelsWithGuarantees_append]
-    exact append_subset_append h_g_subset h_g_subset'
+    · exact Or.inl (h_g_subset h_channel)
+    · exact Or.inr (h_g_subset' h_channel)
   · intro env
     rw [InChannelsOrGuarantees, forAllNoOffset_append]
     exact ⟨h_g env |>.mono (List.subset_append_left _ _),
       h_g' env |>.mono (List.subset_append_right _ _)⟩
-  · rw [subcircuitChannelsWithRequirements_append]
-    exact append_subset_append h_r_subset h_r_subset'
-  · intro env
-    rw [InChannelsOrRequirements, forAllNoOffset_append]
-    exact ⟨h_r env |>.mono (List.subset_append_left _ _),
-      h_r' env |>.mono (List.subset_append_right _ _)⟩
-  · rw [shallowChannels_append]
-    intro channel h_channel
-    rw [List.mem_append] at h_channel
-    rcases h_channel with h_channel | h_channel
-    · rcases h_shallow channel h_channel with h_channel | h_channel
-      · exact Or.inl (List.mem_append_left _ h_channel)
-      · exact Or.inr (List.mem_append_left _ h_channel)
-    · rcases h_shallow' channel h_channel with h_channel | h_channel
-      · exact Or.inl (List.mem_append_right _ h_channel)
-      · exact Or.inr (List.mem_append_right _ h_channel)
   · rw [subcircuitChannelsLawful_append]
     exact ⟨h_sub, h_sub'⟩
 

--- a/Clean/Circuit/Operations.lean
+++ b/Clean/Circuit/Operations.lean
@@ -803,27 +803,16 @@ def FullGuarantees (env : Environment F) (ops : Operations F) : Prop :=
 
 lemma mem_interactions_of_mem_shallowInteractions {i : AbstractInteraction F} {ops : Operations F} :
     i ∈ ops.shallowInteractions → i ∈ ops.interactions := by
-  induction ops using induct with
-  | empty => simp [shallowInteractions]
-  | witness m c ops ih => simpa [shallowInteractions, interactions] using ih
-  | assert e ops ih => simpa [shallowInteractions, interactions] using ih
-  | lookup l ops ih => simpa [shallowInteractions, interactions] using ih
-  | interact i' ops ih =>
-      simp only [shallowInteractions, interactions, List.mem_cons]
-      intro h
-      rcases h with rfl | h
-      · exact Or.inl rfl
-      · exact Or.inr (ih h)
-  | subcircuit s ops ih =>
-      simp only [shallowInteractions, interactions, List.mem_append]
-      intro h
-      exact Or.inr (ih h)
+  induction ops using induct <;> (
+    simp_all [shallowInteractions, interactions]
+    try tauto)
 
 lemma guarantees_of_fullGuarantees {env : Environment F} {ops : Operations F} :
     ops.FullGuarantees env → ops.Guarantees env := by
-  rw [guarantees_iff_forall_mem]
-  intro h i hi
-  exact h i (mem_interactions_of_mem_shallowInteractions hi)
+  rw [guarantees_iff_forall_mem, FullGuarantees]
+  intro grts i hi
+  apply grts
+  exact mem_interactions_of_mem_shallowInteractions hi
 
 -- TODO rename to ShallowRequirements
 @[circuit_norm]
@@ -1156,9 +1145,17 @@ def RequirementsChannelsLawful (ops : Operations F)
     (channelsWithGuarantees channelsWithRequirements : List (RawChannel F)) : Prop :=
   -- The `channelsWithRequirements` cover all subcircuit interactions that add requirements.
   ops.subcircuitChannelsWithRequirements ⊆ channelsWithRequirements ∧
-  -- Guarantee and requirement channel lists cover all shallow interactions.
+
+  -- Together, the two channel lists cover all interactions.
+  -- Even if the conditions so far theoretically allow it, we must not leave out any channels
+  -- we interacted with from the combination of both lists. This is because "did not interact
+  -- with a given channel" is important knowledge during end-to-end proofs, when we need to prove
+  -- that _all_ interactions with a given channel have some property.
+  -- (If this ever becomes too restrictive for real circuits, we can relax by introducing a third
+  -- list of "other channels".)
   (∀ channel ∈ ops.shallowChannels,
     channel ∈ channelsWithGuarantees ∨ channel ∈ channelsWithRequirements) ∧
+
   -- The `channelsWithRequirements` cover all shallow interactions that add requirements, under
   -- the local constraints that may decide whether a conditional interaction is active.
   ∀ env, ConstraintsHold.Shallow env ops →

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -32,9 +32,6 @@ def concat
     · intro a n m
       apply h_localLength_stable
   channelsWithRequirements := circuit1.channelsWithRequirements ++ circuit2.channelsWithRequirements
-  requirementsChannelsLawful := by
-    intro input offset
-    simp only [circuit_norm]
   Assumptions := circuit1.Assumptions
   Spec input output := ∃ mid, circuit1.Spec input mid ∧ circuit2.Spec mid output
   soundness := by
@@ -102,7 +99,7 @@ lemma weakenSpec_assumptions
 lemma weakenSpec_channelsWithRequirements
     (c : FormalCircuit F Input Output) (WeakerSpec : Input F → Output F → Prop) h_spec_implication :
     (c.weakenSpec WeakerSpec h_spec_implication).channelsWithRequirements = c.channelsWithRequirements := by
-  rfl
+  simp only [weakenSpec]
 end FormalCircuit
 
 namespace GeneralFormalCircuit

--- a/Clean/Circuit/StructuralLemmas.lean
+++ b/Clean/Circuit/StructuralLemmas.lean
@@ -31,6 +31,10 @@ def concat
     constructor <;> simp [explicit_circuit_norm]
     · intro a n m
       apply h_localLength_stable
+  channelsWithRequirements := circuit1.channelsWithRequirements ++ circuit2.channelsWithRequirements
+  requirementsChannelsLawful := by
+    intro input offset
+    simp only [circuit_norm]
   Assumptions := circuit1.Assumptions
   Spec input output := ∃ mid, circuit1.Spec input mid ∧ circuit2.Spec mid output
   soundness := by
@@ -73,6 +77,8 @@ def weakenSpec (circuit : FormalCircuit F Input Output)
     FormalCircuit F Input Output where
   main := circuit.main
   elaborated := circuit.elaborated
+  channelsWithRequirements := circuit.channelsWithRequirements
+  requirementsChannelsLawful := circuit.requirementsChannelsLawful
   Assumptions := circuit.Assumptions
   Spec := WeakerSpec
   soundness := by
@@ -96,7 +102,7 @@ lemma weakenSpec_assumptions
 lemma weakenSpec_channelsWithRequirements
     (c : FormalCircuit F Input Output) (WeakerSpec : Input F → Output F → Prop) h_spec_implication :
     (c.weakenSpec WeakerSpec h_spec_implication).channelsWithRequirements = c.channelsWithRequirements := by
-  simp only [FormalCircuitBase.channelsWithRequirements, weakenSpec]
+  rfl
 end FormalCircuit
 
 namespace GeneralFormalCircuit
@@ -110,6 +116,8 @@ def weakenSpec (circuit : GeneralFormalCircuit F Input Output)
     GeneralFormalCircuit F Input Output where
   main := circuit.main
   elaborated := circuit.elaborated
+  channelsWithRequirements := circuit.channelsWithRequirements
+  requirementsChannelsLawful := circuit.requirementsChannelsLawful
   Assumptions := circuit.Assumptions
   Spec := WeakerSpec
   ProverAssumptions := circuit.ProverAssumptions

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -63,6 +63,19 @@ lemma inChannelsOrRequirements_toFlat {env : Environment F} {ops : Operations F}
     ops.InChannelsOrRequirementsFull channels env := by
   simp_all [inChannelsOrRequirements_iff_forall_mem, Operations.InChannelsOrRequirementsFull,
     circuit_norm]
+
+lemma shallowConstraints_of_constraintsHoldFlat {env : Environment F} {ops : Operations F} :
+    ConstraintsHoldFlat env ops.toFlat → ConstraintsHold.Shallow env ops := by
+  intro h_constraints
+  rw [FlatOperation.constraintsHoldFlat_iff_forall_mem] at h_constraints
+  rw [constraintsHold_shallow_iff_forall_mem]
+  rw [Operations.constraints_toFlat, Operations.lookups_toFlat] at h_constraints
+  rw [Operations.forall_constraints_iff] at h_constraints
+  rw [Operations.forall_lookups_iff] at h_constraints
+  constructor
+  · exact h_constraints.1.1
+  · intro l h_mem
+    exact l.table.imply_soundness _ _ (h_constraints.2.1 l h_mem)
 end FlatOperation
 
 @[circuit_norm]
@@ -108,7 +121,7 @@ def FormalCircuit.toSubcircuit (circuit : FormalCircuit F β α)
     rw [ops.toNested_toFlat, FlatOperation.guarantees_toFlat] at h_guarantees
     refine ⟨ ?_, ?_ ⟩
     · have h := can_replace_soundness (constraintsHold_toFlat_iff.mp h_holds) h_guarantees
-      exact (circuit.soundness n env input_var input rfl as h).1
+      exact circuit.soundness n env input_var input rfl as h |>.1
     · have h_nested : nestedOps.toFlat = ops.toFlat := by
         dsimp only [nestedOps]
         exact ops.toNested_toFlat
@@ -270,8 +283,8 @@ def GeneralFormalCircuit.WithHint.toSubcircuit [CircuitType α] [CircuitType β]
     rw [ops.toNested_toFlat] at *
     refine ⟨ ?_, ?_ ⟩
     · rw [FlatOperation.guarantees_toFlat] at guarantees
-      exact (circuit.soundness n env input_var input rfl assumptions
-        (can_replace_soundness (constraintsHold_toFlat_iff.mp constraints) guarantees)).1
+      have h := can_replace_soundness (constraintsHold_toFlat_iff.mp constraints) guarantees
+      exact circuit.soundness n env input_var input rfl assumptions h |>.1
     · rw [FlatOperation.requirements_toFlat]
       rw [FlatOperation.guarantees_toFlat] at guarantees
       have h_soundness_input : ConstraintsHold.Soundness env ops :=
@@ -681,10 +694,12 @@ theorem FormalCircuit.toSubcircuit_channelsLawful
     rw [Operations.toNested_toFlat, FlatOperation.inChannelsOrGuarantees_toFlat]
     exact circuit.in_channels_or_guarantees_full input_var n env
   constructor
-  · intro env
-    simp only [FormalCircuit.toSubcircuit]
+  · intro env h_constraints
+    simp only [FormalCircuit.toSubcircuit] at h_constraints ⊢
+    rw [Operations.toNested_toFlat] at h_constraints
     rw [Operations.toNested_toFlat, FlatOperation.inChannelsOrRequirements_toFlat]
     exact circuit.in_channels_or_requirements_full input_var n env
+      (Circuit.constraintsHold_toFlat_iff.mp h_constraints)
   · simp only [FormalCircuit.toSubcircuit]
     rw [Operations.toNested_toFlat, Operations.channels_toFlat]
     exact circuit.channels_subset input_var n
@@ -699,10 +714,12 @@ theorem FormalAssertion.toSubcircuit_channelsLawful
     rw [Operations.toNested_toFlat, FlatOperation.inChannelsOrGuarantees_toFlat]
     exact circuit.in_channels_or_guarantees_full input_var n env
   constructor
-  · intro env
-    simp only [FormalAssertion.toSubcircuit]
+  · intro env h_constraints
+    simp only [FormalAssertion.toSubcircuit] at h_constraints ⊢
+    rw [Operations.toNested_toFlat] at h_constraints
     rw [Operations.toNested_toFlat, FlatOperation.inChannelsOrRequirements_toFlat]
     exact circuit.in_channels_or_requirements_full input_var n env
+      (Circuit.constraintsHold_toFlat_iff.mp h_constraints)
   · simp only [FormalAssertion.toSubcircuit]
     rw [Operations.toNested_toFlat, Operations.channels_toFlat]
     exact circuit.channels_subset input_var n
@@ -718,24 +735,15 @@ theorem GeneralFormalCircuit.WithHint.toSubcircuit_channelsLawful
     rw [Operations.toNested_toFlat, FlatOperation.inChannelsOrGuarantees_toFlat]
     exact circuit.in_channels_or_guarantees_full input_var n env
   constructor
-  · intro env
-    simp only [GeneralFormalCircuit.WithHint.toSubcircuit]
+  · intro env h_constraints
+    simp only [GeneralFormalCircuit.WithHint.toSubcircuit] at h_constraints ⊢
+    rw [Operations.toNested_toFlat] at h_constraints
     rw [Operations.toNested_toFlat, FlatOperation.inChannelsOrRequirements_toFlat]
     exact circuit.in_channels_or_requirements_full input_var n env
+      (Circuit.constraintsHold_toFlat_iff.mp h_constraints)
   · simp only [GeneralFormalCircuit.WithHint.toSubcircuit]
     rw [Operations.toNested_toFlat, Operations.channels_toFlat]
-    have shallowChannels_subset := circuit.mem_channelsWithGuarantees_or_mem_channelsWithRequirements_of_mem_shallowChannels input_var n
-    have channelsWithGuarantees_subset := circuit.subcircuitChannelsWithGuarantees_subset_channelsWithGuarantees input_var n
-    have channelsWithRequirements_subset := circuit.subcircuitChannelsWithRequirements_subset_channelsWithRequirements input_var n
-    simp only at *
-    set ops := (circuit.main input_var).operations n
-    trans ops.shallowChannels ++ ops.subcircuitChannelsWithGuarantees ++ ops.subcircuitChannelsWithRequirements
-    · apply Operations.channels_subset
-      exact circuit.subcircuitChannelsLawful input_var n
-    · simp_all only [List.append_assoc, List.append_subset, List.subset_append_of_subset_left,
-        List.subset_append_of_subset_right, and_self, and_true]
-      simp only [List.subset_def, List.mem_append]
-      tauto
+    exact circuit.channels_subset input_var n
 
 @[circuit_norm]
 theorem GeneralFormalCircuit.toSubcircuit_channelsLawful
@@ -753,7 +761,6 @@ instance fromSubcircuit (circuit : FormalCircuit F Input Output) (input : Var In
   localLength _ := circuit.localLength input
   operations n := [.subcircuit (circuit.toSubcircuit n input)]
   channelsWithGuarantees _ := circuit.channelsWithGuarantees
-  channelsWithRequirements _ := circuit.channelsWithRequirements
   subcircuitsConsistent n := by
     change Operations.SubcircuitsConsistent n [.subcircuit (_)]
     simp only [Operations.SubcircuitsConsistent, Operations.forAll]
@@ -776,10 +783,6 @@ theorem fromSubcircuit_operations {circuit : FormalCircuit F Input Output} {inpu
 theorem fromSubcircuit_channelsWithGuarantees {circuit : FormalCircuit F Input Output} {input} {n : ℕ} :
     (fromSubcircuit circuit input).channelsWithGuarantees n = circuit.channelsWithGuarantees := rfl
 
-@[circuit_norm, explicit_circuit_norm]
-theorem fromSubcircuit_channelsWithRequirements {circuit : FormalCircuit F Input Output} {input} {n : ℕ} :
-    (fromSubcircuit circuit input).channelsWithRequirements n = circuit.channelsWithRequirements := rfl
-
 @[explicit_circuit_constructor]
 instance fromAssertion (circuit : FormalAssertion F Input) (input : Var Input F) :
     ExplicitCircuit (assertion circuit input) where
@@ -787,7 +790,6 @@ instance fromAssertion (circuit : FormalAssertion F Input) (input : Var Input F)
   localLength _ := circuit.localLength input
   operations n := [.subcircuit (circuit.toSubcircuit n input)]
   channelsWithGuarantees _ := circuit.channelsWithGuarantees
-  channelsWithRequirements _ := circuit.channelsWithRequirements
   subcircuitsConsistent n := by
     change Operations.SubcircuitsConsistent n [.subcircuit (_)]
     simp only [Operations.SubcircuitsConsistent, Operations.forAll]
@@ -810,10 +812,6 @@ theorem fromAssertion_operations {circuit : FormalAssertion F Input} {input} {n 
 theorem fromAssertion_channelsWithGuarantees {circuit : FormalAssertion F Input} {input} {n : ℕ} :
     (fromAssertion circuit input).channelsWithGuarantees n = circuit.channelsWithGuarantees := rfl
 
-@[circuit_norm, explicit_circuit_norm]
-theorem fromAssertion_channelsWithRequirements {circuit : FormalAssertion F Input} {input} {n : ℕ} :
-    (fromAssertion circuit input).channelsWithRequirements n = circuit.channelsWithRequirements := rfl
-
 @[explicit_circuit_constructor]
 instance fromSubcircuitWithAssertion (circuit : GeneralFormalCircuit F Input Output) (input : Var Input F) :
     ExplicitCircuit (subcircuitWithAssertion circuit input) where
@@ -821,7 +819,6 @@ instance fromSubcircuitWithAssertion (circuit : GeneralFormalCircuit F Input Out
   localLength _ := circuit.localLength input
   operations n := [.subcircuit (circuit.toSubcircuit n input)]
   channelsWithGuarantees _ := circuit.channelsWithGuarantees
-  channelsWithRequirements _ := circuit.channelsWithRequirements
   subcircuitsConsistent n := by
     change Operations.SubcircuitsConsistent n [.subcircuit (_)]
     simp only [Operations.SubcircuitsConsistent, Operations.forAll]
@@ -844,10 +841,6 @@ theorem fromSubcircuitWithAssertion_operations {circuit : GeneralFormalCircuit F
 theorem fromSubcircuitWithAssertion_channelsWithGuarantees {circuit : GeneralFormalCircuit F Input Output} {input} {n : ℕ} :
     (fromSubcircuitWithAssertion circuit input).channelsWithGuarantees n = circuit.channelsWithGuarantees := rfl
 
-@[circuit_norm, explicit_circuit_norm]
-theorem fromSubcircuitWithAssertion_channelsWithRequirements {circuit : GeneralFormalCircuit F Input Output} {input} {n : ℕ} :
-    (fromSubcircuitWithAssertion circuit input).channelsWithRequirements n = circuit.channelsWithRequirements := rfl
-
 @[explicit_circuit_constructor]
 instance fromSubcircuitWithHintAssertion {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
     (circuit : GeneralFormalCircuit.WithHint F Input Output) (input : Var Input F) :
@@ -856,7 +849,6 @@ instance fromSubcircuitWithHintAssertion {Input Output : TypeMap} [CircuitType I
   localLength _ := circuit.localLength input
   operations n := [.subcircuit (circuit.toSubcircuit n input)]
   channelsWithGuarantees _ := circuit.channelsWithGuarantees
-  channelsWithRequirements _ := circuit.channelsWithRequirements
   subcircuitsConsistent n := by
     change Operations.SubcircuitsConsistent n [.subcircuit (_)]
     simp only [Operations.SubcircuitsConsistent, Operations.forAll]
@@ -882,11 +874,6 @@ theorem fromSubcircuitWithHintAssertion_operations {Input Output : TypeMap} [Cir
 theorem fromSubcircuitWithHintAssertion_channelsWithGuarantees {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
     {circuit : GeneralFormalCircuit.WithHint F Input Output} {input} {n : ℕ} :
     (fromSubcircuitWithHintAssertion circuit input).channelsWithGuarantees n = circuit.channelsWithGuarantees := rfl
-
-@[circuit_norm, explicit_circuit_norm]
-theorem fromSubcircuitWithHintAssertion_channelsWithRequirements {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
-    {circuit : GeneralFormalCircuit.WithHint F Input Output} {input} {n : ℕ} :
-    (fromSubcircuitWithHintAssertion circuit input).channelsWithRequirements n = circuit.channelsWithRequirements := rfl
 end ExplicitCircuit
 
 -- simplification lemmas for FlatOperations.interactions (toSubcircuit ..).ops.toFlat

--- a/Clean/Circuit/Subcircuit.lean
+++ b/Clean/Circuit/Subcircuit.lean
@@ -67,11 +67,10 @@ lemma inChannelsOrRequirements_toFlat {env : Environment F} {ops : Operations F}
 lemma shallowConstraints_of_constraintsHoldFlat {env : Environment F} {ops : Operations F} :
     ConstraintsHoldFlat env ops.toFlat → ConstraintsHold.Shallow env ops := by
   intro h_constraints
-  rw [FlatOperation.constraintsHoldFlat_iff_forall_mem] at h_constraints
+  rw [FlatOperation.constraintsHoldFlat_iff_forall_mem,
+    Operations.constraints_toFlat, Operations.lookups_toFlat,
+    Operations.forall_constraints_iff, Operations.forall_lookups_iff] at h_constraints
   rw [constraintsHold_shallow_iff_forall_mem]
-  rw [Operations.constraints_toFlat, Operations.lookups_toFlat] at h_constraints
-  rw [Operations.forall_constraints_iff] at h_constraints
-  rw [Operations.forall_lookups_iff] at h_constraints
   constructor
   · exact h_constraints.1.1
   · intro l h_mem
@@ -688,40 +687,34 @@ theorem GeneralFormalCircuit.WithHint.toSubcircuit_channelsWithRequirements
 theorem FormalCircuit.toSubcircuit_channelsLawful
     (circuit : FormalCircuit F Input Output) :
     (circuit.toSubcircuit n input_var).ChannelsLawful := by
+  simp only [Subcircuit.ChannelsLawful, FormalCircuit.toSubcircuit, Operations.toNested_toFlat]
   constructor
   · intro env
-    simp only [FormalCircuit.toSubcircuit]
-    rw [Operations.toNested_toFlat, FlatOperation.inChannelsOrGuarantees_toFlat]
+    rw [FlatOperation.inChannelsOrGuarantees_toFlat]
     exact circuit.in_channels_or_guarantees_full input_var n env
   constructor
   · intro env h_constraints
-    simp only [FormalCircuit.toSubcircuit] at h_constraints ⊢
-    rw [Operations.toNested_toFlat] at h_constraints
-    rw [Operations.toNested_toFlat, FlatOperation.inChannelsOrRequirements_toFlat]
-    exact circuit.in_channels_or_requirements_full input_var n env
-      (Circuit.constraintsHold_toFlat_iff.mp h_constraints)
-  · simp only [FormalCircuit.toSubcircuit]
-    rw [Operations.toNested_toFlat, Operations.channels_toFlat]
+    rw [Circuit.constraintsHold_toFlat_iff] at h_constraints
+    rw [FlatOperation.inChannelsOrRequirements_toFlat]
+    exact circuit.in_channels_or_requirements_full_of_constraints h_constraints
+  · rw [Operations.channels_toFlat]
     exact circuit.channels_subset input_var n
 
 @[circuit_norm]
 theorem FormalAssertion.toSubcircuit_channelsLawful
     (circuit : FormalAssertion F Input) :
     (circuit.toSubcircuit n input_var).ChannelsLawful := by
+  simp only [Subcircuit.ChannelsLawful, FormalAssertion.toSubcircuit, Operations.toNested_toFlat]
   constructor
   · intro env
-    simp only [FormalAssertion.toSubcircuit]
-    rw [Operations.toNested_toFlat, FlatOperation.inChannelsOrGuarantees_toFlat]
+    rw [FlatOperation.inChannelsOrGuarantees_toFlat]
     exact circuit.in_channels_or_guarantees_full input_var n env
   constructor
   · intro env h_constraints
-    simp only [FormalAssertion.toSubcircuit] at h_constraints ⊢
-    rw [Operations.toNested_toFlat] at h_constraints
-    rw [Operations.toNested_toFlat, FlatOperation.inChannelsOrRequirements_toFlat]
-    exact circuit.in_channels_or_requirements_full input_var n env
+    rw [FlatOperation.inChannelsOrRequirements_toFlat]
+    exact circuit.in_channels_or_requirements_full_of_constraints
       (Circuit.constraintsHold_toFlat_iff.mp h_constraints)
-  · simp only [FormalAssertion.toSubcircuit]
-    rw [Operations.toNested_toFlat, Operations.channels_toFlat]
+  · rw [Operations.channels_toFlat]
     exact circuit.channels_subset input_var n
 
 @[circuit_norm]
@@ -729,20 +722,18 @@ theorem GeneralFormalCircuit.WithHint.toSubcircuit_channelsLawful
     {Input Output : TypeMap} [CircuitType Input] [CircuitType Output]
     (circuit : GeneralFormalCircuit.WithHint F Input Output) (input_var : Var Input F) :
     (circuit.toSubcircuit n input_var).ChannelsLawful := by
+  simp only [Subcircuit.ChannelsLawful, GeneralFormalCircuit.WithHint.toSubcircuit,
+    Operations.toNested_toFlat]
   constructor
   · intro env
-    simp only [GeneralFormalCircuit.WithHint.toSubcircuit]
-    rw [Operations.toNested_toFlat, FlatOperation.inChannelsOrGuarantees_toFlat]
+    rw [FlatOperation.inChannelsOrGuarantees_toFlat]
     exact circuit.in_channels_or_guarantees_full input_var n env
   constructor
   · intro env h_constraints
-    simp only [GeneralFormalCircuit.WithHint.toSubcircuit] at h_constraints ⊢
-    rw [Operations.toNested_toFlat] at h_constraints
-    rw [Operations.toNested_toFlat, FlatOperation.inChannelsOrRequirements_toFlat]
-    exact circuit.in_channels_or_requirements_full input_var n env
+    rw [FlatOperation.inChannelsOrRequirements_toFlat]
+    exact circuit.in_channels_or_requirements_full_of_constraints
       (Circuit.constraintsHold_toFlat_iff.mp h_constraints)
-  · simp only [GeneralFormalCircuit.WithHint.toSubcircuit]
-    rw [Operations.toNested_toFlat, Operations.channels_toFlat]
+  · rw [Operations.channels_toFlat]
     exact circuit.channels_subset input_var n
 
 @[circuit_norm]

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -103,8 +103,7 @@ theorem requirements_toFlat_of_soundness {ops : Operations F} {env} :
   rcases h_requirements.2 s h_mem with h_empty | h_assumptions
   · have h_sub_constraints : ConstraintsHoldFlat env s.2.ops.toFlat := by
       rw [FlatOperation.constraintsHoldFlat_iff_forall_mem]
-      rw [Operations.forall_constraints_iff] at h_constraints
-      rw [Operations.forall_lookups_iff] at h_constraints
+      rw [Operations.forall_constraints_iff, Operations.forall_lookups_iff] at h_constraints
       exact ⟨h_constraints.1.2 s h_mem, h_constraints.2.2 s h_mem⟩
     have h_requirements_iff := (h_lawful s h_mem).2.1 env h_sub_constraints
     rw [FlatOperation.inChannelsOrRequirements_iff_forall_mem] at h_requirements_iff
@@ -621,13 +620,14 @@ theorem in_channels_or_guarantees_full
   tauto
 
 omit [ProvableType Output] [ProvableType Input] in
-theorem in_channels_or_requirements_full
+theorem in_channels_or_requirements_full_of_constraints
   [CircuitType Input] [CircuitType Output]
   (circuit : FormalCircuitBase F Input Output)
-  (input_var : Var Input F) (n : ℕ) (env : Environment F)
-  (h_constraints : ((circuit.main input_var).operations n).ConstraintsHold env) :
-    circuit.main input_var |>.operations n
-    |>.InChannelsOrRequirementsFull circuit.channelsWithRequirements env := by
+  {input_var : Var Input F} {n : ℕ} {env : Environment F} :
+    (circuit.main input_var |>.operations n).ConstraintsHold env →
+    (circuit.main input_var |>.operations n
+    |>.InChannelsOrRequirementsFull circuit.channelsWithRequirements env) := by
+  intro h_constraints
   rw [Operations.ConstraintsHold, Operations.forall_constraints_iff, Operations.forall_lookups_iff]
     at h_constraints
   have h_shallow_constraints : ConstraintsHold.Shallow env ((circuit.main input_var).operations n) := by
@@ -676,15 +676,15 @@ theorem Operations.requirements_of_not_mem (ops : Operations F)
   rw [h_eq] at h_in_or_reqs
   tauto
 
-theorem GeneralFormalCircuit.requirements_of_not_mem
+theorem GeneralFormalCircuit.requirements_of_not_mem_of_constraints
   (circuit : GeneralFormalCircuit F Input Output) (channel : RawChannel F)
-  (input_var : Var Input F) (n : ℕ) (env : Environment F)
-  (h_constraints : ((circuit.main input_var).operations n).ConstraintsHold env)
+  {input_var : Var Input F} {n : ℕ} {env : Environment F}
   (h_not_mem : channel ∉ circuit.channelsWithRequirements) :
-    circuit.main input_var |>.operations n
-    |>.ChannelRequirements channel env := by
+    ((circuit.main input_var).operations n).ConstraintsHold env →
+    (circuit.main input_var |>.operations n |>.ChannelRequirements channel env) := by
+  intro h_constraints
   apply Operations.requirements_of_not_mem
-  exact circuit.in_channels_or_requirements_full _ _ _ h_constraints
+  exact circuit.in_channels_or_requirements_full_of_constraints h_constraints
   assumption
 
 theorem Operations.guarantees_iff (ops : Operations F)
@@ -700,8 +700,8 @@ theorem Operations.guarantees_iff (ops : Operations F)
   specialize h_in_or_guars i hi
   tauto
 
-theorem GeneralFormalCircuit.guarantees_iff'
-  (circuit : GeneralFormalCircuit F Input Output) (input_var : Var Input F) (n : ℕ) (env : Environment F) :
+theorem GeneralFormalCircuit.guarantees_iff
+  (circuit : GeneralFormalCircuit F Input Output) {input_var : Var Input F} {n : ℕ} {env : Environment F} :
     (circuit.main input_var |>.operations n).FullGuarantees env ↔
       ∀ channel ∈ circuit.channelsWithGuarantees, (circuit.main input_var |>.operations n).ChannelGuarantees channel env := by
   apply Operations.guarantees_iff
@@ -720,13 +720,14 @@ theorem Operations.requirements_iff (ops : Operations F)
   specialize h_in_or_reqs i hi
   tauto
 
-theorem GeneralFormalCircuit.requirements_iff'
-  (circuit : GeneralFormalCircuit F Input Output) (input_var : Var Input F) (n : ℕ) (env : Environment F)
-  (h_constraints : ((circuit.main input_var).operations n).ConstraintsHold env) :
-  (circuit.main input_var |>.operations n).FullRequirements env ↔
-      ∀ channel ∈ circuit.channelsWithRequirements, (circuit.main input_var |>.operations n).ChannelRequirements channel env := by
+theorem GeneralFormalCircuit.requirements_iff_of_constraints
+  (circuit : GeneralFormalCircuit F Input Output) {input_var : Var Input F} {n : ℕ} {env : Environment F} :
+  (circuit.main input_var |>.operations n).ConstraintsHold env →
+  ((circuit.main input_var |>.operations n).FullRequirements env ↔
+      ∀ channel ∈ circuit.channelsWithRequirements, (circuit.main input_var |>.operations n).ChannelRequirements channel env) := by
+  intro h_constraints
   apply Operations.requirements_iff
-  exact circuit.in_channels_or_requirements_full input_var n env h_constraints
+  exact circuit.in_channels_or_requirements_full_of_constraints h_constraints
 
 theorem Operations.channels_subset {ops : Operations F} :
     ops.SubcircuitChannelsLawful →

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -101,7 +101,12 @@ theorem requirements_toFlat_of_soundness {ops : Operations F} {env} :
   use h_requirements.1
   intro s h_mem
   rcases h_requirements.2 s h_mem with h_empty | h_assumptions
-  · have h_requirements_iff := (h_lawful s h_mem).2.1 env
+  · have h_sub_constraints : ConstraintsHoldFlat env s.2.ops.toFlat := by
+      rw [FlatOperation.constraintsHoldFlat_iff_forall_mem]
+      rw [Operations.forall_constraints_iff] at h_constraints
+      rw [Operations.forall_lookups_iff] at h_constraints
+      exact ⟨h_constraints.1.2 s h_mem, h_constraints.2.2 s h_mem⟩
+    have h_requirements_iff := (h_lawful s h_mem).2.1 env h_sub_constraints
     rw [FlatOperation.inChannelsOrRequirements_iff_forall_mem] at h_requirements_iff
     intro i i_mem
     specialize h_requirements_iff i i_mem
@@ -563,8 +568,10 @@ def FormalCircuit.isGeneralFormalCircuit
   Spec i o _ := orig.Spec i o
   ProverAssumptions i _ _ := orig.Assumptions i
   soundness := by
-    intro offset env input_var input h_input h_assumptions h_holds
-    exact orig.soundness offset env input_var input h_input h_assumptions h_holds
+    intro offset env input_var input h_input
+    have h := orig.soundness offset env input_var input h_input
+    intro h_assumptions h_holds
+    exact h h_assumptions h_holds
   completeness := by
     intro offset env input_var h_env input h_input h_assumptions
     exact ⟨orig.completeness offset env input_var h_env input h_input h_assumptions, trivial⟩
@@ -582,8 +589,10 @@ def FormalAssertion.isGeneralFormalCircuit
   Spec i _ _ := orig.Spec i
   ProverAssumptions i _ _ := orig.Assumptions i ∧ orig.Spec i
   soundness := by
-    intro offset env input_var input h_input h_assumptions h_holds
-    exact orig.soundness offset env input_var input h_input h_assumptions h_holds
+    intro offset env input_var input h_input
+    have h := orig.soundness offset env input_var input h_input
+    intro h_assumptions h_holds
+    exact h h_assumptions h_holds
   completeness := by
     intro offset env input_var h_env input h_input h_assumptions
     exact ⟨orig.completeness offset env input_var h_env input h_input h_assumptions.1 h_assumptions.2, trivial⟩
@@ -615,11 +624,19 @@ omit [ProvableType Output] [ProvableType Input] in
 theorem in_channels_or_requirements_full
   [CircuitType Input] [CircuitType Output]
   (circuit : FormalCircuitBase F Input Output)
-  (input_var : Var Input F) (n : ℕ) (env : Environment F) :
+  (input_var : Var Input F) (n : ℕ) (env : Environment F)
+  (h_constraints : ((circuit.main input_var).operations n).ConstraintsHold env) :
     circuit.main input_var |>.operations n
     |>.InChannelsOrRequirementsFull circuit.channelsWithRequirements env := by
+  rw [Operations.ConstraintsHold, Operations.forall_constraints_iff, Operations.forall_lookups_iff]
+    at h_constraints
+  have h_shallow_constraints : ConstraintsHold.Shallow env ((circuit.main input_var).operations n) := by
+    rw [constraintsHold_shallow_iff_forall_mem]
+    exact ⟨h_constraints.1.1, fun l h_mem =>
+      l.table.imply_soundness _ _ (h_constraints.2.1 l h_mem)⟩
   have h_sublist := circuit.subcircuitChannelsWithRequirements_subset_channelsWithRequirements input_var n
-  have h_requirements_iff := circuit.inChannelsOrRequirements_channelsWithRequirements input_var n
+  have h_requirements_iff := circuit.inChannelsOrRequirements_channelsWithRequirements input_var n env
+    h_shallow_constraints
   have h_lawful := circuit.subcircuitChannelsLawful input_var n
   generalize h_channels : circuit.channelsWithRequirements = channels at *
   generalize h_ops : (circuit.main input_var).operations n = ops at *
@@ -628,7 +645,12 @@ theorem in_channels_or_requirements_full
     Operations.subcircuitChannelsLawful_iff_forall] at *
   simp_all only [implies_true, true_and]
   intro ⟨n, s⟩ s_mem i i_mem
-  have h_requirements_iff := (h_lawful ⟨n, s⟩ s_mem).2.1 env
+  have h_sub_constraints : ConstraintsHoldFlat env s.ops.toFlat := by
+    rw [FlatOperation.constraintsHoldFlat_iff_forall_mem]
+    constructor
+    · exact h_constraints.1.2 ⟨n, s⟩ s_mem
+    · exact h_constraints.2.2 ⟨n, s⟩ s_mem
+  have h_requirements_iff := (h_lawful ⟨n, s⟩ s_mem).2.1 env h_sub_constraints
   rw [FlatOperation.inChannelsOrRequirements_iff_forall_mem] at h_requirements_iff
   specialize h_requirements_iff i i_mem
   tauto
@@ -657,11 +679,12 @@ theorem Operations.requirements_of_not_mem (ops : Operations F)
 theorem GeneralFormalCircuit.requirements_of_not_mem
   (circuit : GeneralFormalCircuit F Input Output) (channel : RawChannel F)
   (input_var : Var Input F) (n : ℕ) (env : Environment F)
+  (h_constraints : ((circuit.main input_var).operations n).ConstraintsHold env)
   (h_not_mem : channel ∉ circuit.channelsWithRequirements) :
     circuit.main input_var |>.operations n
     |>.ChannelRequirements channel env := by
   apply Operations.requirements_of_not_mem
-  apply circuit.in_channels_or_requirements_full
+  exact circuit.in_channels_or_requirements_full _ _ _ h_constraints
   assumption
 
 theorem Operations.guarantees_iff (ops : Operations F)
@@ -698,11 +721,12 @@ theorem Operations.requirements_iff (ops : Operations F)
   tauto
 
 theorem GeneralFormalCircuit.requirements_iff'
-  (circuit : GeneralFormalCircuit F Input Output) (input_var : Var Input F) (n : ℕ) (env : Environment F) :
-    (circuit.main input_var |>.operations n).FullRequirements env ↔
+  (circuit : GeneralFormalCircuit F Input Output) (input_var : Var Input F) (n : ℕ) (env : Environment F)
+  (h_constraints : ((circuit.main input_var).operations n).ConstraintsHold env) :
+  (circuit.main input_var |>.operations n).FullRequirements env ↔
       ∀ channel ∈ circuit.channelsWithRequirements, (circuit.main input_var |>.operations n).ChannelRequirements channel env := by
   apply Operations.requirements_iff
-  apply circuit.in_channels_or_requirements_full
+  exact circuit.in_channels_or_requirements_full input_var n env h_constraints
 
 theorem Operations.channels_subset {ops : Operations F} :
     ops.SubcircuitChannelsLawful →
@@ -733,7 +757,8 @@ omit [ProvableType Output] [ProvableType Input] in
 theorem FormalCircuitBase.channels_subset
   [CircuitType Input] [CircuitType Output]
   (circuit : FormalCircuitBase F Input Output) (input_var : Var Input F) (n : ℕ) :
-    ((circuit.main input_var).operations n).channels ⊆ circuit.channels := by
+    ((circuit.main input_var).operations n).channels ⊆
+      circuit.channelsWithGuarantees ++ circuit.channelsWithRequirements := by
   have shallowChannels_subset := circuit.mem_channelsWithGuarantees_or_mem_channelsWithRequirements_of_mem_shallowChannels input_var n
   have channelsWithGuarantees_subset := circuit.subcircuitChannelsWithGuarantees_subset_channelsWithGuarantees input_var n
   have channelsWithRequirements_subset := circuit.subcircuitChannelsWithRequirements_subset_channelsWithRequirements input_var n
@@ -742,7 +767,7 @@ theorem FormalCircuitBase.channels_subset
   trans ops.shallowChannels ++ ops.subcircuitChannelsWithGuarantees ++ ops.subcircuitChannelsWithRequirements
   apply Operations.channels_subset
   exact circuit.subcircuitChannelsLawful input_var n
-  simp_all only [channels, List.append_assoc, List.append_subset, List.subset_append_of_subset_left,
+  simp_all only [List.append_assoc, List.append_subset, List.subset_append_of_subset_left,
     List.subset_append_of_subset_right, and_self, and_true]
   simp only [List.subset_def, List.mem_append]
   tauto

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -235,44 +235,28 @@ def fibonacciVm : VmTables (F p) fieldTriple where
   tables := [⟨ fib8 ⟩]
   verifier := fibonacciVerifier
   verifier_length_zero := by simp [circuit_norm, fibonacciVerifier]
-  step _ :=
-    let input := varFromOffset Fib8Input 0
-    let z := var ⟨ size Fib8Input ⟩
-    { enabled := input.enabled, pull := (input.n, input.x, input.y), push := (input.n + 1, input.y, z) }
-  verifierStep :=
-    let input := varFromOffset fieldTriple 0
-    { enabled := 1, pull := input, push := (0, 0, 1) }
   tables_channel := by
     intro table table_mem
     simp only [List.mem_singleton] at table_mem
     subst table
-    change
-      { channel := FibonacciChannel.toRaw,
-        interactions :=
-          [(pullIf (channel:=FibonacciChannel) (varFromOffset Fib8Input 0).enabled
-              ((varFromOffset Fib8Input 0).n, (varFromOffset Fib8Input 0).x,
-                (varFromOffset Fib8Input 0).y)).toRaw,
-            (pushIf (channel:=FibonacciChannel) (varFromOffset Fib8Input 0).enabled
-              ((varFromOffset Fib8Input 0).n + 1, (varFromOffset Fib8Input 0).y,
-                var ⟨ size Fib8Input ⟩)).toRaw] } ∈
-        fib8.exposedChannels (varFromOffset Fib8Input 0) (size Fib8Input)
-    simp [circuit_norm, fib8]
-  verifier_channel := by simp [circuit_norm, fibonacciVerifier]
-  tables_enabled_boolean := by
-    intro table table_mem env h_assumptions h_constraints
-    simp only [List.mem_singleton] at table_mem
-    subst table
-    rw [Component.constraintsHold_iff] at h_constraints
-    simp [Component.rowOperations, fib8, circuit_norm] at h_constraints
-    rcases h_constraints with h_zero | h_one
-    · left
-      exact h_zero
-    · right
-      rw [← sub_eq_add_neg] at h_one
-      exact sub_eq_zero.mp h_one
-  verifier_enabled_one := by
-    intro env h_constraints
-    simp [circuit_norm]
+    let input := varFromOffset (F:=F p) Fib8Input 0
+    let z : Expression (F p) := var ⟨ (⟨ fib8 ⟩ : Component (F p)).rowOffset ⟩
+    refine ⟨ { enabled := input.enabled, pull := (input.n, input.x, input.y), push := (input.n + 1, input.y, z) },
+      ?_, ?_ ⟩
+    · simp [circuit_norm, fib8, input, z, Component.exposedChannels, Component.rowOffset]
+    · intro env _h_assumptions h_constraints
+      rw [Component.constraintsHold_iff] at h_constraints
+      simp only [Operations.ConstraintsHold, Component.rowOperations, Circuit.operations, fib8] at h_constraints
+      have h_bool : env (input.enabled * (input.enabled - 1)) = 0 := h_constraints.1 _ (by
+        simp [circuit_norm, input])
+      simp [circuit_norm] at h_bool
+      rcases h_bool with h_zero | h_one
+      · exact Or.inl h_zero
+      · right
+        rw [← sub_eq_add_neg] at h_one
+        exact sub_eq_zero.mp h_one
+  verifier_channel := by
+    simp [circuit_norm, fibonacciVerifier]
   verifier_requirements env := by
     simp only [circuit_norm, fibonacciVerifier, FibonacciChannel, ZMod.val_zero, ZMod.val_one]
     exact ⟨ 0, rfl, rfl ⟩

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -86,7 +86,7 @@ def add8 : GeneralFormalCircuit (F p) Add8Inputs unit where
     circuit_proof_start [BytesTable, Add8Channel]
     set carry := env.get i₀
     obtain ⟨ hz, hcarry, heq ⟩ := h_holds
-    intro hm hx hy
+    intro hm hm0 hx hy
     have add_soundness := Theorems.soundness input_x input_y input_z 0 carry hx hy hz (by left; trivial) hcarry
     simp_all
   completeness := by
@@ -280,3 +280,24 @@ def falseEnsemble := SoundEnsemble.empty (F p) unit
   |>.addFinishedChannel FalseChannel.toRaw
   |>.addTable ⟨ falseCircuit ⟩
     (by simp [circuit_norm, falseCircuit]) (by simp [circuit_norm, falseCircuit])
+
+/--
+Zero multiplicity disables both sides of an interaction. This circuit uses a channel whose
+guarantee is `False`, so it would be impossible to prove if either disabled interaction still
+created an obligation or assumption.
+-/
+def disabledFalseCircuit : GeneralFormalCircuit (F p) unit unit where
+  main _ := do
+    FalseChannel.pullIf 0 ()
+    FalseChannel.pushIf 0 ()
+    return
+  elaborated := by elaborate_circuit_with {
+    channelsWithGuarantees := [FalseChannel.toRaw]
+    channelsWithRequirements := [FalseChannel.toRaw] }
+  Spec _ _ _ := True
+  ProverAssumptions _ _ _ := True
+  soundness := by circuit_proof_start [FalseChannel]
+  completeness := by circuit_proof_start [FalseChannel]
+
+example : ExplicitCircuit ((disabledFalseCircuit (p:=p)).main ()) := by
+  infer_explicit_circuit

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -233,7 +233,6 @@ def fibonacciVm : VmTables (F p) fieldTriple where
   verifier_length_zero := by simp [circuit_norm, fibonacciVerifier]
   tables_channel := by
     -- TODO investigate whnf from `simp`
-    -- plain ConstraintsHold is probably bad
     dsimp only [circuit_norm, fib8]
     set input := varFromOffset (F:=F p) Fib8Input 0
     use input.enabled

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -127,53 +127,75 @@ instance FibonacciChannel : Channel (F p) fieldTriple where
   | (n, x, y), _ =>
     ∃ k : ℕ, (x.val, y.val) = fibonacci k ∧ k % p = n.val
 
-def fib8 : GeneralFormalCircuit (F p) fieldTriple unit where
-  main | (n, x, y) => do
+structure Fib8Input F where
+  enabled : F
+  n : F
+  x : F
+  y : F
+deriving ProvableStruct
+
+def fib8 : GeneralFormalCircuit (F p) Fib8Input unit where
+  main | { enabled, n, x, y } => do
+    assertZero (enabled * (enabled - 1))
     -- pull the current Fibonacci state
-    FibonacciChannel.pull (n, x, y)
+    FibonacciChannel.pullIf enabled (n, x, y)
     -- witness the next Fibonacci value
     let z ← witness fun eval => mod256 (eval (x + y))
     -- pull from the Add8 channel to check addition
-    Add8Channel.pull (x, y, z)
+    Add8Channel.pullIf enabled (x, y, z)
     -- push the next Fibonacci state
-    FibonacciChannel.push (n + 1, y, z)
+    FibonacciChannel.pushIf enabled (n + 1, y, z)
 
   -- expose interactions
   exposedChannels
-  | (n, x, y), i₀ =>
+  | input, i₀ =>
     let z := var ⟨ i₀ ⟩
-    expose FibonacciChannel [ pulled (n, x, y), pushed (n + 1, y, z) ]
-  exposedChannels_eq := by simp only [circuit_norm, Add8Channel, FibonacciChannel]
+    expose FibonacciChannel [
+      pullIf input.enabled (input.n, input.x, input.y),
+      pushIf input.enabled (input.n + 1, input.y, z) ]
+  exposedChannels_eq := by simp [circuit_norm, Add8Channel, FibonacciChannel]
 
   ProverAssumptions
-  | (n, x, y), _, _ =>
-    ∃ k : ℕ, (x.val, y.val) = fibonacci k ∧ k % p = n.val
+  | { enabled, n, x, y }, _, _ =>
+    enabled = 0 ∨ (enabled = 1 ∧ ∃ k : ℕ, (x.val, y.val) = fibonacci k ∧ k % p = n.val)
   Spec _ _ _ := True
 
   soundness := by
     circuit_proof_start
-    rcases input with ⟨ n, x, y ⟩ -- TODO circuit_proof_start should have done this
-    simp only [Prod.mk.injEq] at h_input
-    simp_all only [circuit_norm]
-    set z := env.get i₀
-    simp only [circuit_norm, FibonacciChannel, Add8Channel] at h_holds ⊢
-    obtain ⟨ ⟨k, fiby, hk⟩, hadd ⟩ := h_holds
+    simp_all only [circuit_norm, FibonacciChannel, Add8Channel]
+    rcases h_holds with ⟨ h_bool, h_fib, h_add ⟩
+    have h_enabled_bool : input_enabled = 0 ∨ input_enabled = 1 := by
+      rcases mul_eq_zero.mp h_bool with h_zero | h_one
+      · exact .inl h_zero
+      · right
+        rw [← sub_eq_add_neg] at h_one
+        exact sub_eq_zero.mp h_one
+    intro h_not_neg h_nonzero
+    rcases h_enabled_bool with h_zero | h_one
+    · contradiction
+    have ⟨ k, fiby, hk ⟩ := h_fib (by simp [h_one])
     have ⟨ hx, hy ⟩ := fibonacci_bytes fiby
+    have hz := h_add (by simp [h_one]) hx hy
     use k + 1
     simp only [fibonacci, ← fiby]
-    rw [ZMod.val_add, ← hk, Nat.mod_add_mod, ZMod.val_one]
+    rw [hz, ZMod.val_add, ← hk, Nat.mod_add_mod, ZMod.val_one]
     simp_all
 
   completeness := by
     circuit_proof_start
-    rcases input with ⟨ n, x, y ⟩
-    simp only [Prod.mk.injEq] at h_input
     simp_all only [circuit_norm, FibonacciChannel, Add8Channel]
-    intro hx hy
-    rw [mod256, FieldUtils.mod, FieldUtils.natToField_val, ZMod.val_add_of_lt, PNat.val_ofNat]
-    linarith [hx, hy, ‹Fact (p > 512)›.elim]
+    rcases h_assumptions with h_disabled | ⟨ h_enabled, h_fib ⟩
+    · simp [h_disabled]
+    constructor
+    · simp [h_enabled]
+    constructor
+    · intro h_active
+      exact h_fib
+    · intro h_active hx hy
+      rw [mod256, FieldUtils.mod, FieldUtils.natToField_val, ZMod.val_add_of_lt, PNat.val_ofNat]
+      linarith [hx, hy, ‹Fact (p > 512)›.elim]
 
-example (input : Var fieldTriple (F p)) :
+example (input : Var Fib8Input (F p)) :
     ExplicitCircuit (fib8.main input) := by
   infer_explicit_circuit
 
@@ -213,8 +235,44 @@ def fibonacciVm : VmTables (F p) fieldTriple where
   tables := [⟨ fib8 ⟩]
   verifier := fibonacciVerifier
   verifier_length_zero := by simp [circuit_norm, fibonacciVerifier]
-  tables_channel := by simp [circuit_norm, fib8]
+  step _ :=
+    let input := varFromOffset Fib8Input 0
+    let z := var ⟨ size Fib8Input ⟩
+    { enabled := input.enabled, pull := (input.n, input.x, input.y), push := (input.n + 1, input.y, z) }
+  verifierStep :=
+    let input := varFromOffset fieldTriple 0
+    { enabled := 1, pull := input, push := (0, 0, 1) }
+  tables_channel := by
+    intro table table_mem
+    simp only [List.mem_singleton] at table_mem
+    subst table
+    change
+      { channel := FibonacciChannel.toRaw,
+        interactions :=
+          [(pullIf (channel:=FibonacciChannel) (varFromOffset Fib8Input 0).enabled
+              ((varFromOffset Fib8Input 0).n, (varFromOffset Fib8Input 0).x,
+                (varFromOffset Fib8Input 0).y)).toRaw,
+            (pushIf (channel:=FibonacciChannel) (varFromOffset Fib8Input 0).enabled
+              ((varFromOffset Fib8Input 0).n + 1, (varFromOffset Fib8Input 0).y,
+                var ⟨ size Fib8Input ⟩)).toRaw] } ∈
+        fib8.exposedChannels (varFromOffset Fib8Input 0) (size Fib8Input)
+    simp [circuit_norm, fib8]
   verifier_channel := by simp [circuit_norm, fibonacciVerifier]
+  tables_enabled_boolean := by
+    intro table table_mem env h_assumptions h_constraints
+    simp only [List.mem_singleton] at table_mem
+    subst table
+    rw [Component.constraintsHold_iff] at h_constraints
+    simp [Component.rowOperations, fib8, circuit_norm] at h_constraints
+    rcases h_constraints with h_zero | h_one
+    · left
+      exact h_zero
+    · right
+      rw [← sub_eq_add_neg] at h_one
+      exact sub_eq_zero.mp h_one
+  verifier_enabled_one := by
+    intro env h_constraints
+    simp [circuit_norm]
   verifier_requirements env := by
     simp only [circuit_norm, fibonacciVerifier, FibonacciChannel, ZMod.val_zero, ZMod.val_one]
     exact ⟨ 0, rfl, rfl ⟩

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -195,38 +195,6 @@ def fib8 : GeneralFormalCircuit (F p) Fib8Input unit where
       rw [mod256, FieldUtils.mod, FieldUtils.natToField_val, ZMod.val_add_of_lt, PNat.val_ofNat]
       linarith [hx, hy, ‹Fact (p > 512)›.elim]
 
-def fib8Step : VmStep fieldTriple (F p) :=
-  let input := varFromOffset (F:=F p) Fib8Input 0
-  { enabled := input.enabled
-    pull := (input.n, input.x, input.y)
-    push := (input.n + 1, input.y, var ⟨ size Fib8Input ⟩) }
-
-@[circuit_norm]
-lemma fib8Step_enabled_boolean (env : Environment (F p)) :
-    Operations.ConstraintsHold env (⟨ fib8 ⟩ : Component (F p)).operations →
-      env fib8Step.enabled = 0 ∨ env fib8Step.enabled = 1 := by
-  intro h_constraints
-  let input := varFromOffset (F:=F p) Fib8Input 0
-  rw [Component.constraintsHold_iff] at h_constraints
-  simp only [Operations.ConstraintsHold, Component.rowOperations, Circuit.operations, fib8] at h_constraints
-  have h_bool : env (input.enabled * (input.enabled - 1)) = 0 := h_constraints.1 _ (by
-    simp [circuit_norm, input])
-  simp [circuit_norm] at h_bool
-  rcases h_bool with h_zero | h_one
-  · exact Or.inl h_zero
-  · right
-    rw [← sub_eq_add_neg] at h_one
-    simpa [fib8Step, input] using sub_eq_zero.mp h_one
-
-@[circuit_norm]
-lemma fib8Step_table_enabled_boolean :
-    ∀ env,
-      (⟨ fib8 ⟩ : Component (F p)).Assumptions env →
-      Operations.ConstraintsHold env (⟨ fib8 ⟩ : Component (F p)).operations →
-        env fib8Step.enabled = 0 ∨ env fib8Step.enabled = 1 := by
-  intro env _ h_constraints
-  exact fib8Step_enabled_boolean env h_constraints
-
 example (input : Var Fib8Input (F p)) :
     ExplicitCircuit (fib8.main input) := by
   infer_explicit_circuit
@@ -271,8 +239,9 @@ def fibonacciVm : VmTables (F p) fieldTriple where
     intro table table_mem
     simp only [List.mem_singleton] at table_mem
     subst table
-    refine ⟨ fib8Step, ?_, fib8Step_table_enabled_boolean ⟩
-    simp [circuit_norm, fib8, fib8Step, Component.exposedChannels, Component.rowOffset]
+    let input := varFromOffset (F:=F p) Fib8Input 0
+    refine ⟨ input.enabled, (input.n, input.x, input.y), (input.n + 1, input.y, var ⟨ size Fib8Input ⟩), ?_ ⟩
+    simp [circuit_norm, fib8, input, Component.exposedChannels, Component.rowOffset]
   verifier_channel := by
     simp [circuit_norm, fibonacciVerifier]
   verifier_requirements env := by

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -86,7 +86,7 @@ def add8 : GeneralFormalCircuit (F p) Add8Inputs unit where
     circuit_proof_start [BytesTable, Add8Channel]
     set carry := env.get i₀
     obtain ⟨ hz, hcarry, heq ⟩ := h_holds
-    intro hm hm0 hx hy
+    intro hm h0 hx hy
     have add_soundness := Theorems.soundness input_x input_y input_z 0 carry hx hy hz (by left; trivial) hcarry
     simp_all
   completeness := by
@@ -136,8 +136,8 @@ deriving ProvableStruct
 
 def fib8 : GeneralFormalCircuit (F p) Fib8Input unit where
   main | { enabled, n, x, y } => do
-    -- TODO this doesn't work yet! subcircuit lemmas missing
-    -- assertBool enabled
+    -- boolean constraint for `enabled`
+    -- has to be inline, channels with requirements proof doesn't handle subcircuits
     assertZero (enabled * (enabled - 1))
     -- pull the current Fibonacci state
     FibonacciChannel.pullIf enabled (n, x, y)
@@ -150,87 +150,45 @@ def fib8 : GeneralFormalCircuit (F p) Fib8Input unit where
 
   -- expose interactions
   exposedChannels
-  | input, i₀ =>
+  | { enabled, n, x, y }, i₀ =>
     let z := var ⟨ i₀ ⟩
-    expose FibonacciChannel [
-      pullIf input.enabled (input.n, input.x, input.y),
-      pushIf input.enabled (input.n + 1, input.y, z) ]
-  exposedChannels_eq := by
-    intro input offset
-    simp [circuit_norm, Add8Channel, FibonacciChannel]
-    -- TODO circuit_norm support for (toSubcircuit ..).interactions
-    -- intro a ha
-    -- simp only [FormalAssertion.toSubcircuit, Operations.toNested_toFlat] at ha
-    -- change a ∈ [] at ha
-    -- nomatch ha
+    expose FibonacciChannel [ pullIf enabled (n, x, y), pushIf enabled (n + 1, y, z) ]
+  exposedChannels_eq input i₀ := by
+    simp only [circuit_norm, FibonacciChannel, Add8Channel]
 
   ProverAssumptions
   | { enabled, n, x, y }, _, _ =>
     enabled = 0 ∨ (enabled = 1 ∧ ∃ k : ℕ, (x.val, y.val) = fibonacci k ∧ k % p = n.val)
   Spec _ _ _ := True
+
   channelsWithRequirements := [ FibonacciChannel.toRaw ]
-  requirementsChannelsLawful := by
-    intro input offset
-    -- simp only [circuit_norm, FibonacciChannel, Add8Channel]
-    -- intro env
-    constructor
-    · simp only [circuit_norm, FibonacciChannel, Add8Channel]
-    constructor
-    · simp only [circuit_norm, FibonacciChannel, Add8Channel]
-    · intro env h_bool
-      simp only [circuit_norm, FibonacciChannel, Add8Channel] at *
-      rcases mul_eq_zero.mp h_bool with h_zero | h_one
-      · intro _ h_nonzero
-        simp [h_zero] at h_nonzero
-      · rw [← sub_eq_add_neg] at h_one
-        have h_enabled := sub_eq_zero.mp h_one
-        intro h_not_neg _
-        simp [h_enabled] at h_not_neg
+  requirementsChannelsLawful input_var i₀ := by
+    simp only [circuit_norm, FibonacciChannel, Add8Channel]
+    grind
 
   soundness := by
-    circuit_proof_start
-    simp_all only [circuit_norm, FibonacciChannel, Add8Channel]
-    rcases h_holds with ⟨ h_bool, h_fib, h_add ⟩
-    have h_enabled_bool : input_enabled = 0 ∨ input_enabled = 1 := by
-      rcases mul_eq_zero.mp h_bool with h_zero | h_one
-      · exact .inl h_zero
-      · right
-        rw [← sub_eq_add_neg] at h_one
-        exact sub_eq_zero.mp h_one
-    constructor
-    · intro h_not_neg h_nonzero
-      rcases h_enabled_bool with h_zero | h_one
-      · simp [h_zero] at h_nonzero
-      · simp [h_one] at h_not_neg
-    constructor
-    · intro h_not_neg h_nonzero
-      rcases h_enabled_bool with h_zero | h_one
-      · simp [h_zero] at h_nonzero
-      · simp [h_one] at h_not_neg
-    · intro _ h_nonzero
-      rcases h_enabled_bool with h_zero | h_one
-      · contradiction
-      have ⟨ k, fiby, hk ⟩ := h_fib (by simp [h_one])
-      have ⟨ hx, hy ⟩ := fibonacci_bytes fiby
-      have hz := h_add (by simp [h_one]) hx hy
-      use k + 1
-      simp only [fibonacci, ← fiby]
-      rw [hz, ZMod.val_add, ← hk, Nat.mod_add_mod, ZMod.val_one]
-      simp_all
+    circuit_proof_start [FibonacciChannel, Add8Channel]
+    set z := env.get i₀
+    obtain ⟨ h_bool, h_fib, h_add ⟩ := h_holds
+    rw [mul_eq_zero, add_neg_eq_zero] at h_bool
+    rcases h_bool with rfl | rfl
+    · grind
+    simp_all only [circuit_norm]
+    obtain ⟨k, fiby, hk⟩ := h_fib
+    have ⟨ hx, hy ⟩ := fibonacci_bytes fiby
+    use k + 1
+    simp only [fibonacci, ← fiby]
+    rw [ZMod.val_add, ← hk, Nat.mod_add_mod, ZMod.val_one]
+    simp_all
 
   completeness := by
-    circuit_proof_start
-    simp_all only [circuit_norm, FibonacciChannel, Add8Channel]
-    rcases h_assumptions with h_disabled | ⟨ h_enabled, h_fib ⟩
-    · simp [h_disabled]
-    constructor
-    · simp [h_enabled]
-    constructor
-    · intro h_active
-      exact h_fib
-    · intro h_active hx hy
-      rw [mod256, FieldUtils.mod, FieldUtils.natToField_val, ZMod.val_add_of_lt, PNat.val_ofNat]
-      linarith [hx, hy, ‹Fact (p > 512)›.elim]
+    circuit_proof_start [FibonacciChannel, Add8Channel]
+    rcases h_assumptions with rfl | ⟨ rfl, h_fib ⟩
+    · simp
+    simp_all
+    intro hx hy
+    rw [mod256, FieldUtils.mod, FieldUtils.natToField_val, ZMod.val_add_of_lt, PNat.val_ofNat]
+    linarith [hx, hy, ‹Fact (p > 512)›.elim]
 
 example (input : Var Fib8Input (F p)) :
     ExplicitCircuit (fib8.main input) := by
@@ -274,15 +232,13 @@ def fibonacciVm : VmTables (F p) fieldTriple where
   verifier := fibonacciVerifier
   verifier_length_zero := by simp [circuit_norm, fibonacciVerifier]
   tables_channel := by
-    simp only [Component.constraintsHold_iff]
-    dsimp only [circuit_norm, fib8,
-      Component.exposedChannels, Component.rowOffset, Component.rowOperations]
-    let input := varFromOffset (F:=F p) Fib8Input 0
-    use input.enabled, (input.n, input.x, input.y), (input.n + 1, input.y, var ⟨ size Fib8Input ⟩)
-    simp only [circuit_norm, input]
-    grind
-  verifier_channel := by
-    simp [circuit_norm, fibonacciVerifier]
+    -- TODO investigate whnf from `simp`
+    -- plain ConstraintsHold is probably bad
+    dsimp only [circuit_norm, fib8]
+    set input := varFromOffset (F:=F p) Fib8Input 0
+    use input.enabled
+    simp_all [circuit_norm, mul_eq_zero, add_neg_eq_zero]
+  verifier_channel := by simp [circuit_norm, fibonacciVerifier]
   verifier_requirements env := by
     simp only [circuit_norm, fibonacciVerifier, FibonacciChannel, ZMod.val_zero, ZMod.val_one]
     exact ⟨ 0, rfl, rfl ⟩
@@ -348,24 +304,3 @@ def falseEnsemble := SoundEnsemble.empty (F p) unit
   |>.addFinishedChannel FalseChannel.toRaw
   |>.addTable ⟨ falseCircuit ⟩
     (by simp [circuit_norm, falseCircuit]) (by simp [circuit_norm, falseCircuit])
-
-/--
-Zero multiplicity disables both sides of an interaction. This circuit uses a channel whose
-guarantee is `False`, so it would be impossible to prove if either disabled interaction still
-created an obligation or assumption.
--/
-def disabledFalseCircuit : GeneralFormalCircuit (F p) unit unit where
-  main _ := do
-    FalseChannel.pullIf 0 ()
-    FalseChannel.pushIf 0 ()
-    return
-  elaborated := by elaborate_circuit_with {
-    channelsWithGuarantees := [FalseChannel.toRaw] }
-  channelsWithRequirements := [FalseChannel.toRaw]
-  Spec _ _ _ := True
-  ProverAssumptions _ _ _ := True
-  soundness := by circuit_proof_start [FalseChannel]
-  completeness := by circuit_proof_start [FalseChannel]
-
-example : ExplicitCircuit ((disabledFalseCircuit (p:=p)).main ()) := by
-  infer_explicit_circuit

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -236,9 +236,7 @@ def fibonacciVm : VmTables (F p) fieldTriple where
   verifier := fibonacciVerifier
   verifier_length_zero := by simp [circuit_norm, fibonacciVerifier]
   tables_channel := by
-    intro table table_mem
-    simp only [List.mem_singleton] at table_mem
-    subst table
+    simp only [List.Forall]
     let input := varFromOffset (F:=F p) Fib8Input 0
     refine ⟨ input.enabled, (input.n, input.x, input.y), (input.n + 1, input.y, var ⟨ size Fib8Input ⟩), ?_ ⟩
     simp [circuit_norm, fib8, input, Component.exposedChannels, Component.rowOffset]

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -136,6 +136,8 @@ deriving ProvableStruct
 
 def fib8 : GeneralFormalCircuit (F p) Fib8Input unit where
   main | { enabled, n, x, y } => do
+    -- TODO this doesn't work yet! subcircuit lemmas missing
+    -- assertBool enabled
     assertZero (enabled * (enabled - 1))
     -- pull the current Fibonacci state
     FibonacciChannel.pullIf enabled (n, x, y)
@@ -153,13 +155,37 @@ def fib8 : GeneralFormalCircuit (F p) Fib8Input unit where
     expose FibonacciChannel [
       pullIf input.enabled (input.n, input.x, input.y),
       pushIf input.enabled (input.n + 1, input.y, z) ]
-  exposedChannels_eq := by simp [circuit_norm, Add8Channel, FibonacciChannel]
+  exposedChannels_eq := by
+    intro input offset
+    simp [circuit_norm, Add8Channel, FibonacciChannel]
+    -- TODO circuit_norm support for (toSubcircuit ..).interactions
+    -- intro a ha
+    -- simp only [FormalAssertion.toSubcircuit, Operations.toNested_toFlat] at ha
+    -- change a ∈ [] at ha
+    -- nomatch ha
 
   ProverAssumptions
   | { enabled, n, x, y }, _, _ =>
     enabled = 0 ∨ (enabled = 1 ∧ ∃ k : ℕ, (x.val, y.val) = fibonacci k ∧ k % p = n.val)
   Spec _ _ _ := True
   channelsWithRequirements := [ FibonacciChannel.toRaw ]
+  requirementsChannelsLawful := by
+    intro input offset
+    -- simp only [circuit_norm, FibonacciChannel, Add8Channel]
+    -- intro env
+    constructor
+    · simp only [circuit_norm, FibonacciChannel, Add8Channel]
+    constructor
+    · simp only [circuit_norm, FibonacciChannel, Add8Channel]
+    · intro env h_bool
+      simp only [circuit_norm, FibonacciChannel, Add8Channel] at *
+      rcases mul_eq_zero.mp h_bool with h_zero | h_one
+      · intro _ h_nonzero
+        simp [h_zero] at h_nonzero
+      · rw [← sub_eq_add_neg] at h_one
+        have h_enabled := sub_eq_zero.mp h_one
+        intro h_not_neg _
+        simp [h_enabled] at h_not_neg
 
   soundness := by
     circuit_proof_start
@@ -171,16 +197,26 @@ def fib8 : GeneralFormalCircuit (F p) Fib8Input unit where
       · right
         rw [← sub_eq_add_neg] at h_one
         exact sub_eq_zero.mp h_one
-    intro h_not_neg h_nonzero
-    rcases h_enabled_bool with h_zero | h_one
-    · contradiction
-    have ⟨ k, fiby, hk ⟩ := h_fib (by simp [h_one])
-    have ⟨ hx, hy ⟩ := fibonacci_bytes fiby
-    have hz := h_add (by simp [h_one]) hx hy
-    use k + 1
-    simp only [fibonacci, ← fiby]
-    rw [hz, ZMod.val_add, ← hk, Nat.mod_add_mod, ZMod.val_one]
-    simp_all
+    constructor
+    · intro h_not_neg h_nonzero
+      rcases h_enabled_bool with h_zero | h_one
+      · simp [h_zero] at h_nonzero
+      · simp [h_one] at h_not_neg
+    constructor
+    · intro h_not_neg h_nonzero
+      rcases h_enabled_bool with h_zero | h_one
+      · simp [h_zero] at h_nonzero
+      · simp [h_one] at h_not_neg
+    · intro _ h_nonzero
+      rcases h_enabled_bool with h_zero | h_one
+      · contradiction
+      have ⟨ k, fiby, hk ⟩ := h_fib (by simp [h_one])
+      have ⟨ hx, hy ⟩ := fibonacci_bytes fiby
+      have hz := h_add (by simp [h_one]) hx hy
+      use k + 1
+      simp only [fibonacci, ← fiby]
+      rw [hz, ZMod.val_add, ← hk, Nat.mod_add_mod, ZMod.val_one]
+      simp_all
 
   completeness := by
     circuit_proof_start

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -195,6 +195,38 @@ def fib8 : GeneralFormalCircuit (F p) Fib8Input unit where
       rw [mod256, FieldUtils.mod, FieldUtils.natToField_val, ZMod.val_add_of_lt, PNat.val_ofNat]
       linarith [hx, hy, ‹Fact (p > 512)›.elim]
 
+def fib8Step : VmStep fieldTriple (F p) :=
+  let input := varFromOffset (F:=F p) Fib8Input 0
+  { enabled := input.enabled
+    pull := (input.n, input.x, input.y)
+    push := (input.n + 1, input.y, var ⟨ size Fib8Input ⟩) }
+
+@[circuit_norm]
+lemma fib8Step_enabled_boolean (env : Environment (F p)) :
+    Operations.ConstraintsHold env (⟨ fib8 ⟩ : Component (F p)).operations →
+      env fib8Step.enabled = 0 ∨ env fib8Step.enabled = 1 := by
+  intro h_constraints
+  let input := varFromOffset (F:=F p) Fib8Input 0
+  rw [Component.constraintsHold_iff] at h_constraints
+  simp only [Operations.ConstraintsHold, Component.rowOperations, Circuit.operations, fib8] at h_constraints
+  have h_bool : env (input.enabled * (input.enabled - 1)) = 0 := h_constraints.1 _ (by
+    simp [circuit_norm, input])
+  simp [circuit_norm] at h_bool
+  rcases h_bool with h_zero | h_one
+  · exact Or.inl h_zero
+  · right
+    rw [← sub_eq_add_neg] at h_one
+    simpa [fib8Step, input] using sub_eq_zero.mp h_one
+
+@[circuit_norm]
+lemma fib8Step_table_enabled_boolean :
+    ∀ env,
+      (⟨ fib8 ⟩ : Component (F p)).Assumptions env →
+      Operations.ConstraintsHold env (⟨ fib8 ⟩ : Component (F p)).operations →
+        env fib8Step.enabled = 0 ∨ env fib8Step.enabled = 1 := by
+  intro env _ h_constraints
+  exact fib8Step_enabled_boolean env h_constraints
+
 example (input : Var Fib8Input (F p)) :
     ExplicitCircuit (fib8.main input) := by
   infer_explicit_circuit
@@ -239,22 +271,8 @@ def fibonacciVm : VmTables (F p) fieldTriple where
     intro table table_mem
     simp only [List.mem_singleton] at table_mem
     subst table
-    let input := varFromOffset (F:=F p) Fib8Input 0
-    let z : Expression (F p) := var ⟨ (⟨ fib8 ⟩ : Component (F p)).rowOffset ⟩
-    refine ⟨ { enabled := input.enabled, pull := (input.n, input.x, input.y), push := (input.n + 1, input.y, z) },
-      ?_, ?_ ⟩
-    · simp [circuit_norm, fib8, input, z, Component.exposedChannels, Component.rowOffset]
-    · intro env _h_assumptions h_constraints
-      rw [Component.constraintsHold_iff] at h_constraints
-      simp only [Operations.ConstraintsHold, Component.rowOperations, Circuit.operations, fib8] at h_constraints
-      have h_bool : env (input.enabled * (input.enabled - 1)) = 0 := h_constraints.1 _ (by
-        simp [circuit_norm, input])
-      simp [circuit_norm] at h_bool
-      rcases h_bool with h_zero | h_one
-      · exact Or.inl h_zero
-      · right
-        rw [← sub_eq_add_neg] at h_one
-        exact sub_eq_zero.mp h_one
+    refine ⟨ fib8Step, ?_, fib8Step_table_enabled_boolean ⟩
+    simp [circuit_norm, fib8, fib8Step, Component.exposedChannels, Component.rowOffset]
   verifier_channel := by
     simp [circuit_norm, fibonacciVerifier]
   verifier_requirements env := by

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -152,7 +152,7 @@ def fib8 : GeneralFormalCircuit (F p) Fib8Input unit where
   exposedChannels
   | { enabled, n, x, y }, i₀ =>
     let z := var ⟨ i₀ ⟩
-    expose FibonacciChannel [ pullIf enabled (n, x, y), pushIf enabled (n + 1, y, z) ]
+    expose FibonacciChannel [ pulledIf enabled (n, x, y), pushedIf enabled (n + 1, y, z) ]
   exposedChannels_eq input i₀ := by
     simp only [circuit_norm, FibonacciChannel, Add8Channel]
 

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -45,8 +45,7 @@ def pushBytes : GeneralFormalCircuit (F p) (fields 256) unit where
     let _  ← .mapFinRange 256 fun ⟨ i, _ ⟩ =>
       BytesChannel.emit multiplicities[i] (const i)
 
-  elaborated := by elaborate_circuit_with {
-    channelsWithRequirements := [ BytesChannel.toRaw ] }
+  channelsWithRequirements := [ BytesChannel.toRaw ]
   Spec _ _ _ := True
   soundness := by circuit_proof_start [BytesTable]
   completeness := by circuit_proof_start
@@ -81,6 +80,7 @@ def add8 : GeneralFormalCircuit (F p) Add8Inputs unit where
   ProverAssumptions
   | { x, y, z, m }, _, _ => x.val < 256 ∧ y.val < 256 ∧ z.val < 256 ∧ z.val = (x.val + y.val) % 256
   Spec _ _ _ := True
+  channelsWithRequirements := [ Add8Channel.toRaw ]
 
   soundness := by
     circuit_proof_start [BytesTable, Add8Channel]
@@ -159,6 +159,7 @@ def fib8 : GeneralFormalCircuit (F p) Fib8Input unit where
   | { enabled, n, x, y }, _, _ =>
     enabled = 0 ∨ (enabled = 1 ∧ ∃ k : ℕ, (x.val, y.val) = fibonacci k ∧ k % p = n.val)
   Spec _ _ _ := True
+  channelsWithRequirements := [ FibonacciChannel.toRaw ]
 
   soundness := by
     circuit_proof_start
@@ -214,6 +215,7 @@ def fibonacciVerifier : GeneralFormalCircuit (F p) fieldTriple unit where
   | (n, x, y), _, _ => ∃ k : ℕ, (x.val, y.val) = fibonacci k ∧ k % p = n.val
   Spec
   | (n, x, y), _, _ => ∃ k : ℕ, (x.val, y.val) = fibonacci k ∧ k % p = n.val
+  channelsWithRequirements := [ FibonacciChannel.toRaw ]
   soundness := by
     circuit_proof_start [FibonacciChannel]
     rcases input with ⟨ n, x, y ⟩
@@ -322,8 +324,8 @@ def disabledFalseCircuit : GeneralFormalCircuit (F p) unit unit where
     FalseChannel.pushIf 0 ()
     return
   elaborated := by elaborate_circuit_with {
-    channelsWithGuarantees := [FalseChannel.toRaw]
-    channelsWithRequirements := [FalseChannel.toRaw] }
+    channelsWithGuarantees := [FalseChannel.toRaw] }
+  channelsWithRequirements := [FalseChannel.toRaw]
   Spec _ _ _ := True
   ProverAssumptions _ _ _ := True
   soundness := by circuit_proof_start [FalseChannel]

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -236,10 +236,13 @@ def fibonacciVm : VmTables (F p) fieldTriple where
   verifier := fibonacciVerifier
   verifier_length_zero := by simp [circuit_norm, fibonacciVerifier]
   tables_channel := by
-    simp only [List.Forall]
+    simp only [Component.constraintsHold_iff]
+    dsimp only [circuit_norm, fib8,
+      Component.exposedChannels, Component.rowOffset, Component.rowOperations]
     let input := varFromOffset (F:=F p) Fib8Input 0
-    refine ⟨ input.enabled, (input.n, input.x, input.y), (input.n + 1, input.y, var ⟨ size Fib8Input ⟩), ?_ ⟩
-    simp [circuit_norm, fib8, input, Component.exposedChannels, Component.rowOffset]
+    use input.enabled, (input.n, input.x, input.y), (input.n + 1, input.y, var ⟨ size Fib8Input ⟩)
+    simp only [circuit_norm, input]
+    grind
   verifier_channel := by
     simp [circuit_norm, fibonacciVerifier]
   verifier_requirements env := by

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -231,12 +231,7 @@ def fibonacciVm : VmTables (F p) fieldTriple where
   tables := [⟨ fib8 ⟩]
   verifier := fibonacciVerifier
   verifier_length_zero := by simp [circuit_norm, fibonacciVerifier]
-  tables_channel := by
-    -- TODO investigate whnf from `simp`
-    dsimp only [circuit_norm, fib8]
-    set input := varFromOffset (F:=F p) Fib8Input 0
-    use input.enabled
-    simp_all [circuit_norm, mul_eq_zero, add_neg_eq_zero]
+  tables_channel := by simp [circuit_norm, fib8, add_neg_eq_zero]
   verifier_channel := by simp [circuit_norm, fibonacciVerifier]
   verifier_requirements env := by
     simp only [circuit_norm, fibonacciVerifier, FibonacciChannel, ZMod.val_zero, ZMod.val_one]

--- a/Clean/Gadgets/BLAKE3/ApplyRounds.lean
+++ b/Clean/Gadgets/BLAKE3/ApplyRounds.lean
@@ -398,7 +398,6 @@ instance elaborated : ElaboratedCircuit (F p) Inputs BLAKE3State main := by
   elaborate_circuit_with {
     localLength _ := 5376
     output input i₀ := main input |>.output i₀
-    channelsWithRequirements := []
     channelsWithGuarantees := []
   } using by
     simp only [circuit_norm, main, sevenRoundsApplyStyle, FormalCircuitBase.output]

--- a/Clean/Gadgets/Rotation32/Rotation32Bytes.lean
+++ b/Clean/Gadgets/Rotation32/Rotation32Bytes.lean
@@ -76,6 +76,8 @@ theorem completeness (off : Fin 4) : Completeness (F p) (main off) Assumptions :
 def circuit (off : Fin 4) : FormalCircuit (F p) U32 U32 where
   main := main off
   elaborated := elaborated off
+  requirementsChannelsLawful := by
+    fin_cases off <;> simp only [circuit_norm, main, reduceIte, Fin.reduceFinMk, Fin.reduceEq]
   Assumptions
   Spec := Spec off
   soundness := soundness off

--- a/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
+++ b/Clean/Gadgets/Rotation64/Rotation64Bytes.lean
@@ -85,6 +85,8 @@ theorem completeness (off : Fin 8) : Completeness (F p) (main off) Assumptions :
 def circuit (off : Fin 8) : FormalCircuit (F p) U64 U64 := {
   main := main off
   elaborated := elaborated off
+  requirementsChannelsLawful := by
+    fin_cases off <;> simp only [circuit_norm, main, reduceIte, Fin.reduceFinMk, Fin.reduceEq]
   Assumptions
   Spec := Spec off
   soundness := soundness off

--- a/Clean/Gadgets/SHA256/LowerSigma0.lean
+++ b/Clean/Gadgets/SHA256/LowerSigma0.lean
@@ -24,6 +24,8 @@ def lowerSigma0 (x : Var (fields 32) (F p)) : Circuit (F p) (Var (fields 32) (F 
 
 namespace LowerSigma0
 
+-- TODO: This circuit is written BADLY: it hides `main` behind `lowerSigma0`
+-- and inlines `xor32` instead of calling `Xor32.circuit` as a subcircuit.
 def main (x : Var (fields 32) (F p)) : Circuit (F p) (Var (fields 32) (F p)) :=
   lowerSigma0 x
 

--- a/Clean/Utils/Field.lean
+++ b/Clean/Utils/Field.lean
@@ -12,6 +12,12 @@ instance (p : ℕ) : CommRing (F p) := ZMod.commRing p
 
 instance {p : ℕ} : DecidableEq (F p) := ZMod.decidableEq p
 
+@[circuit_norm]
+lemma zero_ne_neg_one {F : Type} [Field F] : (0 : F) ≠ -1 := by
+  intro h
+  apply zero_ne_one (α:=F)
+  rw [← neg_zero, h, neg_neg]
+
 namespace FieldUtils
 variable {p : ℕ} [p_prime: Fact p.Prime]
 


### PR DESCRIPTION
> this PR description is **fully human-written**

The goal of this PR was to support doing conditional pulls and pushes, as is typical in VMs for padding.

The refactor ends up being a surprisingly large change to the library core.
Source of complexity is that, when the multiplicity is an arbitrary `enabled` or `-enabled` element, we no longer know statically that it is 0, -1 or 1. It is the _constraints of the circuit_ that force it to one of those values.

## Motivating background

Previously we could assume that `channelsWithGuarantees` and `channelsWithRequirements` can be derived statically from the circuit operations:
* guarantees are gated behind the opt-in `assumeGuarantees` flag plus $-1$ multiplicity
* requirements are gated behind multiplicity $\notin 0, -1$ (0 was added in this PR)

With `enabled` flags, multiplicities are no longer statically known! The problem with that is that we would need to conservatively include channels in `channelsWithRequirements` that we conditionally _pulled from_, like Add8 in the FibonacciCircuit. That, in turn, would break the "ordered channels" soundness argument.

For guarantees it's still fine because we have the static `assumeGuarantees` flag: circuits already opt into using guarantees explicitly and statically, and if they don't, then the channel won't be in `channelsWithGuarantees`. Opting out statically here is possible because guarantees are a _premise_, and it's fine to not use a premise without affecting validity of your statement. This is different for requirements which are a conclusion.

The most natural way to solve this was to take into account the actual constraints in proving `channelsWithRequirements` correct, so that we can use the boolean constraint for `enabled`. E.g., now we know that the Add8 interaction is always a pull, and so we retain `OrderedChannel` for the Add8 channel.

## What changed

* Ripped out `channelsWithRequirements` from the entire auto-elaboration machinery (`Explicit.lean`, `ElaboratedCircuit`). Instead it lives as a normal, explicit field on `FormalCircuitBase`. This seems fine because channel pushes are usually done very rarely, at the highest circuit layer (they act as "top level circuit output"); so writing them out won't create noise.
* Added a tactic that manages to automatically prove the default `channelsWithRequirements := []` correct on all of our gadgets except 3. I.e., no disruption to existing gadgets
* On the AIR layer, changed many statements that need to reason about channel requirements to have an additional `Constraints` hypothesis. Luckily the overall AIR ensemble arguments still go through, with almost no user interface changes (they ultimately already had constraints as one of their assumptions that could be threaded through).
* Ported the VM soundness argument from assuming -1/1 multiplicities to support the padded version. This is the biggest change in terms of code size since several long theorems had to be adapted.
* Moved Fibonacci to use an `enabled` flag for padding interactions to demonstrate the new layer is functional