### PR TITLE
Prove Pallas/Vesta group orders, replace pallas_natCard axiom with a theorem

### DIFF
--- a/Clean/Ironwood/Ecc/Mul.lean
+++ b/Clean/Ironwood/Ecc/Mul.lean
@@ -83,8 +83,9 @@ copies. R1b refilled both proofs: the six child-consumption sites go through `su
 (soundness `at h` weakening; completeness goal mode with the `h_spec_i` derived statements —
 no absorption iffs, no `call_constraints_and_specs` copies), and the value algebra is the
 fdee7ac4 donor ladder verbatim modulo the region-faithful cell addresses
-(`env.place i₀ + X`). `#print axioms` on the bundle: the standard three plus the donor Pallas
-trust base (`pallas_natCard` + vendored CompElliptic `native_decide` curve facts).
+(`env.place i₀ + X`). `#print axioms` on the bundle: the standard three plus vendored CompElliptic
+`native_decide` facts (`pallas_natCard` is now a theorem, proved from a `native_decide`
+order certificate in `CompElliptic.Curves.Pasta.Pallas.natCard`).
 -/
 
 namespace Halo2.Ironwood.Ecc.Mul

--- a/Clean/Orchard/Specs/CompElliptic/CurveForms/ShortWeierstrassOrder.lean
+++ b/Clean/Orchard/Specs/CompElliptic/CurveForms/ShortWeierstrassOrder.lean
@@ -1,0 +1,205 @@
+/-
+Copyright (c) 2026 CompElliptic Contributors. All rights reserved.
+Released under the Apache License, Version 2.0, or the MIT license, at your option,
+as described in the files LICENSE-APACHE and LICENSE-MIT.
+Authors: Daira-Emma Hopwood
+-/
+import Clean.Orchard.Specs.CompElliptic.CurveForms.ShortWeierstrass
+import Mathlib.Algebra.Polynomial.Roots
+import Mathlib.GroupTheory.Perm.Cycle.Type
+
+/-!
+# Curve order machinery for short-Weierstrass curves
+
+Generic tools to pin down `Nat.card (SWPoint E)` for a concrete curve `E` over a finite field:
+
+1. **Finiteness and a crude cardinality bound** — `SWPoint E` embeds into `F × F`, and each
+   `x`-coordinate carries at most two curve points (the roots of `y² = x³ + A x + B`), so
+   `Nat.card (SWPoint E) ≤ 2 * Fintype.card F + 1` (`natCard_le`). This is a weak stand-in for
+   Hasse's bound, but it is enough to pin the group order given a prime `q` with `q • G = 0`.
+
+2. **Fast scalar multiplication** — the group `n • P` is unary (`nsmulRec`), hopeless for
+   `native_decide` at cryptographic sizes. `fastNsmul` is the double-and-add form, proven equal to
+   `n • P` (`fastNsmul_eq`), so concrete call sites can evaluate `q • G = 0` via `native_decide`.
+
+3. **Order pinning** — if a prime `q` kills a nonzero point and `2 * Fintype.card F + 1 < 2 * q`,
+   then `Nat.card (SWPoint E) = q` (`natCard_eq_of_prime_nsmul`). When the prime is *smaller* than
+   the field (as for a curve of order `p` over a field of order `q > p`), the weaker bound
+   `2 * Fintype.card F + 1 < 3 * p` suffices provided the group has no 2-torsion
+   (`natCard_eq_of_prime_nsmul_odd`); `two_nsmul_eq_zero` discharges the no-2-torsion side
+   condition from the absence of points with `y = 0`.
+-/
+
+namespace CompElliptic.CurveForms.ShortWeierstrass
+
+variable {F : Type*} [Field F] [DecidableEq F]
+
+instance (a b : F) (p : F × F) : Decidable (Valid a b p) := by
+  unfold Valid; infer_instance
+
+/-! ## Finiteness and the cardinality bound -/
+
+/-- Representable points on `E` are exactly the valid coordinate pairs. -/
+def SWPoint.equivSubtype (E : SWCurve F) : SWPoint E ≃ { pr : F × F // Valid E.A E.B pr } where
+  toFun P := ⟨(P.x, P.y), P.onCurve⟩
+  invFun pr := ⟨pr.1.1, pr.1.2, pr.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+instance {E : SWCurve F} [Finite F] : Finite (SWPoint E) :=
+  Finite.of_injective (fun P => (P.x, P.y)) fun _ _ h => SWPoint.ext_pair h
+
+instance {E : SWCurve F} : Nonempty (SWPoint E) := ⟨0⟩
+
+/-- Each `x`-coordinate carries at most two on-curve points: the fiber injects into the square
+roots of `x³ + A x + B`. -/
+theorem card_filter_onCurve_fst_le [Fintype F] (E : SWCurve F) (x : F) :
+    ((Finset.univ.filter fun pr : F × F => OnCurve E.A E.B pr).filter
+      fun pr => pr.1 = x).card ≤ 2 := by
+  have hmap : ∀ pr ∈ (Finset.univ.filter fun pr : F × F => OnCurve E.A E.B pr).filter
+      (fun pr => pr.1 = x),
+      pr.2 ∈ (Polynomial.nthRoots 2 (x ^ 3 + E.A * x + E.B)).toFinset := by
+    intro pr hpr
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hpr
+    obtain ⟨hOn, hx⟩ := hpr
+    rw [Multiset.mem_toFinset, Polynomial.mem_nthRoots two_pos]
+    rw [OnCurve, hx] at hOn
+    exact hOn
+  have hinj : Set.InjOn (fun pr : F × F => pr.2)
+      ((Finset.univ.filter fun pr : F × F => OnCurve E.A E.B pr).filter fun pr => pr.1 = x) := by
+    intro p hp q hq hpq
+    simp only [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_filter, Finset.mem_univ,
+      true_and] at hp hq
+    exact Prod.ext (hp.2.trans hq.2.symm) hpq
+  calc ((Finset.univ.filter fun pr : F × F => OnCurve E.A E.B pr).filter
+        fun pr => pr.1 = x).card
+      ≤ (Polynomial.nthRoots 2 (x ^ 3 + E.A * x + E.B)).toFinset.card :=
+        Finset.card_le_card_of_injOn _ hmap hinj
+    _ ≤ Multiset.card (Polynomial.nthRoots 2 (x ^ 3 + E.A * x + E.B)) :=
+        Multiset.toFinset_card_le _
+    _ ≤ 2 := Polynomial.card_nthRoots 2 _
+
+/-- Crude cardinality bound: at most two points per `x`-coordinate, plus the identity `𝒪`. -/
+theorem natCard_le [Fintype F] {E : SWCurve F} :
+    Nat.card (SWPoint E) ≤ 2 * Fintype.card F + 1 := by
+  rw [Nat.card_congr (SWPoint.equivSubtype E), Nat.card_eq_fintype_card, Fintype.card_subtype]
+  have hsub : (Finset.univ.filter fun pr : F × F => Valid E.A E.B pr) ⊆
+      (Finset.univ.filter fun pr : F × F => OnCurve E.A E.B pr) ∪ {((0 : F), (0 : F))} := by
+    intro pr hpr
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_union,
+      Finset.mem_singleton] at hpr ⊢
+    exact hpr
+  calc (Finset.univ.filter fun pr : F × F => Valid E.A E.B pr).card
+      ≤ ((Finset.univ.filter fun pr : F × F => OnCurve E.A E.B pr) ∪
+          {((0 : F), (0 : F))}).card :=
+        Finset.card_le_card hsub
+    _ ≤ (Finset.univ.filter fun pr : F × F => OnCurve E.A E.B pr).card + 1 :=
+        le_trans (Finset.card_union_le _ _) (by simp)
+    _ ≤ 2 * Fintype.card F + 1 := by
+        have h := Finset.card_le_mul_card_image_of_maps_to
+          (f := Prod.fst) (t := (Finset.univ : Finset F))
+          (fun _ _ => Finset.mem_univ _) 2 (fun x _ => card_filter_onCurve_fst_le E x)
+        rw [Finset.card_univ] at h
+        omega
+
+/-! ## Fast scalar multiplication
+
+The `AddCommGroup (SWPoint E)` instance uses `nsmulRec`, so `n • P` is a unary tower of additions
+and cannot be evaluated for cryptographic `n`. `fastNsmul` is the standard double-and-add form;
+`fastNsmul_eq` lets concrete call sites decide `n • G = 0` by `native_decide` on `fastNsmul`. -/
+
+/-- Double-and-add scalar multiplication, evaluable for cryptographic-size `n`. -/
+def fastNsmul {E : SWCurve F} (n : ℕ) (P : SWPoint E) : SWPoint E :=
+  if _h : n = 0 then 0
+  else
+    let half := fastNsmul (n / 2) P
+    if n % 2 = 0 then half + half else half + half + P
+  termination_by n
+  decreasing_by omega
+
+/-- `fastNsmul` computes the group-theoretic `n • P`. -/
+theorem fastNsmul_eq {E : SWCurve F} (n : ℕ) (P : SWPoint E) : fastNsmul n P = n • P := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    rw [fastNsmul]
+    by_cases h : n = 0
+    · rw [dif_pos h, h, zero_nsmul]
+    · rw [dif_neg h, ih (n / 2) (Nat.div_lt_self (Nat.pos_of_ne_zero h) one_lt_two)]
+      rcases Nat.mod_two_eq_zero_or_one n with hm | hm
+      · rw [if_pos hm, ← two_nsmul, ← mul_nsmul']
+        congr 1
+        omega
+      · rw [if_neg (by omega), ← two_nsmul, ← mul_nsmul', ← succ_nsmul]
+        congr 1
+        omega
+
+/-! ## Order pinning -/
+
+/-- If a prime `q` kills a nonzero point and `q` exceeds half the crude cardinality bound, the
+group order is exactly `q`: the order divides `Nat.card`, and `Nat.card < 2 * q` leaves `q` as the
+only multiple in range. -/
+theorem natCard_eq_of_prime_nsmul [Fintype F] {E : SWCurve F} {q : ℕ} (hq : Nat.Prime q)
+    {G : SWPoint E} (hG : G ≠ 0) (hsmul : q • G = 0)
+    (hbound : 2 * Fintype.card F + 1 < 2 * q) : Nat.card (SWPoint E) = q := by
+  haveI := Fact.mk hq
+  have horder : addOrderOf G = q := addOrderOf_eq_prime hsmul hG
+  have hdvd : q ∣ Nat.card (SWPoint E) := horder ▸ addOrderOf_dvd_natCard G
+  have hpos : 0 < Nat.card (SWPoint E) := Nat.card_pos
+  exact Nat.eq_of_dvd_of_lt_two_mul hpos.ne' hdvd (lt_of_le_of_lt natCard_le hbound)
+
+/-- Variant of `natCard_eq_of_prime_nsmul` for a prime `p` *below* the field size (so only
+`Nat.card < 3 * p` is available): the multiple `2 * p` is excluded by the absence of 2-torsion,
+via Cauchy's theorem. -/
+theorem natCard_eq_of_prime_nsmul_odd [Fintype F] {E : SWCurve F} {p : ℕ} (hp : Nat.Prime p)
+    {G : SWPoint E} (hG : G ≠ 0) (hsmul : p • G = 0)
+    (hbound : 2 * Fintype.card F + 1 < 3 * p)
+    (h2 : ∀ Q : SWPoint E, 2 • Q = 0 → Q = 0) : Nat.card (SWPoint E) = p := by
+  haveI := Fact.mk hp
+  have horder : addOrderOf G = p := addOrderOf_eq_prime hsmul hG
+  have hdvd : p ∣ Nat.card (SWPoint E) := horder ▸ addOrderOf_dvd_natCard G
+  have hpos : 0 < Nat.card (SWPoint E) := Nat.card_pos
+  have hle : Nat.card (SWPoint E) ≤ 2 * Fintype.card F + 1 := natCard_le
+  obtain ⟨k, hk⟩ := hdvd
+  have hklt : k < 3 := by
+    have h3 : p * k < p * 3 := by
+      calc p * k = Nat.card (SWPoint E) := hk.symm
+        _ ≤ 2 * Fintype.card F + 1 := hle
+        _ < 3 * p := hbound
+        _ = p * 3 := Nat.mul_comm 3 p
+    exact Nat.lt_of_mul_lt_mul_left h3
+  have hk2 : k ≠ 2 := by
+    rintro rfl
+    have h2dvd : 2 ∣ Nat.card (SWPoint E) := ⟨p, by omega⟩
+    haveI : Fintype (SWPoint E) := Fintype.ofFinite _
+    rw [Nat.card_eq_fintype_card] at h2dvd
+    obtain ⟨Q, hQ⟩ := exists_prime_addOrderOf_dvd_card 2 h2dvd
+    have hQ2 : 2 • Q = 0 := hQ ▸ addOrderOf_nsmul_eq_zero Q
+    have hQ0 : Q ≠ 0 := by
+      intro h
+      rw [h, addOrderOf_zero] at hQ
+      omega
+    exact hQ0 (h2 Q hQ2)
+  have hk0 : k ≠ 0 := by
+    rintro rfl
+    rw [Nat.mul_zero] at hk
+    omega
+  have hk1 : k = 1 := by omega
+  rw [hk, hk1, Nat.mul_one]
+
+/-- No 2-torsion when the field has odd characteristic and no curve point has `y = 0`
+(a doubled point `Q = -Q` forces `2 * Q.y = 0`). Discharges the `h2` side condition of
+`natCard_eq_of_prime_nsmul_odd` at concrete call sites. -/
+theorem two_nsmul_eq_zero {E : SWCurve F} (h2 : (2 : F) ≠ 0)
+    (hy : ∀ x : F, ¬OnCurve E.A E.B (x, 0)) (Q : SWPoint E) (hQ : 2 • Q = 0) : Q = 0 := by
+  rw [two_nsmul] at hQ
+  have hneg : Q = -Q := eq_neg_of_add_eq_zero_left hQ
+  have hyy : Q.y = -Q.y := by rw [← SWPoint.neg_y Q, ← hneg]
+  have hQy : Q.y = 0 := by
+    have h2y : 2 * Q.y = 0 := by linear_combination hyy
+    exact (mul_eq_zero.mp h2y).resolve_left h2
+  rcases Q.onCurve with hc | h0
+  · rw [hQy] at hc
+    exact absurd hc (hy Q.x)
+  · exact SWPoint.ext_pair h0
+
+end CompElliptic.CurveForms.ShortWeierstrass

--- a/Clean/Orchard/Specs/CompElliptic/CurveForms/ShortWeierstrassOrder.lean
+++ b/Clean/Orchard/Specs/CompElliptic/CurveForms/ShortWeierstrassOrder.lean
@@ -1,9 +1,3 @@
-/-
-Copyright (c) 2026 CompElliptic Contributors. All rights reserved.
-Released under the Apache License, Version 2.0, or the MIT license, at your option,
-as described in the files LICENSE-APACHE and LICENSE-MIT.
-Authors: Daira-Emma Hopwood
--/
 import Clean.Orchard.Specs.CompElliptic.CurveForms.ShortWeierstrass
 import Mathlib.Algebra.Polynomial.Roots
 import Mathlib.GroupTheory.Perm.Cycle.Type

--- a/Clean/Orchard/Specs/CompElliptic/Curves/PastaOrder.lean
+++ b/Clean/Orchard/Specs/CompElliptic/Curves/PastaOrder.lean
@@ -1,0 +1,119 @@
+import Clean.Orchard.Specs.CompElliptic.Curves.Pasta
+import Clean.Orchard.Specs.CompElliptic.CurveForms.ShortWeierstrassOrder
+
+/-!
+# Group orders of the Pasta curves
+
+Proofs that `Nat.card (SWPoint Pallas.curve) = q` and `Nat.card (SWPoint Vesta.curve) = p`
+(where `p`/`q` are the Pallas base/scalar primes), via the generic order-pinning machinery
+of `CurveForms.ShortWeierstrassOrder`:
+
+* the point `G = (-1, 2)` lies on both curves, and `native_decide` on the compiled
+  double-and-add `fastNsmul` certifies `q • G = 0` on Pallas and `p • G = 0` on Vesta;
+* the trivial count bound `Nat.card ≤ 2 * |F| + 1` then pins the order to the prime
+  (no Hasse bound needed): for Pallas `2p + 1 < 2q` suffices directly, while for Vesta
+  `2q + 1 < 3p` combines with the absence of 2-torsion (no curve point has `y = 0`,
+  since `-5` is not a cube in the Vesta base field).
+-/
+
+namespace CompElliptic.CurveForms.ShortWeierstrass
+
+variable {F : Type*} [Field F] [DecidableEq F]
+
+/-- Point equality is decidable coordinate-wise (`onCurve` is a `Prop`), so scalar-multiple
+certificates like `fastNsmul n G = 0` can be discharged by `native_decide`. -/
+instance {E : SWCurve F} : DecidableEq (SWPoint E) := fun P Q =>
+  decidable_of_iff ((P.x, P.y) = (Q.x, Q.y)) ⟨SWPoint.ext_pair, fun h => h ▸ rfl⟩
+
+end CompElliptic.CurveForms.ShortWeierstrass
+
+namespace CompElliptic.Curves.Pasta
+
+open CompElliptic.CurveForms.ShortWeierstrass CompElliptic.Fields.Pasta
+
+namespace Pallas
+
+/-- The test point `G = (-1, 2)` as a bundled point on the Pallas curve
+(`2² = 4 = (-1)³ + 5`). -/
+def Gpt : SWPoint curve := ⟨-1, 2, Or.inl (by native_decide)⟩
+
+theorem Gpt_ne_zero : Gpt ≠ 0 := by
+  intro h
+  have hx : (-1 : PallasBaseField) = 0 := congrArg SWPoint.x h
+  exact (by decide : (-1 : PallasBaseField) ≠ 0) hx
+
+/-- Order certificate: the Pallas scalar prime `q` kills `G`, evaluated via the compiled
+double-and-add `fastNsmul` (the group's own `n • _` is unary and cannot be evaluated). -/
+theorem scalar_nsmul_Gpt : PALLAS_SCALAR_CARD • Gpt = 0 := by
+  rw [← fastNsmul_eq]
+  native_decide
+
+/-- The Pallas curve group has exactly `q = PALLAS_SCALAR_CARD` points: `q` is prime and
+kills the nonzero point `G`, and the crude count bound gives `Nat.card ≤ 2p + 1 < 2q`. -/
+theorem natCard : Nat.card (SWPoint curve) = PALLAS_SCALAR_CARD := by
+  apply natCard_eq_of_prime_nsmul PALLAS_SCALAR_is_prime Gpt_ne_zero scalar_nsmul_Gpt
+  rw [ZMod.card]
+  decide
+
+end Pallas
+
+namespace Vesta
+
+/-- `-5` is not a cube in the Vesta base field, so `y = 0` is impossible for a curve point. -/
+theorem neg_five_not_isCube : ¬ ∃ x : VestaBaseField, x ^ 3 = -(5 : VestaBaseField) := by
+  rintro ⟨x, hx⟩
+  have hx0 : x ≠ 0 := by
+    intro hzero
+    have hneg : (-(5 : VestaBaseField)) = 0 := by
+      rw [← hx, hzero]
+      norm_num
+    exact (by decide : (-(5 : VestaBaseField)) ≠ 0) hneg
+  have hfermat : x ^ (PALLAS_SCALAR_CARD - 1) = 1 := by
+    simpa [ZMod.card] using FiniteField.pow_card_sub_one_eq_one x hx0
+  have hpow : (-(5 : VestaBaseField)) ^ ((PALLAS_SCALAR_CARD - 1) / 3) = 1 := by
+    rw [← hx, ← pow_mul]
+    have hm : 3 * ((PALLAS_SCALAR_CARD - 1) / 3) = PALLAS_SCALAR_CARD - 1 := by
+      native_decide
+    rw [hm]
+    exact hfermat
+  have hnon : (-(5 : VestaBaseField)) ^ ((PALLAS_SCALAR_CARD - 1) / 3) ≠ 1 := by
+    native_decide
+  exact hnon hpow
+
+/-- No point on the Vesta curve has `y`-coordinate `0`. -/
+theorem no_onCurve_y_zero (x : VestaBaseField) : ¬ OnCurve a b (x, 0) := by
+  intro h
+  have hsum : x ^ 3 + 5 = 0 := by
+    simpa [OnCurve, a, b] using h.symm
+  have h' : x ^ 3 = -(5 : VestaBaseField) := by
+    linear_combination hsum
+  exact neg_five_not_isCube ⟨x, h'⟩
+
+/-- The test point `G = (-1, 2)` as a bundled point on the Vesta curve
+(`2² = 4 = (-1)³ + 5`). -/
+def Gpt : SWPoint curve := ⟨-1, 2, Or.inl (by native_decide)⟩
+
+theorem Gpt_ne_zero : Gpt ≠ 0 := by
+  intro h
+  have hx : (-1 : VestaBaseField) = 0 := congrArg SWPoint.x h
+  exact (by decide : (-1 : VestaBaseField) ≠ 0) hx
+
+/-- Order certificate: the Vesta scalar prime `p` (= Pallas base prime) kills `G`, evaluated
+via the compiled double-and-add `fastNsmul`. -/
+theorem scalar_nsmul_Gpt : PALLAS_BASE_CARD • Gpt = 0 := by
+  rw [← fastNsmul_eq]
+  native_decide
+
+/-- The Vesta curve group has exactly `p = PALLAS_BASE_CARD` points: `p` is prime and kills
+the nonzero point `G`, the crude count bound gives `Nat.card ≤ 2q + 1 < 3p` (here `p` is
+*below* the field size `q`, so the factor-2 bound alone does not suffice), and the group has
+no 2-torsion because no curve point has `y = 0`. -/
+theorem natCard : Nat.card (SWPoint curve) = PALLAS_BASE_CARD := by
+  apply natCard_eq_of_prime_nsmul_odd PALLAS_BASE_is_prime Gpt_ne_zero scalar_nsmul_Gpt
+  · rw [ZMod.card]
+    decide
+  · exact two_nsmul_eq_zero (by decide) no_onCurve_y_zero
+
+end Vesta
+
+end CompElliptic.Curves.Pasta

--- a/Clean/Orchard/Specs/Pallas.lean
+++ b/Clean/Orchard/Specs/Pallas.lean
@@ -1,4 +1,5 @@
 import Clean.Orchard.Specs.CompElliptic.Curves.Pasta
+import Clean.Orchard.Specs.CompElliptic.Curves.PastaOrder
 
 /-!
 # Orchard-facing Pallas vocabulary
@@ -381,15 +382,16 @@ def doubleAndAdd (acc p : Point Fp) : Option (Point Fp) := do
 open CompElliptic.Fields.Pasta (PALLAS_SCALAR_CARD)
 
 /--
-**Axiom**: the Pallas curve group has exactly `q = PALLAS_SCALAR_CARD` points.
-
-This is the published point count of the Pallas curve. The vendored CompElliptic
-formalization has no point counting, so this is the one central trust assumption behind
-scalar-multiplication circuit proofs; all consumers needing order facts derive them from
-here (see `addOrderOf_eq`).
+The Pallas curve group has exactly `q = PALLAS_SCALAR_CARD` points (the published point
+count of the Pallas curve). Proved in `CompElliptic.Curves.Pasta.Pallas.natCard`: the prime
+`q` kills the nonzero point `(-1, 2)` (a `native_decide` double-and-add certificate), and
+the trivial count bound `Nat.card ≤ 2p + 1 < 2q` pins the group order to `q` — no Hasse
+bound needed. All consumers needing order facts derive them from here (see
+`addOrderOf_eq`).
 -/
-axiom pallas_natCard :
-  Nat.card (ShortWeierstrass.SWPoint Pallas.curve) = PALLAS_SCALAR_CARD
+theorem pallas_natCard :
+    Nat.card (ShortWeierstrass.SWPoint Pallas.curve) = PALLAS_SCALAR_CARD :=
+  Pallas.natCard
 
 /-- Every non-identity Pallas point generates the full prime-order group. -/
 theorem addOrderOf_eq {P : ShortWeierstrass.SWPoint Pallas.curve} (h : P ≠ 0) :


### PR DESCRIPTION
## Summary

Removes the repo's one code axiom: `pallas_natCard` (`Clean/Orchard/Specs/Pallas.lean`) is now a **theorem** with the same name and statement, so all downstream consumers compile unchanged. Also adds the previously-missing Vesta counterpart, `Nat.card (SWPoint Vesta.curve) = PALLAS_BASE_CARD`.

## Proof strategy (no Hasse bound needed)

For a prime-order certificate it suffices to combine:

1. **A point of prime order**: `G = (-1, 2)` lies on both curves; `q • G = 0` on Pallas and `p • G = 0` on Vesta are certified by `native_decide` on a compiled binary double-and-add `fastNsmul` (proved equal to the group `n • _`, whose default `nsmulRec` is unary and unusable at 2^254). With the scalar prime, `addOrderOf G = q` and Lagrange give `q ∣ Nat.card`.
2. **The trivial count bound** `Nat.card (SWPoint E) ≤ 2·|F| + 1` (each x-coordinate has at most 2 roots of `y² = x³ + Ax + B`, plus the identity).

- **Pallas** (order q over `F_p`, and q &gt; p): `2p + 1 &lt; 2q` already excludes any cofactor.
- **Vesta** (order p over `F_q`, and p &lt; q): the bound only gives cofactor k ∈ {1, 2}; k = 2 is excluded because the group has no 2-torsion — a 2-torsion point needs `y = 0`, i.e. a root of `x³ + 5`, but `-5` is not a cube in `F_q` (checked by the same power-residue technique the codebase already uses for `five_not_isSquare`).

Primality of p and q reuses the existing Pratt-certificate infrastructure (`PALLAS_BASE_is_prime` / `PALLAS_SCALAR_is_prime`). `native_decide` is used only in ways the codebase already accepts (it was already the basis for `IsElliptic`, `neg_five_not_isCube`, etc.).

## Changes

- **New** `Clean/Orchard/Specs/CompElliptic/CurveForms/ShortWeierstrassOrder.lean` — generic machinery for any `SWCurve` over a finite field: `Finite (SWPoint E)` instance, `natCard_le : Nat.card (SWPoint E) ≤ 2 * Fintype.card F + 1`, binary `fastNsmul` + `fastNsmul_eq`, and order-pinning theorems `natCard_eq_of_prime_nsmul` / `natCard_eq_of_prime_nsmul_odd` (+ `two_nsmul_eq_zero` helper). No `sorry`, no axioms, no `native_decide` in the generic layer.
- **New** `Clean/Orchard/Specs/CompElliptic/Curves/PastaOrder.lean` — the concrete certificates and `Pallas.natCard` / `Vesta.natCard`, plus Vesta's `neg_five_not_isCube` and `no_onCurve_y_zero` (mirroring the existing Pallas lemmas).
- `Clean/Orchard/Specs/Pallas.lean` — `axiom pallas_natCard` → `theorem pallas_natCard := Pallas.natCard`; doc comment updated.
- `Clean/Ironwood/Ecc/Mul.lean` — doc comment no longer lists `pallas_natCard` as a trust base.

## Testing

- `lake build` of both new modules, `Clean.Orchard.Specs.Pallas`, and the downstream consumers (`Clean.Orchard.Ecc.Mul.Assign`, `Clean.Orchard.Ecc.MulFixed.Short`, `Clean.Ironwood.Ecc.Mul`) — clean, no warnings.
- Full-project `lake build` regression check in progress; will confirm on this PR before marking ready for review.
- `grep` confirms no `axiom` remains in `Clean/` outside comments/prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8PSiDDspV5zJvXe4yeZQx

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8PSiDDspV5zJvXe4yeZQx)_