### PR TITLE
feat: Modify `AgreesBelow` to include data and hint agreement.

### DIFF
--- a/Clean.lean
+++ b/Clean.lean
@@ -20,6 +20,7 @@ import Clean.Examples.AddOperations
 import Clean.Examples.Add32Explicit
 import Clean.Examples.ToJson
 import Clean.Examples.HintExample
+import Clean.Examples.DataWitness
 import Clean.Examples.FemtoCairo.FemtoCairo
 import Clean.Examples.FemtoCairo.Plonky3Helpers
 import Clean.Examples.FemtoCairo.Plonky3TestData

--- a/Clean/Circuit/Basic.lean
+++ b/Clean/Circuit/Basic.lean
@@ -421,8 +421,37 @@ def FlatOperation.dynamicWitnesses (ops : List (FlatOperation F)) (hint : Prover
 def FlatOperation.proverEnvironment (ops : List (FlatOperation F)) (hint : ProverHint F) (init : List F) :=
   ProverEnvironment.fromList (FlatOperation.dynamicWitnesses ops hint init) hint
 
+/--
+Two prover environments are indistinguishable to a witness generator running at offset `n`.
+
+A `ProverEnvironment` has three channels a witness generator can read: cells (`get`, via
+`Expression.eval`), committed prover data (`data`, via `FExpr.dataGet`) and prover hints
+(`hint`, via `FExpr.hintGet`). All three appear here, but not in the same way: cells are
+determined incrementally by witness generation, so only those *below* the current offset are
+constrained, whereas `data` and `hint` are ambient inputs fixed before generation begins, so
+they are constrained in full.
+-/
 def ProverEnvironment.AgreesBelow (n : ℕ) (env env' : ProverEnvironment F) :=
-  ∀ i < n, env.get i = env'.get i
+  (∀ i < n, env.get i = env'.get i) ∧ env.data = env'.data ∧ env.hint = env'.hint
+
+namespace ProverEnvironment.AgreesBelow
+variable {env env' : ProverEnvironment F}
+
+omit [FiniteField F] in
+theorem get_eq (h : env.AgreesBelow n env') {i : ℕ} (hi : i < n) : env.get i = env'.get i := h.1 i hi
+
+omit [FiniteField F] in
+theorem data_eq (h : env.AgreesBelow n env') : env.data = env'.data := h.2.1
+
+omit [FiniteField F] in
+theorem hint_eq (h : env.AgreesBelow n env') : env.hint = env'.hint := h.2.2
+
+end ProverEnvironment.AgreesBelow
+
+omit [FiniteField F] in
+theorem ProverEnvironment.agreesBelow_rfl (n : ℕ) (env : ProverEnvironment F) :
+    env.AgreesBelow n env :=
+  ⟨fun _ _ => rfl, rfl, rfl⟩
 
 def ProverEnvironment.OnlyAccessedBelow (n : ℕ) (f : ProverEnvironment F → α) :=
   ∀ env env', env.AgreesBelow n env' → f env = f env'

--- a/Clean/Circuit/Theorems.lean
+++ b/Clean/Circuit/Theorems.lean
@@ -494,6 +494,8 @@ theorem proverEnvironment_usesLocalWitnesses {ops : List (FlatOperation F)} (ini
       simp only [dynamicWitness, Vector.getElem_toList]
       congr 1
       apply h_computable
+      -- `data` and `hint` are literally shared: every environment here is `.fromList _ hint`.
+      refine ⟨?_, rfl, rfl⟩
       intro j hj
       simp [ProverEnvironment.fromList, hj,
         getElem?_dynamicWitnesses_of_lt]
@@ -513,7 +515,8 @@ theorem Circuit.proverEnvironment_usesLocalWitnesses (circuit : Circuit F α) (h
 
 lemma ProverEnvironment.agreesBelow_of_le {F} {n m : ℕ} {env env' : ProverEnvironment F} :
     env.AgreesBelow n env' → m ≤ n → env.AgreesBelow m env' :=
-  fun h_same hi i hi' => h_same i (Nat.lt_of_lt_of_le hi' hi)
+  fun h_same hi =>
+    ⟨fun i hi' => h_same.1 i (Nat.lt_of_lt_of_le hi' hi), h_same.2.1, h_same.2.2⟩
 
 namespace FlatOperation
 /--
@@ -545,8 +548,7 @@ theorem onlyAccessedBelow_all {ops : List (FlatOperation F)} (n : ℕ) :
         ProverEnvironment.OnlyAccessedBelow, ProverEnvironment.AgreesBelow]
       congr 1
       apply h_comp env env'
-      intro i hi
-      exact h_env i (by linarith)
+      exact ⟨fun i hi => h_env.1 i (by linarith), h_env.2.1, h_env.2.2⟩
 end FlatOperation
 
 section

--- a/Clean/Examples/DataWitness.lean
+++ b/Clean/Examples/DataWitness.lean
@@ -1,0 +1,86 @@
+/-
+Example: a witness generator that reads committed prover data.
+
+`Witgen.FExpr.dataGet` is the witness IR's escape hatch for reading `ProverEnvironment.data`
+(`Examples.FemtoCairo` uses it for memory). This file is the smallest circuit that uses it, and
+records both directions of what `ProverEnvironment.AgreesBelow` has to say about such a circuit.
+
+`readMemory_computableWitnesses` proves the `ComputableWitnesses` obligation — the precondition of
+`Circuit.witgen_usesLocalWitnesses`, i.e. that an honest prover can actually run the circuit's
+witness generators. It closes by rewriting with `AgreesBelow.data_eq`, which is exactly the
+component that carries it.
+
+`not_computable_from_cells_alone` shows the converse: agreement on environment *cells* alone does
+not suffice. The obligation would not merely be hard to prove, it would be false. That is why
+`AgreesBelow` constrains all three channels of a `ProverEnvironment` and not just `get`.
+-/
+import Clean.Circuit
+
+namespace Examples.DataWitness
+variable {p : ℕ} [Fact p.Prime]
+
+structure Entry (F : Type) where
+  address : F
+  value : F
+deriving ProvableStruct
+
+/-- A read-only memory table, as in `Examples.FemtoCairo`. -/
+def MemoryTable : Table (F p) Entry where
+  name := "memory"
+  Contains table entry := ∃ (_ : entry.address.val < table.size),
+    entry.address = table[entry.address.val].address ∧
+    entry.value = table[entry.address.val].value
+
+/--
+Witness the memory value committed at `address`, and constrain the resulting pair to be in the
+table. The witness generator reads `env.data`; the constraint system does not.
+-/
+def readMemory (address : Expression (F p)) : Circuit (F p) (Expression (F p)) := do
+  let value ← witness (MemoryTable.dataGet address.val).value
+  lookup MemoryTable ⟨address, value⟩
+  return value
+
+/--
+`readMemory` has computable witnesses whenever its input expression only reads cells below the
+current offset — the standard side condition, supplied by `compose_computableWitnesses` when the
+circuit is used as a subcircuit.
+
+The two rewrites are the whole proof, and they are one per environment channel the witness
+generator reads: `AgreesBelow.data_eq` for the committed table, and the input hypothesis for the
+address expression.
+-/
+theorem readMemory_computableWitnesses (n : ℕ) (address : Expression (F p))
+    (h_input : ProverEnvironment.OnlyAccessedBelow n (F := F p) (eval · address)) :
+    (readMemory address).ComputableWitnesses n := by
+  intro env env'
+  simp only [readMemory, circuit_norm, Operations.ComputableWitnesses, Operations.forAllFlat]
+  intro h_agree
+  have h_address := h_input env env' h_agree
+  simp only [circuit_norm, explicit_provable_type] at h_address
+  rw [h_agree.data_eq, h_address]
+
+/-! ## Why `AgreesBelow` has to constrain `data`
+
+The proof above rests on `ProverEnvironment.AgreesBelow` supplying `env.data = env'.data`. The
+following shows the alternative is not an option: agreement on cells alone makes the obligation
+false. Both environments below agree on every cell (they are constantly zero) yet commit
+different memory, so the witness generator returns different values. -/
+
+private def emptyEnv : ProverEnvironment (F p) :=
+  ⟨⟨fun _ => 0, fun _ _ => #[]⟩, ProverHint.empty _⟩
+
+private def onesEnv : ProverEnvironment (F p) :=
+  ⟨⟨fun _ => 0, fun _ k => #[Vector.replicate k 1]⟩, ProverHint.empty _⟩
+
+theorem not_computable_from_cells_alone :
+    ¬ ∀ (n : ℕ) (compute : Witgen.WitgenIR (F p) 1) (env env' : ProverEnvironment (F p)),
+        (∀ i < n, env.get i = env'.get i) → compute.eval env = compute.eval env' := by
+  intro h
+  -- a one-node witness program reading row 0 of the committed `memory` table
+  have := h 0 (.ofFExpr (.dataGet "memory" 1 (.const 0) 0)) emptyEnv onesEnv (by omega)
+  simp [Witgen.WitgenIR.ofFExpr, Witgen.WitgenIR.eval, Witgen.VExpr.eval, Witgen.evalSteps,
+    Witgen.FExpr.eval, Witgen.U64Expr.eval, emptyEnv, onesEnv] at this
+  -- the empty table reads as the default row, the ones table as `1`
+  exact zero_ne_one (show (0 : F p) = 1 from this)
+
+end Examples.DataWitness


### PR DESCRIPTION
## The problem

`ProverEnvironment.AgreesBelow` (`Clean/Circuit/Basic.lean:424`) is today

```lean
def ProverEnvironment.AgreesBelow (n : ℕ) (env env' : ProverEnvironment F) :=
  ∀ i < n, env.get i = env'.get i
```

but a `ProverEnvironment` has **three** channels a witness generator can read: cells (`get`, via `Expression.eval`), committed prover data (`data`, via `FExpr.dataGet`) and prover hints (`hint`, via `FExpr.hintGet`). Only the first is constrained.

Since `Operations.ComputableWitnesses` is exactly `AgreesBelow n env env' → compute.eval env = compute.eval env'`, the obligation for any witness program containing a `dataGet` or `hintGet` node asks you to show that two environments with *entirely unrelated* committed data compute the same witness. That is not merely hard — it is **false**, and this PR proves it (`Examples.DataWitness.not_computable_from_cells_alone`). So no circuit using the IR's documented nondeterministic escape hatch (`Examples.FemtoCairo`'s memory) can be shown to generate witnesses honestly, and `Circuit.witgen_usesLocalWitnesses` is unavailable to it.

## The change

```lean
def ProverEnvironment.AgreesBelow (n : ℕ) (env env' : ProverEnvironment F) :=
  (∀ i < n, env.get i = env'.get i) ∧ env.data = env'.data ∧ env.hint = env'.hint
```

plus `AgreesBelow.get_eq` / `.data_eq` / `.hint_eq` accessors and `agreesBelow_rfl`, so downstream scripts do not reach for `.2.1`. The body is a plain `∧` rather than a structure, so `⟨h, rfl, rfl⟩` and `simp_all` keep working.

**Nothing downstream weakens.** `AgreesBelow` sits in hypothesis position at every occurrence except one, so strengthening it *weakens* every obligation — existing instances stay true.

## The example

`Clean/Examples/DataWitness.lean` is the smallest circuit reading committed prover data — a memory read modelled on `Examples.FemtoCairo` — and records both directions:

- `readMemory_computableWitnesses` discharges a genuine `Circuit.ComputableWitnesses`. Its proof is two rewrites, one per environment channel the generator reads: `AgreesBelow.data_eq` for the committed table, and the input hypothesis for the address expression.
- `not_computable_from_cells_alone` **proves** the converse: two environments agreeing on every cell but committing different memory compute different witnesses. The claim above that the old obligation was false is a theorem in the tree, not an argument in a PR description.