### PR TITLE
R1CS constraint export for snarkjs

### DIFF
--- a/Clean.lean
+++ b/Clean.lean
@@ -43,3 +43,4 @@ import Clean.Gadgets.BLAKE3.Round
 import Clean.Gadgets.BLAKE3.FinalizeChunk
 import Clean.Examples.FibonacciWithChannels
 import Clean.Gadgets.SHA256.SHA256Compress
+import Clean.Backends.Wasm.Compile

--- a/Clean.lean
+++ b/Clean.lean
@@ -44,3 +44,4 @@ import Clean.Gadgets.BLAKE3.FinalizeChunk
 import Clean.Examples.FibonacciWithChannels
 import Clean.Gadgets.SHA256.SHA256Compress
 import Clean.Backends.Wasm.Compile
+import Clean.Backends.Wasm.R1CS

--- a/Clean/Backends/Wasm/Compile.lean
+++ b/Clean/Backends/Wasm/Compile.lean
@@ -55,16 +55,14 @@ def fieldHelpers (p : ℕ) (numWords : ℕ) : String :=
       s!"  (func $finv (param i64) (result i64)",
       s!"    local.get 0 i64.const {pm2} call $fpow)" ]
   else
-    -- Multi-word arithmetic for large primes (BN254 etc.)
-    -- Each field element is numWords i64 values on the stack / in memory.
-    -- For now, we use memory-based helpers: params pass pointer to 8*numWords bytes.
-    -- For simplicity, we inline the single-word helpers with a note that multi-word
-    -- is not yet fully implemented at the expression level.
+    -- Multi-word arithmetic: expression-level compilation is TODO.
+    -- The snarkjs ABI correctly handles n32 = numWords*2 for large primes.
+    -- Full multi-word field ops (fadd_N, fmul_N, fsub_N, finv_N) will be
+    -- implemented as a separate WAT module that the compiler includes.
     String.intercalate "\n" [
-      s!"  ;; Field arithmetic modulo {ps} (multi-word, {numWords} words)",
-      s!"  ;; NOTE: multi-word compilation at expression level is TODO.",
-      s!"  ;; The snarkjs ABI handles n32={numWords * 2} correctly.",
-      s!"  ;; Direct witness() uses memory: params are pointers to {numWords}×i64 arrays.",
+      s!"  ;; Multi-word field arithmetic for prime {ps} ({numWords} words)",
+      s!"  ;; NOTE: expression-level multi-word compilation is TODO.",
+      s!"  ;; The snarkjs ABI handles n32={numWords * 2} for memory-based access.",
       s!"  (func $fadd (param i64 i64) (result i64) i64.const 0)",
       s!"  (func $fmul (param i64 i64) (result i64) i64.const 0)",
       s!"  (func $fsub (param i64 i64) (result i64) i64.const 0)",

--- a/Clean/Backends/Wasm/Compile.lean
+++ b/Clean/Backends/Wasm/Compile.lean
@@ -179,21 +179,80 @@ def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : Stri
   let vm := VarMap.init numInputs
   let (finalVm, _, bodyLines) := processOps numInputs ops vm numInputs []
   let tw := finalVm.nextLocal - numInputs
-  let rets := List.range tw |>.map fun i => s!"    local.get {numInputs + i}"
-  let allBody := String.intercalate "\n" (bodyLines ++ rets)
+  let totalSignals := 1 + numInputs + tw
+  let ps := toString fieldPrime
+  -- Memory layout: 0=computed_flag, 4=SRWM(word0), 8=signal_array(totalSignals*4 bytes)
+  let srwmBase := 4
+  let signalBase := 8
   let inputParams := String.intercalate " " (List.range numInputs |>.map fun i => s!"(param $in_{i} i64)")
   let locals := String.intercalate " "
     ((List.replicate tw "(local i64)") ++ ["(local $idx i64)"])
+  let rets := List.range tw |>.map fun i => s!"    local.get {numInputs + i}"
+  let computeBody := String.intercalate "\n" (bodyLines ++ rets)
   let results := if tw > 0 then
     s!"(result {String.intercalate " " (List.replicate tw "i64")})" else ""
+  -- Input load lines: read each input from memory as i32, extend to i64 for computation
+  let inputLoads := String.intercalate "\n" (List.range numInputs |>.map fun i =>
+    s!"    i32.const {signalBase + (1 + i) * 4} i32.load  i64.extend_i32_u  local.set $in_{i}")
+  -- Push inputs onto stack for calling $compute
+  let inputPush := String.intercalate "\n" (List.range numInputs |>.map fun i =>
+    s!"    local.get $in_{i}")
+  -- Output store for getWitness: wrap i64 to i32, store to signal array
+  let outputStoresW := String.intercalate "\n" (List.range tw |>.map fun i =>
+    s!"    i32.const {signalBase + (1 + numInputs + i) * 4}  local.get $w_{i}  i32.wrap_i64  i32.store")
+  -- snarkjs ABI exports
+  let snarkjsExports := String.intercalate "\n\n" [
+    s!"  (func (export \"getFieldNumLen32\") (result i32) i32.const 1)",
+    s!"  (func (export \"getRawPrime\")  i32.const {srwmBase}  i32.const {fieldPrime}  i32.store)",
+    s!"  (func (export \"readSharedRWMemory\") (param i32) (result i32)",
+    s!"    i32.const {srwmBase}  local.get 0  i32.const 4  i32.mul  i32.add  i32.load)",
+    s!"  (func (export \"writeSharedRWMemory\") (param $j i32) (param $v i32)",
+    s!"    i32.const {srwmBase}  local.get $j  i32.const 4  i32.mul  i32.add  local.get $v  i32.store)",
+    s!"  (func (export \"getInputSignalSize\") (param i32) (param i32) (result i32) i32.const {numInputs})",
+    s!"  (func (export \"getInputSize\") (result i32) i32.const {numInputs})",
+    s!"  (func (export \"getWitnessSize\") (result i32) i32.const {totalSignals})",
+    s!"  (func (export \"setInputSignal\") (param $hMSB i32) (param $hLSB i32) (param $idx i32)",
+    s!"    i32.const {signalBase + 4}  local.get $idx  i32.const 4  i32.mul  i32.add",
+    s!"    i32.const {srwmBase}  i32.load",
+    s!"    i32.store)",
+    s!"  (func (export \"getWitness\") (param $i i32)",
+    s!"    (local $tmp i32) {String.intercalate " " (List.range numInputs |>.map fun i => s!"(local $in_{i} i64)")} {String.intercalate " " (List.range tw |>.map fun i => s!"(local $w_{i} i64)")} (local $idx i64)",
+    s!"    i32.const 0  i32.load  i32.eqz",
+    s!"    (if (then",
+    s!"{inputLoads}",
+    s!"{inputPush}",
+    s!"      call $compute",
+    s!"{String.intercalate "\n" (List.range tw |>.reverse.map fun i => s!"      local.set $w_{i}")}",
+    s!"{outputStoresW}",
+    s!"      i32.const {signalBase}  i32.const 1  i32.store",
+    s!"      i32.const 0  i32.const 1  i32.store",
+    s!"    ))",
+    s!"    i32.const 0",
+    s!"    i32.const {signalBase}  local.get $i  i32.const 4  i32.mul  i32.add  i32.load",
+    s!"    i32.store offset={srwmBase})",
+    s!"  (func (export \"getMessageChar\") (result i32) i32.const 0)",
+    s!"  (func (export \"getVersion\") (result i32) i32.const 2)",
+    s!"  (func (export \"getMinorVersion\") (result i32) i32.const 0)",
+    s!"  (func (export \"getPatchVersion\") (result i32) i32.const 0)",
+    s!"  (func (export \"init\") (param i32) i32.const 0 i32.const 0 i32.store  i32.const {signalBase} i32.const 1 i32.store)"
+  ]
   String.intercalate "\n" [
     s!"(module",
     s!"  (memory (export \"memory\") 1)",
+    s!"  ;; Pre-initialize signal[0] = 1 (constant)",
+    s!"  (data (i32.const {signalBase}) \"\\01\\00\\00\\00\")",
     fieldHelpers fieldPrime,
+    s!"  ;; Internal compute function (our existing witness logic)",
+    s!"  (func $compute {inputParams} {results}",
+    s!"    {locals}",
+    computeBody,
+    s!"  )",
+    s!"  ;; Direct witness export (for testing)",
     s!"  (func (export \"witness\") {inputParams} {results}",
     s!"    {locals}",
-    allBody,
+    computeBody,
     s!"  )",
+    snarkjsExports,
     s!")"
   ]
 

--- a/Clean/Backends/Wasm/Compile.lean
+++ b/Clean/Backends/Wasm/Compile.lean
@@ -166,18 +166,31 @@ def compileVExpr (vm : VarMap) (vi : ℕ) (acc : List String) : {m : ℕ} → VE
       ({ vmOut with loopIdx := none }, vi + n, ls)
   | _, .append _ _ => (vm, vi, "    ;; append NYI" :: acc)
 
-def processOps (numInputs : ℕ) : List (Operation F) → VarMap → ℕ → List String → VarMap × ℕ × List String
+def flattenOp : Operation F → List (FlatOperation F)
+  | .witness m code => [.witness m code]
+  | .assert e => [.assert e]
+  | .lookup l => [.lookup l]
+  | .interact i => [.interact i]
+  | .subcircuit s => s.ops.toFlat
+
+def flattenOps (ops : List (Operation F)) : List (FlatOperation F) :=
+  match ops with
+  | [] => []
+  | op :: rest => flattenOp op ++ flattenOps rest
+
+def processFlatOps (numInputs : ℕ) : List (FlatOperation F) → VarMap → ℕ → List String → VarMap × ℕ × List String
   | [], vm, _, lines => (vm, numInputs, lines)
   | .witness _ (.ir steps vexpr) :: rest, vm, vi, acc =>
     let vmStep := { vm with letBase := vi }
     let (vmS, viS, stepLines) := compileSteps vmStep vi steps
     let (vmOut, viOut, outLines) := compileVExpr vmS viS stepLines vexpr
-    processOps numInputs rest vmOut viOut (acc ++ outLines)
-  | _ :: rest, vm, vi, acc => processOps numInputs rest vm vi acc
+    processFlatOps numInputs rest vmOut viOut (acc ++ outLines)
+  | _ :: rest, vm, vi, acc => processFlatOps numInputs rest vm vi acc
 
 def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : String :=
   let vm := VarMap.init numInputs
-  let (finalVm, _, bodyLines) := processOps numInputs ops vm numInputs []
+  let flatOps := flattenOps ops
+  let (finalVm, _, bodyLines) := processFlatOps numInputs flatOps vm numInputs []
   let tw := finalVm.nextLocal - numInputs
   let totalSignals := 1 + numInputs + tw
   let ps := toString fieldPrime

--- a/Clean/Backends/Wasm/Compile.lean
+++ b/Clean/Backends/Wasm/Compile.lean
@@ -119,7 +119,7 @@ partial def compileBExpr (vm : VarMap) : BExpr F → Builder → Builder
   | .false, b => b.push "i64.const 0"
   | .feq a e, b => let b := compileFExpr vm a b; let b := compileFExpr vm e b; b.push "i64.eq"
   | .lt a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.lt_u"
-  | .neq a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.eq  i64.eqz"
+  | .neq a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.eq"
   | .not x, b => let b := compileBExpr vm x b; b.push "i64.eqz"
   | .and a e, b => let b := compileBExpr vm a b; let b := compileBExpr vm e b; b.push "i64.and"
 end
@@ -133,12 +133,12 @@ def compileSteps (vm : VarMap) (vi : ℕ) (steps : List (Step F)) : VarMap × �
       let eb : Builder := {}
       let eb := compileFExpr vm e eb
       let (vm', locs) := vm.alloc 1 vi
-      (vm', vi + 1, s!"    local.set {locs.head?.getD 0}" :: eb.build :: ls)
+      (vm', vi + 1, ls ++ [eb.build, s!"    local.set {locs.head?.getD 0}"])
     | .letN e =>
       let eb : Builder := {}
       let eb := compileNExpr vm e eb
       let (vm', locs) := vm.alloc 1 vi
-      (vm', vi + 1, s!"    local.set {locs.head?.getD 0}" :: eb.build :: ls)
+      (vm', vi + 1, ls ++ [eb.build, s!"    local.set {locs.head?.getD 0}"])
   ) (vm, vi, [])
 
 def compileLit (vm : VarMap) (vi : ℕ) (acc : List String) (es : List (FExpr F)) : VarMap × ℕ × List String :=
@@ -146,7 +146,7 @@ def compileLit (vm : VarMap) (vi : ℕ) (acc : List String) (es : List (FExpr F)
     let eb : Builder := {}
     let eb := compileFExpr vm e eb
     let (vm', locs) := vm.alloc 1 vi
-    (vm', vi + 1, s!"    local.set {locs.head?.getD 0}" :: eb.build :: ls)
+    (vm', vi + 1, ls ++ [eb.build, s!"    local.set {locs.head?.getD 0}"])
   ) (vm, vi, acc)
 
 def compileVExpr (vm : VarMap) (vi : ℕ) (acc : List String) : {m : ℕ} → VExpr F m → VarMap × ℕ × List String
@@ -164,13 +164,13 @@ def compileVExpr (vm : VarMap) (vi : ℕ) (acc : List String) : {m : ℕ} → VE
         let vmB := { vmOut' with loopIdx := some idxLocal }
         let eb : Builder := {}
         let eb := compileFExpr vmB body eb
-        s!"    local.set {outBase + i}" :: eb.build :: s!"    local.set {idxLocal}" :: s!"    i64.const {i}" :: ls
+        ls ++ [s!"    i64.const {i}", s!"    local.set {idxLocal}", eb.build, s!"    local.set {outBase + i}"]
       ) acc
       ({ vmOut' with loopIdx := none }, vi + n, ls)
   | _, .append _ _ => (vm, vi, "    ;; append NYI" :: acc)
 
 def processOps (numInputs : ℕ) : List (Operation F) → VarMap → ℕ → List String → VarMap × ℕ × List String
-  | [], vm, _, lines => (vm, numInputs, lines.reverse)
+  | [], vm, _, lines => (vm, numInputs, lines)
   | .witness _ (.ir steps vexpr) :: rest, vm, vi, acc =>
     let vmStep := { vm with letBase := vi }
     let (vmS, viS, stepLines) := compileSteps vmStep vi steps

--- a/Clean/Backends/Wasm/Compile.lean
+++ b/Clean/Backends/Wasm/Compile.lean
@@ -26,32 +26,49 @@ def Builder.indented (n : ℕ) (f : Builder → Builder) (b : Builder) : Builder
 def Builder.build (b : Builder) : String :=
   String.intercalate "\n" b.lines.reverse
 
-def fieldHelpers (p : ℕ) : String :=
+def fieldHelpers (p : ℕ) (numWords : ℕ) : String :=
+  -- Single-word arithmetic (numWords=1, primes < 2^63)
   let ps := toString p
-  let pm2 := toString (p - 2)
-  String.intercalate "\n" [
-    s!"  ;; Field arithmetic modulo {ps}",
-    s!"  (func $fadd (param i64) (param i64) (result i64)",
-    s!"    local.get 0 local.get 1 i64.add i64.const {ps} i64.rem_u)",
-    s!"  (func $fmul (param i64) (param i64) (result i64)",
-    s!"    local.get 0 local.get 1 i64.mul i64.const {ps} i64.rem_u)",
-    s!"  (func $fsub (param i64) (param i64) (result i64)",
-    s!"    (local $d i64) local.get 0 local.get 1 i64.sub local.tee $d",
-    s!"    i64.const 0 i64.lt_s",
-    s!"    (if (result i64) (then local.get $d i64.const {ps} i64.add) (else local.get $d))",
-    s!"    i64.const {ps} i64.rem_u)",
-    s!"  (func $fpow (param i64) (param i64) (result i64)",
-    s!"    (local $r i64) (local $b i64) (local $e i64)",
-    s!"    i64.const 1 local.set $r  local.get 0 local.set $b  local.get 1 local.set $e",
-    s!"    (block $done (loop $loop",
-    s!"      local.get $e i64.eqz br_if $done",
-    s!"      local.get $e i64.const 1 i64.and i64.eqz",
-    s!"      (if (then) (else local.get $r local.get $b call $fmul local.set $r))",
-    s!"      local.get $b local.get $b call $fmul local.set $b",
-    s!"      local.get $e i64.const 1 i64.shr_u local.set $e br $loop))",
-    s!"    local.get $r)",
-    s!"  (func $finv (param i64) (result i64)",
-    s!"    local.get 0 i64.const {pm2} call $fpow)" ]
+  if numWords = 1 then
+    let pm2 := toString (p - 2)
+    String.intercalate "\n" [
+      s!"  ;; Field arithmetic modulo {ps} (single-word)",
+      s!"  (func $fadd (param i64) (param i64) (result i64)",
+      s!"    local.get 0 local.get 1 i64.add i64.const {ps} i64.rem_u)",
+      s!"  (func $fmul (param i64) (param i64) (result i64)",
+      s!"    local.get 0 local.get 1 i64.mul i64.const {ps} i64.rem_u)",
+      s!"  (func $fsub (param i64) (param i64) (result i64)",
+      s!"    (local $d i64) local.get 0 local.get 1 i64.sub local.tee $d",
+      s!"    i64.const 0 i64.lt_s",
+      s!"    (if (result i64) (then local.get $d i64.const {ps} i64.add) (else local.get $d))",
+      s!"    i64.const {ps} i64.rem_u)",
+      s!"  (func $fpow (param i64) (param i64) (result i64)",
+      s!"    (local $r i64) (local $b i64) (local $e i64)",
+      s!"    i64.const 1 local.set $r  local.get 0 local.set $b  local.get 1 local.set $e",
+      s!"    (block $done (loop $loop",
+      s!"      local.get $e i64.eqz br_if $done",
+      s!"      local.get $e i64.const 1 i64.and i64.eqz",
+      s!"      (if (then) (else local.get $r local.get $b call $fmul local.set $r))",
+      s!"      local.get $b local.get $b call $fmul local.set $b",
+      s!"      local.get $e i64.const 1 i64.shr_u local.set $e br $loop))",
+      s!"    local.get $r)",
+      s!"  (func $finv (param i64) (result i64)",
+      s!"    local.get 0 i64.const {pm2} call $fpow)" ]
+  else
+    -- Multi-word arithmetic for large primes (BN254 etc.)
+    -- Each field element is numWords i64 values on the stack / in memory.
+    -- For now, we use memory-based helpers: params pass pointer to 8*numWords bytes.
+    -- For simplicity, we inline the single-word helpers with a note that multi-word
+    -- is not yet fully implemented at the expression level.
+    String.intercalate "\n" [
+      s!"  ;; Field arithmetic modulo {ps} (multi-word, {numWords} words)",
+      s!"  ;; NOTE: multi-word compilation at expression level is TODO.",
+      s!"  ;; The snarkjs ABI handles n32={numWords * 2} correctly.",
+      s!"  ;; Direct witness() uses memory: params are pointers to {numWords}×i64 arrays.",
+      s!"  (func $fadd (param i64 i64) (result i64) i64.const 0)",
+      s!"  (func $fmul (param i64 i64) (result i64) i64.const 0)",
+      s!"  (func $fsub (param i64 i64) (result i64) i64.const 0)",
+      s!"  (func $finv (param i64) (result i64) i64.const 0)" ]
 
 structure VarMap where
   env : List (ℕ × ℕ) := []
@@ -187,16 +204,18 @@ def processFlatOps (numInputs : ℕ) : List (FlatOperation F) → VarMap → ℕ
     processFlatOps numInputs rest vmOut viOut (acc ++ outLines)
   | _ :: rest, vm, vi, acc => processFlatOps numInputs rest vm vi acc
 
-def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : String :=
+def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) (numWords : ℕ := 1) : String :=
   let vm := VarMap.init numInputs
   let flatOps := flattenOps ops
   let (finalVm, _, bodyLines) := processFlatOps numInputs flatOps vm numInputs []
   let tw := finalVm.nextLocal - numInputs
   let totalSignals := 1 + numInputs + tw
   let ps := toString fieldPrime
-  -- Memory layout: 0=computed_flag, 4=SRWM(word0), 8=signal_array(totalSignals*4 bytes)
+  let n32 := numWords * 2  -- i32 words per field element
+  -- Memory layout: 0=computed_flag, 4=SRWM(n32*4 bytes), 4+n32*4=signal_array(totalSignals*n32*4 bytes)
   let srwmBase := 4
-  let signalBase := 8
+  let signalBase := 4 + n32 * 4
+  let signalBytes := n32 * 4  -- bytes per signal
   let inputParams := String.intercalate " " (List.range numInputs |>.map fun i => s!"(param $in_{i} i64)")
   let locals := String.intercalate " "
     ((List.replicate tw "(local i64)") ++ ["(local $idx i64)"])
@@ -204,18 +223,18 @@ def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : Stri
   let computeBody := String.intercalate "\n" (bodyLines ++ rets)
   let results := if tw > 0 then
     s!"(result {String.intercalate " " (List.replicate tw "i64")})" else ""
-  -- Input load lines: read each input from memory as i32, extend to i64 for computation
+  -- Input load lines: read each input from memory as i32, extend to i64
   let inputLoads := String.intercalate "\n" (List.range numInputs |>.map fun i =>
-    s!"    i32.const {signalBase + (1 + i) * 4} i32.load  i64.extend_i32_u  local.set $in_{i}")
+    s!"    i32.const {signalBase + (1 + i) * signalBytes} i32.load  i64.extend_i32_u  local.set $in_{i}")
   -- Push inputs onto stack for calling $compute
   let inputPush := String.intercalate "\n" (List.range numInputs |>.map fun i =>
     s!"    local.get $in_{i}")
   -- Output store for getWitness: wrap i64 to i32, store to signal array
   let outputStoresW := String.intercalate "\n" (List.range tw |>.map fun i =>
-    s!"    i32.const {signalBase + (1 + numInputs + i) * 4}  local.get $w_{i}  i32.wrap_i64  i32.store")
+    s!"    i32.const {signalBase + (1 + numInputs + i) * signalBytes}  local.get $w_{i}  i32.wrap_i64  i32.store")
   -- snarkjs ABI exports
   let snarkjsExports := String.intercalate "\n\n" [
-    s!"  (func (export \"getFieldNumLen32\") (result i32) i32.const 1)",
+    s!"  (func (export \"getFieldNumLen32\") (result i32) i32.const {n32})",
     s!"  (func (export \"getRawPrime\")  i32.const {srwmBase}  i32.const {fieldPrime}  i32.store)",
     s!"  (func (export \"readSharedRWMemory\") (param i32) (result i32)",
     s!"    i32.const {srwmBase}  local.get 0  i32.const 4  i32.mul  i32.add  i32.load)",
@@ -225,7 +244,7 @@ def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : Stri
     s!"  (func (export \"getInputSize\") (result i32) i32.const {numInputs})",
     s!"  (func (export \"getWitnessSize\") (result i32) i32.const {totalSignals})",
     s!"  (func (export \"setInputSignal\") (param $hMSB i32) (param $hLSB i32) (param $idx i32)",
-    s!"    i32.const {signalBase + 4}  local.get $idx  i32.const 4  i32.mul  i32.add",
+    s!"    i32.const {signalBase + signalBytes}  local.get $idx  i32.const {signalBytes}  i32.mul  i32.add",
     s!"    i32.const {srwmBase}  i32.load",
     s!"    i32.store)",
     s!"  (func (export \"getWitness\") (param $i i32)",
@@ -241,7 +260,7 @@ def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : Stri
     s!"      i32.const 0  i32.const 1  i32.store",
     s!"    ))",
     s!"    i32.const 0",
-    s!"    i32.const {signalBase}  local.get $i  i32.const 4  i32.mul  i32.add  i32.load",
+    s!"    i32.const {signalBase}  local.get $i  i32.const {signalBytes}  i32.mul  i32.add  i32.load",
     s!"    i32.store offset={srwmBase})",
     s!"  (func (export \"getMessageChar\") (result i32) i32.const 0)",
     s!"  (func (export \"getVersion\") (result i32) i32.const 2)",
@@ -253,8 +272,8 @@ def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : Stri
     s!"(module",
     s!"  (memory (export \"memory\") 1)",
     s!"  ;; Pre-initialize signal[0] = 1 (constant)",
-    s!"  (data (i32.const {signalBase}) \"\\01\\00\\00\\00\")",
-    fieldHelpers fieldPrime,
+    s!"  (data (i32.const {signalBase}) \"\\01{String.join (List.replicate (signalBytes - 1) "\\00")}\")",
+    fieldHelpers fieldPrime numWords,
     s!"  ;; Internal compute function (our existing witness logic)",
     s!"  (func $compute {inputParams} {results}",
     s!"    {locals}",

--- a/Clean/Backends/Wasm/Compile.lean
+++ b/Clean/Backends/Wasm/Compile.lean
@@ -88,15 +88,15 @@ partial def compileFExpr (vm : VarMap) : FExpr F → Builder → Builder
     let b := Builder.indented 1 (compileFExpr vm e) b; b.push "))"
   | .ofNat n, b => compileNExpr vm n b
   | .localVar i, b => b.push s!"local.get {vm.lookup (vm.letBase + i)}"
-  | .envGet _, b => b.push "i64.const 0"
-  | .listGet _ _, b => b.push "i64.const 0"
-  | .dataGet _ _ _ _, b => b.push "i64.const 0"
-  | .hintGet _ _ _ _, b => b.push "i64.const 0"
+  | .envGet _, b => b.push "i64.const 0  ;; envGet stub"
+  | .listGet _ _, b => b.push "i64.const 0  ;; listGet stub"
+  | .dataGet _ _ _ _, b => b.push "i64.const 0  ;; dataGet stub"
+  | .hintGet _ _ _ _, b => b.push "i64.const 0  ;; hintGet stub"
 
 partial def compileNExpr (vm : VarMap) : NExpr F → Builder → Builder
   | .const n, b => b.push s!"i64.const {n}"
   | .val x, b => compileFExpr vm x b
-  | .idx, b => match vm.loopIdx with | some li => b.push s!"local.get {li}" | none => b.push "i64.const 0"
+  | .idx, b => match vm.loopIdx with | some _ => b.push "local.get $idx" | none => b.push "i64.const 0"
   | .localVar i, b => b.push s!"local.get {vm.lookup (vm.letBase + i)}"
   | .add a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.add"
   | .mul a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.mul"
@@ -157,16 +157,13 @@ def compileVExpr (vm : VarMap) (vi : ℕ) (acc : List String) : {m : ℕ} → VE
     | _ =>
       let (vmOut, _) := vm.alloc n vi
       let outBase := vmOut.nextLocal - n
-      -- Use nextLocal as the idx temp (one extra, not counted in witnesses)
-      let idxLocal := vmOut.nextLocal
-      let vmOut' := { vmOut with nextLocal := vmOut.nextLocal + 1 }
       let ls := (List.range n).foldl (fun (ls : List String) (i : ℕ) =>
-        let vmB := { vmOut' with loopIdx := some idxLocal }
+        let vmB := { vmOut with loopIdx := some 0 }
         let eb : Builder := {}
         let eb := compileFExpr vmB body eb
-        ls ++ [s!"    i64.const {i}", s!"    local.set {idxLocal}", eb.build, s!"    local.set {outBase + i}"]
+        ls ++ [s!"    i64.const {i}", "    local.set $idx", eb.build, s!"    local.set {outBase + i}"]
       ) acc
-      ({ vmOut' with loopIdx := none }, vi + n, ls)
+      ({ vmOut with loopIdx := none }, vi + n, ls)
   | _, .append _ _ => (vm, vi, "    ;; append NYI" :: acc)
 
 def processOps (numInputs : ℕ) : List (Operation F) → VarMap → ℕ → List String → VarMap × ℕ × List String
@@ -182,19 +179,18 @@ def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : Stri
   let vm := VarMap.init numInputs
   let (finalVm, _, bodyLines) := processOps numInputs ops vm numInputs []
   let tw := finalVm.nextLocal - numInputs
-  -- The return values: WASM locals numInputs .. nextLocal-1, skipping idx temps.
-  -- We compute which locals to return by filtering out temps (those not in the VarMap env).
-  -- Simpler: return all allocated locals. Extra temps will be ignored by snarkjs.
   let rets := List.range tw |>.map fun i => s!"    local.get {numInputs + i}"
   let allBody := String.intercalate "\n" (bodyLines ++ rets)
   let inputParams := String.intercalate " " (List.range numInputs |>.map fun i => s!"(param $in_{i} i64)")
-  let locals := String.intercalate " " (List.replicate tw "(local i64)")
-  let results := String.intercalate " " (List.replicate tw "i64")
+  let locals := String.intercalate " "
+    ((List.replicate tw "(local i64)") ++ ["(local $idx i64)"])
+  let results := if tw > 0 then
+    s!"(result {String.intercalate " " (List.replicate tw "i64")})" else ""
   String.intercalate "\n" [
     s!"(module",
     s!"  (memory (export \"memory\") 1)",
     fieldHelpers fieldPrime,
-    s!"  (func (export \"witness\") {inputParams} (result {results})",
+    s!"  (func (export \"witness\") {inputParams} {results}",
     s!"    {locals}",
     allBody,
     s!"  )",

--- a/Clean/Backends/Wasm/Compile.lean
+++ b/Clean/Backends/Wasm/Compile.lean
@@ -208,7 +208,6 @@ def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) (numWo
   let (finalVm, _, bodyLines) := processFlatOps numInputs flatOps vm numInputs []
   let tw := finalVm.nextLocal - numInputs
   let totalSignals := 1 + numInputs + tw
-  let ps := toString fieldPrime
   let n32 := numWords * 2  -- i32 words per field element
   -- Memory layout: 0=computed_flag, 4=SRWM(n32*4 bytes), 4+n32*4=signal_array(totalSignals*n32*4 bytes)
   let srwmBase := 4

--- a/Clean/Backends/Wasm/Compile.lean
+++ b/Clean/Backends/Wasm/Compile.lean
@@ -1,0 +1,204 @@
+/-
+WASM WAT Compiler: WitgenIR → WAT text
+-/
+import Clean.Circuit.WitnessIR
+import Clean.Circuit.Expression
+import Clean.Circuit.Operations
+
+namespace Backends.Wasm
+
+open Witgen (FExpr NExpr BExpr VExpr Step WitgenIR)
+
+variable {F : Type} [FiniteField F]
+
+structure Builder where
+  lines : List String := []
+  indent : ℕ := 0
+
+def Builder.push (line : String) (b : Builder) : Builder :=
+  let pad := String.join (List.replicate b.indent "    ")
+  { b with lines := (pad ++ line) :: b.lines }
+
+def Builder.indented (n : ℕ) (f : Builder → Builder) (b : Builder) : Builder :=
+  let inner := f { b with indent := b.indent + n }
+  { inner with indent := b.indent }
+
+def Builder.build (b : Builder) : String :=
+  String.intercalate "\n" b.lines.reverse
+
+def fieldHelpers (p : ℕ) : String :=
+  let ps := toString p
+  let pm2 := toString (p - 2)
+  String.intercalate "\n" [
+    s!"  ;; Field arithmetic modulo {ps}",
+    s!"  (func $fadd (param i64) (param i64) (result i64)",
+    s!"    local.get 0 local.get 1 i64.add i64.const {ps} i64.rem_u)",
+    s!"  (func $fmul (param i64) (param i64) (result i64)",
+    s!"    local.get 0 local.get 1 i64.mul i64.const {ps} i64.rem_u)",
+    s!"  (func $fsub (param i64) (param i64) (result i64)",
+    s!"    (local $d i64) local.get 0 local.get 1 i64.sub local.tee $d",
+    s!"    i64.const 0 i64.lt_s",
+    s!"    (if (result i64) (then local.get $d i64.const {ps} i64.add) (else local.get $d))",
+    s!"    i64.const {ps} i64.rem_u)",
+    s!"  (func $fpow (param i64) (param i64) (result i64)",
+    s!"    (local $r i64) (local $b i64) (local $e i64)",
+    s!"    i64.const 1 local.set $r  local.get 0 local.set $b  local.get 1 local.set $e",
+    s!"    (block $done (loop $loop",
+    s!"      local.get $e i64.eqz br_if $done",
+    s!"      local.get $e i64.const 1 i64.and i64.eqz",
+    s!"      (if (then) (else local.get $r local.get $b call $fmul local.set $r))",
+    s!"      local.get $b local.get $b call $fmul local.set $b",
+    s!"      local.get $e i64.const 1 i64.shr_u local.set $e br $loop))",
+    s!"    local.get $r)",
+    s!"  (func $finv (param i64) (result i64)",
+    s!"    local.get 0 i64.const {pm2} call $fpow)" ]
+
+structure VarMap where
+  env : List (ℕ × ℕ) := []
+  nextLocal : ℕ := 0
+  loopIdx : Option ℕ := none
+  letBase : ℕ := 0
+
+def VarMap.init (numInputs : ℕ) : VarMap :=
+  { env := List.range numInputs |>.map fun i => (i, i), nextLocal := numInputs }
+
+def VarMap.lookup (vm : VarMap) (idx : ℕ) : ℕ :=
+  match vm.env.find? fun (i, _) => i = idx with | some (_, w) => w | none => idx
+
+def VarMap.alloc (vm : VarMap) (m : ℕ) (baseVarIdx : ℕ) : VarMap × List ℕ :=
+  let wasmLocals := List.range m |>.map fun i => vm.nextLocal + i
+  let newEnv := (List.range m |>.map fun i => (baseVarIdx + i, vm.nextLocal + i)) ++ vm.env
+  ({ env := newEnv, nextLocal := vm.nextLocal + m, loopIdx := vm.loopIdx, letBase := vm.letBase }, wasmLocals)
+
+mutual
+partial def compileFExpr (vm : VarMap) : FExpr F → Builder → Builder
+  | .const c, b => b.push s!"i64.const {FiniteField.val c}"
+  | .add a e, b => let b := compileFExpr vm a b; let b := compileFExpr vm e b; b.push "call $fadd"
+  | .mul a e, b => let b := compileFExpr vm a b; let b := compileFExpr vm e b; b.push "call $fmul"
+  | .inv a, b => let b := compileFExpr vm a b; b.push "call $finv"
+  | .expr (.var i), b => b.push s!"local.get {vm.lookup i.index}"
+  | .expr (.const c), b => b.push s!"i64.const {FiniteField.val c}"
+  | .expr (.add a e), b => let b := compileFExpr vm (.expr a) b; let b := compileFExpr vm (.expr e) b; b.push "call $fadd"
+  | .expr (.mul a e), b => let b := compileFExpr vm (.expr a) b; let b := compileFExpr vm (.expr e) b; b.push "call $fmul"
+  | .ite c t e, b =>
+    let b := compileBExpr vm c b
+    let b := b.push "(if (result i64) (then"
+    let b := Builder.indented 1 (compileFExpr vm t) b
+    let b := b.push ") (else"
+    let b := Builder.indented 1 (compileFExpr vm e) b; b.push "))"
+  | .ofNat n, b => compileNExpr vm n b
+  | .localVar i, b => b.push s!"local.get {vm.lookup (vm.letBase + i)}"
+  | .envGet _, b => b.push "i64.const 0"
+  | .listGet _ _, b => b.push "i64.const 0"
+  | .dataGet _ _ _ _, b => b.push "i64.const 0"
+  | .hintGet _ _ _ _, b => b.push "i64.const 0"
+
+partial def compileNExpr (vm : VarMap) : NExpr F → Builder → Builder
+  | .const n, b => b.push s!"i64.const {n}"
+  | .val x, b => compileFExpr vm x b
+  | .idx, b => match vm.loopIdx with | some li => b.push s!"local.get {li}" | none => b.push "i64.const 0"
+  | .localVar i, b => b.push s!"local.get {vm.lookup (vm.letBase + i)}"
+  | .add a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.add"
+  | .mul a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.mul"
+  | .div a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.div_u"
+  | .mod a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.rem_u"
+  | .land a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.and"
+  | .lor a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.or"
+  | .lxor a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.xor"
+  | .shiftL a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.shl"
+  | .shiftR a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.shr_u"
+  | .ite c t e, b =>
+    let b := compileBExpr vm c b
+    let b := b.push "(if (result i64) (then"
+    let b := Builder.indented 1 (compileNExpr vm t) b
+    let b := b.push ") (else"
+    let b := Builder.indented 1 (compileNExpr vm e) b; b.push "))"
+
+partial def compileBExpr (vm : VarMap) : BExpr F → Builder → Builder
+  | .true, b => b.push "i64.const 1"
+  | .false, b => b.push "i64.const 0"
+  | .feq a e, b => let b := compileFExpr vm a b; let b := compileFExpr vm e b; b.push "i64.eq"
+  | .lt a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.lt_u"
+  | .neq a e, b => let b := compileNExpr vm a b; let b := compileNExpr vm e b; b.push "i64.eq  i64.eqz"
+  | .not x, b => let b := compileBExpr vm x b; b.push "i64.eqz"
+  | .and a e, b => let b := compileBExpr vm a b; let b := compileBExpr vm e b; b.push "i64.and"
+end
+
+/-! ## Module compilation -/
+
+def compileSteps (vm : VarMap) (vi : ℕ) (steps : List (Step F)) : VarMap × ℕ × List String :=
+  steps.foldl (fun ((vm, vi, ls) : VarMap × ℕ × List String) step =>
+    match step with
+    | .letF e =>
+      let eb : Builder := {}
+      let eb := compileFExpr vm e eb
+      let (vm', locs) := vm.alloc 1 vi
+      (vm', vi + 1, s!"    local.set {locs.head?.getD 0}" :: eb.build :: ls)
+    | .letN e =>
+      let eb : Builder := {}
+      let eb := compileNExpr vm e eb
+      let (vm', locs) := vm.alloc 1 vi
+      (vm', vi + 1, s!"    local.set {locs.head?.getD 0}" :: eb.build :: ls)
+  ) (vm, vi, [])
+
+def compileLit (vm : VarMap) (vi : ℕ) (acc : List String) (es : List (FExpr F)) : VarMap × ℕ × List String :=
+  es.foldl (fun ((vm, vi, ls) : VarMap × ℕ × List String) (e : FExpr F) =>
+    let eb : Builder := {}
+    let eb := compileFExpr vm e eb
+    let (vm', locs) := vm.alloc 1 vi
+    (vm', vi + 1, s!"    local.set {locs.head?.getD 0}" :: eb.build :: ls)
+  ) (vm, vi, acc)
+
+def compileVExpr (vm : VarMap) (vi : ℕ) (acc : List String) : {m : ℕ} → VExpr F m → VarMap × ℕ × List String
+  | _, .lit es => compileLit vm vi acc es.toList
+  | _, .mapRange n body =>
+    match body with
+    | .envGet _ => (vm, vi, acc)
+    | _ =>
+      let (vmOut, _) := vm.alloc n vi
+      let outBase := vmOut.nextLocal - n
+      -- Use nextLocal as the idx temp (one extra, not counted in witnesses)
+      let idxLocal := vmOut.nextLocal
+      let vmOut' := { vmOut with nextLocal := vmOut.nextLocal + 1 }
+      let ls := (List.range n).foldl (fun (ls : List String) (i : ℕ) =>
+        let vmB := { vmOut' with loopIdx := some idxLocal }
+        let eb : Builder := {}
+        let eb := compileFExpr vmB body eb
+        s!"    local.set {outBase + i}" :: eb.build :: s!"    local.set {idxLocal}" :: s!"    i64.const {i}" :: ls
+      ) acc
+      ({ vmOut' with loopIdx := none }, vi + n, ls)
+  | _, .append _ _ => (vm, vi, "    ;; append NYI" :: acc)
+
+def processOps (numInputs : ℕ) : List (Operation F) → VarMap → ℕ → List String → VarMap × ℕ × List String
+  | [], vm, _, lines => (vm, numInputs, lines.reverse)
+  | .witness _ (.ir steps vexpr) :: rest, vm, vi, acc =>
+    let vmStep := { vm with letBase := vi }
+    let (vmS, viS, stepLines) := compileSteps vmStep vi steps
+    let (vmOut, viOut, outLines) := compileVExpr vmS viS stepLines vexpr
+    processOps numInputs rest vmOut viOut (acc ++ outLines)
+  | _ :: rest, vm, vi, acc => processOps numInputs rest vm vi acc
+
+def compileModule (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : String :=
+  let vm := VarMap.init numInputs
+  let (finalVm, _, bodyLines) := processOps numInputs ops vm numInputs []
+  let tw := finalVm.nextLocal - numInputs
+  -- The return values: WASM locals numInputs .. nextLocal-1, skipping idx temps.
+  -- We compute which locals to return by filtering out temps (those not in the VarMap env).
+  -- Simpler: return all allocated locals. Extra temps will be ignored by snarkjs.
+  let rets := List.range tw |>.map fun i => s!"    local.get {numInputs + i}"
+  let allBody := String.intercalate "\n" (bodyLines ++ rets)
+  let inputParams := String.intercalate " " (List.range numInputs |>.map fun i => s!"(param $in_{i} i64)")
+  let locals := String.intercalate " " (List.replicate tw "(local i64)")
+  let results := String.intercalate " " (List.replicate tw "i64")
+  String.intercalate "\n" [
+    s!"(module",
+    s!"  (memory (export \"memory\") 1)",
+    fieldHelpers fieldPrime,
+    s!"  (func (export \"witness\") {inputParams} (result {results})",
+    s!"    {locals}",
+    allBody,
+    s!"  )",
+    s!")"
+  ]
+
+end Backends.Wasm

--- a/Clean/Backends/Wasm/R1CS.lean
+++ b/Clean/Backends/Wasm/R1CS.lean
@@ -38,7 +38,7 @@ def addLinCombs (a b : LinComb) (p : ℕ) : LinComb :=
     else (i2, c2) :: addLinCombs ((i1, c1) :: xs) ys p
 
 partial def flattenExpr (p : ℕ) : Expression F → FlattenState → (LinComb × FlattenState)
-  | .var i, st => ([(i.index, 1)], st)
+  | .var i, st => ([(1 + i.index, 1)], st)  -- signal 0 = constant, so var i → signal i+1
   | .const c, st =>
     let val := FiniteField.val c % p
     ([(0, val)], st)

--- a/Clean/Backends/Wasm/R1CS.lean
+++ b/Clean/Backends/Wasm/R1CS.lean
@@ -23,8 +23,6 @@ structure FlattenState where
 def isConstant (lc : LinComb) : Bool :=
   match lc with | [(0, _)] => true | _ => false
 
-def modP (x : ℕ) (p : ℕ) : ℕ := x % p
-
 def scaleLinComb (c : ℕ) (lc : LinComb) (p : ℕ) : LinComb :=
   lc.map fun (i, coeff) => (i, (c * coeff) % p)
 
@@ -58,18 +56,18 @@ partial def flattenExpr (p : ℕ) (vm : VarMap) : Expression F → FlattenState 
       let st3 : FlattenState := { nextSignal := k + 1, constraints := (la, lb, [(k, 1)]) :: st2.constraints }
       ([(k, 1)], st3)
 
-def processOps (p : ℕ) (vm : VarMap) (ops : List (FlatOperation F)) (st : FlattenState) (nextSig : ℕ)
-    (acc : List Constraint) : List Constraint × ℕ :=
+def processOps (p : ℕ) (vm : VarMap) (ops : List (FlatOperation F)) (st : FlattenState) :
+    List Constraint × ℕ :=
   match ops with
-  | [] => (acc, st.nextSignal)
+  | [] => (st.constraints, st.nextSignal)
   | .witness _ _ :: rest =>
-    processOps p vm rest st nextSig acc  -- VarMap already handles witness allocation
+    processOps p vm rest st  -- VarMap already handles witness allocation
   | .assert e :: rest =>
     let (lc, st1) := flattenExpr p vm e st
     let constr : Constraint := (lc, [(0, 1)], [])
     let st2 := { st1 with constraints := constr :: st1.constraints }
-    processOps p vm rest st2 nextSig (constr :: acc)
-  | _ :: rest => processOps p vm rest st nextSig acc
+    processOps p vm rest st2
+  | _ :: rest => processOps p vm rest st
 
 def compileR1CS (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : String :=
   let flatOps := flattenOps ops
@@ -79,7 +77,7 @@ def compileR1CS (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : String
   let (finalVm, _, _) := processFlatOps numInputs flatOps vm numInputs []
   let totalSignals := 1 + finalVm.nextLocal  -- +1 for constant signal
   let st : FlattenState := { nextSignal := totalSignals }
-  let (allConstraints, nVars) := processOps fieldPrime vm flatOps st (1 + numInputs) []
+  let (allConstraints, nVars) := processOps fieldPrime vm flatOps st
   let ps := toString fieldPrime
   let constraintLines := allConstraints.reverse.map fun (a, b, c) =>
     "    [" ++ linCombToJson a ++ ", " ++ linCombToJson b ++ ", " ++ linCombToJson c ++ "]"

--- a/Clean/Backends/Wasm/R1CS.lean
+++ b/Clean/Backends/Wasm/R1CS.lean
@@ -23,51 +23,53 @@ structure FlattenState where
 def isConstant (lc : LinComb) : Bool :=
   match lc with | [(0, _)] => true | _ => false
 
-def scaleLinComb (c : ℕ) (lc : LinComb) : LinComb :=
-  lc.map fun (i, coeff) => (i, c * coeff)
+def modP (x : ℕ) (p : ℕ) : ℕ := x % p
 
-def addLinCombs (a b : LinComb) : LinComb :=
+def scaleLinComb (c : ℕ) (lc : LinComb) (p : ℕ) : LinComb :=
+  lc.map fun (i, coeff) => (i, (c * coeff) % p)
+
+def addLinCombs (a b : LinComb) (p : ℕ) : LinComb :=
   match a, b with
   | [], _ => b
   | _, [] => a
   | (i1, c1) :: xs, (i2, c2) :: ys =>
-    if i1 < i2 then (i1, c1) :: addLinCombs xs ((i2, c2) :: ys)
-    else if i1 = i2 then (i1, c1 + c2) :: addLinCombs xs ys
-    else (i2, c2) :: addLinCombs ((i1, c1) :: xs) ys
+    if i1 < i2 then (i1, c1) :: addLinCombs xs ((i2, c2) :: ys) p
+    else if i1 = i2 then (i1, (c1 + c2) % p) :: addLinCombs xs ys p
+    else (i2, c2) :: addLinCombs ((i1, c1) :: xs) ys p
 
-partial def flattenExpr : Expression F → FlattenState → (LinComb × FlattenState)
+partial def flattenExpr (p : ℕ) : Expression F → FlattenState → (LinComb × FlattenState)
   | .var i, st => ([(i.index, 1)], st)
   | .const c, st =>
-    let val := FiniteField.val c
+    let val := FiniteField.val c % p
     ([(0, val)], st)
   | .add a b, st =>
-    let (la, st1) := flattenExpr a st
-    let (lb, st2) := flattenExpr b st1
-    (addLinCombs la lb, st2)
+    let (la, st1) := flattenExpr p a st
+    let (lb, st2) := flattenExpr p b st1
+    (addLinCombs la lb p, st2)
   | .mul a b, st =>
-    let (la, st1) := flattenExpr a st
-    let (lb, st2) := flattenExpr b st1
+    let (la, st1) := flattenExpr p a st
+    let (lb, st2) := flattenExpr p b st1
     if isConstant la then
-      (scaleLinComb ((la.head?.getD (0,0)).2) lb, st2)
+      (scaleLinComb ((la.head?.getD (0,0)).2) lb p, st2)
     else if isConstant lb then
-      (scaleLinComb ((lb.head?.getD (0,0)).2) la, st2)
+      (scaleLinComb ((lb.head?.getD (0,0)).2) la p, st2)
     else
       let k := st2.nextSignal
       let st3 : FlattenState := { nextSignal := k + 1, constraints := (la, lb, [(k, 1)]) :: st2.constraints }
       ([(k, 1)], st3)
 
-def processOps (ops : List (FlatOperation F)) (st : FlattenState) (nextSig : ℕ)
+def processOps (p : ℕ) (ops : List (FlatOperation F)) (st : FlattenState) (nextSig : ℕ)
     (acc : List Constraint) : List Constraint × ℕ :=
   match ops with
   | [] => (acc, st.nextSignal)
   | .witness m _ :: rest =>
-    processOps rest { st with nextSignal := st.nextSignal + m } (nextSig + m) acc
+    processOps p rest { st with nextSignal := st.nextSignal + m } (nextSig + m) acc
   | .assert e :: rest =>
-    let (lc, st1) := flattenExpr e st
+    let (lc, st1) := flattenExpr p e st
     let constr : Constraint := (lc, [(0, 1)], [])
     let st2 := { st1 with constraints := constr :: st1.constraints }
-    processOps rest st2 nextSig (constr :: acc)
-  | _ :: rest => processOps rest st nextSig acc
+    processOps p rest st2 nextSig (constr :: acc)
+  | _ :: rest => processOps p rest st nextSig acc
 
 def compileR1CS (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : String :=
   let flatOps := flattenOps ops
@@ -75,7 +77,7 @@ def compileR1CS (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : String
   let totalWitness : ℕ := flatOps.foldl (fun (acc : ℕ) (op : FlatOperation F) =>
     match op with | .witness m _ => acc + m | _ => acc) 0
   let st : FlattenState := { nextSignal := 1 + numInputs + totalWitness }
-  let (allConstraints, nVars) := processOps flatOps st (1 + numInputs) []
+  let (allConstraints, nVars) := processOps fieldPrime flatOps st (1 + numInputs) []
   let ps := toString fieldPrime
   -- Build JSON manually (avoid s! for escaped quotes)
   let constraintLines := allConstraints.reverse.map fun (a, b, c) =>

--- a/Clean/Backends/Wasm/R1CS.lean
+++ b/Clean/Backends/Wasm/R1CS.lean
@@ -1,0 +1,102 @@
+/-
+R1CS Constraint Export
+
+Converts Clean circuit operations to R1CS JSON format compatible with snarkjs.
+-/
+import Clean.Circuit.Expression
+import Clean.Circuit.Operations
+import Clean.Backends.Wasm.Compile
+
+namespace Backends.Wasm
+
+open Expression (var const add mul)
+
+variable {F : Type} [FiniteField F]
+
+abbrev LinComb := List (ℕ × ℕ)  -- sparse (signalIndex × coefficient) pairs
+abbrev Constraint := LinComb × LinComb × LinComb  -- (A, B, C)
+
+structure FlattenState where
+  nextSignal : ℕ := 1
+  constraints : List Constraint := []
+
+def isConstant (lc : LinComb) : Bool :=
+  match lc with | [(0, _)] => true | _ => false
+
+def scaleLinComb (c : ℕ) (lc : LinComb) : LinComb :=
+  lc.map fun (i, coeff) => (i, c * coeff)
+
+def addLinCombs (a b : LinComb) : LinComb :=
+  match a, b with
+  | [], _ => b
+  | _, [] => a
+  | (i1, c1) :: xs, (i2, c2) :: ys =>
+    if i1 < i2 then (i1, c1) :: addLinCombs xs ((i2, c2) :: ys)
+    else if i1 = i2 then (i1, c1 + c2) :: addLinCombs xs ys
+    else (i2, c2) :: addLinCombs ((i1, c1) :: xs) ys
+
+partial def flattenExpr : Expression F → FlattenState → (LinComb × FlattenState)
+  | .var i, st => ([(i.index, 1)], st)
+  | .const c, st =>
+    let val := FiniteField.val c
+    ([(0, val)], st)
+  | .add a b, st =>
+    let (la, st1) := flattenExpr a st
+    let (lb, st2) := flattenExpr b st1
+    (addLinCombs la lb, st2)
+  | .mul a b, st =>
+    let (la, st1) := flattenExpr a st
+    let (lb, st2) := flattenExpr b st1
+    if isConstant la then
+      (scaleLinComb ((la.head?.getD (0,0)).2) lb, st2)
+    else if isConstant lb then
+      (scaleLinComb ((lb.head?.getD (0,0)).2) la, st2)
+    else
+      let k := st2.nextSignal
+      let st3 : FlattenState := { nextSignal := k + 1, constraints := (la, lb, [(k, 1)]) :: st2.constraints }
+      ([(k, 1)], st3)
+
+def processOps (ops : List (FlatOperation F)) (st : FlattenState) (nextSig : ℕ)
+    (acc : List Constraint) : List Constraint × ℕ :=
+  match ops with
+  | [] => (acc, st.nextSignal)
+  | .witness m _ :: rest =>
+    processOps rest { st with nextSignal := st.nextSignal + m } (nextSig + m) acc
+  | .assert e :: rest =>
+    let (lc, st1) := flattenExpr e st
+    let constr : Constraint := (lc, [(0, 1)], [])
+    let st2 := { st1 with constraints := constr :: st1.constraints }
+    processOps rest st2 nextSig (constr :: acc)
+  | _ :: rest => processOps rest st nextSig acc
+
+def compileR1CS (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : String :=
+  let flatOps := flattenOps ops
+  -- Count witnesses for signal allocation
+  let totalWitness : ℕ := flatOps.foldl (fun (acc : ℕ) (op : FlatOperation F) =>
+    match op with | .witness m _ => acc + m | _ => acc) 0
+  let st : FlattenState := { nextSignal := 1 + numInputs + totalWitness }
+  let (allConstraints, nVars) := processOps flatOps st (1 + numInputs) []
+  let ps := toString fieldPrime
+  -- Build JSON manually (avoid s! for escaped quotes)
+  let constraintLines := allConstraints.reverse.map fun (a, b, c) =>
+    "    [" ++ linCombToJson a ++ ", " ++ linCombToJson b ++ ", " ++ linCombToJson c ++ "]"
+  "{\n" ++
+  "  \"n8\": 32,\n" ++
+  "  \"prime\": \"" ++ ps ++ "\",\n" ++
+  "  \"nVars\": " ++ toString nVars ++ ",\n" ++
+  "  \"nOutputs\": 1,\n" ++
+  "  \"nPubInputs\": " ++ toString numInputs ++ ",\n" ++
+  "  \"nPrvInputs\": 0,\n" ++
+  "  \"nLabels\": " ++ toString nVars ++ ",\n" ++
+  "  \"nConstraints\": " ++ toString allConstraints.length ++ ",\n" ++
+  "  \"constraints\": [\n" ++
+  String.intercalate ",\n" constraintLines ++ "\n" ++
+  "  ]\n" ++
+  "}"
+where
+  linCombToJson (lc : LinComb) : String :=
+    let entries := lc.map fun (i, coeff) =>
+      "\"" ++ toString i ++ "\": \"" ++ toString coeff ++ "\""
+    "{" ++ String.intercalate ", " entries ++ "}"
+
+end Backends.Wasm

--- a/Clean/Backends/Wasm/R1CS.lean
+++ b/Clean/Backends/Wasm/R1CS.lean
@@ -37,18 +37,18 @@ def addLinCombs (a b : LinComb) (p : ℕ) : LinComb :=
     else if i1 = i2 then (i1, (c1 + c2) % p) :: addLinCombs xs ys p
     else (i2, c2) :: addLinCombs ((i1, c1) :: xs) ys p
 
-partial def flattenExpr (p : ℕ) : Expression F → FlattenState → (LinComb × FlattenState)
-  | .var i, st => ([(1 + i.index, 1)], st)  -- signal 0 = constant, so var i → signal i+1
+partial def flattenExpr (p : ℕ) (vm : VarMap) : Expression F → FlattenState → (LinComb × FlattenState)
+  | .var i, st => ([(1 + vm.lookup i.index, 1)], st)  -- R1CS signal = 1 + WASM local
   | .const c, st =>
     let val := FiniteField.val c % p
     ([(0, val)], st)
   | .add a b, st =>
-    let (la, st1) := flattenExpr p a st
-    let (lb, st2) := flattenExpr p b st1
+    let (la, st1) := flattenExpr p vm a st
+    let (lb, st2) := flattenExpr p vm b st1
     (addLinCombs la lb p, st2)
   | .mul a b, st =>
-    let (la, st1) := flattenExpr p a st
-    let (lb, st2) := flattenExpr p b st1
+    let (la, st1) := flattenExpr p vm a st
+    let (lb, st2) := flattenExpr p vm b st1
     if isConstant la then
       (scaleLinComb ((la.head?.getD (0,0)).2) lb p, st2)
     else if isConstant lb then
@@ -58,28 +58,29 @@ partial def flattenExpr (p : ℕ) : Expression F → FlattenState → (LinComb �
       let st3 : FlattenState := { nextSignal := k + 1, constraints := (la, lb, [(k, 1)]) :: st2.constraints }
       ([(k, 1)], st3)
 
-def processOps (p : ℕ) (ops : List (FlatOperation F)) (st : FlattenState) (nextSig : ℕ)
+def processOps (p : ℕ) (vm : VarMap) (ops : List (FlatOperation F)) (st : FlattenState) (nextSig : ℕ)
     (acc : List Constraint) : List Constraint × ℕ :=
   match ops with
   | [] => (acc, st.nextSignal)
-  | .witness m _ :: rest =>
-    processOps p rest { st with nextSignal := st.nextSignal + m } (nextSig + m) acc
+  | .witness _ _ :: rest =>
+    processOps p vm rest st nextSig acc  -- VarMap already handles witness allocation
   | .assert e :: rest =>
-    let (lc, st1) := flattenExpr p e st
+    let (lc, st1) := flattenExpr p vm e st
     let constr : Constraint := (lc, [(0, 1)], [])
     let st2 := { st1 with constraints := constr :: st1.constraints }
-    processOps p rest st2 nextSig (constr :: acc)
-  | _ :: rest => processOps p rest st nextSig acc
+    processOps p vm rest st2 nextSig (constr :: acc)
+  | _ :: rest => processOps p vm rest st nextSig acc
 
 def compileR1CS (fieldPrime numInputs : ℕ) (ops : List (Operation F)) : String :=
   let flatOps := flattenOps ops
-  -- Count witnesses for signal allocation
-  let totalWitness : ℕ := flatOps.foldl (fun (acc : ℕ) (op : FlatOperation F) =>
-    match op with | .witness m _ => acc + m | _ => acc) 0
-  let st : FlattenState := { nextSignal := 1 + numInputs + totalWitness }
-  let (allConstraints, nVars) := processOps fieldPrime flatOps st (1 + numInputs) []
+  -- Use the WASM compiler's VarMap to get the same signal layout
+  -- Process operations to build the variable-to-signal mapping
+  let vm := VarMap.init numInputs
+  let (finalVm, _, _) := processFlatOps numInputs flatOps vm numInputs []
+  let totalSignals := 1 + finalVm.nextLocal  -- +1 for constant signal
+  let st : FlattenState := { nextSignal := totalSignals }
+  let (allConstraints, nVars) := processOps fieldPrime vm flatOps st (1 + numInputs) []
   let ps := toString fieldPrime
-  -- Build JSON manually (avoid s! for escaped quotes)
   let constraintLines := allConstraints.reverse.map fun (a, b, c) =>
     "    [" ++ linCombToJson a ++ ", " ++ linCombToJson b ++ ", " ++ linCombToJson c ++ "]"
   "{\n" ++


### PR DESCRIPTION
Adds R1CS constraint generation from Clean circuit operations. Generates JSON compatible with snarkjs for Groth16 prove/verify.

## How it works

Walks each `assert expr` and recursively flattens the expression tree to degree-2 R1CS constraints by introducing intermediate signals for non-constant multiplications. Signal 0 is constant 1, signals 1..numInputs are inputs, the rest are witnesses and intermediates.

## Current status

Draft. Generates valid R1CS JSON. Still needs Clean's internal `a + (-1)*b` encoding normalization to match circom-generated R1CS exactly.