### PR TITLE
[codex] Bind Plonky3 verifier trace degrees

### DIFF
--- a/backends/plonky3/src/clean_air.rs
+++ b/backends/plonky3/src/clean_air.rs
@@ -24,6 +24,8 @@ where
     clean_ops: CleanOps,
     /// Width of the trace
     width: usize,
+    /// Expected trace height for this AIR.
+    trace_height: usize,
     /// Number of registered lookups (for add_lookup_columns)
     num_lookups: usize,
     /// Row scope for each lookup, parallel to the lookups vec from get_lookups
@@ -241,6 +243,7 @@ impl<F: Field> MainAir<F> {
         Self {
             clean_ops,
             width,
+            trace_height,
             num_lookups: 0,
             lookup_row_scopes: Vec::new(),
             preprocessed,
@@ -282,6 +285,11 @@ impl<F: Field> MainAir<F> {
     /// Get reference to the clean operations
     pub fn clean_ops(&self) -> &CleanOps {
         &self.clean_ops
+    }
+
+    /// Return the expected trace height supplied when this AIR was constructed.
+    pub fn trace_height(&self) -> usize {
+        self.trace_height
     }
 
     /// Process circuit operations and apply constraints
@@ -368,6 +376,15 @@ impl<F: Field> CleanAirInstance<F> {
             CleanAirInstance::Main(air) => air.lookup_row_scopes.clone(),
             CleanAirInstance::Preprocessed(_) => vec![],
             CleanAirInstance::ProverTable(_) => vec![],
+        }
+    }
+
+    /// Returns a verifier-known trace height when this AIR has static row metadata.
+    pub fn expected_trace_height(&self) -> Option<usize> {
+        match self {
+            CleanAirInstance::Main(air) => Some(air.trace_height()),
+            CleanAirInstance::Preprocessed(air) => air.preprocessed_trace().map(|t| t.height()),
+            CleanAirInstance::ProverTable(_) => None,
         }
     }
 }

--- a/backends/plonky3/src/key.rs
+++ b/backends/plonky3/src/key.rs
@@ -14,6 +14,7 @@ pub struct AirInfo<F: Field> {
     pub lookups: Vec<Lookup<F>>,
     pub lookup_row_scopes: Vec<LookupRowScope>,
     pub preprocessed: Option<RowMajorMatrix<F>>,
+    pub expected_trace_height: Option<usize>,
 }
 
 impl<F: Field> AirInfo<F> {
@@ -22,6 +23,7 @@ impl<F: Field> AirInfo<F> {
         let lookups =
             <CleanAirInstance<F> as Air<SymbolicAirBuilder<F>>>::get_lookups(&mut air);
         let lookup_row_scopes = air.lookup_row_scopes();
+        let expected_trace_height = air.expected_trace_height();
         let preprocessed = air.preprocessed_trace();
 
         Self {
@@ -29,6 +31,7 @@ impl<F: Field> AirInfo<F> {
             lookups,
             lookup_row_scopes,
             preprocessed,
+            expected_trace_height,
         }
     }
 }

--- a/backends/plonky3/src/verifier.rs
+++ b/backends/plonky3/src/verifier.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 use p3_batch_stark::{BatchProof, ProverData, verify_batch};
 use p3_field::BasedVectorSpace;
 use p3_uni_stark::SymbolicExpression;
+use p3_util::log2_strict_usize;
 use tracing::instrument;
 
 use crate::{AirInfo, CleanAirInstance, PcsError, StarkGenericConfig, Val};
@@ -30,11 +31,12 @@ where
          Multiple main traces are not supported yet."
     );
 
+    let degree_bits = verifier_degree_bits(config, air_infos, &proof.degree_bits)?;
+
     // Rebuild CommonData deterministically from air_infos (same as prover).
     let mut airs: Vec<CleanAirInstance<Val<SC>>> =
         air_infos.iter().map(|ai| ai.air.clone()).collect();
-    let prover_data =
-        ProverData::from_airs_and_degrees(config, &mut airs, &proof.degree_bits);
+    let prover_data = ProverData::from_airs_and_degrees(config, &mut airs, &degree_bits);
     let common = prover_data.common;
 
     let airs: Vec<CleanAirInstance<Val<SC>>> =
@@ -44,4 +46,33 @@ where
         air_infos.iter().map(|_| public_values.to_vec()).collect();
 
     verify_batch(config, &airs, proof, &per_instance_pvs, &common)
+}
+
+fn verifier_degree_bits<SC>(
+    config: &SC,
+    air_infos: &[AirInfo<Val<SC>>],
+    proof_degree_bits: &[usize],
+) -> Result<Vec<usize>, VerificationError<PcsError<SC>>>
+where
+    SC: StarkGenericConfig,
+{
+    if air_infos.len() != proof_degree_bits.len() {
+        return Err(VerificationError::InvalidProofShape);
+    }
+
+    air_infos
+        .iter()
+        .zip(proof_degree_bits.iter())
+        .map(|(air_info, &proof_degree_bits)| {
+            let Some(trace_height) = air_info.expected_trace_height else {
+                return Ok(proof_degree_bits);
+            };
+
+            let expected_degree_bits = log2_strict_usize(trace_height) + config.is_zk();
+            if proof_degree_bits != expected_degree_bits {
+                return Err(VerificationError::InvalidProofShape);
+            }
+            Ok(expected_degree_bits)
+        })
+        .collect()
 }

--- a/backends/plonky3/tests/lookup_tests.rs
+++ b/backends/plonky3/tests/lookup_tests.rs
@@ -8,8 +8,29 @@ use p3_baby_bear::BabyBear;
 use p3_field::PrimeCharacteristicRing;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
+use p3_uni_stark::VerificationError;
 
 use common::setup;
+
+#[test]
+fn verifier_rejects_unexpected_static_trace_degree() {
+    let config = setup::test_config(17);
+    let json_content = "[]";
+    let width = 1;
+    let main_trace = RowMajorMatrix::new((0..8).map(|_| BabyBear::from_u64(0)).collect(), width);
+    let main_air = MainAir::<BabyBear>::new(json_content, width, main_trace.height());
+    let air_infos = vec![AirInfo::new(CleanAirInstance::Main(main_air))];
+    let traces = vec![main_trace];
+    let pis = vec![];
+
+    let mut proof = prove(&config, &air_infos, &traces, &pis);
+    verify(&config, &air_infos, &proof, &pis)
+        .expect("verification should accept matching metadata");
+
+    proof.degree_bits[0] += 1;
+    let result = verify(&config, &air_infos, &proof, &pis);
+    assert!(matches!(result, Err(VerificationError::InvalidProofShape)));
+}
 
 /// Test multi-column lookups with RLC compression.
 /// Demonstrates a 2-column preprocessed table (address, value) with


### PR DESCRIPTION
## Summary

This PR proposes a verifier-side guard for static trace degrees in the Plonky3 backend.

## Context

`MainAir::new(..., trace_height)` receives verifier-side row-count metadata, but that metadata was not preserved in the verifier path. Verification rebuilt common data from the proof-provided degree metadata. For AIRs with a verifier-known static height, the verifier should reject proofs whose degree metadata does not match that expected height.

## Changes

- Store the expected trace height in `MainAir`.
- Carry verifier-known static trace height metadata through `AirInfo`.
- Before rebuilding `CommonData`, reject proof degree metadata that differs from verifier-known static heights.
- Leave `ProverTableAir` dynamic-height behavior unchanged.
- Add a generic regression test for mismatched static degree metadata.

## Validation

- `cd backends/plonky3 && cargo test --test lookup_tests -- --nocapture`
- `cd backends/plonky3 && cargo test --lib`

Both commands pass locally.