### PR TITLE
Witgen IR: replace the Nat sort with u64 sort

### DIFF
--- a/Clean/Circomlib/BinSub.lean
+++ b/Clean/Circomlib/BinSub.lean
@@ -244,11 +244,11 @@ def main (n : ℕ) [NeZero n] (inp : BinSubInput n (Expression (F p))) := do
     (2^n : F p)
 
   -- Witness output bits
-  let out ← witnessVector n (.range n fun i => ((lin.val >>> i) % 2).toField)
+  let out ← witnessVector n (lin.bits n)
 
   -- Witness aux bit
   -- the borrow bit is exactly the nth bit of lin
-  let aux ← witness ((lin.val >>> n) % 2).toField
+  let aux ← witness (lin.bit n)
 
   -- Calculate output linear sum and constrain bits
   let (lout, _) ← Circuit.foldlRange n ((0 : Expression (F p)), (1 : Expression (F p))) fun (lout, e2) i => do

--- a/Clean/Circomlib/Bitify.lean
+++ b/Clean/Circomlib/Bitify.lean
@@ -34,7 +34,7 @@ template Num2Bits(n) {
 }
 -/
 def main (n : ℕ) (inp : Expression (F p)) := do
-  let out ← witnessVector n (.range n fun i => ((inp.val >>> i) % 2).toField)
+  let out ← witnessVector n (inp.bits n)
 
   let (lc1, _) ← Circuit.foldlRange n (0, 1) fun (lc1, e2) i => do
     out[i] * (out[i] - 1) === 0

--- a/Clean/Circomlib/Bitify2.lean
+++ b/Clean/Circomlib/Bitify2.lean
@@ -177,7 +177,7 @@ template Num2BitsNeg(n) {
 def main (n : ℕ) (input : Expression (F p)) := do
   -- Witness the bits of 2^n - input (when n > 0)
   let diff : Expression (F p) := (2^n : F p) - input
-  let out ← witnessVector n (.range n fun i => ((diff.val >>> i) % 2).toField)
+  let out ← witnessVector n (diff.bits n)
 
   -- Constrain each bit to be 0 or 1 and compute linear combination
   let lc1 ← Circuit.foldlRange n 0 fun lc1 i => do

--- a/Clean/Circuit/Extensions.lean
+++ b/Clean/Circuit/Extensions.lean
@@ -30,7 +30,7 @@ theorem eval_varFromOffset_valueFromOffset (M : TypeMap) [ProvableType M] (offse
 
 def witnessAny (M: TypeMap) [ProvableType M] : Circuit F (Var M F) := do
   let offset ← getOffset
-  witnessIR M (.ir [] (.range (size M) fun i => .envGet (offset + i)))
+  witnessIR M (.ir [] (.envRange offset))
 
 theorem witnessAny_localWitnesses (n : ℕ) (env : ProverEnvironment F) :
     env.UsesLocalWitnessesCompleteness n (witnessAny M |>.operations n) ↔ True := by

--- a/Clean/Circuit/Lookup.lean
+++ b/Clean/Circuit/Lookup.lean
@@ -155,36 +155,36 @@ def Table.fromStatic (table : StaticTable F Row) : Table F Row :=
 namespace Table
 
 /-- Read a typed row from committed prover data. -/
-def dataGet (table : Table F Row) (row : Witgen.NExpr F) : Row (Witgen.FExpr F) :=
+def dataGet (table : Table F Row) (row : Witgen.UExpr F) : Row (Witgen.FExpr F) :=
   fromElements <| Vector.mapFinRange (size Row) fun col =>
     Witgen.FExpr.dataGet table.name (size Row) row col
 
 /-- Read a typed row from prover hints. -/
-def hintGet (table : Table F Row) (row : Witgen.NExpr F) : Row (Witgen.FExpr F) :=
+def hintGet (table : Table F Row) (row : Witgen.UExpr F) : Row (Witgen.FExpr F) :=
   fromElements <| Vector.mapFinRange (size Row) fun col =>
     Witgen.FExpr.hintGet table.name (size Row) row col
 
 @[circuit_norm]
-lemma eval_dataGet [FiniteField F] (table : Table F Row) (row : Witgen.NExpr F) (ctx : Witgen.Ctx F) :
+lemma eval_dataGet [FiniteField F] (table : Table F Row) (row : Witgen.UExpr F) (ctx : Witgen.Ctx F) :
     Witgen.eval ctx (table.dataGet row) =
-      ((ctx.env.data.getTable table)[row.eval ctx]?.getD default) := by
+      ((ctx.env.data.getTable table)[(row.eval ctx).toNat]?.getD default) := by
   simp only [Witgen.eval, dataGet, ProverData.getTable]
   rw [ProvableType.fromElements_eq_iff, ProvableType.toElements_fromElements, Vector.map_mapFinRange]
   simp only [Witgen.FExpr.eval]
-  by_cases h : row.eval ctx < (ctx.env.data table.name (size Row)).size
+  by_cases h : (row.eval ctx).toNat < (ctx.env.data table.name (size Row)).size
   · simp [h]
     rw [ProvableType.toElements_fromElements, Vector.mapFinRange_eq_self]
   · simp [h, Vector.mapFinRange_eq_self]
     simp only [default, ProvableType.toElements_fromElements]
 
 @[circuit_norm]
-lemma eval_hintGet [FiniteField F] (table : Table F Row) (row : Witgen.NExpr F) (ctx : Witgen.Ctx F) :
+lemma eval_hintGet [FiniteField F] (table : Table F Row) (row : Witgen.UExpr F) (ctx : Witgen.Ctx F) :
     Witgen.eval ctx (table.hintGet row) =
-      fromElements (((ctx.env.hint table.name (size Row))[row.eval ctx]?).getD default) := by
+      fromElements (((ctx.env.hint table.name (size Row))[(row.eval ctx).toNat]?).getD default) := by
   simp only [Witgen.eval, hintGet]
   rw [ProvableType.fromElements_eq_iff, ProvableType.toElements_fromElements, Vector.map_mapFinRange]
   simp only [Witgen.FExpr.eval]
-  by_cases h : row.eval ctx < (ctx.env.hint table.name (size Row)).size
+  by_cases h : (row.eval ctx).toNat < (ctx.env.hint table.name (size Row)).size
   · simp [h]
     rw [ProvableType.toElements_fromElements, Vector.mapFinRange_eq_self]
   · simp [h, Vector.mapFinRange_eq_self]

--- a/Clean/Circuit/Lookup.lean
+++ b/Clean/Circuit/Lookup.lean
@@ -155,17 +155,17 @@ def Table.fromStatic (table : StaticTable F Row) : Table F Row :=
 namespace Table
 
 /-- Read a typed row from committed prover data. -/
-def dataGet (table : Table F Row) (row : Witgen.UExpr F) : Row (Witgen.FExpr F) :=
+def dataGet (table : Table F Row) (row : Witgen.U64Expr F) : Row (Witgen.FExpr F) :=
   fromElements <| Vector.mapFinRange (size Row) fun col =>
     Witgen.FExpr.dataGet table.name (size Row) row col
 
 /-- Read a typed row from prover hints. -/
-def hintGet (table : Table F Row) (row : Witgen.UExpr F) : Row (Witgen.FExpr F) :=
+def hintGet (table : Table F Row) (row : Witgen.U64Expr F) : Row (Witgen.FExpr F) :=
   fromElements <| Vector.mapFinRange (size Row) fun col =>
     Witgen.FExpr.hintGet table.name (size Row) row col
 
 @[circuit_norm]
-lemma eval_dataGet [FiniteField F] (table : Table F Row) (row : Witgen.UExpr F) (ctx : Witgen.Ctx F) :
+lemma eval_dataGet [FiniteField F] (table : Table F Row) (row : Witgen.U64Expr F) (ctx : Witgen.Ctx F) :
     Witgen.eval ctx (table.dataGet row) =
       ((ctx.env.data.getTable table)[(row.eval ctx).toNat]?.getD default) := by
   simp only [Witgen.eval, dataGet, ProverData.getTable]
@@ -178,7 +178,7 @@ lemma eval_dataGet [FiniteField F] (table : Table F Row) (row : Witgen.UExpr F) 
     simp only [default, ProvableType.toElements_fromElements]
 
 @[circuit_norm]
-lemma eval_hintGet [FiniteField F] (table : Table F Row) (row : Witgen.UExpr F) (ctx : Witgen.Ctx F) :
+lemma eval_hintGet [FiniteField F] (table : Table F Row) (row : Witgen.U64Expr F) (ctx : Witgen.Ctx F) :
     Witgen.eval ctx (table.hintGet row) =
       fromElements (((ctx.env.hint table.name (size Row))[(row.eval ctx).toNat]?).getD default) := by
   simp only [Witgen.eval, hintGet]

--- a/Clean/Circuit/WitnessExport.lean
+++ b/Clean/Circuit/WitnessExport.lean
@@ -60,7 +60,6 @@ def FExpr.toJson : FExpr F → Json
   | .mul x y => Json.mkObj [("type", "mul"), ("lhs", x.toJson), ("rhs", y.toJson)]
   | .inv x => Json.mkObj [("type", "inv"), ("arg", x.toJson)]
   | .ofU64 n => Json.mkObj [("type", "ofU64"), ("arg", n.toJson)]
-  | .bitOf x i => Json.mkObj [("type", "bitOf"), ("arg", x.toJson), ("bit", Lean.toJson i)]
   | .ite c t e => Json.mkObj [("type", "ite"),
       ("cond", c.toJson), ("then", t.toJson), ("else", e.toJson)]
   | .listGet xs i => Json.mkObj [("type", "listGet"),
@@ -77,7 +76,7 @@ def FExpr.listToJson : List (FExpr F) → List Json
   | x :: xs => x.toJson :: FExpr.listToJson xs
 
 def U64Expr.toJson : U64Expr F → Json
-  | .const n => Json.mkObj [("type", "const"), ("value", Lean.toJson n)]
+  | .const n => Json.mkObj [("type", "const"), ("value", Lean.toJson n.toNat)]
   | .val x => Json.mkObj [("type", "val"), ("arg", x.toJson)]
   | .idx => Json.mkObj [("type", "idx")]
   | .localVar i => Json.mkObj [("type", "localVar"), ("index", Lean.toJson i)]
@@ -100,6 +99,7 @@ def BExpr.toJson : BExpr F → Json
   | .neq x y => Json.mkObj [("type", "u64Eq"), ("lhs", x.toJson), ("rhs", y.toJson)]
   | .lt x y => Json.mkObj [("type", "u64Lt"), ("lhs", x.toJson), ("rhs", y.toJson)]
   | .flt x y => Json.mkObj [("type", "lt"), ("lhs", x.toJson), ("rhs", y.toJson)]
+  | .bit x i => Json.mkObj [("type", "bit"), ("arg", x.toJson), ("bit", Lean.toJson i)]
   | .not b => Json.mkObj [("type", "not"), ("arg", b.toJson)]
   | .and x y => Json.mkObj [("type", "and"), ("lhs", x.toJson), ("rhs", y.toJson)]
 

--- a/Clean/Circuit/WitnessExport.lean
+++ b/Clean/Circuit/WitnessExport.lean
@@ -76,7 +76,7 @@ def FExpr.listToJson : List (FExpr F) → List Json
   | [] => []
   | x :: xs => x.toJson :: FExpr.listToJson xs
 
-def UExpr.toJson : UExpr F → Json
+def U64Expr.toJson : U64Expr F → Json
   | .const n => Json.mkObj [("type", "const"), ("value", Lean.toJson n)]
   | .val x => Json.mkObj [("type", "val"), ("arg", x.toJson)]
   | .idx => Json.mkObj [("type", "idx")]
@@ -98,14 +98,15 @@ def BExpr.toJson : BExpr F → Json
   | .false => Json.mkObj [("type", "false")]
   | .feq x y => Json.mkObj [("type", "eq"), ("lhs", x.toJson), ("rhs", y.toJson)]
   | .neq x y => Json.mkObj [("type", "u64Eq"), ("lhs", x.toJson), ("rhs", y.toJson)]
-  | .lt x y => Json.mkObj [("type", "lt"), ("lhs", x.toJson), ("rhs", y.toJson)]
+  | .lt x y => Json.mkObj [("type", "u64Lt"), ("lhs", x.toJson), ("rhs", y.toJson)]
+  | .flt x y => Json.mkObj [("type", "lt"), ("lhs", x.toJson), ("rhs", y.toJson)]
   | .not b => Json.mkObj [("type", "not"), ("arg", b.toJson)]
   | .and x y => Json.mkObj [("type", "and"), ("lhs", x.toJson), ("rhs", y.toJson)]
 
 end
 
 instance : ToJson (FExpr F) := ⟨FExpr.toJson⟩
-instance : ToJson (UExpr F) := ⟨UExpr.toJson⟩
+instance : ToJson (U64Expr F) := ⟨U64Expr.toJson⟩
 instance : ToJson (BExpr F) := ⟨BExpr.toJson⟩
 
 def VExpr.toJson {n : ℕ} : VExpr F n → Json

--- a/Clean/Circuit/WitnessExport.lean
+++ b/Clean/Circuit/WitnessExport.lean
@@ -54,13 +54,13 @@ mutual
 
 def FExpr.toJson : FExpr F → Json
   | .expr e => Json.mkObj [("type", "expr"), ("expr", Lean.toJson e)]
-  | .envGet i => Json.mkObj [("type", "envGet"), ("index", i.toJson)]
   | .const c => Json.mkObj [("type", "const"), ("value", Lean.toJson c)]
   | .localVar i => Json.mkObj [("type", "localVar"), ("index", Lean.toJson i)]
   | .add x y => Json.mkObj [("type", "add"), ("lhs", x.toJson), ("rhs", y.toJson)]
   | .mul x y => Json.mkObj [("type", "mul"), ("lhs", x.toJson), ("rhs", y.toJson)]
   | .inv x => Json.mkObj [("type", "inv"), ("arg", x.toJson)]
-  | .ofNat n => Json.mkObj [("type", "ofNat"), ("arg", n.toJson)]
+  | .ofU64 n => Json.mkObj [("type", "ofU64"), ("arg", n.toJson)]
+  | .bitOf x i => Json.mkObj [("type", "bitOf"), ("arg", x.toJson), ("bit", Lean.toJson i)]
   | .ite c t e => Json.mkObj [("type", "ite"),
       ("cond", c.toJson), ("then", t.toJson), ("else", e.toJson)]
   | .listGet xs i => Json.mkObj [("type", "listGet"),
@@ -76,7 +76,7 @@ def FExpr.listToJson : List (FExpr F) → List Json
   | [] => []
   | x :: xs => x.toJson :: FExpr.listToJson xs
 
-def NExpr.toJson : NExpr F → Json
+def UExpr.toJson : UExpr F → Json
   | .const n => Json.mkObj [("type", "const"), ("value", Lean.toJson n)]
   | .val x => Json.mkObj [("type", "val"), ("arg", x.toJson)]
   | .idx => Json.mkObj [("type", "idx")]
@@ -97,7 +97,7 @@ def BExpr.toJson : BExpr F → Json
   | .true => Json.mkObj [("type", "true")]
   | .false => Json.mkObj [("type", "false")]
   | .feq x y => Json.mkObj [("type", "eq"), ("lhs", x.toJson), ("rhs", y.toJson)]
-  | .neq x y => Json.mkObj [("type", "natEq"), ("lhs", x.toJson), ("rhs", y.toJson)]
+  | .neq x y => Json.mkObj [("type", "u64Eq"), ("lhs", x.toJson), ("rhs", y.toJson)]
   | .lt x y => Json.mkObj [("type", "lt"), ("lhs", x.toJson), ("rhs", y.toJson)]
   | .not b => Json.mkObj [("type", "not"), ("arg", b.toJson)]
   | .and x y => Json.mkObj [("type", "and"), ("lhs", x.toJson), ("rhs", y.toJson)]
@@ -105,13 +105,17 @@ def BExpr.toJson : BExpr F → Json
 end
 
 instance : ToJson (FExpr F) := ⟨FExpr.toJson⟩
-instance : ToJson (NExpr F) := ⟨NExpr.toJson⟩
+instance : ToJson (UExpr F) := ⟨UExpr.toJson⟩
 instance : ToJson (BExpr F) := ⟨BExpr.toJson⟩
 
 def VExpr.toJson {n : ℕ} : VExpr F n → Json
   | .lit es => Json.mkObj [("type", "elements"), ("elements", Lean.toJson es.toList)]
   | .mapRange n body => Json.mkObj [("type", "mapRange"),
       ("n", Lean.toJson n), ("body", body.toJson)]
+  | .envRange (n := n) offset => Json.mkObj [("type", "envRange"),
+      ("n", Lean.toJson n), ("offset", Lean.toJson offset)]
+  | .bitsOf (n := n) x => Json.mkObj [("type", "bitsOf"),
+      ("n", Lean.toJson n), ("arg", x.toJson)]
   | .append a b => Json.mkObj [("type", "append"),
       ("left", a.toJson), ("right", b.toJson)]
 
@@ -119,7 +123,7 @@ instance {n : ℕ} : ToJson (VExpr F n) := ⟨VExpr.toJson⟩
 
 def Step.toJson : Step F → Json
   | .letF e => Json.mkObj [("sort", "field"), ("value", Lean.toJson e)]
-  | .letN e => Json.mkObj [("sort", "nat"), ("value", Lean.toJson e)]
+  | .letU e => Json.mkObj [("sort", "u64"), ("value", Lean.toJson e)]
 
 instance : ToJson (Step F) := ⟨Step.toJson⟩
 

--- a/Clean/Circuit/WitnessIR.lean
+++ b/Clean/Circuit/WitnessIR.lean
@@ -239,6 +239,55 @@ attribute [circuit_norm]
 theorem UInt64.eq_iff_toNat_eq {a b : UInt64} : a = b ↔ a.toNat = b.toNat :=
   UInt64.toNat_inj.symm
 
+section U64Wrap
+open Lean Meta Simp
+
+/-- Closed `ℕ` value of an expression, seeing through `b ^ k` (which `Meta.evalNat` does
+not reduce at the `Monoid.toPow` instance that `2 ^ 64` elaborates to). -/
+private partial def natLit? (e : Expr) : MetaM (Option ℕ) := do
+  if let some n ← evalNat e |>.run then return some n
+  if e.isAppOfArity ``HPow.hPow 6 then
+    let args := e.getAppArgs
+    let some b ← natLit? args[4]! | return none
+    let some k ← natLit? args[5]! | return none
+    if k ≤ 64 && b ≤ 64 then return some (b ^ k)
+  return none
+
+/--
+Erase a `u64` wrap that provably does not wrap.
+
+Pushing `UInt64.toNat` through a `UExpr` evaluation leaves two kinds of truncation
+behind: `n % 2^64` (from `UExpr.val`, `UExpr.const` and the arithmetic operations) and
+`n % 64` (the shift-amount mask of `<<<` / `>>>`). Gadgets always work well inside those
+bounds — bytes, 32-bit limbs, bit indices — but the bound lives in the gadget's own
+assumptions (`x.val < 256`, `i < 32`, …), so no unconditional rewrite can remove the
+wrap, and a conditional simp lemma cannot discharge it either.
+
+This simproc closes exactly that gap: on `n % 2^64` / `n % 64` it asks `omega` (with the
+local hypotheses as facts) whether `n` is already below the modulus, and rewrites to `n`
+when it is. Other moduli are left alone, so ordinary `% 256`-style specification
+arithmetic is untouched.
+-/
+private def u64WrapSimproc (e : Expr) : SimpM Simp.Step := do
+  unless e.isAppOfArity ``HMod.hMod 6 do return .continue
+  let args := e.getAppArgs
+  let n := args[4]!
+  let m := args[5]!
+  unless (← whnfR (← inferType n)).isConstOf ``Nat do return .continue
+  let some mVal ← natLit? m | return .continue
+  unless mVal == 18446744073709551616 || mVal == 64 do return .continue
+  let g ← mkFreshExprMVar (← mkAppM ``LT.lt #[n, m])
+  try
+    let some g' ← g.mvarId!.falseOrByContra | return .continue
+    g'.withContext do Lean.Elab.Tactic.Omega.omega (← getLocalHyps).toList g'
+  catch _ =>
+    return .continue
+  return .done { expr := n, proof? := ← mkAppM ``Nat.mod_eq_of_lt #[g] }
+
+simproc u64Wrap ((_ : ℕ) % _) := u64WrapSimproc
+attribute [circuit_norm] u64Wrap
+end U64Wrap
+
 variable {M : TypeMap} [ProvableType M]
 
 /-- Evaluation for higher-level provable types. -/

--- a/Clean/Circuit/WitnessIR.lean
+++ b/Clean/Circuit/WitnessIR.lean
@@ -65,8 +65,6 @@ inductive FExpr (F : Type) where
   equals `Nat.cast` on prime fields, but interprets binary digits as coefficients
   on binary fields, where `Nat.cast` would collapse via the characteristic). -/
   | ofU64 (n : U64Expr F)
-  /-- Bit `i` of `FiniteField.val x`, as the field element `0` or `1`. -/
-  | bitOf (x : FExpr F) (i : ℕ)
   | ite (c : BExpr F) (t e : FExpr F)
   /-- Read an expression list at a computed index, 0 if out of range -/
   | listGet (xs : List (FExpr F)) (i : U64Expr F)
@@ -80,8 +78,7 @@ inductive FExpr (F : Type) where
 /-- u64-sorted (bounded-nat) witness expressions. All operations wrap modulo `2^64`,
 matching Rust's `u64`. -/
 inductive U64Expr (F : Type) where
-  /-- A `ℕ` literal, truncated to 64 bits. -/
-  | const (n : ℕ)
+  | const (n : UInt64)
   /-- The field→u64 bridge: `ZMod.val` truncated to 64 bits. -/
   | val (x : FExpr F)
   /-- The index of the innermost enclosing `VExpr.mapRange` (0 outside). -/
@@ -112,6 +109,8 @@ inductive BExpr (F : Type) where
   /-- Field-sorted less-than condition, comparing the `ℕ` values of both operands
   (`FiniteField.val`), so it is exact on fields wider than 64 bits. -/
   | flt (x y : FExpr F)
+  /-- Bit `i` of `FiniteField.val x` is set. -/
+  | bit (x : FExpr F) (i : ℕ)
   /-- Negation of a condition. -/
   | not (b : BExpr F)
   /-- Conjunction of conditions. -/
@@ -155,7 +154,6 @@ def FExpr.eval (ctx : Ctx F) : FExpr F → F
   | .mul x y => x.eval ctx * y.eval ctx
   | .inv x => (x.eval ctx)⁻¹
   | .ofU64 n => FiniteField.fromNat (n.eval ctx).toNat
-  | .bitOf x i => FiniteField.fromNat (FiniteField.val (x.eval ctx) >>> i % 2)
   | .ite c t e => if c.eval ctx then t.eval ctx else e.eval ctx
   | .listGet xs i => FExpr.evalList ctx (i.eval ctx).toNat xs
   | .dataGet key n row col =>
@@ -171,7 +169,7 @@ def FExpr.evalList (ctx : Ctx F) : ℕ → List (FExpr F) → F
 
 @[circuit_norm]
 def U64Expr.eval (ctx : Ctx F) : U64Expr F → UInt64
-  | .const n => UInt64.ofNat n
+  | .const n => n
   | .val x => UInt64.ofNat (FiniteField.val (x.eval ctx))
   | .idx => UInt64.ofNat ctx.idx
   | .localVar i =>
@@ -197,6 +195,7 @@ def BExpr.eval (ctx : Ctx F) : BExpr F → Bool
   | .neq x y => x.eval ctx = y.eval ctx
   | .lt x y => x.eval ctx < y.eval ctx
   | .flt x y => FiniteField.val (x.eval ctx) < FiniteField.val (y.eval ctx)
+  | .bit x i => (FiniteField.val (x.eval ctx)).testBit i
   | .not b => !b.eval ctx
   | .and x y => x.eval ctx && y.eval ctx
 

--- a/Clean/Circuit/WitnessIR.lean
+++ b/Clean/Circuit/WitnessIR.lean
@@ -23,38 +23,18 @@ Scalar expressions come in 3 sorts, reflecting the codebase's pervasive
 - `FExpr` — field-sorted: embedded circuit `Expression`s (which is how callbacks read
   inputs and earlier witnesses), arithmetic, inverse (IsZeroField), conditionals,
   bit extraction, constant-table reads, prover-data/hint reads.
-- `UExpr` — **u64-sorted** (bounded nat): arithmetic, div/mod, bitwise ops, shifts;
-  bridges are `UExpr.val : FExpr → UExpr` and `FExpr.ofU64 : UExpr → FExpr`.
-- `BExpr` — conditions: field equality and u64 comparison (requirement B.7).
+- `U64Expr` — u64-sorted: arithmetic, div/mod, bitwise ops, shifts, all wrapping modulo
+  `2^64` like Rust's `u64`. The bridges are `U64Expr.val : FExpr → U64Expr` (`ZMod.val`
+  truncated to 64 bits) and `FExpr.ofU64 : U64Expr → FExpr` (back via `UInt64.toNat`).
+- `BExpr` — conditions: field and u64 equality, field and u64 comparison (requirement B.7).
 
 The output is a `VExpr`: a literal list, a `mapRange n body` (body may reference the
-running index via `UExpr.idx`) — kept as a *loop* rather than unrolled — an environment
+running index via `U64Expr.idx`) — kept as a *loop* rather than unrolled — an environment
 range, a field-element bit decomposition, or an append.
-
-## Why u64 and not `ℕ`
-
-Arbitrary-precision naturals are not what a witness-generation backend wants to run
-(issue #429): they are expensive, awkward to implement outside Lean, and operations like
-unbounded `mul`/`add` have no counterpart in real code. The integer sort is therefore
-`UInt64` throughout, with **wrapping** semantics that mirror Rust's `u64`:
-
-- `UExpr.val x` is `FiniteField.val x` truncated to 64 bits (`UInt64.ofNat`, i.e. `mod 2^64`),
-- `FExpr.ofU64 n` casts back through `FiniteField.fromNat n.toNat`,
-- `UExpr.const n` truncates its `ℕ` payload the same way.
-
-Two operations that genuinely need more than 64 bits are kept at the *field* level
-instead of being expressed through the integer sort, so no gadget has to assume that a
-254-bit field element fits in a `u64`:
-
-- `FExpr.bitOf x i` — bit `i` of `FiniteField.val x` (a static bit index),
-- `VExpr.bitsOf` — the `n` low bits of `FiniteField.val x` (bit-decomposition gadgets).
-
-Similarly `VExpr.envRange offset` replaces per-element environment reads at computed
-indices, so witness offsets never round-trip through `u64`.
 
 ## TOOD Potential open issues
 
-1. **One index binder.** `UExpr.idx` refers to the innermost enclosing `VExpr.mapRange`;
+1. **One index binder.** `U64Expr.idx` refers to the innermost enclosing `VExpr.mapRange`;
    nesting shadows. No surveyed gadget nests mapRanges inside a single callback. If that
    changes, `idx` generalizes to de Bruijn levels.
 2. **Untyped locals.** `localVar i` is resolved in an `F ⊕ UInt64` array with a 0 default
@@ -84,24 +64,22 @@ inductive FExpr (F : Type) where
   /-- Cast from the u64 sort via `FiniteField.fromNat` (the inverse of `val`;
   equals `Nat.cast` on prime fields, but interprets binary digits as coefficients
   on binary fields, where `Nat.cast` would collapse via the characteristic). -/
-  | ofU64 (n : UExpr F)
-  /-- Bit `i` of `FiniteField.val x`, as the field element `0` or `1`. Kept at the
-  field level (rather than `(x.val >>> i) % 2`) so that bit indices beyond 64 stay
-  meaningful on large fields. -/
+  | ofU64 (n : U64Expr F)
+  /-- Bit `i` of `FiniteField.val x`, as the field element `0` or `1`. -/
   | bitOf (x : FExpr F) (i : ℕ)
   | ite (c : BExpr F) (t e : FExpr F)
   /-- Read an expression list at a computed index, 0 if out of range -/
-  | listGet (xs : List (FExpr F)) (i : UExpr F)
+  | listGet (xs : List (FExpr F)) (i : U64Expr F)
   /-- Read committed prover data (`Environment.data`), keyed like `ProverData`:
   row `row` of table `key` with rows of width `n`, projected at column `col`.
   Missing rows read as 0. The nondeterministic escape hatch (FemtoCairo memory). -/
-  | dataGet (key : String) (n : ℕ) (row : UExpr F) (col : Fin n)
+  | dataGet (key : String) (n : ℕ) (row : U64Expr F) (col : Fin n)
   /-- Same as `dataGet` but reads the uncommitted `ProverEnvironment.hint`. -/
-  | hintGet (key : String) (n : ℕ) (row : UExpr F) (col : Fin n)
+  | hintGet (key : String) (n : ℕ) (row : U64Expr F) (col : Fin n)
 
 /-- u64-sorted (bounded-nat) witness expressions. All operations wrap modulo `2^64`,
 matching Rust's `u64`. -/
-inductive UExpr (F : Type) where
+inductive U64Expr (F : Type) where
   /-- A `ℕ` literal, truncated to 64 bits. -/
   | const (n : ℕ)
   /-- The field→u64 bridge: `ZMod.val` truncated to 64 bits. -/
@@ -110,16 +88,16 @@ inductive UExpr (F : Type) where
   | idx
   /-- Reference to an earlier `Step` result (must be a `letU` step). -/
   | localVar (i : ℕ)
-  | add (x y : UExpr F)
-  | mul (x y : UExpr F)
-  | div (x y : UExpr F)
-  | mod (x y : UExpr F)
-  | land (x y : UExpr F)
-  | lor (x y : UExpr F)
-  | lxor (x y : UExpr F)
-  | shiftL (x y : UExpr F)
-  | shiftR (x y : UExpr F)
-  | ite (c : BExpr F) (t e : UExpr F)
+  | add (x y : U64Expr F)
+  | mul (x y : U64Expr F)
+  | div (x y : U64Expr F)
+  | mod (x y : U64Expr F)
+  | land (x y : U64Expr F)
+  | lor (x y : U64Expr F)
+  | lxor (x y : U64Expr F)
+  | shiftL (x y : U64Expr F)
+  | shiftR (x y : U64Expr F)
+  | ite (c : BExpr F) (t e : U64Expr F)
 
 /-- Conditions. -/
 inductive BExpr (F : Type) where
@@ -128,9 +106,12 @@ inductive BExpr (F : Type) where
   /-- Field equality condition (decided via the injective `ℕ` embedding). -/
   | feq (x y : FExpr F)
   /-- u64 equality condition. -/
-  | neq (x y : UExpr F)
+  | neq (x y : U64Expr F)
   /-- u64-sorted less-than condition. -/
-  | lt (x y : UExpr F)
+  | lt (x y : U64Expr F)
+  /-- Field-sorted less-than condition, comparing the `ℕ` values of both operands
+  (`FiniteField.val`), so it is exact on fields wider than 64 bits. -/
+  | flt (x y : FExpr F)
   /-- Negation of a condition. -/
   | not (b : BExpr F)
   /-- Conjunction of conditions. -/
@@ -145,10 +126,10 @@ end
 @[reducible] def FExpr.neg [Field F] (x : FExpr F) : FExpr F := .mul (.const (-1)) x
 
 /-- `2^k` as a derived u64 expression. -/
-@[reducible] def UExpr.pow2 (k : UExpr F) : UExpr F := .shiftL (.const 1) k
+@[reducible] def U64Expr.pow2 (k : U64Expr F) : U64Expr F := .shiftL (.const 1) k
 
 /-- `Nat.testBit x i` as a derived u64 expression, valued in {0, 1}. -/
-@[reducible] def UExpr.testBit (x i : UExpr F) : UExpr F := .mod (.shiftR x i) (.const 2)
+@[reducible] def U64Expr.testBit (x i : U64Expr F) : U64Expr F := .mod (.shiftR x i) (.const 2)
 
 /-- Evaluation context: the prover environment, the values of the `let`-steps computed
 so far, and the innermost `mapRange` index. -/
@@ -189,7 +170,7 @@ def FExpr.evalList (ctx : Ctx F) : ℕ → List (FExpr F) → F
   | i + 1, _ :: xs => FExpr.evalList ctx i xs
 
 @[circuit_norm]
-def UExpr.eval (ctx : Ctx F) : UExpr F → UInt64
+def U64Expr.eval (ctx : Ctx F) : U64Expr F → UInt64
   | .const n => UInt64.ofNat n
   | .val x => UInt64.ofNat (FiniteField.val (x.eval ctx))
   | .idx => UInt64.ofNat ctx.idx
@@ -215,6 +196,7 @@ def BExpr.eval (ctx : Ctx F) : BExpr F → Bool
   | .feq x y => x.eval ctx = y.eval ctx
   | .neq x y => x.eval ctx = y.eval ctx
   | .lt x y => x.eval ctx < y.eval ctx
+  | .flt x y => FiniteField.val (x.eval ctx) < FiniteField.val (y.eval ctx)
   | .not b => !b.eval ctx
   | .and x y => x.eval ctx && y.eval ctx
 
@@ -224,7 +206,7 @@ end
 
 Witness-IR proofs live in `ℕ`: every u64-sorted subterm reaches the field via
 `FExpr.ofU64`, which applies `UInt64.toNat`. Pushing `toNat` through the operations turns
-a `UExpr` evaluation into ordinary `ℕ` arithmetic with explicit `% 2^64` wraps, which
+a `U64Expr` evaluation into ordinary `ℕ` arithmetic with explicit `% 2^64` wraps, which
 `omega` / `Nat.mod_eq_of_lt` discharge whenever the gadget's own bounds make the
 operation non-wrapping. -/
 attribute [circuit_norm]
@@ -256,8 +238,8 @@ private partial def natLit? (e : Expr) : MetaM (Option ℕ) := do
 /--
 Erase a `u64` wrap that provably does not wrap.
 
-Pushing `UInt64.toNat` through a `UExpr` evaluation leaves two kinds of truncation
-behind: `n % 2^64` (from `UExpr.val`, `UExpr.const` and the arithmetic operations) and
+Pushing `UInt64.toNat` through a `U64Expr` evaluation leaves two kinds of truncation
+behind: `n % 2^64` (from `U64Expr.val`, `U64Expr.const` and the arithmetic operations) and
 `n % 64` (the shift-amount mask of `<<<` / `>>>`). Gadgets always work well inside those
 bounds — bytes, 32-bit limbs, bit indices — but the bound lives in the gadget's own
 assumptions (`x.val < 256`, `i < 32`, …), so no unconditional rewrite can remove the
@@ -323,11 +305,9 @@ inductive VExpr (F : Type) : ℕ → Type where
   | lit {n : ℕ} (es : Vector (FExpr F) n) : VExpr F n
   | mapRange (n : ℕ) (body : FExpr F) : VExpr F n
   /-- `n` consecutive environment cells starting at `offset` — the "witness a fresh
-  variable per cell" former (`witnessAny`, table rows). The offset is a static `ℕ`, so
-  witness offsets never round-trip through the u64 sort. -/
+  variable per cell" former (`witnessAny`, table rows). -/
   | envRange {n : ℕ} (offset : ℕ) : VExpr F n
-  /-- The `n` low bits of `FiniteField.val x`, each as the field element `0` or `1` —
-  the bit-decomposition former. Kept at the field level so that `n` may exceed 64. -/
+  /-- The `n` low bits of `FiniteField.val x`, each as the field element `0` or `1`. -/
   | bitsOf {n : ℕ} (x : FExpr F) : VExpr F n
   | append {m n : ℕ} (a : VExpr F m) (b : VExpr F n) : VExpr F (m + n)
 
@@ -346,7 +326,7 @@ def VExpr.eval [FiniteField F] (ctx : Ctx F) : {n : ℕ} → VExpr F n → Vecto
 earlier steps. Referenced by position via `localVar`. -/
 inductive Step (F : Type) where
   | letF (e : FExpr F)
-  | letU (e : UExpr F)
+  | letU (e : U64Expr F)
 
 /-- Evaluate the `let`-steps left to right, accumulating their values. -/
 @[circuit_norm]

--- a/Clean/Circuit/WitnessIR.lean
+++ b/Clean/Circuit/WitnessIR.lean
@@ -19,24 +19,46 @@ A witness program (`WitgenIR F m`) is either
   vector-shaped output expression.
 
 Scalar expressions come in 3 sorts, reflecting the codebase's pervasive
-`field → ZMod.val → Nat ops → cast → field` pattern:
+`field → ZMod.val → integer ops → cast → field` pattern:
 - `FExpr` — field-sorted: embedded circuit `Expression`s (which is how callbacks read
-  inputs and earlier witnesses), env reads at computed indices, arithmetic, inverse
-  (IsZeroField), conditionals, constant-table reads, prover-data/hint reads.
-- `NExpr` — Nat-sorted: arithmetic, div/mod, bitwise ops, shifts; bridges are
-  `NExpr.val : FExpr → NExpr` and `FExpr.ofNat : NExpr → FExpr`.
-- `BExpr` — conditions: field equality and Nat comparison (requirement B.7).
+  inputs and earlier witnesses), arithmetic, inverse (IsZeroField), conditionals,
+  bit extraction, constant-table reads, prover-data/hint reads.
+- `UExpr` — **u64-sorted** (bounded nat): arithmetic, div/mod, bitwise ops, shifts;
+  bridges are `UExpr.val : FExpr → UExpr` and `FExpr.ofU64 : UExpr → FExpr`.
+- `BExpr` — conditions: field equality and u64 comparison (requirement B.7).
 
 The output is a `VExpr`: a literal list, a `mapRange n body` (body may reference the
-running index via `NExpr.idx`) — kept as a *loop* rather than unrolled — or an append.
+running index via `UExpr.idx`) — kept as a *loop* rather than unrolled — an environment
+range, a field-element bit decomposition, or an append.
+
+## Why u64 and not `ℕ`
+
+Arbitrary-precision naturals are not what a witness-generation backend wants to run
+(issue #429): they are expensive, awkward to implement outside Lean, and operations like
+unbounded `mul`/`add` have no counterpart in real code. The integer sort is therefore
+`UInt64` throughout, with **wrapping** semantics that mirror Rust's `u64`:
+
+- `UExpr.val x` is `FiniteField.val x` truncated to 64 bits (`UInt64.ofNat`, i.e. `mod 2^64`),
+- `FExpr.ofU64 n` casts back through `FiniteField.fromNat n.toNat`,
+- `UExpr.const n` truncates its `ℕ` payload the same way.
+
+Two operations that genuinely need more than 64 bits are kept at the *field* level
+instead of being expressed through the integer sort, so no gadget has to assume that a
+254-bit field element fits in a `u64`:
+
+- `FExpr.bitOf x i` — bit `i` of `FiniteField.val x` (a static bit index),
+- `VExpr.bitsOf` — the `n` low bits of `FiniteField.val x` (bit-decomposition gadgets).
+
+Similarly `VExpr.envRange offset` replaces per-element environment reads at computed
+indices, so witness offsets never round-trip through `u64`.
 
 ## TOOD Potential open issues
 
-1. **One index binder.** `NExpr.idx` refers to the innermost enclosing `VExpr.mapRange`;
+1. **One index binder.** `UExpr.idx` refers to the innermost enclosing `VExpr.mapRange`;
    nesting shadows. No surveyed gadget nests mapRanges inside a single callback. If that
    changes, `idx` generalizes to de Bruijn levels.
-2. **Untyped locals.** `localVar i` is resolved in an `F ⊕ ℕ` array with a 0 default on
-   sort mismatch / out of range, keeping `eval` total without intrinsically-typed
+2. **Untyped locals.** `localVar i` is resolved in an `F ⊕ UInt64` array with a 0 default
+   on sort mismatch / out of range, keeping `eval` total without intrinsically-typed
    syntax. A decidable well-sortedness check can be layered on top later (it will be
    needed for serialization anyway).
 -/
@@ -52,8 +74,6 @@ inductive FExpr (F : Type) where
   /-- Embedded circuit expression; this is how callbacks read input vars and earlier
   witnesses (`env x`). -/
   | expr (e : Expression F)
-  /-- Read the environment at a computed index (e.g. consecutive vars in a mapRange). -/
-  | envGet (i : NExpr F)
   | const (c : F)
   /-- Reference to an earlier `Step` result (must be a `letF` step). -/
   | localVar (i : ℕ)
@@ -61,39 +81,45 @@ inductive FExpr (F : Type) where
   | mul (x y : FExpr F)
   /-- Field inverse, with `0⁻¹ = 0` (the `IsZeroField` witness). -/
   | inv (x : FExpr F)
-  /-- Cast from the Nat sort via `FiniteField.fromNat` (the inverse of `val`;
+  /-- Cast from the u64 sort via `FiniteField.fromNat` (the inverse of `val`;
   equals `Nat.cast` on prime fields, but interprets binary digits as coefficients
   on binary fields, where `Nat.cast` would collapse via the characteristic). -/
-  | ofNat (n : NExpr F)
+  | ofU64 (n : UExpr F)
+  /-- Bit `i` of `FiniteField.val x`, as the field element `0` or `1`. Kept at the
+  field level (rather than `(x.val >>> i) % 2`) so that bit indices beyond 64 stay
+  meaningful on large fields. -/
+  | bitOf (x : FExpr F) (i : ℕ)
   | ite (c : BExpr F) (t e : FExpr F)
   /-- Read an expression list at a computed index, 0 if out of range -/
-  | listGet (xs : List (FExpr F)) (i : NExpr F)
+  | listGet (xs : List (FExpr F)) (i : UExpr F)
   /-- Read committed prover data (`Environment.data`), keyed like `ProverData`:
   row `row` of table `key` with rows of width `n`, projected at column `col`.
   Missing rows read as 0. The nondeterministic escape hatch (FemtoCairo memory). -/
-  | dataGet (key : String) (n : ℕ) (row : NExpr F) (col : Fin n)
+  | dataGet (key : String) (n : ℕ) (row : UExpr F) (col : Fin n)
   /-- Same as `dataGet` but reads the uncommitted `ProverEnvironment.hint`. -/
-  | hintGet (key : String) (n : ℕ) (row : NExpr F) (col : Fin n)
+  | hintGet (key : String) (n : ℕ) (row : UExpr F) (col : Fin n)
 
-/-- Nat-sorted witness expressions. -/
-inductive NExpr (F : Type) where
+/-- u64-sorted (bounded-nat) witness expressions. All operations wrap modulo `2^64`,
+matching Rust's `u64`. -/
+inductive UExpr (F : Type) where
+  /-- A `ℕ` literal, truncated to 64 bits. -/
   | const (n : ℕ)
-  /-- The field→Nat bridge (`ZMod.val`). -/
+  /-- The field→u64 bridge: `ZMod.val` truncated to 64 bits. -/
   | val (x : FExpr F)
   /-- The index of the innermost enclosing `VExpr.mapRange` (0 outside). -/
   | idx
-  /-- Reference to an earlier `Step` result (must be a `letN` step). -/
+  /-- Reference to an earlier `Step` result (must be a `letU` step). -/
   | localVar (i : ℕ)
-  | add (x y : NExpr F)
-  | mul (x y : NExpr F)
-  | div (x y : NExpr F)
-  | mod (x y : NExpr F)
-  | land (x y : NExpr F)
-  | lor (x y : NExpr F)
-  | lxor (x y : NExpr F)
-  | shiftL (x y : NExpr F)
-  | shiftR (x y : NExpr F)
-  | ite (c : BExpr F) (t e : NExpr F)
+  | add (x y : UExpr F)
+  | mul (x y : UExpr F)
+  | div (x y : UExpr F)
+  | mod (x y : UExpr F)
+  | land (x y : UExpr F)
+  | lor (x y : UExpr F)
+  | lxor (x y : UExpr F)
+  | shiftL (x y : UExpr F)
+  | shiftR (x y : UExpr F)
+  | ite (c : BExpr F) (t e : UExpr F)
 
 /-- Conditions. -/
 inductive BExpr (F : Type) where
@@ -101,10 +127,10 @@ inductive BExpr (F : Type) where
   | false
   /-- Field equality condition (decided via the injective `ℕ` embedding). -/
   | feq (x y : FExpr F)
-  /-- Nat equality condition. -/
-  | neq (x y : NExpr F)
-  /-- Nat-sorted less-than condition. -/
-  | lt (x y : NExpr F)
+  /-- u64 equality condition. -/
+  | neq (x y : UExpr F)
+  /-- u64-sorted less-than condition. -/
+  | lt (x y : UExpr F)
   /-- Negation of a condition. -/
   | not (b : BExpr F)
   /-- Conjunction of conditions. -/
@@ -118,17 +144,17 @@ end
 /-- `-x` as a derived field expression. -/
 @[reducible] def FExpr.neg [Field F] (x : FExpr F) : FExpr F := .mul (.const (-1)) x
 
-/-- `2^k` as a derived Nat expression. -/
-@[reducible] def NExpr.pow2 (k : NExpr F) : NExpr F := .shiftL (.const 1) k
+/-- `2^k` as a derived u64 expression. -/
+@[reducible] def UExpr.pow2 (k : UExpr F) : UExpr F := .shiftL (.const 1) k
 
-/-- `Nat.testBit x i` as a derived Nat expression, valued in {0, 1}. -/
-@[reducible] def NExpr.testBit (x i : NExpr F) : NExpr F := .mod (.shiftR x i) (.const 2)
+/-- `Nat.testBit x i` as a derived u64 expression, valued in {0, 1}. -/
+@[reducible] def UExpr.testBit (x i : UExpr F) : UExpr F := .mod (.shiftR x i) (.const 2)
 
 /-- Evaluation context: the prover environment, the values of the `let`-steps computed
 so far, and the innermost `mapRange` index. -/
 structure Ctx (F : Type) where
   env : ProverEnvironment F
-  locals : Array (F ⊕ ℕ) := #[]
+  locals : Array (F ⊕ UInt64) := #[]
   idx : ℕ := 0
 
 section Eval
@@ -139,7 +165,6 @@ mutual
 @[circuit_norm]
 def FExpr.eval (ctx : Ctx F) : FExpr F → F
   | .expr e => e.eval ctx.env.toEnvironment
-  | .envGet i => ctx.env.get (i.eval ctx)
   | .const c => c
   | .localVar i =>
     match ctx.locals[i]? with
@@ -148,13 +173,14 @@ def FExpr.eval (ctx : Ctx F) : FExpr F → F
   | .add x y => x.eval ctx + y.eval ctx
   | .mul x y => x.eval ctx * y.eval ctx
   | .inv x => (x.eval ctx)⁻¹
-  | .ofNat n => FiniteField.fromNat (n.eval ctx)
+  | .ofU64 n => FiniteField.fromNat (n.eval ctx).toNat
+  | .bitOf x i => FiniteField.fromNat (FiniteField.val (x.eval ctx) >>> i % 2)
   | .ite c t e => if c.eval ctx then t.eval ctx else e.eval ctx
-  | .listGet xs i => FExpr.evalList ctx (i.eval ctx) xs
+  | .listGet xs i => FExpr.evalList ctx (i.eval ctx).toNat xs
   | .dataGet key n row col =>
-    ((ctx.env.data key n)[row.eval ctx]?.getD default)[col.val]'col.isLt
+    ((ctx.env.data key n)[(row.eval ctx).toNat]?.getD default)[col.val]'col.isLt
   | .hintGet key n row col =>
-    ((ctx.env.hint key n)[row.eval ctx]?.getD default)[col.val]'col.isLt
+    ((ctx.env.hint key n)[(row.eval ctx).toNat]?.getD default)[col.val]'col.isLt
 
 @[circuit_norm]
 def FExpr.evalList (ctx : Ctx F) : ℕ → List (FExpr F) → F
@@ -163,10 +189,10 @@ def FExpr.evalList (ctx : Ctx F) : ℕ → List (FExpr F) → F
   | i + 1, _ :: xs => FExpr.evalList ctx i xs
 
 @[circuit_norm]
-def NExpr.eval (ctx : Ctx F) : NExpr F → ℕ
-  | .const n => n
-  | .val x => FiniteField.val (x.eval ctx)
-  | .idx => ctx.idx
+def UExpr.eval (ctx : Ctx F) : UExpr F → UInt64
+  | .const n => UInt64.ofNat n
+  | .val x => UInt64.ofNat (FiniteField.val (x.eval ctx))
+  | .idx => UInt64.ofNat ctx.idx
   | .localVar i =>
     match ctx.locals[i]? with
     | some (.inr n) => n
@@ -193,6 +219,25 @@ def BExpr.eval (ctx : Ctx F) : BExpr F → Bool
   | .and x y => x.eval ctx && y.eval ctx
 
 end
+
+/-! ### `u64` normalization
+
+Witness-IR proofs live in `ℕ`: every u64-sorted subterm reaches the field via
+`FExpr.ofU64`, which applies `UInt64.toNat`. Pushing `toNat` through the operations turns
+a `UExpr` evaluation into ordinary `ℕ` arithmetic with explicit `% 2^64` wraps, which
+`omega` / `Nat.mod_eq_of_lt` discharge whenever the gadget's own bounds make the
+operation non-wrapping. -/
+attribute [circuit_norm]
+  UInt64.toNat_add UInt64.toNat_mul UInt64.toNat_div UInt64.toNat_mod
+  UInt64.toNat_and UInt64.toNat_or UInt64.toNat_xor
+  UInt64.toNat_shiftLeft UInt64.toNat_shiftRight
+  UInt64.toNat_ofNat' UInt64.toNat_ofNat UInt64.lt_iff_toNat_lt
+
+/-- `u64` equality is `ℕ` equality of the truncations — the shape the `toNat`-pushing
+`circuit_norm` lemmas above leave the rest of a condition in. -/
+@[circuit_norm]
+theorem UInt64.eq_iff_toNat_eq {a b : UInt64} : a = b ↔ a.toNat = b.toNat :=
+  UInt64.toNat_inj.symm
 
 variable {M : TypeMap} [ProvableType M]
 
@@ -228,6 +273,13 @@ constraint system — porting its computation to the IR must keep it a hint. -/
 inductive VExpr (F : Type) : ℕ → Type where
   | lit {n : ℕ} (es : Vector (FExpr F) n) : VExpr F n
   | mapRange (n : ℕ) (body : FExpr F) : VExpr F n
+  /-- `n` consecutive environment cells starting at `offset` — the "witness a fresh
+  variable per cell" former (`witnessAny`, table rows). The offset is a static `ℕ`, so
+  witness offsets never round-trip through the u64 sort. -/
+  | envRange {n : ℕ} (offset : ℕ) : VExpr F n
+  /-- The `n` low bits of `FiniteField.val x`, each as the field element `0` or `1` —
+  the bit-decomposition former. Kept at the field level so that `n` may exceed 64. -/
+  | bitsOf {n : ℕ} (x : FExpr F) : VExpr F n
   | append {m n : ℕ} (a : VExpr F m) (b : VExpr F n) : VExpr F (m + n)
 
 instance {n} : Coe (Vector (FExpr F) n) (VExpr F n) where
@@ -236,22 +288,25 @@ instance {n} : Coe (Vector (FExpr F) n) (VExpr F n) where
 def VExpr.eval [FiniteField F] (ctx : Ctx F) : {n : ℕ} → VExpr F n → Vector F n
   | _, .lit es => es.map (FExpr.eval ctx)
   | _, .mapRange n body => .mapRange n fun i => body.eval { ctx with idx := i }
+  | n, .envRange offset => .mapRange n fun i => ctx.env.get (offset + i)
+  | n, .bitsOf x => .mapRange n fun i =>
+      FiniteField.fromNat (FiniteField.val (x.eval ctx) >>> i % 2)
   | _, .append a b => a.eval ctx ++ b.eval ctx
 
-/-- A scalar `let`-step: computes one field or Nat value from the environment and
+/-- A scalar `let`-step: computes one field or u64 value from the environment and
 earlier steps. Referenced by position via `localVar`. -/
 inductive Step (F : Type) where
   | letF (e : FExpr F)
-  | letN (e : NExpr F)
+  | letU (e : UExpr F)
 
 /-- Evaluate the `let`-steps left to right, accumulating their values. -/
 @[circuit_norm]
 def evalSteps [FiniteField F] (env : ProverEnvironment F)
-    (steps : List (Step F)) (locals : Array (F ⊕ ℕ) := #[]) : Array (F ⊕ ℕ) :=
+    (steps : List (Step F)) (locals : Array (F ⊕ UInt64) := #[]) : Array (F ⊕ UInt64) :=
   match steps with
   | [] => locals
   | .letF e :: steps => evalSteps env steps (locals.push (.inl (e.eval { env, locals })))
-  | .letN e :: steps => evalSteps env steps (locals.push (.inr (e.eval { env, locals })))
+  | .letU e :: steps => evalSteps env steps (locals.push (.inr (e.eval { env, locals })))
 
 /-- A witness-generation program producing `m` field elements. -/
 inductive WitgenIR (F : Type) : ℕ → Type where
@@ -357,6 +412,21 @@ attribute [circuit_norm] decide_eq_true_eq
 theorem VExpr.getElem_eval_mapRange [FiniteField F] (ctx : Ctx F) (n : ℕ) (body : FExpr F)
     (i : ℕ) (hi : i < n) :
     (VExpr.eval ctx (.mapRange n body))[i] = body.eval { ctx with idx := i } := by
+  simp [VExpr.eval, Vector.getElem_mapRange]
+
+/-- Elementwise evaluation of environment ranges, keyed on the eval term. -/
+@[circuit_norm ↓]
+theorem VExpr.getElem_eval_envRange [FiniteField F] (ctx : Ctx F) {n : ℕ} (offset : ℕ)
+    (i : ℕ) (hi : i < n) :
+    (VExpr.eval ctx (.envRange (n := n) offset))[i] = ctx.env.get (offset + i) := by
+  simp [VExpr.eval, Vector.getElem_mapRange]
+
+/-- Elementwise evaluation of bit decompositions, keyed on the eval term. -/
+@[circuit_norm ↓]
+theorem VExpr.getElem_eval_bitsOf [FiniteField F] (ctx : Ctx F) {n : ℕ} (x : FExpr F)
+    (i : ℕ) (hi : i < n) :
+    (VExpr.eval ctx (.bitsOf (n := n) x))[i]
+      = FiniteField.fromNat (FiniteField.val (x.eval ctx) >>> i % 2) := by
   simp [VExpr.eval, Vector.getElem_mapRange]
 
 /-- Elementwise evaluation of literal vector outputs, keyed on the eval term. -/

--- a/Clean/Circuit/WitnessIRSugar.lean
+++ b/Clean/Circuit/WitnessIRSugar.lean
@@ -6,20 +6,20 @@ import Clean.Circuit.WitnessIR
 Makes witness-IR programs read like normal code:
 
 - typeclass operators on the IR expression types (`+ * - ⁻¹` on `FExpr`;
-  `+ * / % &&& ||| ^^^ <<< >>>` on `NExpr`), numeric literals via `OfNat`,
+  `+ * / % &&& ||| ^^^ <<< >>>` on `UExpr`), numeric literals via `OfNat`,
   and a coercion from circuit `Expression`s,
-- dot-notation bridges `x.val : NExpr` (on `Expression` and `FExpr`) and
+- dot-notation bridges `x.val : UExpr` (on `Expression` and `FExpr`) and
   `n.toField : FExpr`,
 - condition notation `=?` / `<?`,
 - `VExpr.range n fun i => ...` — loop former whose body receives the index as an
-  `NExpr` (applied to `.idx` at construction time, so the lambda is authoring-time
+  `UExpr` (applied to `.idx` at construction time, so the lambda is authoring-time
   only and the result is first-order data),
-- a builder monad `Witgen.M` with `letF`/`letN` for shared intermediate values.
+- a builder monad `Witgen.M` with `letF`/`letU` for shared intermediate values.
 
 Example (SHA256 `Add32`-style):
 ```
 witnessVectorProgram 32 do
-  let s ← (bitsVal a + bitsVal b) % ((2^32 : ℕ) : NExpr F)
+  let s ← (bitsVal a + bitsVal b) % ((2^32 : ℕ) : UExpr F)
   return .range 32 fun i => ((s >>> i) % 2).toField
 ```
 -/
@@ -45,26 +45,26 @@ instance : Inv (FExpr F) := ⟨.inv⟩
 instance [Field F] : Neg (FExpr F) := ⟨.neg⟩
 instance [Field F] : Sub (FExpr F) := ⟨.sub⟩
 
-instance : Coe ℕ (NExpr F) := ⟨.const⟩
-instance {n : ℕ} : OfNat (NExpr F) n := ⟨.const n⟩
-instance : Inhabited (NExpr F) where
+instance : Coe ℕ (UExpr F) := ⟨.const⟩
+instance {n : ℕ} : OfNat (UExpr F) n := ⟨.const n⟩
+instance : Inhabited (UExpr F) where
   default := .const 0
-instance : Add (NExpr F) := ⟨.add⟩
-instance : Mul (NExpr F) := ⟨.mul⟩
-instance : Div (NExpr F) := ⟨.div⟩
-instance : HDiv (NExpr F) ℕ (NExpr F) where
+instance : Add (UExpr F) := ⟨.add⟩
+instance : Mul (UExpr F) := ⟨.mul⟩
+instance : Div (UExpr F) := ⟨.div⟩
+instance : HDiv (UExpr F) ℕ (UExpr F) where
   hDiv n m := .div n m
-instance : Mod (NExpr F) := ⟨.mod⟩
-instance : HMod (NExpr F) ℕ (NExpr F) where
+instance : Mod (UExpr F) := ⟨.mod⟩
+instance : HMod (UExpr F) ℕ (UExpr F) where
   hMod n m := .mod n m
-instance : AndOp (NExpr F) := ⟨.land⟩
-instance : OrOp (NExpr F) := ⟨.lor⟩
-instance : XorOp (NExpr F) := ⟨.lxor⟩
-instance : ShiftLeft (NExpr F) := ⟨.shiftL⟩
-instance : ShiftRight (NExpr F) := ⟨.shiftR⟩
-instance : HShiftLeft (NExpr F) ℕ (NExpr F) where
+instance : AndOp (UExpr F) := ⟨.land⟩
+instance : OrOp (UExpr F) := ⟨.lor⟩
+instance : XorOp (UExpr F) := ⟨.lxor⟩
+instance : ShiftLeft (UExpr F) := ⟨.shiftL⟩
+instance : ShiftRight (UExpr F) := ⟨.shiftR⟩
+instance : HShiftLeft (UExpr F) ℕ (UExpr F) where
   hShiftLeft n m := .shiftL n m
-instance : HShiftRight (NExpr F) ℕ (NExpr F) where
+instance : HShiftRight (UExpr F) ℕ (UExpr F) where
   hShiftRight n m := .shiftR n m
 
 /-- A single field-sorted expression is a length-1 witness program, so scalar
@@ -73,14 +73,24 @@ instance : Coe (FExpr F) (WitgenIR F 1) := ⟨.ofFExpr⟩
 
 /-! ## Bridges as dot notation -/
 
-/-- The `ℕ` value of an IR field expression: `e.val`. -/
-abbrev FExpr.val (e : FExpr F) : NExpr F := .val e
+/-- The `u64` value of an IR field expression (truncated `ZMod.val`): `e.val`. -/
+abbrev FExpr.val (e : FExpr F) : UExpr F := .val e
 
-/-- The `ℕ` value of a circuit expression, as a witness-IR expression: `x.val`. -/
-abbrev _root_.Expression.val (e : Expression F) : NExpr F := .val (.expr e)
+/-- The `u64` value of a circuit expression, as a witness-IR expression: `x.val`. -/
+abbrev _root_.Expression.val (e : Expression F) : UExpr F := .val (.expr e)
 
-/-- Cast a Nat-sorted IR expression back into the field (via `FiniteField.fromNat`). -/
-abbrev NExpr.toField (n : NExpr F) : FExpr F := .ofNat n
+/-- Cast a u64-sorted IR expression back into the field (via `FiniteField.fromNat`). -/
+abbrev UExpr.toField (n : UExpr F) : FExpr F := .ofU64 n
+
+/-- Bit `i` of the field value of an IR expression, as the field element `0` or `1`.
+Unlike `(e.val >>> i) % 2` this is computed at the field level, so `i` may exceed 64. -/
+abbrev FExpr.bit (e : FExpr F) (i : ℕ) : FExpr F := .bitOf e i
+
+/-- Bit `i` of the field value of a circuit expression: `x.bit i`. -/
+abbrev _root_.Expression.bit (e : Expression F) (i : ℕ) : FExpr F := .bitOf (.expr e) i
+
+/-- The `n` low bits of the field value of an IR expression, as a vector output. -/
+abbrev VExpr.bits (n : ℕ) (e : FExpr F) : VExpr F n := .bitsOf e
 
 /-- Cast a boolean expression to a field element that is 0 or 1. -/
 abbrev BExpr.toField [Field F] (b : BExpr F) : FExpr F := .ite b 1 0
@@ -88,8 +98,8 @@ abbrev BExpr.toField [Field F] (b : BExpr F) : FExpr F := .ite b 1 0
 /-! ## Conditions -/
 
 /-- Overload witness-IR equality tests while keeping a single parser entry for
-`=?`. Field-sorted operands become `BExpr.feq`; Nat-sorted operands become
-`BExpr.neq` (Nat equality).  The operand types are heterogeneous so
+`=?`. Field-sorted operands become `BExpr.feq`; u64-sorted operands become
+`BExpr.neq` (u64 equality).  The operand types are heterogeneous so
 `x =? 0` can keep `x` as an `Expression` while interpreting `0` as an IR
 constant, preserving the exported witness shape. -/
 class EqCond (α β : Type) (F : outParam Type) where
@@ -109,9 +119,9 @@ instance [NatCast F] : EqCond (Expression F) ℕ F where eqCond x n := .feq x (n
 instance [NatCast F] : EqCond ℕ (Expression F) F where eqCond n x := .feq (n : F) x
 instance [NatCast F] : EqCond (FExpr F) ℕ F where eqCond x n := .feq x (n : F)
 instance [NatCast F] : EqCond ℕ (FExpr F) F where eqCond n x := .feq (n : F) x
-instance : EqCond (NExpr F) (NExpr F) F := ⟨.neq⟩
-instance : EqCond (NExpr F) ℕ F where eqCond x n := .neq x (.const n)
-instance : EqCond ℕ (NExpr F) F where eqCond n x := .neq (.const n) x
+instance : EqCond (UExpr F) (UExpr F) F := ⟨.neq⟩
+instance : EqCond (UExpr F) ℕ F where eqCond x n := .neq x (.const n)
+instance : EqCond ℕ (UExpr F) F where eqCond n x := .neq (.const n) x
 
 @[inherit_doc BExpr.lt] infix:50 " <? " => BExpr.lt
 
@@ -120,16 +130,16 @@ instance : AndOp (BExpr F) := ⟨.and⟩
 
 /-! ## Index access notation for .listGet -/
 
-instance {F : Type} {n : ℕ} : GetElem (Vector F n) (NExpr F) (FExpr F) (fun _ _ => True) where
+instance {F : Type} {n : ℕ} : GetElem (Vector F n) (UExpr F) (FExpr F) (fun _ _ => True) where
   getElem v i _ := FExpr.listGet (v.toList.map FExpr.const) i
 
-instance {F : Type} {n : ℕ} : GetElem (Vector (Expression F) n) (NExpr F) (FExpr F) (fun _ _ => True) where
+instance {F : Type} {n : ℕ} : GetElem (Vector (Expression F) n) (UExpr F) (FExpr F) (fun _ _ => True) where
   getElem v i _ := FExpr.listGet (v.toList.map FExpr.expr) i
 
-instance {F : Type} {n : ℕ} : GetElem (Var (fields n) F) (NExpr F) (FExpr F) (fun _ _ => True) :=
-  inferInstanceAs (GetElem (Vector (Expression F) n) (NExpr F) _ _)
+instance {F : Type} {n : ℕ} : GetElem (Var (fields n) F) (UExpr F) (FExpr F) (fun _ _ => True) :=
+  inferInstanceAs (GetElem (Vector (Expression F) n) (UExpr F) _ _)
 
-instance {F : Type} {n : ℕ} : GetElem (Vector (FExpr F) n) (NExpr F) (FExpr F) (fun _ _ => True) where
+instance {F : Type} {n : ℕ} : GetElem (Vector (FExpr F) n) (UExpr F) (FExpr F) (fun _ _ => True) where
   getElem v i _ := FExpr.listGet v.toList i
 
 @[circuit_norm]
@@ -155,20 +165,20 @@ lemma evalList_map_vector_fexpr {F : Type} {ctx : Ctx F} [FiniteField F] {n : �
 
 /-! ## Loop former -/
 
-/-- Vector output built per index; the body receives the loop index as an `NExpr`.
+/-- Vector output built per index; the body receives the loop index as an `UExpr`.
 The lambda is applied to `.idx` at construction time — authoring-time HOAS,
 first-order result. -/
-def VExpr.range (n : ℕ) (body : NExpr F → FExpr F) : VExpr F n :=
+def VExpr.range (n : ℕ) (body : UExpr F → FExpr F) : VExpr F n :=
   .mapRange n (body .idx)
 
 @[circuit_norm]
-theorem VExpr.range_def (n : ℕ) (body : NExpr F → FExpr F) :
+theorem VExpr.range_def (n : ℕ) (body : UExpr F → FExpr F) :
     VExpr.range n body = .mapRange n (body .idx) := rfl
 
 /-! ## Builder monad for stepped programs -/
 
 /-- Witness-program builder: accumulates `let`-steps, so shared values are written
-in `do`-notation via `letF` / `letN`. -/
+in `do`-notation via `letF` / `letU`. -/
 def M (F : Type) (α : Type) : Type :=
   Array (Step F) → α × Array (Step F)
 
@@ -191,15 +201,15 @@ theorem M.bind_def (m : M F α) (f : α → M F β) :
 theorem M.map_def (f : α → β) (m : M F α) :
     (f <$> m) = fun s => let (a, s') := m s; (f a, s') := rfl
 
-/-- Bind a Nat-sorted value as a shared step; returns a reference to it. -/
-def letN (e : NExpr F) : M F (NExpr F) :=
-  fun s => (.localVar s.size, s.push (.letN e))
+/-- Bind a u64-sorted value as a shared step; returns a reference to it. -/
+def letU (e : UExpr F) : M F (UExpr F) :=
+  fun s => (.localVar s.size, s.push (.letU e))
 
-instance : CoeOut (NExpr F) (M F (NExpr F)) := ⟨letN⟩
+instance : CoeOut (UExpr F) (M F (UExpr F)) := ⟨letU⟩
 
 @[circuit_norm]
-theorem letN_def (e : NExpr F) :
-    letN e = fun s => (.localVar s.size, s.push (.letN e)) := rfl
+theorem letU_def (e : UExpr F) :
+    letU e = fun s => (.localVar s.size, s.push (.letU e)) := rfl
 
 /-- Bind a field-sorted value as a shared step; returns a reference to it. -/
 def letF (e : FExpr F) : M F (FExpr F) :=
@@ -234,7 +244,7 @@ def evalBool (env : ProverEnvironment F) (program : M F (BExpr F)) : Bool :=
   out.eval { env, locals := evalSteps env steps.toList }
 
 @[circuit_norm]
-def evalNat (env : ProverEnvironment F) (program : M F (NExpr F)) : ℕ :=
+def evalU64 (env : ProverEnvironment F) (program : M F (UExpr F)) : UInt64 :=
   let (out, steps) := program #[]
   out.eval { env, locals := evalSteps env steps.toList }
 
@@ -367,50 +377,50 @@ end UnconstrainedBool
 
 export UnconstrainedBool (unconstrainedBool)
 
-/-- IR-backed prover-only Nat input for `GeneralFormalCircuit.WithHint`. -/
-structure UnconstrainedNat (F : Type) where
-  program : Witgen.M F (Witgen.NExpr F)
+/-- IR-backed prover-only u64 input for `GeneralFormalCircuit.WithHint`. -/
+structure UnconstrainedU64 (F : Type) where
+  program : Witgen.M F (Witgen.UExpr F)
 
-namespace UnconstrainedNat
+namespace UnconstrainedU64
 open Witgen
 
-@[reducible] instance : CircuitType UnconstrainedNat where
-  Var F := M F (NExpr F)
-  ProverValue _ := ℕ
+@[reducible] instance : CircuitType UnconstrainedU64 where
+  Var F := M F (UExpr F)
+  ProverValue _ := UInt64
   Value _ := Unit
   evalVerifier _ _ := ()
-  evalProver env program := program.evalNat env
+  evalProver env program := program.evalU64 env
 
-instance : Inhabited (Var UnconstrainedNat F) :=
-  inferInstanceAs (Inhabited (M F (NExpr F)))
+instance : Inhabited (Var UnconstrainedU64 F) :=
+  inferInstanceAs (Inhabited (M F (UExpr F)))
 
-@[circuit_norm] lemma var_of_unconstrainedNat :
-    Var UnconstrainedNat F = M F (NExpr F) := rfl
+@[circuit_norm] lemma var_of_unconstrainedU64 :
+    Var UnconstrainedU64 F = M F (UExpr F) := rfl
 
-@[circuit_norm] lemma proverValue_of_unconstrainedNat :
-    ProverValue UnconstrainedNat F = ℕ := rfl
+@[circuit_norm] lemma proverValue_of_unconstrainedU64 :
+    ProverValue UnconstrainedU64 F = UInt64 := rfl
 
-@[circuit_norm] lemma value_of_unconstrainedNat :
-    Value UnconstrainedNat F = Unit := rfl
+@[circuit_norm] lemma value_of_unconstrainedU64 :
+    Value UnconstrainedU64 F = Unit := rfl
 
-@[circuit_norm] lemma eval_unconstrainedNat [FiniteField F]
-    (env : Environment F) (v : Var UnconstrainedNat F) :
+@[circuit_norm] lemma eval_unconstrainedU64 [FiniteField F]
+    (env : Environment F) (v : Var UnconstrainedU64 F) :
     eval env v = () := by rfl
 
-@[circuit_norm] lemma eval_unconstrainedNat_prover [FiniteField F]
-    (env : ProverEnvironment F) (v : Var UnconstrainedNat F) :
-    eval env v = M.evalNat env v := by
-  rw [CircuitType.eval_prover (M := UnconstrainedNat)]
+@[circuit_norm] lemma eval_unconstrainedU64_prover [FiniteField F]
+    (env : ProverEnvironment F) (v : Var UnconstrainedU64 F) :
+    eval env v = M.evalU64 env v := by
+  rw [CircuitType.eval_prover (M := UnconstrainedU64)]
   rfl
 
-@[circuit_norm] lemma eval_unconstrainedNat_prover' [FiniteField F] :
-  @eval (ProverEnvironment F) (M F (NExpr F)) ℕ (CircuitType.proverEval UnconstrainedNat)
-    = M.evalNat := by
+@[circuit_norm] lemma eval_unconstrainedU64_prover' [FiniteField F] :
+  @eval (ProverEnvironment F) (M F (UExpr F)) UInt64 (CircuitType.proverEval UnconstrainedU64)
+    = M.evalU64 := by
   with_unfolding_all rfl
 
 @[circuit_norm]
-def unconstrainedNat (program : Witgen.M F (Witgen.NExpr F)) : Var UnconstrainedNat F :=
+def unconstrainedU64 (program : Witgen.M F (Witgen.UExpr F)) : Var UnconstrainedU64 F :=
   program
-end UnconstrainedNat
+end UnconstrainedU64
 
-export UnconstrainedNat (unconstrainedNat)
+export UnconstrainedU64 (unconstrainedU64)

--- a/Clean/Circuit/WitnessIRSugar.lean
+++ b/Clean/Circuit/WitnessIRSugar.lean
@@ -6,20 +6,20 @@ import Clean.Circuit.WitnessIR
 Makes witness-IR programs read like normal code:
 
 - typeclass operators on the IR expression types (`+ * - ⁻¹` on `FExpr`;
-  `+ * / % &&& ||| ^^^ <<< >>>` on `UExpr`), numeric literals via `OfNat`,
+  `+ * / % &&& ||| ^^^ <<< >>>` on `U64Expr`), numeric literals via `OfNat`,
   and a coercion from circuit `Expression`s,
-- dot-notation bridges `x.val : UExpr` (on `Expression` and `FExpr`) and
+- dot-notation bridges `x.val : U64Expr` (on `Expression` and `FExpr`) and
   `n.toField : FExpr`,
 - condition notation `=?` / `<?`,
 - `VExpr.range n fun i => ...` — loop former whose body receives the index as an
-  `UExpr` (applied to `.idx` at construction time, so the lambda is authoring-time
+  `U64Expr` (applied to `.idx` at construction time, so the lambda is authoring-time
   only and the result is first-order data),
 - a builder monad `Witgen.M` with `letF`/`letU` for shared intermediate values.
 
 Example (SHA256 `Add32`-style):
 ```
 witnessVectorProgram 32 do
-  let s ← (bitsVal a + bitsVal b) % ((2^32 : ℕ) : UExpr F)
+  let s ← (bitsVal a + bitsVal b) % ((2^32 : ℕ) : U64Expr F)
   return .range 32 fun i => ((s >>> i) % 2).toField
 ```
 -/
@@ -45,26 +45,26 @@ instance : Inv (FExpr F) := ⟨.inv⟩
 instance [Field F] : Neg (FExpr F) := ⟨.neg⟩
 instance [Field F] : Sub (FExpr F) := ⟨.sub⟩
 
-instance : Coe ℕ (UExpr F) := ⟨.const⟩
-instance {n : ℕ} : OfNat (UExpr F) n := ⟨.const n⟩
-instance : Inhabited (UExpr F) where
+instance : Coe ℕ (U64Expr F) := ⟨.const⟩
+instance {n : ℕ} : OfNat (U64Expr F) n := ⟨.const n⟩
+instance : Inhabited (U64Expr F) where
   default := .const 0
-instance : Add (UExpr F) := ⟨.add⟩
-instance : Mul (UExpr F) := ⟨.mul⟩
-instance : Div (UExpr F) := ⟨.div⟩
-instance : HDiv (UExpr F) ℕ (UExpr F) where
+instance : Add (U64Expr F) := ⟨.add⟩
+instance : Mul (U64Expr F) := ⟨.mul⟩
+instance : Div (U64Expr F) := ⟨.div⟩
+instance : HDiv (U64Expr F) ℕ (U64Expr F) where
   hDiv n m := .div n m
-instance : Mod (UExpr F) := ⟨.mod⟩
-instance : HMod (UExpr F) ℕ (UExpr F) where
+instance : Mod (U64Expr F) := ⟨.mod⟩
+instance : HMod (U64Expr F) ℕ (U64Expr F) where
   hMod n m := .mod n m
-instance : AndOp (UExpr F) := ⟨.land⟩
-instance : OrOp (UExpr F) := ⟨.lor⟩
-instance : XorOp (UExpr F) := ⟨.lxor⟩
-instance : ShiftLeft (UExpr F) := ⟨.shiftL⟩
-instance : ShiftRight (UExpr F) := ⟨.shiftR⟩
-instance : HShiftLeft (UExpr F) ℕ (UExpr F) where
+instance : AndOp (U64Expr F) := ⟨.land⟩
+instance : OrOp (U64Expr F) := ⟨.lor⟩
+instance : XorOp (U64Expr F) := ⟨.lxor⟩
+instance : ShiftLeft (U64Expr F) := ⟨.shiftL⟩
+instance : ShiftRight (U64Expr F) := ⟨.shiftR⟩
+instance : HShiftLeft (U64Expr F) ℕ (U64Expr F) where
   hShiftLeft n m := .shiftL n m
-instance : HShiftRight (UExpr F) ℕ (UExpr F) where
+instance : HShiftRight (U64Expr F) ℕ (U64Expr F) where
   hShiftRight n m := .shiftR n m
 
 /-- A single field-sorted expression is a length-1 witness program, so scalar
@@ -74,13 +74,13 @@ instance : Coe (FExpr F) (WitgenIR F 1) := ⟨.ofFExpr⟩
 /-! ## Bridges as dot notation -/
 
 /-- The `u64` value of an IR field expression (truncated `ZMod.val`): `e.val`. -/
-abbrev FExpr.val (e : FExpr F) : UExpr F := .val e
+abbrev FExpr.val (e : FExpr F) : U64Expr F := .val e
 
 /-- The `u64` value of a circuit expression, as a witness-IR expression: `x.val`. -/
-abbrev _root_.Expression.val (e : Expression F) : UExpr F := .val (.expr e)
+abbrev _root_.Expression.val (e : Expression F) : U64Expr F := .val (.expr e)
 
 /-- Cast a u64-sorted IR expression back into the field (via `FiniteField.fromNat`). -/
-abbrev UExpr.toField (n : UExpr F) : FExpr F := .ofU64 n
+abbrev U64Expr.toField (n : U64Expr F) : FExpr F := .ofU64 n
 
 /-- Bit `i` of the field value of an IR expression, as the field element `0` or `1`.
 Unlike `(e.val >>> i) % 2` this is computed at the field level, so `i` may exceed 64. -/
@@ -122,27 +122,49 @@ instance [NatCast F] : EqCond (Expression F) ℕ F where eqCond x n := .feq x (n
 instance [NatCast F] : EqCond ℕ (Expression F) F where eqCond n x := .feq (n : F) x
 instance [NatCast F] : EqCond (FExpr F) ℕ F where eqCond x n := .feq x (n : F)
 instance [NatCast F] : EqCond ℕ (FExpr F) F where eqCond n x := .feq (n : F) x
-instance : EqCond (UExpr F) (UExpr F) F := ⟨.neq⟩
-instance : EqCond (UExpr F) ℕ F where eqCond x n := .neq x (.const n)
-instance : EqCond ℕ (UExpr F) F where eqCond n x := .neq (.const n) x
+instance : EqCond (U64Expr F) (U64Expr F) F := ⟨.neq⟩
+instance : EqCond (U64Expr F) ℕ F where eqCond x n := .neq x (.const n)
+instance : EqCond ℕ (U64Expr F) F where eqCond n x := .neq (.const n) x
 
-@[inherit_doc BExpr.lt] infix:50 " <? " => BExpr.lt
+/-- Overload witness-IR less-than tests while keeping a single parser entry for `<?`.
+Field-sorted operands become `BExpr.flt` (comparing `FiniteField.val`s, so it stays exact
+on fields wider than 64 bits); u64-sorted operands become `BExpr.lt`. -/
+class LtCond (α β : Type) (F : outParam Type) where
+  /-- Build a witness-IR less-than condition for these operand sorts. -/
+  ltCond : α → β → BExpr F
+
+@[inherit_doc LtCond.ltCond] infix:50 " <? " => LtCond.ltCond
+
+instance : LtCond (FExpr F) (FExpr F) F := ⟨.flt⟩
+instance : LtCond (Expression F) (FExpr F) F where ltCond x y := .flt x y
+instance : LtCond (FExpr F) (Expression F) F where ltCond x y := .flt x y
+instance : LtCond (FExpr F) F F where ltCond x y := .flt x y
+instance : LtCond F (FExpr F) F where ltCond x y := .flt x y
+instance : LtCond (Expression F) F F where ltCond x y := .flt x y
+instance : LtCond F (Expression F) F where ltCond x y := .flt x y
+instance [NatCast F] : LtCond (Expression F) ℕ F where ltCond x n := .flt x (n : F)
+instance [NatCast F] : LtCond ℕ (Expression F) F where ltCond n x := .flt (n : F) x
+instance [NatCast F] : LtCond (FExpr F) ℕ F where ltCond x n := .flt x (n : F)
+instance [NatCast F] : LtCond ℕ (FExpr F) F where ltCond n x := .flt (n : F) x
+instance : LtCond (U64Expr F) (U64Expr F) F := ⟨.lt⟩
+instance : LtCond (U64Expr F) ℕ F where ltCond x n := .lt x (.const n)
+instance : LtCond ℕ (U64Expr F) F where ltCond n x := .lt (.const n) x
 
 instance : Inhabited (BExpr F) := ⟨.false⟩
 instance : AndOp (BExpr F) := ⟨.and⟩
 
 /-! ## Index access notation for .listGet -/
 
-instance {F : Type} {n : ℕ} : GetElem (Vector F n) (UExpr F) (FExpr F) (fun _ _ => True) where
+instance {F : Type} {n : ℕ} : GetElem (Vector F n) (U64Expr F) (FExpr F) (fun _ _ => True) where
   getElem v i _ := FExpr.listGet (v.toList.map FExpr.const) i
 
-instance {F : Type} {n : ℕ} : GetElem (Vector (Expression F) n) (UExpr F) (FExpr F) (fun _ _ => True) where
+instance {F : Type} {n : ℕ} : GetElem (Vector (Expression F) n) (U64Expr F) (FExpr F) (fun _ _ => True) where
   getElem v i _ := FExpr.listGet (v.toList.map FExpr.expr) i
 
-instance {F : Type} {n : ℕ} : GetElem (Var (fields n) F) (UExpr F) (FExpr F) (fun _ _ => True) :=
-  inferInstanceAs (GetElem (Vector (Expression F) n) (UExpr F) _ _)
+instance {F : Type} {n : ℕ} : GetElem (Var (fields n) F) (U64Expr F) (FExpr F) (fun _ _ => True) :=
+  inferInstanceAs (GetElem (Vector (Expression F) n) (U64Expr F) _ _)
 
-instance {F : Type} {n : ℕ} : GetElem (Vector (FExpr F) n) (UExpr F) (FExpr F) (fun _ _ => True) where
+instance {F : Type} {n : ℕ} : GetElem (Vector (FExpr F) n) (U64Expr F) (FExpr F) (fun _ _ => True) where
   getElem v i _ := FExpr.listGet v.toList i
 
 @[circuit_norm]
@@ -168,14 +190,14 @@ lemma evalList_map_vector_fexpr {F : Type} {ctx : Ctx F} [FiniteField F] {n : �
 
 /-! ## Loop former -/
 
-/-- Vector output built per index; the body receives the loop index as an `UExpr`.
+/-- Vector output built per index; the body receives the loop index as an `U64Expr`.
 The lambda is applied to `.idx` at construction time — authoring-time HOAS,
 first-order result. -/
-def VExpr.range (n : ℕ) (body : UExpr F → FExpr F) : VExpr F n :=
+def VExpr.range (n : ℕ) (body : U64Expr F → FExpr F) : VExpr F n :=
   .mapRange n (body .idx)
 
 @[circuit_norm]
-theorem VExpr.range_def (n : ℕ) (body : UExpr F → FExpr F) :
+theorem VExpr.range_def (n : ℕ) (body : U64Expr F → FExpr F) :
     VExpr.range n body = .mapRange n (body .idx) := rfl
 
 /-! ## Builder monad for stepped programs -/
@@ -205,13 +227,13 @@ theorem M.map_def (f : α → β) (m : M F α) :
     (f <$> m) = fun s => let (a, s') := m s; (f a, s') := rfl
 
 /-- Bind a u64-sorted value as a shared step; returns a reference to it. -/
-def letU (e : UExpr F) : M F (UExpr F) :=
+def letU (e : U64Expr F) : M F (U64Expr F) :=
   fun s => (.localVar s.size, s.push (.letU e))
 
-instance : CoeOut (UExpr F) (M F (UExpr F)) := ⟨letU⟩
+instance : CoeOut (U64Expr F) (M F (U64Expr F)) := ⟨letU⟩
 
 @[circuit_norm]
-theorem letU_def (e : UExpr F) :
+theorem letU_def (e : U64Expr F) :
     letU e = fun s => (.localVar s.size, s.push (.letU e)) := rfl
 
 /-- Bind a field-sorted value as a shared step; returns a reference to it. -/
@@ -247,7 +269,7 @@ def evalBool (env : ProverEnvironment F) (program : M F (BExpr F)) : Bool :=
   out.eval { env, locals := evalSteps env steps.toList }
 
 @[circuit_norm]
-def evalU64 (env : ProverEnvironment F) (program : M F (UExpr F)) : UInt64 :=
+def evalU64 (env : ProverEnvironment F) (program : M F (U64Expr F)) : UInt64 :=
   let (out, steps) := program #[]
   out.eval { env, locals := evalSteps env steps.toList }
 
@@ -382,23 +404,23 @@ export UnconstrainedBool (unconstrainedBool)
 
 /-- IR-backed prover-only u64 input for `GeneralFormalCircuit.WithHint`. -/
 structure UnconstrainedU64 (F : Type) where
-  program : Witgen.M F (Witgen.UExpr F)
+  program : Witgen.M F (Witgen.U64Expr F)
 
 namespace UnconstrainedU64
 open Witgen
 
 @[reducible] instance : CircuitType UnconstrainedU64 where
-  Var F := M F (UExpr F)
+  Var F := M F (U64Expr F)
   ProverValue _ := UInt64
   Value _ := Unit
   evalVerifier _ _ := ()
   evalProver env program := program.evalU64 env
 
 instance : Inhabited (Var UnconstrainedU64 F) :=
-  inferInstanceAs (Inhabited (M F (UExpr F)))
+  inferInstanceAs (Inhabited (M F (U64Expr F)))
 
 @[circuit_norm] lemma var_of_unconstrainedU64 :
-    Var UnconstrainedU64 F = M F (UExpr F) := rfl
+    Var UnconstrainedU64 F = M F (U64Expr F) := rfl
 
 @[circuit_norm] lemma proverValue_of_unconstrainedU64 :
     ProverValue UnconstrainedU64 F = UInt64 := rfl
@@ -417,12 +439,12 @@ instance : Inhabited (Var UnconstrainedU64 F) :=
   rfl
 
 @[circuit_norm] lemma eval_unconstrainedU64_prover' [FiniteField F] :
-  @eval (ProverEnvironment F) (M F (UExpr F)) UInt64 (CircuitType.proverEval UnconstrainedU64)
+  @eval (ProverEnvironment F) (M F (U64Expr F)) UInt64 (CircuitType.proverEval UnconstrainedU64)
     = M.evalU64 := by
   with_unfolding_all rfl
 
 @[circuit_norm]
-def unconstrainedU64 (program : Witgen.M F (Witgen.UExpr F)) : Var UnconstrainedU64 F :=
+def unconstrainedU64 (program : Witgen.M F (Witgen.U64Expr F)) : Var UnconstrainedU64 F :=
   program
 end UnconstrainedU64
 

--- a/Clean/Circuit/WitnessIRSugar.lean
+++ b/Clean/Circuit/WitnessIRSugar.lean
@@ -92,6 +92,9 @@ abbrev _root_.Expression.bit (e : Expression F) (i : ℕ) : FExpr F := .bitOf (.
 /-- The `n` low bits of the field value of an IR expression, as a vector output. -/
 abbrev VExpr.bits (n : ℕ) (e : FExpr F) : VExpr F n := .bitsOf e
 
+/-- The `n` low bits of a circuit expression, as a vector output: `x.bits n`. -/
+abbrev _root_.Expression.bits (e : Expression F) (n : ℕ) : VExpr F n := .bitsOf (.expr e)
+
 /-- Cast a boolean expression to a field element that is 0 or 1. -/
 abbrev BExpr.toField [Field F] (b : BExpr F) : FExpr F := .ite b 1 0
 

--- a/Clean/Circuit/WitnessIRSugar.lean
+++ b/Clean/Circuit/WitnessIRSugar.lean
@@ -45,27 +45,28 @@ instance : Inv (FExpr F) := ⟨.inv⟩
 instance [Field F] : Neg (FExpr F) := ⟨.neg⟩
 instance [Field F] : Sub (FExpr F) := ⟨.sub⟩
 
-instance : Coe ℕ (U64Expr F) := ⟨.const⟩
-instance {n : ℕ} : OfNat (U64Expr F) n := ⟨.const n⟩
+instance : Coe ℕ (U64Expr F) := ⟨(.const <| UInt64.ofNat ·)⟩
+instance : Coe UInt64 (U64Expr F) := ⟨.const⟩
+instance {n : ℕ} : OfNat (U64Expr F) n := ⟨.const (OfNat.ofNat n)⟩
 instance : Inhabited (U64Expr F) where
   default := .const 0
 instance : Add (U64Expr F) := ⟨.add⟩
 instance : Mul (U64Expr F) := ⟨.mul⟩
 instance : Div (U64Expr F) := ⟨.div⟩
 instance : HDiv (U64Expr F) ℕ (U64Expr F) where
-  hDiv n m := .div n m
+  hDiv n m := .div n (.const (UInt64.ofNat m))
 instance : Mod (U64Expr F) := ⟨.mod⟩
 instance : HMod (U64Expr F) ℕ (U64Expr F) where
-  hMod n m := .mod n m
+  hMod n m := .mod n (.const (UInt64.ofNat m))
 instance : AndOp (U64Expr F) := ⟨.land⟩
 instance : OrOp (U64Expr F) := ⟨.lor⟩
 instance : XorOp (U64Expr F) := ⟨.lxor⟩
 instance : ShiftLeft (U64Expr F) := ⟨.shiftL⟩
 instance : ShiftRight (U64Expr F) := ⟨.shiftR⟩
 instance : HShiftLeft (U64Expr F) ℕ (U64Expr F) where
-  hShiftLeft n m := .shiftL n m
+  hShiftLeft n m := .shiftL n (.const (UInt64.ofNat m))
 instance : HShiftRight (U64Expr F) ℕ (U64Expr F) where
-  hShiftRight n m := .shiftR n m
+  hShiftRight n m := .shiftR n (.const (UInt64.ofNat m))
 
 /-- A single field-sorted expression is a length-1 witness program, so scalar
 sites can pass an `FExpr` to the generic `witness`. -/
@@ -82,13 +83,6 @@ abbrev _root_.Expression.val (e : Expression F) : U64Expr F := .val (.expr e)
 /-- Cast a u64-sorted IR expression back into the field (via `FiniteField.fromNat`). -/
 abbrev U64Expr.toField (n : U64Expr F) : FExpr F := .ofU64 n
 
-/-- Bit `i` of the field value of an IR expression, as the field element `0` or `1`.
-Unlike `(e.val >>> i) % 2` this is computed at the field level, so `i` may exceed 64. -/
-abbrev FExpr.bit (e : FExpr F) (i : ℕ) : FExpr F := .bitOf e i
-
-/-- Bit `i` of the field value of a circuit expression: `x.bit i`. -/
-abbrev _root_.Expression.bit (e : Expression F) (i : ℕ) : FExpr F := .bitOf (.expr e) i
-
 /-- The `n` low bits of the field value of an IR expression, as a vector output. -/
 abbrev VExpr.bits (n : ℕ) (e : FExpr F) : VExpr F n := .bitsOf e
 
@@ -97,6 +91,25 @@ abbrev _root_.Expression.bits (e : Expression F) (n : ℕ) : VExpr F n := .bitsO
 
 /-- Cast a boolean expression to a field element that is 0 or 1. -/
 abbrev BExpr.toField [Field F] (b : BExpr F) : FExpr F := .ite b 1 0
+
+/-- Bit `i` of the field value of an IR expression, as the field element `0` or `1`. -/
+abbrev FExpr.bit [Field F] (e : FExpr F) (i : ℕ) : FExpr F := (BExpr.bit e i).toField
+
+/-- Bit `i` of the field value of a circuit expression: `x.bit i`. -/
+abbrev _root_.Expression.bit [Field F] (e : Expression F) (i : ℕ) : FExpr F :=
+  (BExpr.bit (.expr e) i).toField
+
+/-- A bit-valued condition cast into the field is the corresponding `0`/`1` element —
+the same normal form `VExpr.bitsOf` evaluates to, so bit-decomposition proofs see one
+shape whether the bit index is static or the loop index. Keyed as a pre-rewrite so it
+fires before `FExpr.eval` unfolds the underlying `ite`. -/
+@[circuit_norm ↓]
+theorem FExpr.eval_bit [FiniteField F] (ctx : Ctx F) (e : FExpr F) (i : ℕ) :
+    FExpr.eval ctx (e.bit i) = FiniteField.fromNat (FiniteField.val (e.eval ctx) >>> i % 2) := by
+  simp only [FExpr.eval, BExpr.eval, ← Nat.decide_shiftRight_mod_two_eq_one,
+    decide_eq_true_eq]
+  rcases Nat.mod_two_eq_zero_or_one (FiniteField.val (e.eval ctx) >>> i) with h | h <;>
+    simp [h]
 
 /-! ## Conditions -/
 
@@ -123,8 +136,8 @@ instance [NatCast F] : EqCond ℕ (Expression F) F where eqCond n x := .feq (n :
 instance [NatCast F] : EqCond (FExpr F) ℕ F where eqCond x n := .feq x (n : F)
 instance [NatCast F] : EqCond ℕ (FExpr F) F where eqCond n x := .feq (n : F) x
 instance : EqCond (U64Expr F) (U64Expr F) F := ⟨.neq⟩
-instance : EqCond (U64Expr F) ℕ F where eqCond x n := .neq x (.const n)
-instance : EqCond ℕ (U64Expr F) F where eqCond n x := .neq (.const n) x
+instance : EqCond (U64Expr F) ℕ F where eqCond x n := .neq x (.const (UInt64.ofNat n))
+instance : EqCond ℕ (U64Expr F) F where eqCond n x := .neq (.const (UInt64.ofNat n)) x
 
 /-- Overload witness-IR less-than tests while keeping a single parser entry for `<?`.
 Field-sorted operands become `BExpr.flt` (comparing `FiniteField.val`s, so it stays exact
@@ -147,8 +160,8 @@ instance [NatCast F] : LtCond ℕ (Expression F) F where ltCond n x := .flt (n :
 instance [NatCast F] : LtCond (FExpr F) ℕ F where ltCond x n := .flt x (n : F)
 instance [NatCast F] : LtCond ℕ (FExpr F) F where ltCond n x := .flt (n : F) x
 instance : LtCond (U64Expr F) (U64Expr F) F := ⟨.lt⟩
-instance : LtCond (U64Expr F) ℕ F where ltCond x n := .lt x (.const n)
-instance : LtCond ℕ (U64Expr F) F where ltCond n x := .lt (.const n) x
+instance : LtCond (U64Expr F) ℕ F where ltCond x n := .lt x (.const (UInt64.ofNat n))
+instance : LtCond ℕ (U64Expr F) F where ltCond n x := .lt (.const (UInt64.ofNat n)) x
 
 instance : Inhabited (BExpr F) := ⟨.false⟩
 instance : AndOp (BExpr F) := ⟨.and⟩

--- a/Clean/Examples/FemtoCairo/FemtoCairo.lean
+++ b/Clean/Examples/FemtoCairo/FemtoCairo.lean
@@ -159,8 +159,10 @@ def fetchInstruction
 
     return { rawInstrType, op1, op2, op3 }
 
+  -- the witness generator computes program addresses in `u64`,
+  -- so the program has to fit into that index range
   ProverAssumptions
-  | pc, _, _ => pc.val + 3 < programSize
+  | pc, _, _ => pc.val + 3 < programSize ∧ programSize ≤ 2^64
 
   Spec
   | pc, output, _ =>
@@ -180,12 +182,16 @@ def fetchInstruction
 
   completeness := by
     circuit_proof_start [Table.staticOfFn]
+    obtain ⟨ h_pc_bound, h_programSize_u64 ⟩ := h_assumptions
     have val_3 : ZMod.val (3 : F p) = 3 := ZMod.val_natCast_of_lt (by linarith)
     have val_2 : ZMod.val (2 : F p) = 2 := ZMod.val_natCast_of_lt (by linarith)
     have val_1 : ZMod.val (1 : F p) = 1 := ZMod.val_one p
     have : input.val < programSize := by linarith
     have : input.val + 1 < programSize := by linarith
     have : input.val + 2 < programSize := by linarith
+    -- the addresses are computed in `u64` by the witness generator;
+    -- this bound lets the `u64` wrapping simplify away
+    have h_no_wrap : input.val + 3 < 2^64 := by omega
     -- TODO `field` should get simped away
     change F p at input
     have : (input + 1).val = input.val + 1 := by field_to_nat
@@ -219,10 +225,11 @@ def memory (env : ProverData (F p)) : Fin (memorySize env) → F p :=
   fun i => mem[i.val].value
 
 -- to satisfy memory lookup constraints, the prover needs to make sure that `memory[addr] = (addr, ·)`,
--- and that the memory is non-empty (so we can use address 0 as a dummy address)
+-- that the memory is non-empty (so we can use address 0 as a dummy address),
+-- and that it fits into the `u64` index range used by the witness generator
 def MemoryCompletenessAssumption (env : ProverData (F p)) : Prop :=
   let mem := env.getTable MemoryTable;
-  mem.size > 0 ∧
+  mem.size > 0 ∧ mem.size ≤ 2^64 ∧
   ∀ (addr : F p) (ha : addr.val < mem.size), mem[addr.val].address = addr
 
 /--
@@ -368,7 +375,9 @@ def readFromMemory : GeneralFormalCircuit (F p) MemoryReadInput field where
     obtain ⟨_pc, ap, fp⟩ := input_state
     simp only [circuit_norm, explicit_provable_type, DecodedAddressingMode.mk.injEq, State.mk.injEq] at h_input
     simp only [h_input, DecodedAddressingMode.val, memoryAccess, MemoryCompletenessAssumption] at h_assumptions addr1_def addr2_def ⊢
-    obtain ⟨ h_mode_encode, ⟨ h_pos, h_mem_completeness ⟩, h_mem_access ⟩ := h_assumptions
+    obtain ⟨ h_mode_encode, ⟨ h_pos, h_size_le, h_mem_completeness ⟩, h_mem_access ⟩ := h_assumptions
+    -- the witness generator indexes memory in `u64`; this bound lets the wrapping simplify away
+    have h_size_le' : memoryTable.size ≤ 2^64 := h_size_le
 
     -- simplify the goal using MemoryCompletenessAssumption and witness info
     suffices h_goal : addr1.val < memoryTable.size ∧ addr2.val < memoryTable.size by
@@ -570,14 +579,17 @@ def femtoCairoStepSpec
 /--
   Assumptions required for the FemtoCairo step circuit completeness.
   1. ValidProgramSize: programSize + 3 < p (ensures no field wraparound in address arithmetic)
-  2. ValidProgram: All instruction bytes in program memory are < 256
-  3. MemoryCompletenessAssumption: memory table is non-empty and filled correctly
-  4. The state transition succeeds (execution doesn't fail)
+  2. programSize ≤ 2^64: the program fits into the `u64` index range that the witness
+     generator uses to address it
+  3. ValidProgram: All instruction bytes in program memory are < 256
+  4. MemoryCompletenessAssumption: memory table is non-empty and filled correctly
+  5. The state transition succeeds (execution doesn't fail)
 -/
 def femtoCairoStepAssumptions
     {programSize : ℕ} (program : Fin programSize → F p)
     (state : State (F p)) (data : ProverData (F p)) (_hint : ProverHint (F p)) : Prop :=
   ValidProgramSize p programSize ∧
+  programSize ≤ 2^64 ∧
   ValidProgram program ∧
   MemoryCompletenessAssumption data ∧
   (Spec.femtoCairoMachineTransition program (memory data) state).isSome
@@ -675,7 +687,8 @@ def femtoCairoStepCompleteness {programSize : ℕ} (program : Fin programSize �
   circuit_proof_start [femtoCairoStepAssumptions, femtoCairoStepMain,
     fetchInstruction, decodeInstruction, readFromMemory, nextState, Gadgets.toBits]
 
-  obtain ⟨h_valid_size, h_valid_program, h_memory_completeness, h_transition_isSome⟩ := h_assumptions
+  obtain ⟨h_valid_size, h_programSize_u64, h_valid_program, h_memory_completeness,
+    h_transition_isSome⟩ := h_assumptions
 
   -- Decompose transition into components
   have h_decompose := Spec.transition_isSome_implies_computeNextState_isSome
@@ -701,7 +714,7 @@ def femtoCairoStepCompleteness {programSize : ℕ} (program : Fin programSize �
   have h_eval_pc : Expression.eval env input_var.pc = input.pc := by
     rw [← State.eval_pc env input_var, h_input]
   simp only [h_eval_pc] at h_fetch_env
-  specialize h_fetch_env h_pc_bound
+  specialize h_fetch_env ⟨h_pc_bound, h_programSize_u64⟩
   simp only [h_fetch, circuit_norm, explicit_provable_type, RawInstruction.mk.injEq] at h_fetch_env
   obtain ⟨h_rawInstrType, h_op1, h_op2, h_op3⟩ := h_fetch_env
   specialize h_decode_env (by
@@ -728,7 +741,7 @@ def femtoCairoStepCompleteness {programSize : ℕ} (program : Fin programSize �
   simp only [h_op3, h_mode3_val, h_v3] at h_read3_value
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [h_eval_pc]
-    exact h_pc_bound
+    exact ⟨h_pc_bound, h_programSize_u64⟩
   · rw [h_rawInstrType]
     exact h_instr_bound
   · exact ⟨h_mode1_encoded_correctly, h_memory_completeness, by
@@ -773,7 +786,9 @@ def femtoCairoTable (n : ℕ) : InductiveTable (F p) State unit where
 
   -- For completeness, we assume that execution on the initial state succeeds, for all steps up to a maximum N
   InputAssumptions i _ _ := i < n
+  -- the witness generator indexes the program in `u64`, so the program has to fit
   InitialStateAssumptions initialState env :=
+    programSize ≤ 2^64 ∧
     MemoryCompletenessAssumption env ∧
     ∀ i ≤ n, (Spec.femtoCairoMachineBoundedExecution program (memory env) (some initialState) i).isSome
 
@@ -784,7 +799,7 @@ def femtoCairoTable (n : ℕ) : InductiveTable (F p) State unit where
 
   completeness := by
     intro initialState i env acc_var x_var acc x xs xs_len h_eval h_witnesses
-    rintro ⟨ ⟨ h_mem_completeness, h_initial_state ⟩, h_spec, h_i⟩
+    rintro ⟨ ⟨ h_programSize_u64, h_mem_completeness, h_initial_state ⟩, h_spec, h_i⟩
     specialize h_initial_state (i+1) h_i
     simp_all [circuit_norm, Spec.femtoCairoMachineBoundedExecution, femtoCairoStep, femtoCairoStepAssumptions, MemoryCompletenessAssumption]
 

--- a/Clean/Examples/FibonacciWithChannels.lean
+++ b/Clean/Examples/FibonacciWithChannels.lean
@@ -102,6 +102,12 @@ def add8 : GeneralFormalCircuit (F p) Add8Inputs unit where
       · linarith [hx, hy, ‹Fact (p > 512)›.elim]
       · grw [Nat.mod_lt _ (by norm_num)]
         linarith [‹Fact (p > 512)›.elim]
+    -- the witness is computed in `u64` arithmetic, which doesn't wrap here since
+    -- `input_x + input_y` is a sum of two bytes
+    have h_no_wrap : ZMod.val (input_x + input_y) < 2 ^ 64 := by
+      rw [ZMod.val_add_of_lt (by linarith [‹Fact (p > 512)›.elim])]
+      omega
+    rw [Nat.mod_eq_of_lt h_no_wrap] at h_env
     change carry = floorDiv (input_x + input_y) 256 at h_env
     grind
 

--- a/Clean/Examples/WitnessExport.lean
+++ b/Clean/Examples/WitnessExport.lean
@@ -103,4 +103,66 @@ info: {"version": 1,
 #guard_msgs in
 #witgen_json (Gadgets.IsZeroField.circuit (F := F pBabybear))
 
+-- JSON schema golden tests for the u64 sort and the field-level bit decomposition
+private def u64Circuit : Circuit (F pBabybear) (Expression (F pBabybear)) := do
+  let x : Expression (F pBabybear) ← witness (F := F pBabybear) 5
+  witness (((x.val &&& 3) >>> 1) % 2).toField
+
+private def bitsCircuit : Circuit (F pBabybear) (Var (fields 2) (F pBabybear)) := do
+  let x : Expression (F pBabybear) ← witness (F := F pBabybear) 5
+  witnessVector 2 (x.bits 2)
+
+/--
+info: {"version": 1,
+ "operations":
+ [{"witness": 1,
+   "code":
+   {"steps": [],
+    "output":
+    {"type": "elements", "elements": [{"value": 5, "type": "const"}]}}},
+  {"witness": 1,
+   "code":
+   {"steps": [],
+    "output":
+    {"type": "elements",
+     "elements":
+     [{"type": "ofU64",
+       "arg":
+       {"type": "mod",
+        "rhs": {"value": 2, "type": "const"},
+        "lhs":
+        {"type": "shiftRight",
+         "rhs": {"value": 1, "type": "const"},
+         "lhs":
+         {"type": "and",
+          "rhs": {"value": 3, "type": "const"},
+          "lhs":
+          {"type": "val",
+           "arg":
+           {"type": "expr", "expr": {"type": "var", "index": 0}}}}}}}]}}}],
+ "localLength": 2}
+-/
+#guard_msgs in
+#witgen_json u64Circuit
+
+/--
+info: {"version": 1,
+ "operations":
+ [{"witness": 1,
+   "code":
+   {"steps": [],
+    "output":
+    {"type": "elements", "elements": [{"value": 5, "type": "const"}]}}},
+  {"witness": 2,
+   "code":
+   {"steps": [],
+    "output":
+    {"type": "bitsOf",
+     "n": 2,
+     "arg": {"type": "expr", "expr": {"type": "var", "index": 0}}}}}],
+ "localLength": 3}
+-/
+#guard_msgs in
+#witgen_json bitsCircuit
+
 end Examples.WitnessExport

--- a/Clean/Gadgets/Addition32/Addition32Full.lean
+++ b/Clean/Gadgets/Addition32/Addition32Full.lean
@@ -113,29 +113,36 @@ theorem completeness : Completeness (F p) main Assumptions := by
   set c3 := env.get (i₀ + 7)
   obtain ⟨ hz0, hc0, hz1, hc1, hz2, hc2, hz3, hc3 ⟩ := h_env
 
-  -- the add8 completeness proof, four times
+  -- the add8 completeness proof, four times.
+  -- the witness IR computes on `u64`s, but `x + y + c_in` is a sum of two bytes and a
+  -- bit, hence < 512, so the `% 2 ^ 64` truncations are inert.
   have add8_completeness {x y c_in z c_out : F p}
-    (hz : z = mod256 (x + y + c_in)) (hc_out : c_out = floorDiv (x + y + c_in) 256) :
-    x.val < 256 → y.val < 256 → IsBool c_in →
+    (x_byte : x.val < 256) (y_byte : y.val < 256) (hc : IsBool c_in)
+    (hz : z = (((x + y + c_in).val % 2 ^ 64 % 256 : ℕ) : F p))
+    (hc_out : c_out = (((x + y + c_in).val % 2 ^ 64 / 256 : ℕ) : F p)) :
     z.val < 256 ∧ IsBool c_out ∧ x + y + c_in - z - c_out * 256 = 0
   := by
-    intro x_byte y_byte hc
+    have carry_lt_2 : c_in.val < 2 := IsBool.val_lt_two hc
+    have h512 : (x + y + c_in).val < 512 :=
+      ByteUtils.byte_sum_and_bit_lt_512 x y c_in x_byte y_byte carry_lt_2
+    have h_wrap : (x + y + c_in).val % 2 ^ 64 = (x + y + c_in).val :=
+      Nat.mod_eq_of_lt (by omega)
+    rw [h_wrap] at hz hc_out
+    replace hz : z = mod256 (x + y + c_in) := hz
+    replace hc_out : c_out = floorDiv (x + y + c_in) 256 := hc_out
     have : z.val < 256 := hz ▸ ByteUtils.mod256_lt (x + y + c_in)
     use this
-    have carry_lt_2 : c_in.val < 2 := IsBool.val_lt_two hc
-    have : (x + y + c_in).val < 512 :=
-      ByteUtils.byte_sum_and_bit_lt_512 x y c_in x_byte y_byte carry_lt_2
-    use (hc_out ▸ ByteUtils.floorDiv256_bool this)
+    use (hc_out ▸ ByteUtils.floorDiv256_bool h512)
     rw [← ByteUtils.mod_add_div256 (x + y + c_in), hz, hc_out]
     ring
 
   have ⟨ x_norm, y_norm, carry_in_bool ⟩ := h_assumptions
   have ⟨ x0_byte, x1_byte, x2_byte, x3_byte ⟩ := x_norm
   have ⟨ y0_byte, y1_byte, y2_byte, y3_byte ⟩ := y_norm
-  have ⟨ z0_byte, c0_bool, h0 ⟩ := add8_completeness hz0 hc0 x0_byte y0_byte carry_in_bool
-  have ⟨ z1_byte, c1_bool, h1 ⟩ := add8_completeness hz1 hc1 x1_byte y1_byte c0_bool
-  have ⟨ z2_byte, c2_bool, h2 ⟩ := add8_completeness hz2 hc2 x2_byte y2_byte c1_bool
-  have ⟨ z3_byte, c3_bool, h3 ⟩ := add8_completeness hz3 hc3 x3_byte y3_byte c2_bool
+  have ⟨ z0_byte, c0_bool, h0 ⟩ := add8_completeness x0_byte y0_byte carry_in_bool hz0 hc0
+  have ⟨ z1_byte, c1_bool, h1 ⟩ := add8_completeness x1_byte y1_byte c0_bool hz1 hc1
+  have ⟨ z2_byte, c2_bool, h2 ⟩ := add8_completeness x2_byte y2_byte c1_bool hz2 hc2
+  have ⟨ z3_byte, c3_bool, h3 ⟩ := add8_completeness x3_byte y3_byte c2_bool hz3 hc3
 
   exact ⟨ z0_byte, c0_bool, h0, z1_byte, c1_bool, h1, z2_byte, c2_bool, h2, z3_byte, c3_bool, h3 ⟩
 

--- a/Clean/Gadgets/Addition8/Addition8FullCarry.lean
+++ b/Clean/Gadgets/Addition8/Addition8FullCarry.lean
@@ -86,15 +86,20 @@ def circuit : FormalCircuit (F p) Inputs Outputs where
     replace h_inputs : x_var.eval env = x ∧ y_var.eval env = y ∧ carry_in_var.eval env = carry_in := by
       simpa [circuit_norm] using h_inputs
 
+    obtain ⟨as_x, as_y, as_carry_in⟩ := h_assumptions
+    have carry_in_bound := IsBool.val_lt_two as_carry_in
+
+    -- the sum fits in a `u64`, so the witness IR's `u64` arithmetic doesn't wrap
+    have sum_val : (x + y + carry_in).val = x.val + y.val + carry_in.val := by field_to_nat
+    have sum_lt : (x + y + carry_in).val < 2 ^ 64 := by
+      rw [sum_val]; omega
+
     -- simplify assumptions and goal
-    simp only [circuit_norm, h_inputs, Assumptions, main, ByteTable] at *
+    simp only [circuit_norm, h_inputs, main, ByteTable] at *
 
     obtain ⟨hz, hcarry_out⟩ := h_env
     set z := env.get i0
     set carry_out := env.get (i0 + 1)
-
-    -- now it's just mathematics!
-    guard_hyp h_assumptions : x.val < 256 ∧ y.val < 256 ∧ IsBool carry_in
 
     let goal_byte := z.val < 256
     let goal_bool := IsBool carry_out
@@ -105,9 +110,6 @@ def circuit : FormalCircuit (F p) Inputs Outputs where
     have completeness1 : z.val < 256 := by
       rw [hz, ByteUtils.mod256, FieldUtils.mod_val]
       exact Nat.mod_lt _ (by norm_num)
-
-    have ⟨as_x, as_y, as_carry_in⟩ := h_assumptions
-    have carry_in_bound := IsBool.val_lt_two as_carry_in
 
     have completeness2 : IsBool carry_out := by
       rw [hcarry_out]

--- a/Clean/Gadgets/And/And8.lean
+++ b/Clean/Gadgets/And/And8.lean
@@ -107,8 +107,10 @@ theorem soundness : Soundness (Input:=Inputs) (Output:=field) (F p) main Assumpt
 
 theorem completeness : Completeness (Input:=Inputs) (Output:=field) (F p) main Assumptions := by
   intro i env ⟨ x_var, y_var ⟩ h_env ⟨ x, y ⟩ h_input h_assumptions
-  simp_all only [circuit_norm, main, Assumptions, ByteXorTable, Inputs.mk.injEq]
+  -- destructure the byte bounds first, so that the `u64Wrap` simproc can discharge
+  -- the `% 2^64` truncations coming from the witness IR
   obtain ⟨ hx_byte, hy_byte ⟩ := h_assumptions
+  simp_all only [circuit_norm, main, ByteXorTable, Inputs.mk.injEq]
   set w : F p := ZMod.val x &&& ZMod.val y
   have hw : w = ZMod.val x &&& ZMod.val y := rfl
 

--- a/Clean/Gadgets/Bits.lean
+++ b/Clean/Gadgets/Bits.lean
@@ -9,7 +9,7 @@ variable {p : ℕ} [prime: Fact p.Prime] [p_large_enough: Fact (p > 2)]
 
 def main (n : ℕ) (x : Expression (F p)) : Circuit (F p) (Vector (Expression (F p)) n) := do
   -- witness the bits of `x`
-  let bits ← witnessVector n (.range n fun i => ((x.val >>> i) % 2).toField)
+  let bits ← witnessVector n (x.bits n)
 
   -- add boolean constraints on all bits
   Circuit.forEach bits assertBool

--- a/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
+++ b/Clean/Gadgets/ByteDecomposition/ByteDecomposition.lean
@@ -95,6 +95,8 @@ theorem soundness (offset : Fin 8) : Soundness (Input:=field) (Output:=Outputs) 
 theorem completeness (offset : Fin 8) : Completeness (Input:=field) (Output:=Outputs) (F p) (main offset) Assumptions := by
   rintro i0 env x_var henv (x : F p) h_input (x_byte : x.val < 256)
   simp only [circuit_norm] at h_input
+  -- bound on `2^offset` so that the witness generator's u64 wrapping simplifies away
+  have h_pow_64 : 2^offset.val < 2^64 := Nat.pow_lt_pow_right (by norm_num) (by omega)
   simp only [circuit_norm, main, h_input, ByteTable] at henv ⊢
   simp only [henv]
   have pow_8_nat : 2^8 = 2^(8-offset.val) * 2^offset.val := by simp [←pow_add]

--- a/Clean/Gadgets/SHA256/Add32.lean
+++ b/Clean/Gadgets/SHA256/Add32.lean
@@ -32,13 +32,13 @@ private def bitsVal (a : Var (fields 32) (F p)) : Witgen.UExpr (F p) :=
 
 omit h_large in
 private lemma bitsVal_eval (env : ProverEnvironment (F p)) (a : Var (fields 32) (F p)) :
-    (bitsVal a).eval { env } = evalBitsNat env a := by
+    (bitsVal a).eval { env } = UInt64.ofNat (evalBitsNat env a) := by
   rw [evalBitsNat, Fin.sum_univ_def, bitsVal, List.sum_eq_foldr, List.foldr_map]
   generalize List.finRange 32 = l
   induction l with
   | nil => rfl
   | cons i l ih =>
-    simp only [List.foldr_cons, circuit_norm, ih]
+    simp only [List.foldr_cons, circuit_norm, ih, UInt64.ofNat_add, UInt64.ofNat_mul]
 
 /-- Add two 32-bit words mod 2^32.
     Both inputs are assumed to have boolean values in each bit position. -/
@@ -308,11 +308,28 @@ theorem completeness : Completeness (F p) main Assumptions := by
   obtain ⟨ha, hb⟩ := h_assumptions
   obtain ⟨h_input_a, h_input_b⟩ := h_input
   obtain ⟨h_env_z, h_env_cout⟩ := h_env
-  simp only [bitsVal_eval, Nat.shiftRight_eq_div_pow] at h_env_z h_env_cout
+  -- The witnessed values are `evalBitsNat` of the inputs, which equal `valueBits`
+  have h_evalBits_a : evalBitsNat env input_var_a = valueBits input_a :=
+    evalBitsNat_eq_valueBits env input_var_a input_a h_input_a
+  have h_evalBits_b : evalBitsNat env input_var_b = valueBits input_b :=
+    evalBitsNat_eq_valueBits env input_var_b input_b h_input_b
+  -- valueBits bounds
+  have hva_lt : valueBits input_a < 2^32 := valueBits_lt_two_pow input_a ha
+  have hvb_lt : valueBits input_b < 2^32 := valueBits_lt_two_pow input_b hb
+  -- These bounds have to be in context *before* normalizing the witness equations, so
+  -- that the `u64Wrap` simproc can discharge the `% 2^64` truncations introduced by the
+  -- `UInt64`-sorted witness IR.
+  have ha_lt : evalBitsNat env input_var_a < 2^32 := by omega
+  have hb_lt : evalBitsNat env input_var_b < 2^32 := by omega
+  simp only [bitsVal_eval, UInt64.toNat_ofNat', Nat.shiftRight_eq_div_pow,
+    Witgen.u64Wrap] at h_env_z h_env_cout
   set S := evalBitsNat env input_var_a + evalBitsNat env input_var_b with hS_def
   have h_p_large := h_large.elim
   have h33 : (2:ℕ)^33 = 2^32 + 2^32 := by norm_num
   have hp32 : (2:ℕ)^32 < p := by linarith
+  have hS_eq : S = valueBits input_a + valueBits input_b := by
+    rw [hS_def, h_evalBits_a, h_evalBits_b]
+  have hS_lt_33 : S < 2^33 := by rw [hS_eq]; linarith
   refine ⟨fun i => ?_, ?_, ?_⟩
   · -- Boolean constraint for z[i]: z[i] * (z[i] - 1) = 0
     have henv_i := h_env_z i
@@ -324,17 +341,6 @@ theorem completeness : Completeness (F p) main Assumptions := by
     rcases Nat.mod_two_eq_zero_or_one (S / 2^32) with h | h <;>
       rw [h] <;> push_cast <;> ring
   · -- Linear constraint: FA + FB - FZ - 2^32 * cout = 0 in F p
-    -- We prove evalBitsNat env a = valueBits input_a, similarly for b
-    have h_evalBits_a : evalBitsNat env input_var_a = valueBits input_a :=
-      evalBitsNat_eq_valueBits env input_var_a input_a h_input_a
-    have h_evalBits_b : evalBitsNat env input_var_b = valueBits input_b :=
-      evalBitsNat_eq_valueBits env input_var_b input_b h_input_b
-    have hS_eq : S = valueBits input_a + valueBits input_b := by
-      rw [hS_def, h_evalBits_a, h_evalBits_b]
-    -- valueBits bounds
-    have hva_lt : valueBits input_a < 2^32 := valueBits_lt_two_pow input_a ha
-    have hvb_lt : valueBits input_b < 2^32 := valueBits_lt_two_pow input_b hb
-    have hS_lt_33 : S < 2^33 := by rw [hS_eq]; linarith
     -- Bit decomposition of S % 2^32: S % 2^32 = ∑ i, (S%2^32 / 2^i % 2) * 2^i
     have h_S_mod_lt : S % 2^32 < 2^32 := Nat.mod_lt _ (by norm_num)
     -- S / 2^32 ∈ {0, 1} since S < 2^33

--- a/Clean/Gadgets/SHA256/Add32.lean
+++ b/Clean/Gadgets/SHA256/Add32.lean
@@ -26,7 +26,7 @@ private def evalBitsNat (env : ProverEnvironment (F p)) (a : Var (fields 32) (F 
 
 /-- IR expression for the ℕ value of a vector of bit-variables: `Σ a[i].val · 2^i`
 (authoring-time fold; the witness-IR counterpart of `evalBitsNat`). -/
-private def bitsVal (a : Var (fields 32) (F p)) : Witgen.UExpr (F p) :=
+private def bitsVal (a : Var (fields 32) (F p)) : Witgen.U64Expr (F p) :=
   (List.finRange 32).foldr
     (fun i acc => a[i.val].val * (2^i.val : ℕ) + acc) 0
 

--- a/Clean/Gadgets/SHA256/Add32.lean
+++ b/Clean/Gadgets/SHA256/Add32.lean
@@ -26,7 +26,7 @@ private def evalBitsNat (env : ProverEnvironment (F p)) (a : Var (fields 32) (F 
 
 /-- IR expression for the ℕ value of a vector of bit-variables: `Σ a[i].val · 2^i`
 (authoring-time fold; the witness-IR counterpart of `evalBitsNat`). -/
-private def bitsVal (a : Var (fields 32) (F p)) : Witgen.NExpr (F p) :=
+private def bitsVal (a : Var (fields 32) (F p)) : Witgen.UExpr (F p) :=
   (List.finRange 32).foldr
     (fun i acc => a[i.val].val * (2^i.val : ℕ) + acc) 0
 

--- a/Clean/Gadgets/SHA256/LowerSigma0.lean
+++ b/Clean/Gadgets/SHA256/LowerSigma0.lean
@@ -404,6 +404,10 @@ theorem completeness : Completeness (F p) main Assumptions := by
     rw [h1, hr7, hr18]
     have b7 : input[(i + 7).val] = (0 : F p) ∨ input[(i + 7).val] = 1 := h_assumptions (i + 7)
     have b18 : input[(i + 18).val] = (0 : F p) ∨ input[(i + 18).val] = 1 := h_assumptions (i + 18)
+    -- the witness IR computes the xor on `u64`s; the operands are bits, so nothing wraps
+    have b7v : ZMod.val input[(i + 7).val] < 2 := IsBool.val_lt_two b7
+    have b18v : ZMod.val input[(i + 18).val] < 2 := IsBool.val_lt_two b18
+    simp only [circuit_norm]
     have hc : ((input[(i + 7).val].val ^^^ input[(i + 18).val].val : ℕ) : F p) =
         input[(i + 7).val] + input[(i + 18).val] -
           2 * input[(i + 7).val] * input[(i + 18).val] := by
@@ -441,6 +445,12 @@ theorem completeness : Completeness (F p) main Assumptions := by
           2 * ((r7.val ^^^ r18.val : ℕ) : F p) * s3 := by
       rw [← IsBool.xor_eq_val_xor hxor1_bool bs3, ZMod.natCast_val]
       exact ZMod.cast_id p _
+    -- the witness IR computes the xors on `u64`s; all operands are bits, so nothing wraps
+    have b7v : ZMod.val r7 < 2 := IsBool.val_lt_two b7
+    have b18v : ZMod.val r18 < 2 := IsBool.val_lt_two b18
+    have bs3v : ZMod.val s3 < 2 := IsBool.val_lt_two bs3
+    have hxor1v : ZMod.val (((r7.val ^^^ r18.val : ℕ) : F p)) < 2 := IsBool.val_lt_two hxor1_bool
+    simp only [circuit_norm]
     rw [hxor3, hxor1]; ring
 
 def circuit : FormalCircuit (F p) (fields 32) (fields 32) where

--- a/Clean/Gadgets/SHA256/LowerSigma1.lean
+++ b/Clean/Gadgets/SHA256/LowerSigma1.lean
@@ -178,6 +178,10 @@ theorem completeness : Completeness (F p) main Assumptions := by
     rw [h1, hr17, hr19]
     have b17 : input[(i + 17).val] = (0 : F p) ∨ input[(i + 17).val] = 1 := h_assumptions (i + 17)
     have b19 : input[(i + 19).val] = (0 : F p) ∨ input[(i + 19).val] = 1 := h_assumptions (i + 19)
+    -- the witness IR computes the xor on `u64`s; the operands are bits, so nothing wraps
+    have b17v : ZMod.val input[(i + 17).val] < 2 := IsBool.val_lt_two b17
+    have b19v : ZMod.val input[(i + 19).val] < 2 := IsBool.val_lt_two b19
+    simp only [circuit_norm]
     have hc : ((input[(i + 17).val].val ^^^ input[(i + 19).val].val : ℕ) : F p) =
         input[(i + 17).val] + input[(i + 19).val] -
           2 * input[(i + 17).val] * input[(i + 19).val] := by
@@ -213,6 +217,12 @@ theorem completeness : Completeness (F p) main Assumptions := by
           2 * ((r17.val ^^^ r19.val : ℕ) : F p) * s10 := by
       rw [← IsBool.xor_eq_val_xor hxor1_bool bs10, ZMod.natCast_val]
       exact ZMod.cast_id p _
+    -- the witness IR computes the xors on `u64`s; all operands are bits, so nothing wraps
+    have b17v : ZMod.val r17 < 2 := IsBool.val_lt_two b17
+    have b19v : ZMod.val r19 < 2 := IsBool.val_lt_two b19
+    have bs10v : ZMod.val s10 < 2 := IsBool.val_lt_two bs10
+    have hxor1v : ZMod.val (((r17.val ^^^ r19.val : ℕ) : F p)) < 2 := IsBool.val_lt_two hxor1_bool
+    simp only [circuit_norm]
     rw [hxor3, hxor1]; ring
 
 def circuit : FormalCircuit (F p) (fields 32) (fields 32) where

--- a/Clean/Gadgets/SHA256/UpperSigma0.lean
+++ b/Clean/Gadgets/SHA256/UpperSigma0.lean
@@ -170,6 +170,10 @@ theorem completeness : Completeness (F p) main Assumptions := by
     rw [h1, hr2, hr13]
     have b2 : input[(i + 2).val] = (0 : F p) ∨ input[(i + 2).val] = 1 := h_assumptions (i + 2)
     have b13 : input[(i + 13).val] = (0 : F p) ∨ input[(i + 13).val] = 1 := h_assumptions (i + 13)
+    -- the witness IR computes the xor on `u64`s; the operands are bits, so nothing wraps
+    have b2v : ZMod.val input[(i + 2).val] < 2 := IsBool.val_lt_two b2
+    have b13v : ZMod.val input[(i + 13).val] < 2 := IsBool.val_lt_two b13
+    simp only [circuit_norm]
     have hc : ((input[(i + 2).val].val ^^^ input[(i + 13).val].val : ℕ) : F p) =
         input[(i + 2).val] + input[(i + 13).val] -
           2 * input[(i + 2).val] * input[(i + 13).val] := by
@@ -200,6 +204,12 @@ theorem completeness : Completeness (F p) main Assumptions := by
           2 * ((r2.val ^^^ r13.val : ℕ) : F p) * r22 := by
       rw [← IsBool.xor_eq_val_xor hxor1_bool b22, ZMod.natCast_val]
       exact ZMod.cast_id p _
+    -- the witness IR computes the xors on `u64`s; all operands are bits, so nothing wraps
+    have b2v : ZMod.val r2 < 2 := IsBool.val_lt_two b2
+    have b13v : ZMod.val r13 < 2 := IsBool.val_lt_two b13
+    have b22v : ZMod.val r22 < 2 := IsBool.val_lt_two b22
+    have hxor1v : ZMod.val (((r2.val ^^^ r13.val : ℕ) : F p)) < 2 := IsBool.val_lt_two hxor1_bool
+    simp only [circuit_norm]
     rw [hxor3, hxor1]; ring
 
 def circuit : FormalCircuit (F p) (fields 32) (fields 32) where

--- a/Clean/Gadgets/SHA256/UpperSigma1.lean
+++ b/Clean/Gadgets/SHA256/UpperSigma1.lean
@@ -170,6 +170,10 @@ theorem completeness : Completeness (F p) main Assumptions := by
     rw [h1, hr6, hr11]
     have b6 : input[(i + 6).val] = (0 : F p) ∨ input[(i + 6).val] = 1 := h_assumptions (i + 6)
     have b11 : input[(i + 11).val] = (0 : F p) ∨ input[(i + 11).val] = 1 := h_assumptions (i + 11)
+    -- the witness IR computes the xor on `u64`s; the operands are bits, so nothing wraps
+    have b6v : ZMod.val input[(i + 6).val] < 2 := IsBool.val_lt_two b6
+    have b11v : ZMod.val input[(i + 11).val] < 2 := IsBool.val_lt_two b11
+    simp only [circuit_norm]
     have hc : ((input[(i + 6).val].val ^^^ input[(i + 11).val].val : ℕ) : F p) =
         input[(i + 6).val] + input[(i + 11).val] -
           2 * input[(i + 6).val] * input[(i + 11).val] := by
@@ -200,6 +204,12 @@ theorem completeness : Completeness (F p) main Assumptions := by
           2 * ((r6.val ^^^ r11.val : ℕ) : F p) * r25 := by
       rw [← IsBool.xor_eq_val_xor hxor1_bool b25, ZMod.natCast_val]
       exact ZMod.cast_id p _
+    -- the witness IR computes the xors on `u64`s; all operands are bits, so nothing wraps
+    have b6v : ZMod.val r6 < 2 := IsBool.val_lt_two b6
+    have b11v : ZMod.val r11 < 2 := IsBool.val_lt_two b11
+    have b25v : ZMod.val r25 < 2 := IsBool.val_lt_two b25
+    have hxor1v : ZMod.val (((r6.val ^^^ r11.val : ℕ) : F p)) < 2 := IsBool.val_lt_two hxor1_bool
+    simp only [circuit_norm]
     rw [hxor3, hxor1]; ring
 
 def circuit : FormalCircuit (F p) (fields 32) (fields 32) where

--- a/Clean/Gadgets/SHA256/Xor32.lean
+++ b/Clean/Gadgets/SHA256/Xor32.lean
@@ -146,6 +146,11 @@ theorem completeness : Completeness (F p) main Assumptions := by
   have h_bi : ∀ i : Fin 32, Expression.eval env.toEnvironment input_var_b[i.val] = input_b[i] := by
     intro i; have := Vector.ext_iff.mp h_input_b i i.isLt; simp [Vector.getElem_map] at this; exact this
   intro i
+  -- the witness generator computes in `u64`; these bounds let the wrapping simplify away
+  have ha_lt : ZMod.val (Expression.eval env.toEnvironment input_var_a[i.val]) < 2 ^ 64 := by
+    rw [h_ai i]; rcases ha i with h | h <;> simp [h, ZMod.val_zero, ZMod.val_one]
+  have hb_lt : ZMod.val (Expression.eval env.toEnvironment input_var_b[i.val]) < 2 ^ 64 := by
+    rw [h_bi i]; rcases hb i with h | h <;> simp [h, ZMod.val_zero, ZMod.val_one]
   have henv := h_env i
   simp only [circuit_norm] at henv
   rw [h_ai i, h_bi i] at henv

--- a/Clean/Table/Basic.lean
+++ b/Clean/Table/Basic.lean
@@ -397,8 +397,7 @@ def getRow (row : Fin W) : TableConstraint W S F (Var S F) :=
   modifyGet fun ctx =>
     let ctx' : TableContext W S F := {
       inputSize := ctx.inputSize,
-      circuit := ctx.circuit ++ [.witness (size S) (.ir []
-        (.range (size S) fun i => .envGet (((ctx.offset : ℕ) : Witgen.NExpr F) + i)))],
+      circuit := ctx.circuit ++ [.witness (size S) (.ir [] (.envRange ctx.offset))],
       assignment := ctx.assignment.pushRow row
     }
     (varFromOffset S ctx.offset, ctx')

--- a/Clean/Test.lean
+++ b/Clean/Test.lean
@@ -4,6 +4,7 @@ import Clean.Utils.Test.TestSplitProvableStructEq
 import Clean.Utils.Test.TestCircuitProofStart
 import Clean.Utils.Test.TestSimplifyProvableStructEval
 import Clean.Utils.Test.TestWitgenEvalProjection
+import Clean.Utils.Test.TestU64Wrap
 import Clean.Utils.Test.TestElaborateCircuit
 import Clean.Utils.Test.TestCircuitStructDeriving
 import Clean.Utils.Test.TestMixedCircuitType

--- a/Clean/Utils/FiniteField.lean
+++ b/Clean/Utils/FiniteField.lean
@@ -56,6 +56,12 @@ theorem fromNat_val (x : F) : fromNat (val x) = x :=
 theorem fieldSize_pos : FiniteField.size F > 1 := by
   have := val_lt (1 : F); rwa [val_one] at this
 
+@[simp, circuit_norm] theorem fromNat_zero : (fromNat 0 : F) = 0 :=
+  val_injective (by rw [val_fromNat 0 (by have := fieldSize_pos (F := F); omega), val_zero])
+
+@[simp, circuit_norm] theorem fromNat_one : (fromNat 1 : F) = 1 :=
+  val_injective (by rw [val_fromNat 1 fieldSize_pos, val_one])
+
 /-- Two field elements are equal iff their values are equal. -/
 theorem ext {x y : F} (h : val x = val y) : x = y :=
   val_injective h

--- a/Clean/Utils/Test/TestMixedCircuitType.lean
+++ b/Clean/Utils/Test/TestMixedCircuitType.lean
@@ -75,25 +75,25 @@ def parent : GeneralFormalCircuit F field field where
     guard_target = input * input⁻¹ = 1
     exact mul_inv_cancel₀ (G₀ := F) h_assumptions
 
-structure BoolNatInput (F : Type) where
+structure BoolU64Input (F : Type) where
   x : F
   isZero : UnconstrainedBool F
-  xNat : UnconstrainedNat F
+  xU64 : UnconstrainedU64 F
 deriving CircuitType
 
 -- TODO automate this in the CircuitType deriver
-instance : Inhabited (Var BoolNatInput F) where
-  default := { x := default, isZero := default, xNat := default }
+instance : Inhabited (Var BoolU64Input F) where
+  default := { x := default, isZero := default, xU64 := default }
 
-def boolNatCircuit : GeneralFormalCircuit.WithHint F BoolNatInput field where
+def boolU64Circuit : GeneralFormalCircuit.WithHint F BoolU64Input field where
   main input := return input.x
 
   Spec input out _ :=
     out = input.x
 
   ProverAssumptions input _ _ :=
-    input.isZero = ((FiniteField.val (F:=F) input.x : ℕ) = 0) ∧
-    input.xNat = FiniteField.val (F:=F) input.x
+    input.isZero = (UInt64.ofNat (FiniteField.val (F:=F) input.x) = 0) ∧
+    input.xU64 = UInt64.ofNat (FiniteField.val (F:=F) input.x)
 
   soundness := by
     circuit_proof_start
@@ -101,21 +101,21 @@ def boolNatCircuit : GeneralFormalCircuit.WithHint F BoolNatInput field where
   completeness := by
     circuit_proof_start
 
-def boolNatParent : GeneralFormalCircuit F field field where
+def boolU64Parent : GeneralFormalCircuit F field field where
   main (input : Expression F) := do
-    boolNatCircuit {
+    boolU64Circuit {
       x := input
       isZero := unconstrainedBool (do return ((input.val =? 0) &&& .true))
-      xNat := unconstrainedNat (do return input.val)
+      xU64 := unconstrainedU64 (do return input.val)
     }
 
   Spec input out _ :=
     out = input
 
   soundness := by
-    circuit_proof_start [boolNatCircuit]
+    circuit_proof_start [boolU64Circuit]
 
   completeness := by
-    circuit_proof_start [boolNatCircuit]
+    circuit_proof_start [boolU64Circuit]
 
 end TestMixedCircuitType

--- a/Clean/Utils/Test/TestU64Wrap.lean
+++ b/Clean/Utils/Test/TestU64Wrap.lean
@@ -1,0 +1,24 @@
+import Clean.Circuit.WitnessIR
+
+/-!
+Regression tests for the `u64Wrap` simproc: the `% 2^64` / `% 64` truncations left behind
+by the u64 witness sort are erased exactly when the local hypotheses bound the operand.
+-/
+
+/-- The wrap is erased when `omega` can bound the operand from the local context. -/
+example (a b : ℕ) (h : a < 256 ∧ b < 256) :
+    (a % 18446744073709551616 ^^^ b % 2^64) = a ^^^ b := by
+  simp only [circuit_norm]
+
+/-- Shift-amount masks (`% 64`) are erased the same way. -/
+example (i : ℕ) (h : i < 32) : (7 >>> (i % 64)) = 7 >>> i := by
+  simp only [circuit_norm]
+
+/-- Without a bound the wrap stays: `circuit_norm` must not "simplify" it away. -/
+example (a : ℕ) : a % 18446744073709551616 = a % 2 ^ 64 := by
+  norm_num
+
+/-- Other moduli are left alone, so specification arithmetic is untouched. -/
+example (a : ℕ) (h : a < 8) : a % 256 = a := by
+  fail_if_success simp only [circuit_norm]
+  omega

--- a/Clean/Utils/Test/TestU64Wrap.lean
+++ b/Clean/Utils/Test/TestU64Wrap.lean
@@ -48,3 +48,19 @@ example (ctx : Ctx F) (x y : FExpr F) :
       = decide (FiniteField.val (x.eval ctx) % 2^64 < FiniteField.val (y.eval ctx) % 2^64) := by
   simp [BExpr.eval, U64Expr.eval, UInt64.lt_iff_toNat_lt]
 end LtCond
+
+section BitOf
+open Witgen
+variable {F : Type} [FiniteField F]
+
+/-- `BExpr.bit` is a condition; casting it into the field gives the `0`/`1` element, in
+the same normal form `VExpr.bitsOf` produces for the loop-indexed case. -/
+example (ctx : Ctx F) (x : FExpr F) (i : ℕ) :
+    FExpr.eval ctx (x.bit i) = FiniteField.fromNat (FiniteField.val (x.eval ctx) >>> i % 2) := by
+  simp only [circuit_norm]
+
+/-- The bit index is a static `ℕ`, so it is exact past 64 on large fields. -/
+example (ctx : Ctx F) (x : FExpr F) :
+    (BExpr.bit x 200).eval ctx = (FiniteField.val (x.eval ctx)).testBit 200 :=
+  rfl
+end BitOf

--- a/Clean/Utils/Test/TestU64Wrap.lean
+++ b/Clean/Utils/Test/TestU64Wrap.lean
@@ -1,4 +1,4 @@
-import Clean.Circuit.WitnessIR
+import Clean.Circuit.WitnessIRSugar
 
 /-!
 Regression tests for the `u64Wrap` simproc: the `% 2^64` / `% 64` truncations left behind
@@ -22,3 +22,29 @@ example (a : ℕ) : a % 18446744073709551616 = a % 2 ^ 64 := by
 example (a : ℕ) (h : a < 8) : a % 256 = a := by
   fail_if_success simp only [circuit_norm]
   omega
+
+/-!
+`<?` overloads on the operand sort: field-sorted operands compare `ZMod.val`s exactly,
+u64-sorted operands compare `u64`s (and so agree only below `2^64`).
+-/
+section LtCond
+open Witgen
+variable {F : Type} [FiniteField F]
+
+/-- Field operands produce the exact `ZMod.val` comparison, with no truncation. -/
+example (ctx : Ctx F) (x y : FExpr F) :
+    (x <? y).eval ctx = decide (FiniteField.val (x.eval ctx) < FiniteField.val (y.eval ctx)) :=
+  rfl
+
+/-- u64 operands still produce the `u64` comparison. -/
+example (ctx : Ctx F) (x y : U64Expr F) :
+    (x <? y).eval ctx = decide (x.eval ctx < y.eval ctx) :=
+  rfl
+
+/-- `x.val <? y.val` goes through the u64 sort, so it compares truncated values —
+the field-sorted form above is the one to use when operands may exceed `2^64`. -/
+example (ctx : Ctx F) (x y : FExpr F) :
+    (x.val <? y.val).eval ctx
+      = decide (FiniteField.val (x.eval ctx) % 2^64 < FiniteField.val (y.eval ctx) % 2^64) := by
+  simp [BExpr.eval, U64Expr.eval, UInt64.lt_iff_toNat_lt]
+end LtCond

--- a/Clean/Utils/Test/TestWitgenEvalProjection.lean
+++ b/Clean/Utils/Test/TestWitgenEvalProjection.lean
@@ -20,14 +20,14 @@ def TestTable (F : Type) : Table F TestRow where
   name := "test"
   Contains _ _ := True
 
-example {F : Type} [FiniteField F] (ctx : Witgen.Ctx F) (row : Witgen.NExpr F) :
+example {F : Type} [FiniteField F] (ctx : Witgen.Ctx F) (row : Witgen.UExpr F) :
     Witgen.FExpr.eval ctx ((TestTable F).dataGet row).second =
-      (((ctx.env.data.getTable (TestTable F))[row.eval ctx]?.getD default).second) := by
+      (((ctx.env.data.getTable (TestTable F))[(row.eval ctx).toNat]?.getD default).second) := by
   simp [circuit_norm]
 
-example {F : Type} [FiniteField F] (ctx : Witgen.Ctx F) (row : Witgen.NExpr F) :
+example {F : Type} [FiniteField F] (ctx : Witgen.Ctx F) (row : Witgen.UExpr F) :
     Witgen.FExpr.eval ctx ((TestTable F).hintGet row).second =
-      ((fromElements (((ctx.env.hint (TestTable F).name (size TestRow))[row.eval ctx]?).getD default)
+      ((fromElements (((ctx.env.hint (TestTable F).name (size TestRow))[(row.eval ctx).toNat]?).getD default)
         : TestRow F).second) := by
   simp [circuit_norm]
 

--- a/Clean/Utils/Test/TestWitgenEvalProjection.lean
+++ b/Clean/Utils/Test/TestWitgenEvalProjection.lean
@@ -20,12 +20,12 @@ def TestTable (F : Type) : Table F TestRow where
   name := "test"
   Contains _ _ := True
 
-example {F : Type} [FiniteField F] (ctx : Witgen.Ctx F) (row : Witgen.UExpr F) :
+example {F : Type} [FiniteField F] (ctx : Witgen.Ctx F) (row : Witgen.U64Expr F) :
     Witgen.FExpr.eval ctx ((TestTable F).dataGet row).second =
       (((ctx.env.data.getTable (TestTable F))[(row.eval ctx).toNat]?.getD default).second) := by
   simp [circuit_norm]
 
-example {F : Type} [FiniteField F] (ctx : Witgen.Ctx F) (row : Witgen.UExpr F) :
+example {F : Type} [FiniteField F] (ctx : Witgen.Ctx F) (row : Witgen.U64Expr F) :
     Witgen.FExpr.eval ctx ((TestTable F).hintGet row).second =
       ((fromElements (((ctx.env.hint (TestTable F).name (size TestRow))[(row.eval ctx).toNat]?).getD default)
         : TestRow F).second) := by

--- a/doc/witgen-authoring.md
+++ b/doc/witgen-authoring.md
@@ -26,17 +26,35 @@ let z ← witness (Vector.ofFn fun (i : Fin 32) => .expr (a[i] * b[i]))
 Building blocks:
 
 - `Expression F` coerces into `FExpr` (`.expr`), so circuit vars/expressions drop in.
-- `x.val : NExpr` (the `ℕ` value of an expression), `n.toField : FExpr` (cast back,
-  via `FiniteField.fromNat` so it is also correct on binary fields).
-- `NExpr` has `+ * / % &&& ||| ^^^ <<< >>>` and `OfNat` literals; `FExpr` has
-  `+ * - ⁻¹` and constants.
-- conditions: `a =? b` (field equality), `a <? b` (Nat comparison), used with `.ite`.
+- `x.val : UExpr` (the **u64** value of an expression: `ZMod.val` truncated to 64 bits),
+  `n.toField : FExpr` (cast back, via `FiniteField.fromNat` so it is also correct on
+  binary fields).
+- `UExpr` has `+ * / % &&& ||| ^^^ <<< >>>` and `OfNat` literals, all with wrapping
+  `u64` semantics; `FExpr` has `+ * - ⁻¹` and constants.
+- conditions: `a =? b` (field equality), `a <? b` (u64 comparison), used with `.ite`.
+- bit extraction stays at the *field* level, so it is not limited to 64 bits:
+  `x.bit i : FExpr` is bit `i` of `ZMod.val x`, and `x.bits n : VExpr F n` is its `n`
+  low bits (`Bits`, `Num2Bits`, `BinSub`).
+
+### The integer sort is `u64`, and it wraps
+
+Witness IR is meant to be executable outside Lean (`#witgen_json` → a Rust interpreter),
+so its integer sort is `UInt64`, not `ℕ` (issue #429). Every operation wraps modulo
+`2^64`, exactly like Rust's `u64`; `x.val` truncates and `n.toField` casts back through
+`UInt64.toNat`. Gadgets work on bytes, 32-bit limbs and small indices, so the wraps are
+never taken — and in proofs the `circuit_norm` simproc `u64Wrap` erases a `% 2^64` (or a
+shift's `% 64`) as soon as `omega` can bound the operand from the gadget's own
+assumptions. If a wrap survives simplification, the missing piece is usually a bound
+that has not been destructured into the local context yet.
+
+Anything genuinely wider than 64 bits must stay field-sorted: use `x.bit i` / `x.bits n`
+for bit decomposition, and `VExpr.envRange offset` for a run of environment cells.
 
 ## Programs with sharing: `witnessProgram`
 
 When a typed witness needs `let`-bound shared values, use `witnessProgram`.
 It is `witness`, but in the `Witgen.M` builder monad. Binding an `FExpr` or
-`NExpr` with `←` creates a shared witness-IR step:
+`UExpr` with `←` creates a shared witness-IR step:
 
 ```lean
 let z ← witnessProgram do
@@ -45,7 +63,7 @@ let z ← witnessProgram do
 ```
 
 For vector witnesses, `witnessVectorProgram` exposes the lower-level `VExpr` API,
-including compact loops via `.range` (the lambda receives the index as an `NExpr`):
+including compact loops via `.range` (the lambda receives the index as a `UExpr`):
 
 ```lean
 -- SHA256 Add32: shared 32-bit sum, then one output bit per index
@@ -53,8 +71,8 @@ let z ← witnessVectorProgram 32 do
   let sum ← (bitsVal a + bitsVal b) % (2^32 : ℕ)
   return .range 32 fun i => ((sum >>> i) % 2).toField
 
--- generic-length bit decomposition (Bits, Bitify)
-let bits ← witnessVector n (.range n fun i => ((x.val >>> i) % 2).toField)
+-- generic-length bit decomposition (Bits, Bitify) — field-level, so `n` may exceed 64
+let bits ← witnessVector n (x.bits n)
 ```
 
 `witnessIR` remains available for constructing a `WitgenIR` directly.
@@ -63,7 +81,7 @@ let bits ← witnessVector n (.range n fun i => ((x.val >>> i) % 2).toField)
 
 When a program starts by binding an *opaque* sub-program — typically reading an
 `Unconstrained*` hint passed in from the caller — derive values from it with a plain
-Lean `let`, not `←`/`letN`/`letF`:
+Lean `let`, not `←`/`letU`/`letF`:
 
 ```lean
 let row ← witnessProgram do
@@ -72,7 +90,7 @@ let row ← witnessProgram do
   return CoordsRow.mk k.toField xs[k] ys[k] us[k]
 ```
 
-A `letN` here would allocate its local at a step index that depends on the opaque
+A `letU` here would allocate its local at a step index that depends on the opaque
 prefix's step count, and — more fundamentally — proofs would need to know that the
 prefix's own output is unaffected by the extension of the locals array, an invariant
 with no syntactic handle in `circuit_norm`. Plain `let` duplicates the derived node in

--- a/doc/witgen-authoring.md
+++ b/doc/witgen-authoring.md
@@ -26,35 +26,35 @@ let z ← witness (Vector.ofFn fun (i : Fin 32) => .expr (a[i] * b[i]))
 Building blocks:
 
 - `Expression F` coerces into `FExpr` (`.expr`), so circuit vars/expressions drop in.
-- `x.val : UExpr` (the **u64** value of an expression: `ZMod.val` truncated to 64 bits),
+- `x.val : U64Expr` (the **u64** value of an expression: `ZMod.val` truncated to 64 bits),
   `n.toField : FExpr` (cast back, via `FiniteField.fromNat` so it is also correct on
   binary fields).
-- `UExpr` has `+ * / % &&& ||| ^^^ <<< >>>` and `OfNat` literals, all with wrapping
+- `U64Expr` has `+ * / % &&& ||| ^^^ <<< >>>` and `OfNat` literals, all with wrapping
   `u64` semantics; `FExpr` has `+ * - ⁻¹` and constants.
-- conditions: `a =? b` (field equality), `a <? b` (u64 comparison), used with `.ite`.
-- bit extraction stays at the *field* level, so it is not limited to 64 bits:
-  `x.bit i : FExpr` is bit `i` of `ZMod.val x`, and `x.bits n : VExpr F n` is its `n`
-  low bits (`Bits`, `Num2Bits`, `BinSub`).
+- conditions: `a =? b` (equality) and `a <? b` (comparison), used with `.ite`. Both
+  overload on the operand sort: field-sorted operands compare `ZMod.val`s exactly,
+  u64-sorted operands compare `u64`s.
+- bit extraction is field-sorted, so it is not limited to 64 bits: `x.bit i : FExpr` is
+  bit `i` of `ZMod.val x`, and `x.bits n : VExpr F n` is its `n` low bits.
+- `VExpr.envRange offset` witnesses a run of `n` consecutive environment cells.
 
-### The integer sort is `u64`, and it wraps
+### Wrapping, and what it means for proofs
 
-Witness IR is meant to be executable outside Lean (`#witgen_json` → a Rust interpreter),
-so its integer sort is `UInt64`, not `ℕ` (issue #429). Every operation wraps modulo
-`2^64`, exactly like Rust's `u64`; `x.val` truncates and `n.toField` casts back through
-`UInt64.toNat`. Gadgets work on bytes, 32-bit limbs and small indices, so the wraps are
+The integer sort is `UInt64` and every operation on it wraps modulo `2^64`, exactly like
+Rust's `u64`. Gadgets work on bytes, 32-bit limbs and small indices, so the wraps are
 never taken — and in proofs the `circuit_norm` simproc `u64Wrap` erases a `% 2^64` (or a
 shift's `% 64`) as soon as `omega` can bound the operand from the gadget's own
-assumptions. If a wrap survives simplification, the missing piece is usually a bound
-that has not been destructured into the local context yet.
+assumptions. If a wrap survives simplification, the missing piece is usually a bound that
+has not been destructured into the local context yet.
 
-Anything genuinely wider than 64 bits must stay field-sorted: use `x.bit i` / `x.bits n`
-for bit decomposition, and `VExpr.envRange offset` for a run of environment cells.
+Anything genuinely wider than 64 bits must stay field-sorted: `x.bit i` / `x.bits n` for
+bit decomposition, `a <? b` on field operands for comparison.
 
 ## Programs with sharing: `witnessProgram`
 
 When a typed witness needs `let`-bound shared values, use `witnessProgram`.
 It is `witness`, but in the `Witgen.M` builder monad. Binding an `FExpr` or
-`UExpr` with `←` creates a shared witness-IR step:
+`U64Expr` with `←` creates a shared witness-IR step:
 
 ```lean
 let z ← witnessProgram do
@@ -63,7 +63,7 @@ let z ← witnessProgram do
 ```
 
 For vector witnesses, `witnessVectorProgram` exposes the lower-level `VExpr` API,
-including compact loops via `.range` (the lambda receives the index as a `UExpr`):
+including compact loops via `.range` (the lambda receives the index as a `U64Expr`):
 
 ```lean
 -- SHA256 Add32: shared 32-bit sum, then one output bit per index


### PR DESCRIPTION
## Human description

Closes #429.

Replaces `Nat` computation in the IR with U64. This is useful for exporting and for arguing about the concrete and asymptotic runtime of the witness generation.

Conversion between field elements and u64 is done by lifting to `Nat` and taking the modular reduction. Added instructions for computing `lt` over field elements (because casting to `Nat` is not there anymore), and for getting the `n`-th bit of a field element. Proof ergonomics should be fine.

## Agent description

`WitgenIR`'s integer sort was arbitrary-precision `ℕ`, which is not what a witness-generation backend can run. `NExpr` becomes `U64Expr`, evaluating to `UInt64` with Rust-`u64` wrapping:

- `U64Expr.val x` is `FiniteField.val x` truncated to 64 bits (`UInt64.ofNat`)
- `FExpr.ofU64 n` casts back through `FiniteField.fromNat n.toNat`
- `U64Expr.const n` truncates its `ℕ` payload the same way

`Step.letN` / `M.evalNat` / `UnconstrainedNat` follow as `letU` / `evalU64` / `UnconstrainedU64`. JSON export follows too (`ofU64`, `u64Eq`, `u64Lt`, `"sort": "u64"`).

### Operations that can't live in 64 bits

Two stay field-sorted, so no gadget has to assume a 254-bit element fits in a `u64`:

- `FExpr.bitOf x i` (`x.bit i`) and `VExpr.bitsOf` (`x.bits n`) — `CompConstant` decomposes 135 bits of a 254-bit prime, where `(x.val >>> i) % 2` returns `0` for every `i ≥ 64`. They evaluate to exactly the old terms, so `Bits`, `Num2Bits`, `Num2BitsNeg` and `BinSub` needed **no proof changes**.
- `VExpr.envRange offset` — replaces `FExpr.envGet` at a computed index; `witnessAny` and `Table.getRow` read `env.get (offset + i)` with an abstract `offset`, and `env.get ((offset + i) % 2^64)` is not provable there.

Net: `FExpr` −`envGet` +`bitOf`; `VExpr` +`envRange` +`bitsOf`. `BExpr` also gains `flt`, a field-sorted less-than over `FiniteField.val`s; `<?` is now an overloaded `LtCond` class mirroring `EqCond`, so `x <? y` on field operands is exact at any width while `x.val <? y.val` compares truncated `u64`s.

### Proofs

`circuit_norm` gained the `UInt64.toNat_*` push lemmas, so goals stay in `ℕ` but pick up `% 2^64` (values) and `% 64` (shift amounts). Gadgets work well inside those bounds, but the bound lives in their own assumptions — so neither an unconditional rewrite nor a conditional simp lemma can remove the wrap. New `circuit_norm` simproc `Witgen.u64Wrap` asks `omega`, with the local hypotheses as facts, whether the operand is already below the modulus, and rewrites only then. Other moduli are untouched.

That fixed five modules outright; for most of the rest the repair was exposing the byte/bit bound *before* the normalizing `simp`. Two needed more:

- **`Addition32Full`** — the bound chains through the carries and can't be hoisted, so `add8_completeness` takes its byte/bool facts as leading arguments and unwraps internally from the `< 512` bound it already derives.
- **`SHA256.Add32`** — `bitsVal_eval` restated as `= UInt64.ofNat (evalBitsNat env a)`, unconditionally. Generally: state lemmas about u64 quantities as `= UInt64.ofNat <ℕ expr>`, not about `.toNat`, since `omega` treats `UInt64.toNat x` as an unbounded atom.

### One API change worth review

`FemtoCairo` indexes its program and memory tables at a computed row, so completeness needs them to fit in `2^64` rows. Rather than `Fact (p < 2^64)` — which would restrict soundness too — the bounds went into prover-side assumptions only: `programSize ≤ 2^64` (`fetchInstruction.ProverAssumptions`, `femtoCairoStepAssumptions`, `InitialStateAssumptions`) and `mem.size ≤ 2^64` (`MemoryCompletenessAssumption`). Soundness stays fully general; no `Spec` was weakened anywhere in this PR.

### Tests

- `TestU64Wrap.lean` — the simproc erases wraps when bounded, leaves other moduli alone, does **not** fire unbounded; plus `<?` sort dispatch and the contrast case where `x.val <? y.val` compares `% 2^64` values.
- `Examples/WitnessExport.lean` — golden `#witgen_json` pinning the u64 nodes and `bitsOf`.