### PR TITLE
BabyJubJub spec and point addition circuit

### DIFF
--- a/Clean.lean
+++ b/Clean.lean
@@ -1,4 +1,6 @@
 import Clean.Circuit
+import Clean.Specs.BabyJubJub
+import Clean.Circomlib.BabyJubJub.PointAdd
 import Clean.Examples.WitnessExport
 import Clean.Utils.FiniteField
 import Clean.Utils.SourceSinkPath

--- a/Clean/Circomlib/BabyJubJub/PointAdd.lean
+++ b/Clean/Circomlib/BabyJubJub/PointAdd.lean
@@ -1,0 +1,96 @@
+/-
+BabyJubJub Point Addition Circuit
+
+Implements the unified Edwards point addition formula from circomlib's BabyAdd.
+Original source: https://github.com/iden3/circomlib/blob/master/circuits/babyjub.circom
+
+Formula:
+  x₃ = (x₁·y₂ + y₁·x₂) / (1 + d·x₁·x₂·y₁·y₂)
+  y₃ = (y₁·y₂ - a·x₁·x₂) / (1 - d·x₁·x₂·y₁·y₂)
+
+Division is handled via witness + multiplication check (same pattern as Comparators.IsZero).
+-/
+import Clean.Circuit
+import Clean.Specs.BabyJubJub
+import Clean.Utils.Tactics.CircuitProofStart
+
+namespace Circomlib.BabyJubJub
+
+open Specs.BabyJubJub (Point a_nat d_nat)
+
+variable {p : ℕ} [Fact p.Prime]
+
+instance : ProvableType Point where
+  size := 2
+  toElements pt := #v[pt.x, pt.y]
+  fromElements v :=
+    let ⟨.mk [x, y], _⟩ := v
+    ⟨x, y⟩
+  fromElements_toElements x := by
+    cases x; rfl
+
+-- TODO: add proper eval lemmas for custom ProvableType Point.
+-- `ProvableType.eval` needs a circuit_norm lemma that reduces `eval env p` to
+-- `Point.mk (Expression.eval env p.x) (Expression.eval env p.y)` so that
+-- `circuit_proof_start` can decompose struct inputs in soundness/completeness proofs.
+@[circuit_norm]
+theorem eval_point {F : Type} [FiniteField F] (env : Environment F) (p : Point (Expression F)) :
+    eval env p = Point.mk (Expression.eval env p.x) (Expression.eval env p.y) := by
+  sorry
+
+structure Inputs (F : Type) where
+  p1 : Point F
+  p2 : Point F
+deriving ProvableStruct
+
+namespace PointAdd
+
+def main (input : Inputs (Expression (F p))) : Circuit (F p) (Point (Expression (F p))) := do
+  let { p1, p2 } := input
+  let a : Expression (F p) := (a_nat : F p)
+  let d : Expression (F p) := (d_nat : F p)
+  let x1x2 <== p1.x * p2.x
+  let y1y2 <== p1.y * p2.y
+  let x1y2 <== p1.x * p2.y
+  let y1x2 <== p1.y * p2.x
+  let tau <== d * x1x2 * y1y2
+  let denom1 <== 1 + tau
+  let denom2 <== 1 - tau
+  let num1 <== x1y2 + y1x2
+  let num2 <== y1y2 - a * x1x2
+  let inv1 ← witness (.ite (denom1 =? 0) 0 denom1⁻¹)
+  let inv2 ← witness (.ite (denom2 =? 0) 0 denom2⁻¹)
+  let x3 <== inv1 * num1
+  let y3 <== inv2 * num2
+  x3 * denom1 === num1
+  y3 * denom2 === num2
+  return { x := x3, y := y3 }
+
+def Assumptions (input : Inputs (F p)) : Prop :=
+  let a := (a_nat : F p); let d := (d_nat : F p)
+  Point.onCurve a d input.p1 ∧ Point.onCurve a d input.p2
+
+def Spec (input : Inputs (F p)) (output : Point (F p)) : Prop :=
+  let a := (a_nat : F p); let d := (d_nat : F p)
+  output = Point.add a d input.p1 input.p2
+
+instance elaborated : ElaboratedCircuit (F p) Inputs Point main := by
+  elaborate_circuit
+
+theorem soundness : Soundness (F p) main Assumptions Spec := by
+  circuit_proof_start
+  sorry
+
+theorem completeness : Completeness (F p) main Assumptions := by
+  circuit_proof_start
+  sorry
+
+def circuit : FormalCircuit (F p) Inputs Point where
+  main
+  Assumptions
+  Spec
+  soundness
+  completeness
+
+end PointAdd
+end Circomlib.BabyJubJub

--- a/Clean/Specs/BabyJubJub.lean
+++ b/Clean/Specs/BabyJubJub.lean
@@ -1,0 +1,94 @@
+/-
+BabyJubJub Elliptic Curve Specification
+
+This file defines the BabyJubJub twisted Edwards curve mathematically, matching
+the circomlib implementation in circuits/babyjub.circom and the iden3 specification.
+
+Curve equation: a*x^2 + y^2 = 1 + d*x^2*y^2
+-/
+import Clean.Specs.Poseidon
+
+namespace Specs.BabyJubJub
+
+open Specs.Poseidon (BN254_PRIME)
+
+/-! Curve parameters (from circomlib babyjub.circom, as Nat constants) -/
+
+def a_nat : ℕ := 168700
+def d_nat : ℕ := 168696
+
+def subgroupOrder : ℕ :=
+  2736030358979909402780800718157159386076813972158567259200215660948447373041
+
+def cofactor : ℕ := 8
+
+/-! Point type -/
+
+@[ext]
+structure Point (F : Type) where
+  x : F
+  y : F
+deriving Repr, DecidableEq, Inhabited
+
+namespace Point
+
+variable {F : Type} [Field F]
+
+instance : Zero (Point F) where
+  zero := { x := 0, y := 1 }
+
+instance : Neg (Point F) where
+  neg p := { x := -p.x, y := p.y }
+
+/-! Curve equation: onCurve a d p := a*p.x^2 + p.y^2 = 1 + d*p.x^2*p.y^2 -/
+
+def onCurve (a d : F) (p : Point F) : Prop :=
+  a * p.x^2 + p.y^2 = 1 + d * p.x^2 * p.y^2
+
+/-!
+Point arithmetic using the unified Edwards addition formula.
+These are complete on BabyJubJub because d is a non-square,
+so the denominators never vanish for any valid curve points.
+
+  x₃ = (x₁·y₂ + y₁·x₂) / (1 + d·x₁·x₂·y₁·y₂)
+  y₃ = (y₁·y₂ - a·x₁·x₂) / (1 - d·x₁·x₂·y₁·y₂)
+-/
+
+def add (a d : F) (p q : Point F) : Point F :=
+  let x1x2 := p.x * q.x
+  let y1y2 := p.y * q.y
+  let tau := d * x1x2 * y1y2
+  { x := (p.x * q.y + p.y * q.x) / (1 + tau)
+    y := (y1y2 - a * x1x2) / (1 - tau)
+  }
+
+def double (a d : F) (p : Point F) : Point F := add a d p p
+
+/-- Scalar multiplication: double-and-add (simple, not constant-time). -/
+def scalarMul (a d : F) (k : ℕ) (p : Point F) : Point F :=
+  match k with
+  | 0 => 0
+  | 1 => p
+  | k' + 2 =>
+    let half := scalarMul a d (k' / 2 + 1) p
+    let doubled := double a d half
+    if k' % 2 = 0 then doubled else add a d doubled p
+
+end Point
+
+/-! Generator points (over BN254 scalar field) -/
+
+-- Full curve generator G (order 8*l)
+def G : Point (ZMod BN254_PRIME) :=
+  { x := 995203441582195749578291179787384436505546430278305826713579947235728471134
+    y := 5472060717959818805561601436314318772137091100104008585924551046643952123905
+  }
+
+-- Base point B = 8*G, generator of the prime-order subgroup (order l).
+-- This is Base8 in circomlib's EdDSA.
+def Base8 : Point (ZMod BN254_PRIME) :=
+  { x := 5299619240641551281634865583518297030282874472190772894086521144482721001553
+    y := 16950150798460657717958625567821834550301663161624707787222815936182638968203
+  }
+
+end Specs.BabyJubJub


### PR DESCRIPTION
## Summary

Adds the BabyJubJub elliptic curve specification and a point addition circuit, following circomlib's BabyAdd template. Part of the circomlib formalization effort ([issue #155](https://github.com/Verified-zkEVM/clean/issues/155)).

## What this PR implements

### Spec file (`Clean/Specs/BabyJubJub.lean`)

- [x] **Point type** — `Point F` with `x : F`, `y : F`, and `Zero`/`Neg` instances (identity = `(0, 1)`, negation = `(-x, y)`)
- [x] **Curve constants** — `a_nat = 168700`, `d_nat = 168696` (matching circomlib's `babyjub.circom`), subgroup order `l`, cofactor 8
- [x] **Curve equation** — `onCurve a d p` defined as `a * p.x^2 + p.y^2 = 1 + d * p.x^2 * p.y^2`
- [x] **Point arithmetic** — `add` (unified Edwards formula), `double`, `scalarMul` (double-and-add). The unified formula is complete on BabyJubJub since `d` is a non-square, so denominators never vanish for valid curve points.
- [x] **Generator points** — `G` (full curve generator, order `8*l`) and `Base8` (`8*G`, prime-order subgroup generator). Both defined over the BN254 scalar field (`ZMod BN254_PRIME`).

### Circuit file (`Clean/Circomlib/BabyJubJub/PointAdd.lean`)

- [x] **ProvableType Point** — manual instance (`size := 2`, `toElements`/`fromElements`) so `Point` can be used as circuit input/output
- [x] **Inputs struct** — `Inputs F` with `p1 p2 : Point F`, deriving `ProvableStruct` (following the `Mux1.lean` pattern)
- [x] **Circuit implementation** — `main` implements the unified Edwards addition formula:
  - 4 intermediate products (`x1x2`, `y1y2`, `x1y2`, `y1x2`)
  - `tau = d * x1x2 * y1y2`, denominators `denom1 = 1 + tau`, `denom2 = 1 - tau`
  - numerators `num1 = x1y2 + y1x2`, `num2 = y1y2 - a * x1x2`
  - Division via the standard zk circuit pattern: witness the inverse with `.ite (denom =? 0) 0 denom⁻¹`, then constrain `x3 * denom1 = num1` (same pattern as `Comparators.IsZero`)
- [x] **All witness generation in the witgen IR** — no `witnessNative`, so the circuit is fully exportable (`#assert_exportable` will pass once proofs are complete)
- [x] **ElaboratedCircuit instance** — via `elaborate_circuit`, needed for subcircuit composition
- [x] **FormalCircuit bundling** — with `Assumptions` (both input points on the curve) and `Spec` (output equals `Point.add`)

## What's still TODO in this PR

- [ ] **`eval_point` lemma** — `ProvableType.eval` on `Point` needs a `circuit_norm` lemma that reduces `eval env p` to `Point.mk (Expression.eval env p.x) (Expression.eval env p.y)`. This is blocked on the framework: `ProvableType.eval` is a `def` that `simp`/`dsimp`/`delta` can't unfold. Without this lemma, `circuit_proof_start` can't decompose struct inputs into component `Expression.eval`s, which means we can't connect the constraint equations (which mention `Expression.eval env input_var.p1.x`) to the spec (which mentions `input.p1.x`).
- [ ] **Soundness proof** — the structure is clear (destructure 13 constraint equations from `<==` and `===`, chain-substitute through the intermediate value definitions, then for each coordinate: `h_check_x` gives `x3 * denom1 = num1`, the goal is `x3 = num1 / denom1`, close with `field_simp` or case-split on denominator zero). Blocked on `eval_point`.
- [ ] **Completeness proof** — follows the standard pattern for circuits using `<==` (witness + constrain simultaneously, so constraints hold by construction). Blocked on `eval_point`.

## What's out of scope (future PRs)

- CurveCheck circuit (point-on-curve validation)
- Scalar multiplication circuit (double-and-add composing PointAdd + Num2Bits)
- EdDSA verification