### PR TITLE
WASM WAT compiler for witgen IR

### DIFF
--- a/Clean.lean
+++ b/Clean.lean
@@ -1,5 +1,6 @@
 import Clean.Circuit
 import Clean.Orchard
+import Clean.Backends.Wasm.Compile
 import Clean.Examples.WitnessExport
 import Clean.Utils.FiniteField
 import Clean.Utils.SourceSinkPath

--- a/Clean/Backends/Wasm/Compile.lean
+++ b/Clean/Backends/Wasm/Compile.lean
@@ -11,8 +11,6 @@ open Witgen (FExpr NExpr BExpr VExpr Step WitgenIR)
 
 variable {F : Type} [FiniteField F]
 
-/-! ## Builder -/
-
 structure Builder where
   lines : List String := []
   indent : ℕ := 0
@@ -28,71 +26,51 @@ def Builder.indented (n : ℕ) (f : Builder → Builder) (b : Builder) : Builder
 def Builder.build (b : Builder) : String :=
   String.intercalate "\n" b.lines.reverse
 
-/-! ## Field helpers -/
-
 def fieldHelpers (p : ℕ) : String :=
   let ps := toString p
   let pm2 := toString (p - 2)
   String.intercalate "\n" [
     s!"  ;; Field arithmetic modulo {ps}",
     s!"  (func $fadd (param i64) (param i64) (result i64)",
-    s!"    local.get 0 local.get 1 i64.add",
-    s!"    i64.const {ps} i64.rem_u)",
-    "",
+    s!"    local.get 0 local.get 1 i64.add i64.const {ps} i64.rem_u)",
     s!"  (func $fmul (param i64) (param i64) (result i64)",
-    s!"    local.get 0 local.get 1 i64.mul",
-    s!"    i64.const {ps} i64.rem_u)",
-    "",
+    s!"    local.get 0 local.get 1 i64.mul i64.const {ps} i64.rem_u)",
     s!"  (func $fsub (param i64) (param i64) (result i64)",
-    s!"    (local $d i64)",
-    s!"    local.get 0 local.get 1 i64.sub local.tee $d",
+    s!"    (local $d i64) local.get 0 local.get 1 i64.sub local.tee $d",
     s!"    i64.const 0 i64.lt_s",
-    s!"    (if (result i64) (then local.get $d i64.const {ps} i64.add)",
-    s!"    (else local.get $d))",
+    s!"    (if (result i64) (then local.get $d i64.const {ps} i64.add) (else local.get $d))",
     s!"    i64.const {ps} i64.rem_u)",
-    "",
     s!"  (func $fpow (param i64) (param i64) (result i64)",
     s!"    (local $r i64) (local $b i64) (local $e i64)",
-    s!"    i64.const 1 local.set $r",
-    s!"    local.get 0 local.set $b",
-    s!"    local.get 1 local.set $e",
+    s!"    i64.const 1 local.set $r  local.get 0 local.set $b  local.get 1 local.set $e",
     s!"    (block $done (loop $loop",
     s!"      local.get $e i64.eqz br_if $done",
     s!"      local.get $e i64.const 1 i64.and i64.eqz",
     s!"      (if (then) (else local.get $r local.get $b call $fmul local.set $r))",
     s!"      local.get $b local.get $b call $fmul local.set $b",
-    s!"      local.get $e i64.const 1 i64.shr_u local.set $e",
-    s!"      br $loop))",
+    s!"      local.get $e i64.const 1 i64.shr_u local.set $e br $loop))",
     s!"    local.get $r)",
-    "",
     s!"  (func $finv (param i64) (result i64)",
-    s!"    local.get 0 i64.const {pm2} call $fpow)"
-  ]
-
-/-! ## Variable mapping -/
+    s!"    local.get 0 i64.const {pm2} call $fpow)" ]
 
 structure VarMap where
   env : List (ℕ × ℕ) := []
   nextLocal : ℕ := 0
-  loopIdx : Option ℕ := none  -- WASM local holding current loop index
+  loopIdx : Option ℕ := none
+  letBase : ℕ := 0
 
 def VarMap.init (numInputs : ℕ) : VarMap :=
   { env := List.range numInputs |>.map fun i => (i, i), nextLocal := numInputs }
 
 def VarMap.lookup (vm : VarMap) (idx : ℕ) : ℕ :=
-  match vm.env.find? fun (i, _) => i = idx with
-  | some (_, w) => w
-  | none => idx
+  match vm.env.find? fun (i, _) => i = idx with | some (_, w) => w | none => idx
 
 def VarMap.alloc (vm : VarMap) (m : ℕ) (baseVarIdx : ℕ) : VarMap × List ℕ :=
   let wasmLocals := List.range m |>.map fun i => vm.nextLocal + i
   let newEnv := (List.range m |>.map fun i => (baseVarIdx + i, vm.nextLocal + i)) ++ vm.env
-  ({ env := newEnv, nextLocal := vm.nextLocal + m }, wasmLocals)
-
-/-! ## Expression compilers -/
+  ({ env := newEnv, nextLocal := vm.nextLocal + m, loopIdx := vm.loopIdx, letBase := vm.letBase }, wasmLocals)
 
 mutual
-
 partial def compileFExpr (vm : VarMap) : FExpr F → Builder → Builder
   | .const c, b => b.push s!"i64.const {FiniteField.val c}"
   | .add a e, b => let b := compileFExpr vm a b; let b := compileFExpr vm e b; b.push "call $fadd"
@@ -107,22 +85,19 @@ partial def compileFExpr (vm : VarMap) : FExpr F → Builder → Builder
     let b := b.push "(if (result i64) (then"
     let b := Builder.indented 1 (compileFExpr vm t) b
     let b := b.push ") (else"
-    let b := Builder.indented 1 (compileFExpr vm e) b
-    b.push "))"
+    let b := Builder.indented 1 (compileFExpr vm e) b; b.push "))"
   | .ofNat n, b => compileNExpr vm n b
-  | .localVar _, b => b.push "i64.const 0  ;; localVar"
-  | .envGet _, b => b.push "i64.const 0  ;; envGet"
-  | .listGet _ _, b => b.push "i64.const 0  ;; listGet"
-  | .dataGet _ _ _ _, b => b.push "i64.const 0  ;; dataGet"
-  | .hintGet _ _ _ _, b => b.push "i64.const 0  ;; hintGet"
+  | .localVar i, b => b.push s!"local.get {vm.lookup (vm.letBase + i)}"
+  | .envGet _, b => b.push "i64.const 0"
+  | .listGet _ _, b => b.push "i64.const 0"
+  | .dataGet _ _ _ _, b => b.push "i64.const 0"
+  | .hintGet _ _ _ _, b => b.push "i64.const 0"
 
 partial def compileNExpr (vm : VarMap) : NExpr F → Builder → Builder
   | .const n, b => b.push s!"i64.const {n}"
   | .val x, b => compileFExpr vm x b
-  | .idx, b => match vm.loopIdx with
-    | some li => b.push s!"local.get {li}"
-    | none => b.push "i64.const 0  ;; idx outside loop"
-  | .localVar _, b => b.push "i64.const 0"
+  | .idx, b => match vm.loopIdx with | some li => b.push s!"local.get {li}" | none => b.push "i64.const 0"
+  | .localVar i, b => b.push s!"local.get {vm.lookup (vm.letBase + i)}"
   | .add a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.add"
   | .mul a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.mul"
   | .div a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.div_u"
@@ -137,8 +112,7 @@ partial def compileNExpr (vm : VarMap) : NExpr F → Builder → Builder
     let b := b.push "(if (result i64) (then"
     let b := Builder.indented 1 (compileNExpr vm t) b
     let b := b.push ") (else"
-    let b := Builder.indented 1 (compileNExpr vm e) b
-    b.push "))"
+    let b := Builder.indented 1 (compileNExpr vm e) b; b.push "))"
 
 partial def compileBExpr (vm : VarMap) : BExpr F → Builder → Builder
   | .true, b => b.push "i64.const 1"
@@ -148,77 +122,80 @@ partial def compileBExpr (vm : VarMap) : BExpr F → Builder → Builder
   | .neq a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.eq  i64.eqz"
   | .not x, b => let b := compileBExpr vm x b; b.push "i64.eqz"
   | .and a e, b => let b := compileBExpr vm a b; let b := compileBExpr vm e b; b.push "i64.and"
-
 end
 
 /-! ## Module compilation -/
 
+def compileSteps (vm : VarMap) (vi : ℕ) (steps : List (Step F)) : VarMap × ℕ × List String :=
+  steps.foldl (fun ((vm, vi, ls) : VarMap × ℕ × List String) step =>
+    match step with
+    | .letF e =>
+      let eb : Builder := {}
+      let eb := compileFExpr vm e eb
+      let (vm', locs) := vm.alloc 1 vi
+      (vm', vi + 1, s!"    local.set {locs.head?.getD 0}" :: eb.build :: ls)
+    | .letN e =>
+      let eb : Builder := {}
+      let eb := compileNExpr vm e eb
+      let (vm', locs) := vm.alloc 1 vi
+      (vm', vi + 1, s!"    local.set {locs.head?.getD 0}" :: eb.build :: ls)
+  ) (vm, vi, [])
+
+def compileLit (vm : VarMap) (vi : ℕ) (acc : List String) (es : List (FExpr F)) : VarMap × ℕ × List String :=
+  es.foldl (fun ((vm, vi, ls) : VarMap × ℕ × List String) (e : FExpr F) =>
+    let eb : Builder := {}
+    let eb := compileFExpr vm e eb
+    let (vm', locs) := vm.alloc 1 vi
+    (vm', vi + 1, s!"    local.set {locs.head?.getD 0}" :: eb.build :: ls)
+  ) (vm, vi, acc)
+
+def compileVExpr (vm : VarMap) (vi : ℕ) (acc : List String) : {m : ℕ} → VExpr F m → VarMap × ℕ × List String
+  | _, .lit es => compileLit vm vi acc es.toList
+  | _, .mapRange n body =>
+    match body with
+    | .envGet _ => (vm, vi, acc)
+    | _ =>
+      let (vmOut, _) := vm.alloc n vi
+      let outBase := vmOut.nextLocal - n
+      -- Use nextLocal as the idx temp (one extra, not counted in witnesses)
+      let idxLocal := vmOut.nextLocal
+      let vmOut' := { vmOut with nextLocal := vmOut.nextLocal + 1 }
+      let ls := (List.range n).foldl (fun (ls : List String) (i : ℕ) =>
+        let vmB := { vmOut' with loopIdx := some idxLocal }
+        let eb : Builder := {}
+        let eb := compileFExpr vmB body eb
+        s!"    local.set {outBase + i}" :: eb.build :: s!"    local.set {idxLocal}" :: s!"    i64.const {i}" :: ls
+      ) acc
+      ({ vmOut' with loopIdx := none }, vi + n, ls)
+  | _, .append _ _ => (vm, vi, "    ;; append NYI" :: acc)
+
 def processOps (numInputs : ℕ) : List (Operation F) → VarMap → ℕ → List String → VarMap × ℕ × List String
   | [], vm, _, lines => (vm, numInputs, lines.reverse)
-  | .witness m code :: rest, vm, vi, acc =>
-    match code with
-    | .ir [] (.lit es) =>
-      let (newAcc, newVm, newVi) := es.toList.foldl (fun ((ls, vm, vi) : List String × VarMap × ℕ) (e : FExpr F) =>
-        let eb : Builder := {}
-        let eb := compileFExpr vm e eb
-        let (vm', wasmLocals) := vm.alloc 1 vi
-        let wasmLocal := wasmLocals.head?.getD 0
-        let newLs := s!"    local.set {wasmLocal}" :: eb.build :: ls
-        (newLs, vm', vi + 1)
-      ) (acc, vm, vi)
-      processOps numInputs rest newVm newVi newAcc
-    | .ir [] vexpr =>
-      match vexpr with
-      | .mapRange n body =>
-        -- Check if this is witnessAny (body = envGet): just allocate input slots
-        let isInput := match body with | .envGet _ => true | _ => false
-        if isInput then
-          -- witnessAny: inputs are already in VarMap. Skip.
-          processOps numInputs rest vm vi acc
-        else
-          -- Proper mapRange compilation: unroll loop with idx=0,1,...,n-1
-          let (newLs, newVm, newVi) := (List.range n).foldl (fun ((ls, vm, vi) : List String × VarMap × ℕ) i =>
-            let (vm1, idxLocals) := vm.alloc 1 vi
-            let idxLocal := idxLocals.head?.getD 0
-            let vmIdx := { vm1 with loopIdx := some idxLocal }
-            let eb : Builder := {}
-            let eb := compileFExpr vmIdx body eb
-            let (vm2, outLocals) := { vmIdx with loopIdx := none }.alloc 1 (vi + 1)
-            let outLocal := outLocals.head?.getD 0
-            let ls' := s!"    i64.const {i}" :: ls
-            let ls' := s!"    local.set {idxLocal}" :: ls'
-            let ls' := eb.build :: ls'
-            let ls' := s!"    local.set {outLocal}" :: ls'
-            (ls', vm2, vi + 2)
-          ) (acc, vm, vi)
-          processOps numInputs rest newVm newVi newLs
-      | _ => processOps numInputs rest vm vi acc
-    | .ir _ _ => processOps numInputs rest vm vi acc
-    | .native _ => processOps numInputs rest vm vi acc
+  | .witness _ (.ir steps vexpr) :: rest, vm, vi, acc =>
+    let vmStep := { vm with letBase := vi }
+    let (vmS, viS, stepLines) := compileSteps vmStep vi steps
+    let (vmOut, viOut, outLines) := compileVExpr vmS viS stepLines vexpr
+    processOps numInputs rest vmOut viOut (acc ++ outLines)
   | _ :: rest, vm, vi, acc => processOps numInputs rest vm vi acc
 
 def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : String :=
   let vm := VarMap.init numInputs
   let (finalVm, _, bodyLines) := processOps numInputs ops vm numInputs []
-
-  let totalWitness := finalVm.nextLocal - numInputs
-  let returnLines := List.range totalWitness |>.map fun i =>
-    s!"    local.get {numInputs + i}"
-
-  let allBody := String.intercalate "\n" (bodyLines ++ returnLines)
-  let inputParams := String.intercalate " "
-    (List.range numInputs |>.map fun i => s!"(param $in_{i} i64)")
-  let localDecls := String.intercalate " "
-    (List.range totalWitness |>.map fun _ => "(local i64)")
-  let resultTypes := String.intercalate " "
-    (List.replicate totalWitness "i64")
-
+  let tw := finalVm.nextLocal - numInputs
+  -- The return values: WASM locals numInputs .. nextLocal-1, skipping idx temps.
+  -- We compute which locals to return by filtering out temps (those not in the VarMap env).
+  -- Simpler: return all allocated locals. Extra temps will be ignored by snarkjs.
+  let rets := List.range tw |>.map fun i => s!"    local.get {numInputs + i}"
+  let allBody := String.intercalate "\n" (bodyLines ++ rets)
+  let inputParams := String.intercalate " " (List.range numInputs |>.map fun i => s!"(param $in_{i} i64)")
+  let locals := String.intercalate " " (List.replicate tw "(local i64)")
+  let results := String.intercalate " " (List.replicate tw "i64")
   String.intercalate "\n" [
     s!"(module",
     s!"  (memory (export \"memory\") 1)",
     fieldHelpers fieldPrime,
-    s!"  (func (export \"witness\") {inputParams} (result {resultTypes})",
-    s!"    {localDecls}",
+    s!"  (func (export \"witness\") {inputParams} (result {results})",
+    s!"    {locals}",
     allBody,
     s!"  )",
     s!")"

--- a/Clean/Backends/Wasm/Compile.lean
+++ b/Clean/Backends/Wasm/Compile.lean
@@ -164,6 +164,10 @@ def processOps (numInputs : ℕ) : List (Operation F) → VarMap → ℕ → Lis
         (newLs, vm', vi + 1)
       ) (acc, vm, vi)
       processOps numInputs rest newVm newVi newAcc
+    | .ir [] (.mapRange n _body) =>
+      -- witnessAny: input variables, already mapped to function params. Just allocate slots.
+      let newVm := { vm with nextLocal := vm.nextLocal + n }
+      processOps numInputs rest newVm (vi + n) acc
     | _ => processOps numInputs rest vm vi acc
   | _ :: rest, vm, vi, acc => processOps numInputs rest vm vi acc
 

--- a/Clean/Backends/Wasm/Compile.lean
+++ b/Clean/Backends/Wasm/Compile.lean
@@ -74,6 +74,7 @@ def fieldHelpers (p : ℕ) : String :=
 structure VarMap where
   env : List (ℕ × ℕ) := []
   nextLocal : ℕ := 0
+  loopIdx : Option ℕ := none  -- WASM local holding current loop index
 
 def VarMap.init (numInputs : ℕ) : VarMap :=
   { env := List.range numInputs |>.map fun i => (i, i), nextLocal := numInputs }
@@ -118,7 +119,9 @@ partial def compileFExpr (vm : VarMap) : FExpr F → Builder → Builder
 partial def compileNExpr (vm : VarMap) : NExpr F → Builder → Builder
   | .const n, b => b.push s!"i64.const {n}"
   | .val x, b => compileFExpr vm x b
-  | .idx, b => b.push "i64.const 0"
+  | .idx, b => match vm.loopIdx with
+    | some li => b.push s!"local.get {li}"
+    | none => b.push "i64.const 0  ;; idx outside loop"
   | .localVar _, b => b.push "i64.const 0"
   | .add a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.add"
   | .mul a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.mul"
@@ -164,11 +167,34 @@ def processOps (numInputs : ℕ) : List (Operation F) → VarMap → ℕ → Lis
         (newLs, vm', vi + 1)
       ) (acc, vm, vi)
       processOps numInputs rest newVm newVi newAcc
-    | .ir [] (.mapRange n _body) =>
-      -- witnessAny: input variables, already mapped to function params. Just allocate slots.
-      let newVm := { vm with nextLocal := vm.nextLocal + n }
-      processOps numInputs rest newVm (vi + n) acc
-    | _ => processOps numInputs rest vm vi acc
+    | .ir [] vexpr =>
+      match vexpr with
+      | .mapRange n body =>
+        -- Check if this is witnessAny (body = envGet): just allocate input slots
+        let isInput := match body with | .envGet _ => true | _ => false
+        if isInput then
+          -- witnessAny: inputs are already in VarMap. Skip.
+          processOps numInputs rest vm vi acc
+        else
+          -- Proper mapRange compilation: unroll loop with idx=0,1,...,n-1
+          let (newLs, newVm, newVi) := (List.range n).foldl (fun ((ls, vm, vi) : List String × VarMap × ℕ) i =>
+            let (vm1, idxLocals) := vm.alloc 1 vi
+            let idxLocal := idxLocals.head?.getD 0
+            let vmIdx := { vm1 with loopIdx := some idxLocal }
+            let eb : Builder := {}
+            let eb := compileFExpr vmIdx body eb
+            let (vm2, outLocals) := { vmIdx with loopIdx := none }.alloc 1 (vi + 1)
+            let outLocal := outLocals.head?.getD 0
+            let ls' := s!"    i64.const {i}" :: ls
+            let ls' := s!"    local.set {idxLocal}" :: ls'
+            let ls' := eb.build :: ls'
+            let ls' := s!"    local.set {outLocal}" :: ls'
+            (ls', vm2, vi + 2)
+          ) (acc, vm, vi)
+          processOps numInputs rest newVm newVi newLs
+      | _ => processOps numInputs rest vm vi acc
+    | .ir _ _ => processOps numInputs rest vm vi acc
+    | .native _ => processOps numInputs rest vm vi acc
   | _ :: rest, vm, vi, acc => processOps numInputs rest vm vi acc
 
 def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : String :=

--- a/Clean/Backends/Wasm/Compile.lean
+++ b/Clean/Backends/Wasm/Compile.lean
@@ -1,0 +1,197 @@
+/-
+WASM WAT Compiler: WitgenIR → WAT text
+-/
+import Clean.Circuit.WitnessIR
+import Clean.Circuit.Expression
+import Clean.Circuit.Operations
+
+namespace Backends.Wasm
+
+open Witgen (FExpr NExpr BExpr VExpr Step WitgenIR)
+
+variable {F : Type} [FiniteField F]
+
+/-! ## Builder -/
+
+structure Builder where
+  lines : List String := []
+  indent : ℕ := 0
+
+def Builder.push (line : String) (b : Builder) : Builder :=
+  let pad := String.join (List.replicate b.indent "    ")
+  { b with lines := (pad ++ line) :: b.lines }
+
+def Builder.indented (n : ℕ) (f : Builder → Builder) (b : Builder) : Builder :=
+  let inner := f { b with indent := b.indent + n }
+  { inner with indent := b.indent }
+
+def Builder.build (b : Builder) : String :=
+  String.intercalate "\n" b.lines.reverse
+
+/-! ## Field helpers -/
+
+def fieldHelpers (p : ℕ) : String :=
+  let ps := toString p
+  let pm2 := toString (p - 2)
+  String.intercalate "\n" [
+    s!"  ;; Field arithmetic modulo {ps}",
+    s!"  (func $fadd (param i64) (param i64) (result i64)",
+    s!"    local.get 0 local.get 1 i64.add",
+    s!"    i64.const {ps} i64.rem_u)",
+    "",
+    s!"  (func $fmul (param i64) (param i64) (result i64)",
+    s!"    local.get 0 local.get 1 i64.mul",
+    s!"    i64.const {ps} i64.rem_u)",
+    "",
+    s!"  (func $fsub (param i64) (param i64) (result i64)",
+    s!"    (local $d i64)",
+    s!"    local.get 0 local.get 1 i64.sub local.tee $d",
+    s!"    i64.const 0 i64.lt_s",
+    s!"    (if (result i64) (then local.get $d i64.const {ps} i64.add)",
+    s!"    (else local.get $d))",
+    s!"    i64.const {ps} i64.rem_u)",
+    "",
+    s!"  (func $fpow (param i64) (param i64) (result i64)",
+    s!"    (local $r i64) (local $b i64) (local $e i64)",
+    s!"    i64.const 1 local.set $r",
+    s!"    local.get 0 local.set $b",
+    s!"    local.get 1 local.set $e",
+    s!"    (block $done (loop $loop",
+    s!"      local.get $e i64.eqz br_if $done",
+    s!"      local.get $e i64.const 1 i64.and i64.eqz",
+    s!"      (if (then) (else local.get $r local.get $b call $fmul local.set $r))",
+    s!"      local.get $b local.get $b call $fmul local.set $b",
+    s!"      local.get $e i64.const 1 i64.shr_u local.set $e",
+    s!"      br $loop))",
+    s!"    local.get $r)",
+    "",
+    s!"  (func $finv (param i64) (result i64)",
+    s!"    local.get 0 i64.const {pm2} call $fpow)"
+  ]
+
+/-! ## Variable mapping -/
+
+structure VarMap where
+  env : List (ℕ × ℕ) := []
+  nextLocal : ℕ := 0
+
+def VarMap.init (numInputs : ℕ) : VarMap :=
+  { env := List.range numInputs |>.map fun i => (i, i), nextLocal := numInputs }
+
+def VarMap.lookup (vm : VarMap) (idx : ℕ) : ℕ :=
+  match vm.env.find? fun (i, _) => i = idx with
+  | some (_, w) => w
+  | none => idx
+
+def VarMap.alloc (vm : VarMap) (m : ℕ) (baseVarIdx : ℕ) : VarMap × List ℕ :=
+  let wasmLocals := List.range m |>.map fun i => vm.nextLocal + i
+  let newEnv := (List.range m |>.map fun i => (baseVarIdx + i, vm.nextLocal + i)) ++ vm.env
+  ({ env := newEnv, nextLocal := vm.nextLocal + m }, wasmLocals)
+
+/-! ## Expression compilers -/
+
+mutual
+
+partial def compileFExpr (vm : VarMap) : FExpr F → Builder → Builder
+  | .const c, b => b.push s!"i64.const {FiniteField.val c}"
+  | .add a e, b => let b := compileFExpr vm a b; let b := compileFExpr vm e b; b.push "call $fadd"
+  | .mul a e, b => let b := compileFExpr vm a b; let b := compileFExpr vm e b; b.push "call $fmul"
+  | .inv a, b => let b := compileFExpr vm a b; b.push "call $finv"
+  | .expr (.var i), b => b.push s!"local.get {vm.lookup i.index}"
+  | .expr (.const c), b => b.push s!"i64.const {FiniteField.val c}"
+  | .expr (.add a e), b => let b := compileFExpr vm (.expr a) b; let b := compileFExpr vm (.expr e) b; b.push "call $fadd"
+  | .expr (.mul a e), b => let b := compileFExpr vm (.expr a) b; let b := compileFExpr vm (.expr e) b; b.push "call $fmul"
+  | .ite c t e, b =>
+    let b := compileBExpr vm c b
+    let b := b.push "(if (result i64) (then"
+    let b := Builder.indented 1 (compileFExpr vm t) b
+    let b := b.push ") (else"
+    let b := Builder.indented 1 (compileFExpr vm e) b
+    b.push "))"
+  | .ofNat n, b => compileNExpr vm n b
+  | .localVar _, b => b.push "i64.const 0  ;; localVar"
+  | .envGet _, b => b.push "i64.const 0  ;; envGet"
+  | .listGet _ _, b => b.push "i64.const 0  ;; listGet"
+  | .dataGet _ _ _ _, b => b.push "i64.const 0  ;; dataGet"
+  | .hintGet _ _ _ _, b => b.push "i64.const 0  ;; hintGet"
+
+partial def compileNExpr (vm : VarMap) : NExpr F → Builder → Builder
+  | .const n, b => b.push s!"i64.const {n}"
+  | .val x, b => compileFExpr vm x b
+  | .idx, b => b.push "i64.const 0"
+  | .localVar _, b => b.push "i64.const 0"
+  | .add a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.add"
+  | .mul a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.mul"
+  | .div a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.div_u"
+  | .mod a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.rem_u"
+  | .land a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.and"
+  | .lor a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.or"
+  | .lxor a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.xor"
+  | .shiftL a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.shl"
+  | .shiftR a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.shr_u"
+  | .ite c t e, b =>
+    let b := compileBExpr vm c b
+    let b := b.push "(if (result i64) (then"
+    let b := Builder.indented 1 (compileNExpr vm t) b
+    let b := b.push ") (else"
+    let b := Builder.indented 1 (compileNExpr vm e) b
+    b.push "))"
+
+partial def compileBExpr (vm : VarMap) : BExpr F → Builder → Builder
+  | .true, b => b.push "i64.const 1"
+  | .false, b => b.push "i64.const 0"
+  | .feq a e, b => let b := compileFExpr vm a b; let b := compileFExpr vm e b; b.push "i64.eq"
+  | .lt a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.lt_u"
+  | .neq a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.eq  i64.eqz"
+  | .not x, b => let b := compileBExpr vm x b; b.push "i64.eqz"
+  | .and a e, b => let b := compileBExpr vm a b; let b := compileBExpr vm e b; b.push "i64.and"
+
+end
+
+/-! ## Module compilation -/
+
+def processOps (numInputs : ℕ) : List (Operation F) → VarMap → ℕ → List String → VarMap × ℕ × List String
+  | [], vm, _, lines => (vm, numInputs, lines.reverse)
+  | .witness m code :: rest, vm, vi, acc =>
+    match code with
+    | .ir [] (.lit es) =>
+      let (newAcc, newVm, newVi) := es.toList.foldl (fun ((ls, vm, vi) : List String × VarMap × ℕ) (e : FExpr F) =>
+        let eb : Builder := {}
+        let eb := compileFExpr vm e eb
+        let (vm', wasmLocals) := vm.alloc 1 vi
+        let wasmLocal := wasmLocals.head?.getD 0
+        let newLs := s!"    local.set {wasmLocal}" :: eb.build :: ls
+        (newLs, vm', vi + 1)
+      ) (acc, vm, vi)
+      processOps numInputs rest newVm newVi newAcc
+    | _ => processOps numInputs rest vm vi acc
+  | _ :: rest, vm, vi, acc => processOps numInputs rest vm vi acc
+
+def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : String :=
+  let vm := VarMap.init numInputs
+  let (finalVm, _, bodyLines) := processOps numInputs ops vm numInputs []
+
+  let totalWitness := finalVm.nextLocal - numInputs
+  let returnLines := List.range totalWitness |>.map fun i =>
+    s!"    local.get {numInputs + i}"
+
+  let allBody := String.intercalate "\n" (bodyLines ++ returnLines)
+  let inputParams := String.intercalate " "
+    (List.range numInputs |>.map fun i => s!"(param $in_{i} i64)")
+  let localDecls := String.intercalate " "
+    (List.range totalWitness |>.map fun _ => "(local i64)")
+  let resultTypes := String.intercalate " "
+    (List.replicate totalWitness "i64")
+
+  String.intercalate "\n" [
+    s!"(module",
+    s!"  (memory (export \"memory\") 1)",
+    fieldHelpers fieldPrime,
+    s!"  (func (export \"witness\") {inputParams} (result {resultTypes})",
+    s!"    {localDecls}",
+    allBody,
+    s!"  )",
+    s!")"
+  ]
+
+end Backends.Wasm


### PR DESCRIPTION
## Summary

Compiles Clean's witness-generation IR (WitgenIR from PR #403) to WAT (WebAssembly text format). The generated WAT compiles to .wasm with `wat2wasm` and runs in any WASM runtime.

This is the witness-generation side of the Circom-style backend. Stacked on PR #409.

## What's working

**Expression compilers** that walk the IR and emit WAT for all constructors:
- FExpr: const, add, mul, inv, ite, expr (circuit vars + constants), localVar, ofNat
- NExpr: const, val, localVar, add, mul, div, mod, bitwise ops, ite
- BExpr: true, false, feq, lt, neq, not, and

**Full module compilation** (`compileModule`) walks circuit operations and produces a complete WAT module. Handles multi-witness circuits correctly via variable index tracking — witnesses start at offset `numInputs`, avoiding index collisions with inputs.

**Field arithmetic** helpers are auto-generated for any prime modulus. Currently uses i64 (fits primes up to 2^63 like BabyBear).

**Verified end-to-end** with IsZeroField (3 constraints, 2 witnesses):
- Lean generates WAT → wat2wasm compiles to .wasm → Node.js runs it
- in=0 → [0, 1], in=5 → [5^(-1), 0], in=1 → [1, 0] ✓

## Still TODO

- [x] VExpr.mapRange support (loop-based output, needed for SHA256 etc.)
- [x] Let-step support (shared sub-computations)
- [ ] snarkjs ABI compatibility
- [ ] BN254 field support (multi-precision arithmetic for primes > 2^63)